### PR TITLE
[codex] Reject same-owner self-matches

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -335,6 +335,13 @@ pub mod verify {
         stored == signer
     }
 
+    /// Counterparty isolation: the two trade slots must not share one owner.
+    /// Used by: TradeNoCpi, TradeCpi.
+    #[inline]
+    pub fn owners_distinct_ok(lhs: [u8; 32], rhs: [u8; 32]) -> bool {
+        lhs != rhs
+    }
+
     /// Admin authorization: admin must be non-zero (not burned) and match signer.
     /// Used by: UpdateAuthority, UpdateConfig, and other admin-gated ops.
     #[inline]
@@ -488,6 +495,7 @@ pub mod verify {
     ///   LP authorization is delegated to the matcher program at registration
     ///   time — the CPI identity binding (matcher_identity_ok) is the actual
     ///   LP-side authorization gate. This parameter models key-equality only.
+    /// * `owners_distinct` - Whether the two counterparties have different owners
     /// * `exec_size` - The exec_size from matcher return
     #[inline]
     pub fn decide_trade_cpi(
@@ -498,6 +506,7 @@ pub mod verify {
         abi_ok: bool,
         user_auth_ok: bool,
         lp_key_ok: bool,
+        owners_distinct: bool,
         exec_size: i128,
     ) -> TradeCpiDecision {
         // Check in order of actual program execution:
@@ -509,8 +518,8 @@ pub mod verify {
         if !pda_ok {
             return TradeCpiDecision::Reject;
         }
-        // 3. Owner authorization (user signer + LP key equality)
-        if !user_auth_ok || !lp_key_ok {
+        // 3. Owner authorization + counterparty isolation
+        if !user_auth_ok || !lp_key_ok || !owners_distinct {
             return TradeCpiDecision::Reject;
         }
         // 4. Matcher identity binding
@@ -610,6 +619,7 @@ pub mod verify {
     /// * `user_auth_ok` - Whether user signer matches user owner
     /// * `lp_key_ok` - Whether provided LP owner key matches stored LP owner
     ///   (key-equality only, not signer — see decide_trade_cpi docs)
+    /// * `owners_distinct` - Whether the two counterparties have different owners
     /// * `ret` - The matcher return fields (from CPI)
     /// * `lp_account_id` - Expected LP account ID from request
     /// * `oracle_price_e6` - Expected oracle price from request
@@ -622,6 +632,7 @@ pub mod verify {
         pda_ok: bool,
         user_auth_ok: bool,
         lp_key_ok: bool,
+        owners_distinct: bool,
         ret: MatcherReturnFields,
         lp_account_id: u64,
         oracle_price_e6: u64,
@@ -636,8 +647,8 @@ pub mod verify {
         if !pda_ok {
             return TradeCpiDecision::Reject;
         }
-        // 3. Owner authorization (user signer + LP key equality)
-        if !user_auth_ok || !lp_key_ok {
+        // 3. Owner authorization + counterparty isolation
+        if !user_auth_ok || !lp_key_ok || !owners_distinct {
             return TradeCpiDecision::Reject;
         }
         // 4. Matcher identity binding
@@ -673,12 +684,14 @@ pub mod verify {
     /// Pure decision function for TradeNoCpi instruction.
     /// * `lp_auth_ok` - Whether LP signer matches stored LP owner.
     ///   NOTE: TradeNoCpi requires LP to be a signer (unlike TradeCpi).
+    /// * `owners_distinct` - Whether the two counterparties have different owners.
     #[inline]
     pub fn decide_trade_nocpi(
         user_auth_ok: bool,
         lp_auth_ok: bool,
+        owners_distinct: bool,
     ) -> TradeNoCpiDecision {
-        if !user_auth_ok || !lp_auth_ok {
+        if !user_auth_ok || !lp_auth_ok || !owners_distinct {
             return TradeNoCpiDecision::Reject;
         }
         TradeNoCpiDecision::Accept
@@ -1203,6 +1216,9 @@ pub mod error {
         /// (with a minimum floor of 1 unit to avoid Zeno's-paradox lockout
         /// at small bps × small insurance).
         InsuranceWithdrawCapExceeded,
+        /// Trade counterparties must have distinct owners. Rejects same-owner
+        /// self-matching before one account can externalize losses to insurance.
+        SameOwnerTradeForbidden,
     }
 
     impl From<PercolatorError> for ProgramError {
@@ -5596,6 +5612,9 @@ pub mod processor {
                 if !crate::verify::owner_ok(l_owner, a_lp.key.to_bytes()) {
                     return Err(PercolatorError::EngineUnauthorized.into());
                 }
+                if !crate::verify::owners_distinct_ok(u_owner, l_owner) {
+                    return Err(PercolatorError::SameOwnerTradeForbidden.into());
+                }
 
                 // Side-mode gating is handled inside engine.execute_trade_not_atomic()
 
@@ -5876,6 +5895,9 @@ pub mod processor {
                     let l_owner = engine.accounts[lp_idx as usize].owner;
                     if !crate::verify::owner_ok(l_owner, a_lp_owner.key.to_bytes()) {
                         return Err(PercolatorError::EngineUnauthorized.into());
+                    }
+                    if !crate::verify::owners_distinct_ok(u_owner, l_owner) {
+                        return Err(PercolatorError::SameOwnerTradeForbidden.into());
                     }
 
                     let lp_acc = &engine.accounts[lp_idx as usize];

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -745,6 +745,19 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
+    fn ensure_owner_funded(&mut self, owner: &Pubkey) {
+        const MIN_OWNER_LAMPORTS: u64 = 1_000_000_000;
+        let current = self
+            .svm
+            .get_account(owner)
+            .map(|account| account.lamports)
+            .unwrap_or(0);
+        let needed = MIN_OWNER_LAMPORTS.saturating_sub(current);
+        if needed > 0 {
+            self.svm.airdrop(owner, needed).unwrap();
+        }
+    }
+
     pub fn new() -> Self {
         let path = program_path();
 
@@ -1201,7 +1214,7 @@ impl TestEnv {
 
     pub fn init_lp(&mut self, owner: &Keypair) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 100);
         let matcher = spl_token::ID;
         let ctx = Pubkey::new_unique();
@@ -1244,7 +1257,7 @@ impl TestEnv {
 
     pub fn init_lp_with_fee(&mut self, owner: &Keypair, fee: u64) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), fee);
         let matcher = spl_token::ID;
         let ctx = Pubkey::new_unique();
@@ -1287,7 +1300,7 @@ impl TestEnv {
 
     pub fn init_user(&mut self, owner: &Keypair) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 100);
 
         let ix = Instruction {
@@ -1861,7 +1874,7 @@ impl TestEnv {
     /// Returns the next available user index (first user is 0, second is 1, etc)
     pub fn init_user_with_fee(&mut self, owner: &Keypair, fee: u64) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), fee);
 
         let ix = Instruction {
@@ -3200,6 +3213,19 @@ pub struct TradeCpiTestEnv {
 }
 
 impl TradeCpiTestEnv {
+    fn ensure_owner_funded(&mut self, owner: &Pubkey) {
+        const MIN_OWNER_LAMPORTS: u64 = 1_000_000_000;
+        let current = self
+            .svm
+            .get_account(owner)
+            .map(|account| account.lamports)
+            .unwrap_or(0);
+        let needed = MIN_OWNER_LAMPORTS.saturating_sub(current);
+        if needed > 0 {
+            self.svm.airdrop(owner, needed).unwrap();
+        }
+    }
+
     pub fn new() -> Self {
         let percolator_path = program_path();
         let matcher_path = matcher_program_path();
@@ -3366,7 +3392,7 @@ impl TradeCpiTestEnv {
     /// Returns (lp_idx, matcher_context_pubkey)
     pub fn init_lp_with_matcher(&mut self, owner: &Keypair, matcher_prog: &Pubkey) -> (u16, Pubkey) {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 100);
 
         // Derive the LP PDA that will be used later (must match percolator derivation)
@@ -3452,7 +3478,7 @@ impl TradeCpiTestEnv {
         matcher_ctx: &Pubkey,
     ) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 100);
 
         let ix = Instruction {
@@ -3483,7 +3509,7 @@ impl TradeCpiTestEnv {
 
     pub fn init_user(&mut self, owner: &Keypair) -> u16 {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 100);
 
         let ix = Instruction {
@@ -4728,7 +4754,7 @@ impl TestEnv {
     /// Try to init user with a specific signer (for auth tests)
     pub fn try_init_user(&mut self, owner: &Keypair) -> Result<u16, String> {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 0);
 
         let ix = Instruction {
@@ -5478,7 +5504,7 @@ impl TestEnv {
     /// Try to init user with specific fee, returns Result.
     pub fn try_init_user_with_fee(&mut self, owner: &Keypair, fee: u64) -> Result<u16, String> {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), fee);
 
         let ix = Instruction {
@@ -5512,7 +5538,7 @@ impl TestEnv {
     /// Try to init LP with correct 8-account layout, returns Result.
     pub fn try_init_lp_proper(&mut self, owner: &Keypair, matcher: &Pubkey, ctx: &Pubkey, fee: u64) -> Result<u16, String> {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), fee);
 
         let ix = Instruction {
@@ -5914,7 +5940,7 @@ impl TestEnv {
 impl TestEnv {
     pub fn try_init_lp(&mut self, owner: &Keypair) -> Result<u16, String> {
         let idx = self.account_count;
-        self.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+        self.ensure_owner_funded(&owner.pubkey());
         let ata = self.create_ata(&owner.pubkey(), 0);
 
         let ix = Instruction {

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -500,7 +500,7 @@ fn valid_shape() -> MatcherAccountsShape {
 }
 
 /// Universal characterization of decide_trade_cpi: fully symbolic inputs.
-/// Proves: Accept iff shape_ok && identity && pda && abi && user && lp.
+/// Proves: Accept iff shape_ok && identity && pda && abi && user && lp && distinct_owner.
 /// On Accept: new_nonce == nonce_on_success(old_nonce), chosen_size == exec_size.
 #[kani::proof]
 fn kani_decide_trade_cpi_universal() {
@@ -517,15 +517,16 @@ fn kani_decide_trade_cpi_universal() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_key_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
 
     let decision = decide_trade_cpi(
         old_nonce, shape, identity_ok, pda_ok, abi_ok,
-        user_auth_ok, lp_key_ok, exec_size,
+        user_auth_ok, lp_key_ok, owners_distinct, exec_size,
     );
 
     let should_accept = matcher_shape_ok(shape)
         && identity_ok && pda_ok && abi_ok
-        && user_auth_ok && lp_key_ok
+        && user_auth_ok && lp_key_ok && owners_distinct
         && old_nonce < u64::MAX; // nonce overflow gate
 
     if should_accept {
@@ -560,7 +561,7 @@ fn kani_tradecpi_reject_nonce_unchanged() {
     kani::assume(!matcher_shape_ok(shape));
 
     let decision = decide_trade_cpi(
-        old_nonce, shape, true, true, true, true, true, exec_size,
+        old_nonce, shape, true, true, true, true, true, true, exec_size,
     );
 
     assert_eq!(
@@ -604,6 +605,7 @@ fn kani_tradecpi_accept_increments_nonce() {
         true,
         true,
         true,
+        true,
         exec_size,
     );
 
@@ -640,11 +642,12 @@ fn kani_tradecpi_accept_increments_nonce() {
 fn kani_tradenocpi_auth_failure_rejects() {
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
 
     // At least one auth must fail
     kani::assume(!user_auth_ok || !lp_auth_ok);
 
-    let decision = decide_trade_nocpi(user_auth_ok, lp_auth_ok);
+    let decision = decide_trade_nocpi(user_auth_ok, lp_auth_ok, owners_distinct);
     assert_eq!(
         decision,
         TradeNoCpiDecision::Reject,
@@ -657,11 +660,12 @@ fn kani_tradenocpi_auth_failure_rejects() {
 fn kani_tradenocpi_universal_characterization() {
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
 
-    let decision = decide_trade_nocpi(user_auth_ok, lp_auth_ok);
+    let decision = decide_trade_nocpi(user_auth_ok, lp_auth_ok, owners_distinct);
 
     // Full characterization: accept iff all auth passes
-    let should_accept = user_auth_ok && lp_auth_ok;
+    let should_accept = user_auth_ok && lp_auth_ok && owners_distinct;
     if should_accept {
         assert_eq!(decision, TradeNoCpiDecision::Accept, "must accept when all conditions pass");
     } else {
@@ -718,7 +722,7 @@ fn kani_tradecpi_any_reject_nonce_unchanged() {
             ctx_owner_is_prog: true,
             ctx_len_ok: true,
         };
-        let d = decide_trade_cpi(0, bad, true, true, true, true, true, 0);
+        let d = decide_trade_cpi(0, bad, true, true, true, true, true, true, 0);
         assert!(
             matches!(d, TradeCpiDecision::Reject),
             "non-vacuity: bad shape must reject"
@@ -740,6 +744,7 @@ fn kani_tradecpi_any_reject_nonce_unchanged() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -750,6 +755,7 @@ fn kani_tradecpi_any_reject_nonce_unchanged() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -771,7 +777,7 @@ fn kani_tradecpi_any_reject_nonce_unchanged() {
 fn kani_tradecpi_any_accept_increments_nonce() {
     // Non-vacuity witness: all-valid inputs produce Accept
     {
-        let d = decide_trade_cpi(0, valid_shape(), true, true, true, true, true, 0);
+        let d = decide_trade_cpi(0, valid_shape(), true, true, true, true, true, true, 0);
         assert!(
             matches!(d, TradeCpiDecision::Accept { .. }),
             "non-vacuity: all-valid inputs must accept"
@@ -793,6 +799,7 @@ fn kani_tradecpi_any_accept_increments_nonce() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -803,6 +810,7 @@ fn kani_tradecpi_any_accept_increments_nonce() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1012,7 +1020,7 @@ fn kani_tradecpi_from_ret_any_reject_nonce_unchanged() {
             oracle_price_e6: 0,
             reserved: 0,
         };
-        let d = decide_trade_cpi_from_ret(0, bad, true, true, true, true, dummy_ret, 0, 0, 0);
+        let d = decide_trade_cpi_from_ret(0, bad, true, true, true, true, true, dummy_ret, 0, 0, 0);
         assert!(
             matches!(d, TradeCpiDecision::Reject),
             "non-vacuity: bad shape must reject"
@@ -1030,6 +1038,7 @@ fn kani_tradecpi_from_ret_any_reject_nonce_unchanged() {
     let pda_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let ret = any_matcher_return_fields();
     let lp_account_id: u64 = kani::any();
     let oracle_price_e6: u64 = kani::any();
@@ -1042,6 +1051,7 @@ fn kani_tradecpi_from_ret_any_reject_nonce_unchanged() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1078,7 +1088,7 @@ fn kani_tradecpi_from_ret_any_accept_increments_nonce() {
             reserved: 0,
         };
         let d = decide_trade_cpi_from_ret(
-            42, valid_shape(), true, true, true, true, valid_ret, 1, 50_000_000, 100,
+            42, valid_shape(), true, true, true, true, true, valid_ret, 1, 50_000_000, 100,
         );
         assert!(
             matches!(d, TradeCpiDecision::Accept { .. }),
@@ -1097,6 +1107,7 @@ fn kani_tradecpi_from_ret_any_accept_increments_nonce() {
     let pda_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let ret = any_matcher_return_fields();
     let lp_account_id: u64 = kani::any();
     let oracle_price_e6: u64 = kani::any();
@@ -1109,6 +1120,7 @@ fn kani_tradecpi_from_ret_any_accept_increments_nonce() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1187,6 +1199,7 @@ fn kani_tradecpi_from_ret_accept_uses_exec_size() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        true,
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1509,6 +1522,7 @@ fn kani_universal_shape_fail_rejects() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1519,6 +1533,7 @@ fn kani_universal_shape_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1545,6 +1560,7 @@ fn kani_universal_pda_fail_rejects() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1555,6 +1571,7 @@ fn kani_universal_pda_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1581,6 +1598,7 @@ fn kani_universal_user_auth_fail_rejects() {
     let abi_ok: bool = kani::any();
     let user_auth_ok = false; // Force failure
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1591,6 +1609,7 @@ fn kani_universal_user_auth_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1617,6 +1636,7 @@ fn kani_universal_lp_auth_fail_rejects() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok = false; // Force failure
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1627,6 +1647,7 @@ fn kani_universal_lp_auth_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1653,6 +1674,7 @@ fn kani_universal_identity_fail_rejects() {
     let abi_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1663,6 +1685,7 @@ fn kani_universal_identity_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1689,6 +1712,7 @@ fn kani_universal_abi_fail_rejects() {
     let abi_ok = false; // Force failure
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let exec_size: i128 = kani::any();
 
     let decision = decide_trade_cpi(
@@ -1699,6 +1723,7 @@ fn kani_universal_abi_fail_rejects() {
         abi_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         exec_size,
     );
 
@@ -1724,6 +1749,7 @@ fn kani_tradecpi_variants_consistent_valid_shape() {
     let pda_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
 
     // Create ret fields
     let ret = any_matcher_return_fields();
@@ -1750,6 +1776,7 @@ fn kani_tradecpi_variants_consistent_valid_shape() {
         abi_passes,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret.exec_size,
     );
 
@@ -1760,6 +1787,7 @@ fn kani_tradecpi_variants_consistent_valid_shape() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1809,6 +1837,7 @@ fn kani_tradecpi_variants_consistent_invalid_shape() {
     let pda_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
     let ret = any_matcher_return_fields();
     let lp_account_id: u64 = kani::any();
     let oracle_price_e6: u64 = kani::any();
@@ -1827,6 +1856,7 @@ fn kani_tradecpi_variants_consistent_invalid_shape() {
         abi_passes,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret.exec_size,
     );
 
@@ -1837,6 +1867,7 @@ fn kani_tradecpi_variants_consistent_invalid_shape() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1896,6 +1927,7 @@ fn kani_tradecpi_from_ret_req_id_is_nonce_plus_one() {
         true,  // pda_ok
         true,  // user_auth_ok
         true,  // lp_auth_ok
+        true,  // owners_distinct
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -1970,6 +2002,7 @@ fn kani_tradecpi_from_ret_forced_acceptance() {
         true,  // pda_ok
         true,  // user_auth_ok
         true,  // lp_auth_ok
+        true,  // owners_distinct
         ret,
         lp_account_id,
         oracle_price_e6,
@@ -2621,6 +2654,7 @@ fn kani_decide_trade_cpi_from_ret_universal() {
     let pda_ok: bool = kani::any();
     let user_auth_ok: bool = kani::any();
     let lp_auth_ok: bool = kani::any();
+    let owners_distinct: bool = kani::any();
 
     // Construct an ABI-valid ret symbolically.
     // The `abi_ok` call inside `decide_trade_cpi_from_ret` uses:
@@ -2640,6 +2674,7 @@ fn kani_decide_trade_cpi_from_ret_universal() {
                 pda_ok,
                 user_auth_ok,
                 lp_auth_ok,
+                owners_distinct,
                 any_matcher_return_fields(),
                 kani::any(),
                 kani::any(),
@@ -2676,6 +2711,7 @@ fn kani_decide_trade_cpi_from_ret_universal() {
         && pda_ok
         && user_auth_ok
         && lp_auth_ok
+        && owners_distinct
         && identity_ok
         && abi_valid;
 
@@ -2686,6 +2722,7 @@ fn kani_decide_trade_cpi_from_ret_universal() {
         pda_ok,
         user_auth_ok,
         lp_auth_ok,
+        owners_distinct,
         ret,
         lp_account_id,
         oracle_price_e6,

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -4874,6 +4874,60 @@ fn test_trade_nocpi_allows_user_user_bilateral() {
     assert!(result.is_ok(), "User-user bilateral trade must be allowed: {:?}", result);
 }
 
+/// Regression: TradeNoCpi must reject same-owner counterparties.
+/// Without this, one owner can split state across two slots and self-match.
+#[test]
+fn test_trade_nocpi_rejects_same_owner_counterparties() {
+    program_path();
+    let mut env = TestEnv::new();
+    env.init_market_with_invert(0);
+
+    let owner = Keypair::new();
+    let lp_idx = env.init_lp(&owner);
+    env.deposit(&owner, lp_idx, 10_000_000_000);
+
+    let user_idx = env.init_user(&owner);
+    env.deposit(&owner, user_idx, 10_000_000_000);
+
+    let user_pos_before = env.read_account_position(user_idx);
+    let lp_pos_before = env.read_account_position(lp_idx);
+    let user_cap_before = env.read_account_capital(user_idx);
+    let lp_cap_before = env.read_account_capital(lp_idx);
+    let vault_before = env.vault_balance();
+
+    let result = env.try_trade(&owner, &owner, lp_idx, user_idx, 1_000);
+    assert!(
+        result.is_err(),
+        "Same-owner TradeNoCpi must reject instead of self-matching: {:?}",
+        result
+    );
+    assert_eq!(
+        env.read_account_position(user_idx),
+        user_pos_before,
+        "Rejected same-owner TradeNoCpi must preserve user position"
+    );
+    assert_eq!(
+        env.read_account_position(lp_idx),
+        lp_pos_before,
+        "Rejected same-owner TradeNoCpi must preserve counterparty position"
+    );
+    assert_eq!(
+        env.read_account_capital(user_idx),
+        user_cap_before,
+        "Rejected same-owner TradeNoCpi must preserve user capital"
+    );
+    assert_eq!(
+        env.read_account_capital(lp_idx),
+        lp_cap_before,
+        "Rejected same-owner TradeNoCpi must preserve counterparty capital"
+    );
+    assert_eq!(
+        env.vault_balance(),
+        vault_before,
+        "Rejected same-owner TradeNoCpi must preserve the SPL vault"
+    );
+}
+
 // ============================================================================
 // Regression tests: TDD round-4 blockers
 // ============================================================================

--- a/tests/test_tradecpi.rs
+++ b/tests/test_tradecpi.rs
@@ -117,6 +117,76 @@ fn test_tradecpi_permissionless_lp_no_signature_required() {
     println!("  - This enables permissionless trading for LP pools");
 }
 
+/// Regression: TradeCpi must reject same-owner counterparties.
+/// LP-side delegation to a matcher is not permission to self-match one owner's
+/// user and LP slots against each other.
+#[test]
+fn test_tradecpi_rejects_same_owner_counterparties() {
+    let mut env = TradeCpiTestEnv::new();
+    env.init_market();
+
+    let matcher_prog = env.matcher_program_id;
+    let owner = Keypair::new();
+    let (lp_idx, matcher_ctx) = env.init_lp_with_matcher(&owner, &matcher_prog);
+    env.deposit(&owner, lp_idx, 100_000_000_000);
+
+    let user_idx = env.init_user(&owner);
+    env.deposit(&owner, user_idx, 10_000_000_000);
+
+    let user_pos_before = env.read_account_position(user_idx);
+    let lp_pos_before = env.read_account_position(lp_idx);
+    let user_cap_before = env.read_account_capital(user_idx);
+    let lp_cap_before = env.read_account_capital(lp_idx);
+    let spl_vault_before = env.vault_balance();
+    let engine_vault_before = env.read_vault();
+
+    let result = env.try_trade_cpi(
+        &owner,
+        &owner.pubkey(),
+        lp_idx,
+        user_idx,
+        1_000_000,
+        &matcher_prog,
+        &matcher_ctx,
+    );
+
+    assert!(
+        result.is_err(),
+        "Same-owner TradeCpi must reject instead of self-matching: {:?}",
+        result
+    );
+    assert_eq!(
+        env.read_account_position(user_idx),
+        user_pos_before,
+        "Rejected same-owner TradeCpi must preserve user position"
+    );
+    assert_eq!(
+        env.read_account_position(lp_idx),
+        lp_pos_before,
+        "Rejected same-owner TradeCpi must preserve LP position"
+    );
+    assert_eq!(
+        env.read_account_capital(user_idx),
+        user_cap_before,
+        "Rejected same-owner TradeCpi must preserve user capital"
+    );
+    assert_eq!(
+        env.read_account_capital(lp_idx),
+        lp_cap_before,
+        "Rejected same-owner TradeCpi must preserve LP capital"
+    );
+    assert_eq!(
+        env.vault_balance(),
+        spl_vault_before,
+        "Rejected same-owner TradeCpi must preserve the SPL vault"
+    );
+    assert_eq!(
+        env.read_vault(),
+        engine_vault_before,
+        "Rejected same-owner TradeCpi must preserve engine vault accounting"
+    );
+}
+
 /// CRITICAL: TradeCpi rejects PDA that exists but has wrong shape
 ///
 /// Even if the correct PDA address is passed, it must have:
@@ -6055,4 +6125,3 @@ fn test_tradecpi_empty_tail_is_canonical() {
     )
     .expect("TradeCpi with empty tail must succeed (canonical 8-account form)");
 }
-

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -5,11 +5,11 @@
 
 use percolator::{I128, MAX_ACCOUNTS, U128};
 use percolator_prog::{
-    constants::MAGIC,
+    constants::{MAGIC, MATCHER_CONTEXT_LEN},
     error::PercolatorError,
     oracle,
     processor::process_instruction,
-    state, units, zc,
+    state, units, verify, zc,
 };
 use solana_program::{
     account_info::AccountInfo, clock::Clock, program_error::ProgramError, program_pack::Pack,
@@ -376,6 +376,7 @@ fn encode_trade_cpi(lp: u16, user: u16, size: i128) -> Vec<u8> {
     encode_u16(lp, &mut data);
     encode_u16(user, &mut data);
     encode_i128(size, &mut data);
+    encode_u64(0, &mut data); // limit_price_e6 = 0 => no slippage bound
     data
 }
 
@@ -721,6 +722,328 @@ fn test_trade() {
         )
         .unwrap();
     }
+}
+
+#[test]
+fn test_trade_runtime_rejects_same_owner_counterparties() {
+    let mut f = setup_market();
+    let init_data = encode_init_market(&f, 100);
+    {
+        let accounts = vec![
+            f.admin.to_info(),
+            f.slab.to_info(),
+            f.mint.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+            f.rent.to_info(),
+            f.pyth_index.to_info(),
+            f.system.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &init_data).unwrap();
+    }
+
+    let owner_key = Pubkey::new_unique();
+
+    let mut lp_owner = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut lp_ata = TestAccount::new(
+        Pubkey::new_unique(),
+        spl_token::ID,
+        0,
+        make_token_account(f.mint.key, owner_key, 2_000),
+    )
+    .writable();
+    let matcher_prog_key = Pubkey::new_unique();
+    let matcher_ctx_key = Pubkey::new_unique();
+    {
+        let accounts = vec![
+            lp_owner.to_info(),
+            f.slab.to_info(),
+            lp_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(
+            &f.program_id,
+            &accounts,
+            &encode_init_lp(matcher_prog_key, matcher_ctx_key, 100),
+        )
+        .unwrap();
+    }
+    let lp_idx = 0u16;
+    {
+        let accounts = vec![
+            lp_owner.to_info(),
+            f.slab.to_info(),
+            lp_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_deposit(lp_idx, 1_000)).unwrap();
+    }
+
+    let mut user_owner = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut user_ata = TestAccount::new(
+        Pubkey::new_unique(),
+        spl_token::ID,
+        0,
+        make_token_account(f.mint.key, owner_key, 2_000),
+    )
+    .writable();
+    {
+        let accounts = vec![
+            user_owner.to_info(),
+            f.slab.to_info(),
+            user_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_init_user(100)).unwrap();
+    }
+    let user_idx = 1u16;
+    {
+        let accounts = vec![
+            user_owner.to_info(),
+            f.slab.to_info(),
+            user_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_deposit(user_idx, 1_000)).unwrap();
+    }
+
+    let slab_before = f.slab.data.clone();
+    let vault_before = f.vault.data.clone();
+    let mut user_signer = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut lp_signer = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let accounts = vec![
+        user_signer.to_info(),
+        lp_signer.to_info(),
+        f.slab.to_info(),
+        f.clock.to_info(),
+        f.pyth_index.to_info(),
+    ];
+    let res = process_instruction(
+        &f.program_id,
+        &accounts,
+        &encode_trade(lp_idx, user_idx, 100),
+    );
+    assert_eq!(res, Err(PercolatorError::SameOwnerTradeForbidden.into()));
+    assert_eq!(
+        f.slab.data,
+        slab_before,
+        "Rejected same-owner TradeNoCpi must not mutate slab state"
+    );
+    assert_eq!(
+        f.vault.data,
+        vault_before,
+        "Rejected same-owner TradeNoCpi must not mutate vault state"
+    );
+}
+
+#[test]
+fn test_trade_cpi_runtime_rejects_same_owner_counterparties() {
+    let mut f = setup_market();
+    let init_data = encode_init_market(&f, 100);
+    {
+        let accounts = vec![
+            f.admin.to_info(),
+            f.slab.to_info(),
+            f.mint.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+            f.rent.to_info(),
+            f.pyth_index.to_info(),
+            f.system.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &init_data).unwrap();
+    }
+
+    let owner_key = Pubkey::new_unique();
+    let matcher_prog_key = Pubkey::new_unique();
+    let matcher_ctx_key = Pubkey::new_unique();
+
+    let mut lp_owner = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut lp_ata = TestAccount::new(
+        Pubkey::new_unique(),
+        spl_token::ID,
+        0,
+        make_token_account(f.mint.key, owner_key, 2_000),
+    )
+    .writable();
+    {
+        let accounts = vec![
+            lp_owner.to_info(),
+            f.slab.to_info(),
+            lp_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(
+            &f.program_id,
+            &accounts,
+            &encode_init_lp(matcher_prog_key, matcher_ctx_key, 100),
+        )
+        .unwrap();
+    }
+    let lp_idx = 0u16;
+    {
+        let accounts = vec![
+            lp_owner.to_info(),
+            f.slab.to_info(),
+            lp_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_deposit(lp_idx, 1_000)).unwrap();
+    }
+
+    let mut user_owner = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut user_ata = TestAccount::new(
+        Pubkey::new_unique(),
+        spl_token::ID,
+        0,
+        make_token_account(f.mint.key, owner_key, 2_000),
+    )
+    .writable();
+    {
+        let accounts = vec![
+            user_owner.to_info(),
+            f.slab.to_info(),
+            user_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_init_user(100)).unwrap();
+    }
+    let user_idx = 1u16;
+    {
+        let accounts = vec![
+            user_owner.to_info(),
+            f.slab.to_info(),
+            user_ata.to_info(),
+            f.vault.to_info(),
+            f.token_prog.to_info(),
+            f.clock.to_info(),
+        ];
+        process_instruction(&f.program_id, &accounts, &encode_deposit(user_idx, 1_000)).unwrap();
+    }
+
+    let lp_bytes = lp_idx.to_le_bytes();
+    let (lp_pda_key, _) =
+        Pubkey::find_program_address(&[b"lp", f.slab.key.as_ref(), &lp_bytes], &f.program_id);
+    let mut user_signer = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    )
+    .signer();
+    let mut lp_owner_meta = TestAccount::new(
+        owner_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    );
+    let mut matcher_prog = TestAccount::new(
+        matcher_prog_key,
+        Pubkey::default(),
+        0,
+        vec![],
+    )
+    .executable();
+    let mut matcher_ctx = TestAccount::new(
+        matcher_ctx_key,
+        matcher_prog_key,
+        0,
+        vec![0u8; MATCHER_CONTEXT_LEN],
+    )
+    .writable();
+    let mut lp_pda = TestAccount::new(
+        lp_pda_key,
+        solana_program::system_program::id(),
+        0,
+        vec![],
+    );
+
+    let slab_before = f.slab.data.clone();
+    let vault_before = f.vault.data.clone();
+    let matcher_ctx_before = matcher_ctx.data.clone();
+    let accounts = vec![
+        user_signer.to_info(),
+        lp_owner_meta.to_info(),
+        f.slab.to_info(),
+        f.clock.to_info(),
+        f.pyth_index.to_info(),
+        matcher_prog.to_info(),
+        matcher_ctx.to_info(),
+        lp_pda.to_info(),
+    ];
+    let res = process_instruction(
+        &f.program_id,
+        &accounts,
+        &encode_trade_cpi(lp_idx, user_idx, 100),
+    );
+    assert_eq!(res, Err(PercolatorError::SameOwnerTradeForbidden.into()));
+    assert_eq!(
+        f.slab.data,
+        slab_before,
+        "Rejected same-owner TradeCpi must not mutate slab state"
+    );
+    assert_eq!(
+        f.vault.data,
+        vault_before,
+        "Rejected same-owner TradeCpi must not mutate vault state"
+    );
+    assert_eq!(
+        matcher_ctx.data,
+        matcher_ctx_before,
+        "Rejected same-owner TradeCpi must not mutate matcher context"
+    );
 }
 
 #[test]
@@ -1078,4 +1401,83 @@ fn test_nonce_overflow_does_not_reopen_request_id_space() {
     // Verify the previous value still works
     let before_max = percolator_prog::verify::nonce_on_success(u64::MAX - 1);
     assert_eq!(before_max, Some(u64::MAX), "u64::MAX-1 should advance to u64::MAX");
+}
+
+#[test]
+fn test_verify_owners_distinct_ok_rejects_same_owner() {
+    assert!(verify::owners_distinct_ok([1u8; 32], [2u8; 32]));
+    assert!(!verify::owners_distinct_ok([7u8; 32], [7u8; 32]));
+}
+
+#[test]
+fn test_verify_trade_nocpi_rejects_same_owner_even_with_auth() {
+    assert_eq!(
+        verify::decide_trade_nocpi(true, true, false),
+        verify::TradeNoCpiDecision::Reject,
+        "TradeNoCpi must reject same-owner counterparties even when auth passes"
+    );
+}
+
+#[test]
+fn test_verify_trade_cpi_rejects_same_owner_even_when_other_gates_pass() {
+    let shape = verify::MatcherAccountsShape {
+        prog_executable: true,
+        ctx_executable: false,
+        ctx_owner_is_prog: true,
+        ctx_len_ok: true,
+    };
+
+    assert_eq!(
+        verify::decide_trade_cpi(
+            41,
+            shape,
+            true,
+            true,
+            true,
+            true,
+            true,
+            false,
+            123,
+        ),
+        verify::TradeCpiDecision::Reject,
+        "TradeCpi must reject same-owner counterparties before matcher execution"
+    );
+}
+
+#[test]
+fn test_verify_trade_cpi_from_ret_rejects_same_owner_before_abi() {
+    let shape = verify::MatcherAccountsShape {
+        prog_executable: true,
+        ctx_executable: false,
+        ctx_owner_is_prog: true,
+        ctx_len_ok: true,
+    };
+    let ret = verify::MatcherReturnFields {
+        abi_version: 0,
+        flags: 0,
+        exec_price_e6: 0,
+        exec_size: 0,
+        req_id: 0,
+        lp_account_id: 0,
+        oracle_price_e6: 0,
+        reserved: 0,
+    };
+
+    assert_eq!(
+        verify::decide_trade_cpi_from_ret(
+            41,
+            shape,
+            true,
+            true,
+            true,
+            true,
+            false,
+            ret,
+            0,
+            0,
+            0,
+        ),
+        verify::TradeCpiDecision::Reject,
+        "TradeCpi from_ret path must reject same-owner counterparties before ABI validation"
+    );
 }


### PR DESCRIPTION
Closes #38

## What changed

This PR rejects same-owner counterparties in both `TradeNoCpi` and `TradeCpi`.

Concretely, it:
- adds a wrapper-level `SameOwnerTradeForbidden` error
- rejects trades where `engine.accounts[user_idx].owner == engine.accounts[lp_idx].owner`
- updates the pure `verify::*` decision helpers to model the same-owner ban explicitly
- adds regression coverage in unit tests, LiteSVM integration tests, and Kani harnesses
- makes the shared LiteSVM owner-funding helper idempotent so same-owner regressions do not fail with a false `AlreadyProcessed` replay during setup

## Why this changed

A single owner can currently materialize both sides of a trade across separate slots and self-match them. That breaks the wrapper's intended owner-level isolation: conversion, withdrawal, and liquidation are enforced per account, while insurance is communal.

In the confirmed path, one owner can crystallize gains on the winning account while the losing same-owner account externalizes losses into the shared insurance fund. Even when the loop is not net-profitable to the attacker, it is a repeatable high-amplification insurance-drain / grief vector.

The supporting search traces and mainnet observations are consistent with this surface: same-owner `user + LP` footprints exist on the challenge market, often after insurance top-ups and near-max-leverage warmup-latched positions.

The smallest surgical defense is to reject same-owner counterparties before any trade execution or matcher CPI.

## Impact

- closes the confirmed same-owner insurance-drain vector
- preserves existing bilateral / matcher flows for distinct owners
- leaves unrelated scratch search artifacts out of the PR

## Root cause

The risk engine tracks authorization and solvency per slot, not per owner. The wrapper authenticated each side independently, but it did not enforce that those two authenticated slots belonged to different owners.

That allowed one owner to split state across two slots, self-match, and later realize gains/losses asymmetrically against shared insurance.

## Validation

I ran:

- `cargo build-sbf` in `../percolator-match`
- `cargo build-sbf`
- `cargo test --test unit same_owner -- --nocapture`
- `cargo test --test unit test_trade -- --exact --nocapture`
- `cargo test --test test_basic test_trade_nocpi_rejects_same_owner_counterparties -- --exact --nocapture`
- `cargo test --test test_tradecpi test_tradecpi_rejects_same_owner_counterparties -- --exact --nocapture`
- `cargo test same_owner -- --nocapture`

These cover:
- pure helper rejection for same-owner `TradeNoCpi`
- pure helper rejection for same-owner `TradeCpi`
- runtime handler rejection for same-owner `TradeNoCpi`
- runtime handler rejection for same-owner `TradeCpi`
- SBF-backed rejection for same-owner `TradeNoCpi`
- SBF-backed rejection for same-owner `TradeCpi`
- regression that normal distinct-owner `TradeNoCpi` still succeeds
