### PR TITLE
fix: decrement engine.vault in WithdrawInsurance

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -4226,6 +4226,13 @@ pub mod processor {
                 // Zero out insurance fund
                 engine.insurance_fund.balance = percolator::U128::ZERO;
 
+                // Decrement vault to maintain conservation invariant (vault >= C_tot + insurance)
+                let ins = percolator::U128::new(insurance_units);
+                if ins > engine.vault {
+                    return Err(PercolatorError::EngineInsufficientBalance.into());
+                }
+                engine.vault = engine.vault - ins;
+
                 // Transfer from vault to admin
                 let seed1: &[u8] = b"vault";
                 let seed2: &[u8] = a_slab.key.as_ref();


### PR DESCRIPTION
WithdrawInsurance zeroed insurance_fund.balance and transferred SPL tokens from the vault, but did not decrement engine.vault. This violates the conservation invariant (vault >= C_tot + insurance) and permanently blocks CloseSlab since engine.vault.is_zero() never passes.

Add the missing vault decrement after zeroing the insurance fund, mirroring how close_account() handles vault accounting (line 1317 in vendor/percolator/src/percolator.rs).

Add regression test that exercises the full wind-down path: init → deposit → trade → resolve → force-close → withdraw insurance → close slab. Verifies engine.vault == 0 after WithdrawInsurance and CloseSlab succeeds.