### PR TITLE
[codex] prove wrapper boundary policies

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -512,6 +512,144 @@ pub mod policy {
         s.owned_by_program && s.correct_len
     }
 
+    /// Account-free catchup cannot safely perform equity-active accrual on an
+    /// exposed market. Without a candidate list or account touch set, there is
+    /// no liquidation/revalidation turn between cumulative price/funding moves.
+    #[inline]
+    pub fn account_free_catchup_allows_accrual(
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+        last_oracle_price: u64,
+        fresh_price: u64,
+        funding_rate_e9: i128,
+        fund_px_last: u64,
+    ) -> bool {
+        let exposed = oi_eff_long_q != 0 || oi_eff_short_q != 0;
+        if !exposed {
+            return true;
+        }
+
+        let price_move_active = last_oracle_price > 0 && fresh_price != last_oracle_price;
+        let funding_active =
+            funding_rate_e9 != 0 && oi_eff_long_q != 0 && oi_eff_short_q != 0 && fund_px_last > 0;
+
+        !price_move_active && !funding_active
+    }
+
+    /// True when the wrapper knows the raw oracle/Hyperp target still differs
+    /// from the engine's last effective accrued price.
+    #[inline]
+    pub fn target_lag_pending(
+        is_hyperp: bool,
+        external_oracle_target_price_e6: u64,
+        hyperp_target_price_e6: u64,
+        engine_last_oracle_price: u64,
+    ) -> bool {
+        let target = if is_hyperp {
+            hyperp_target_price_e6
+        } else {
+            external_oracle_target_price_e6
+        };
+        target != 0 && target != engine_last_oracle_price
+    }
+
+    /// True when the latest oracle read produced an effective engine price that
+    /// still has not caught up to the raw target. TradeCpi uses this before CPI
+    /// so a matcher is not invoked for a trade the wrapper must reject anyway.
+    #[inline]
+    pub fn target_lag_after_read(
+        is_hyperp: bool,
+        external_oracle_target_price_e6: u64,
+        hyperp_target_price_e6: u64,
+        effective_price_e6: u64,
+    ) -> bool {
+        let target = if is_hyperp {
+            hyperp_target_price_e6
+        } else {
+            external_oracle_target_price_e6
+        };
+        target != 0 && target != effective_price_e6
+    }
+
+    /// Public extraction-sensitive/risk-increasing user operations are allowed
+    /// only after the raw target has caught up to the engine's effective price.
+    #[inline]
+    pub fn user_value_op_allowed_after_accrual(
+        is_hyperp: bool,
+        external_oracle_target_price_e6: u64,
+        hyperp_target_price_e6: u64,
+        engine_last_oracle_price: u64,
+    ) -> bool {
+        !target_lag_pending(
+            is_hyperp,
+            external_oracle_target_price_e6,
+            hyperp_target_price_e6,
+            engine_last_oracle_price,
+        )
+    }
+
+    /// Pre-CPI TradeCpi admission under raw-target/effective-price lag policy.
+    #[inline]
+    pub fn trade_cpi_allowed_after_oracle_read(
+        is_hyperp: bool,
+        external_oracle_target_price_e6: u64,
+        hyperp_target_price_e6: u64,
+        effective_price_e6: u64,
+    ) -> bool {
+        !target_lag_after_read(
+            is_hyperp,
+            external_oracle_target_price_e6,
+            hyperp_target_price_e6,
+            effective_price_e6,
+        )
+    }
+
+    /// Account index must be inside both the compiled hard cap and the
+    /// market's configured account capacity.
+    #[inline]
+    pub fn market_idx_within_capacity(idx: usize, market_max_accounts: u64) -> bool {
+        idx < percolator::MAX_ACCOUNTS && (idx as u64) < market_max_accounts
+    }
+
+    /// Fee sync must never advance beyond the market boundary that has already
+    /// been economically accrued. Live markets use last_market_slot; resolved
+    /// markets use the immutable resolved_slot.
+    #[inline]
+    pub fn fee_sync_anchor_within_accrued_boundary(
+        is_resolved: bool,
+        anchor_slot: u64,
+        last_market_slot: u64,
+        resolved_slot: u64,
+    ) -> bool {
+        if is_resolved {
+            anchor_slot <= resolved_slot
+        } else {
+            anchor_slot <= last_market_slot
+        }
+    }
+
+    /// No-oracle instructions cannot accrue market price/funding state, so they
+    /// may only sync fees up to the already-accrued market boundary. Returning
+    /// None means there is no safe forward fee interval for this instruction.
+    #[inline]
+    pub fn no_oracle_fee_sync_anchor(
+        wallclock_slot: u64,
+        last_market_slot: u64,
+        current_slot: u64,
+        account_last_fee_slot: u64,
+    ) -> Option<u64> {
+        let anchor = if wallclock_slot < last_market_slot {
+            wallclock_slot
+        } else {
+            last_market_slot
+        };
+        if anchor < current_slot || anchor < account_last_fee_slot {
+            None
+        } else {
+            Some(anchor)
+        }
+    }
+
     // =========================================================================
     // Per-instruction authorization helpers
     // =========================================================================
@@ -3243,7 +3381,7 @@ pub mod processor {
         state::{self, MarketConfig, SlabHeader},
         zc,
     };
-    use percolator::{RiskEngine, RiskError, MAX_ACCOUNTS};
+    use percolator::{RiskEngine, RiskError};
 
     // settle_and_close_resolved removed — replaced by engine.force_close_resolved_not_atomic()
     // which handles K-pair PnL, checked arithmetic, and all settlement internally.
@@ -3414,6 +3552,20 @@ pub mod processor {
         if config.maintenance_fee_per_slot == 0 {
             return Ok(());
         }
+        let is_resolved = engine.is_resolved();
+        let resolved_slot = if is_resolved {
+            engine.resolved_context().1
+        } else {
+            0
+        };
+        if !crate::policy::fee_sync_anchor_within_accrued_boundary(
+            is_resolved,
+            now_slot,
+            engine.last_market_slot,
+            resolved_slot,
+        ) {
+            return Err(PercolatorError::CatchupRequired.into());
+        }
         engine
             .sync_account_fee_to_slot_not_atomic(idx, now_slot, config.maintenance_fee_per_slot)
             .map_err(map_risk_error)
@@ -3441,15 +3593,14 @@ pub mod processor {
             return Ok(());
         }
         check_idx(engine, idx)?;
-        let anchor = core::cmp::min(wallclock_slot, engine.last_market_slot);
-        // No-oracle paths must not move fee time beyond the market's
-        // accrued slot. If engine.current_slot or this account's fee
-        // cursor is already past that boundary, there is nothing safe
-        // to realize here; the next oracle-backed op will accrue the
-        // market and cover the tail.
-        if anchor < engine.current_slot || anchor < engine.accounts[idx as usize].last_fee_slot {
+        let Some(anchor) = crate::policy::no_oracle_fee_sync_anchor(
+            wallclock_slot,
+            engine.last_market_slot,
+            engine.current_slot,
+            engine.accounts[idx as usize].last_fee_slot,
+        ) else {
             return Ok(());
-        }
+        };
         engine
             .sync_account_fee_to_slot_not_atomic(idx, anchor, config.maintenance_fee_per_slot)
             .map_err(map_risk_error)
@@ -3495,12 +3646,6 @@ pub mod processor {
         Ok(if rem == 0 { max_dt } else { rem })
     }
 
-    fn external_oracle_target_pending(config: &MarketConfig, engine: &RiskEngine) -> bool {
-        !oracle::is_hyperp_mode(config)
-            && config.oracle_target_price_e6 != 0
-            && config.oracle_target_price_e6 != engine.last_oracle_price
-    }
-
     fn hyperp_target_price(config: &MarketConfig) -> u64 {
         if config.mark_ewma_e6 > 0 {
             config.mark_ewma_e6
@@ -3510,12 +3655,12 @@ pub mod processor {
     }
 
     fn oracle_target_pending(config: &MarketConfig, engine: &RiskEngine) -> bool {
-        if oracle::is_hyperp_mode(config) {
-            let target = hyperp_target_price(config);
-            target != 0 && target != engine.last_oracle_price
-        } else {
-            external_oracle_target_pending(config, engine)
-        }
+        !crate::policy::user_value_op_allowed_after_accrual(
+            oracle::is_hyperp_mode(config),
+            config.oracle_target_price_e6,
+            hyperp_target_price(config),
+            engine.last_oracle_price,
+        )
     }
 
     fn reject_any_target_lag(
@@ -3529,12 +3674,12 @@ pub mod processor {
     }
 
     fn target_lag_after_read(config: &MarketConfig, effective_price: u64) -> bool {
-        if oracle::is_hyperp_mode(config) {
-            let target = hyperp_target_price(config);
-            target != 0 && target != effective_price
-        } else {
-            config.oracle_target_price_e6 != 0 && config.oracle_target_price_e6 != effective_price
-        }
+        !crate::policy::trade_cpi_allowed_after_oracle_read(
+            oracle::is_hyperp_mode(config),
+            config.oracle_target_price_e6,
+            hyperp_target_price(config),
+            effective_price,
+        )
     }
 
     fn effective_pos_q_checked(engine: &RiskEngine, idx: usize) -> Result<i128, ProgramError> {
@@ -4109,7 +4254,7 @@ pub mod processor {
 
     #[inline]
     fn idx_within_market_capacity(engine: &RiskEngine, idx: usize) -> bool {
-        idx < MAX_ACCOUNTS && (idx as u64) < engine.params.max_accounts
+        crate::policy::market_idx_within_capacity(idx, engine.params.max_accounts)
     }
 
     #[inline]
@@ -5955,7 +6100,7 @@ pub mod processor {
                 #[cfg(feature = "cu-audit")]
                 {
                     msg!("CRANK_STATS");
-                    sol_log_64(0xC8A4C, liqs, MAX_ACCOUNTS as u64, ins_low, 0);
+                    sol_log_64(0xC8A4C, liqs, percolator::MAX_ACCOUNTS as u64, ins_low, 0);
                 }
             }
             Instruction::TradeNoCpi {
@@ -8856,11 +9001,10 @@ pub mod processor {
                 //
                 //   COMPLETE — the instruction can advance the engine all
                 //   the way to clock.slot in this single call
-                //   (gap ≤ CATCHUP_CHUNKS_MAX × max_dt). Behaves like any
-                //   ordinary inline accrue-bearing op: oracle read mutates
-                //   config, pre-read rate chunks the historical interval
-                //   at stored P_last, final accrue to clock.slot installs
-                //   the fresh observation. Persist mutated config.
+                //   (gap ≤ CATCHUP_CHUNKS_MAX × max_dt), but only when the
+                //   account-free path is not equity-active for exposed OI.
+                //   Price movement or active funding with OI must use an
+                //   account-touching path such as KeeperCrank/liquidation.
                 //
                 //   PARTIAL  — the gap is too large to finish in one
                 //   call. Oracle is STILL read (liveness proof), but the
@@ -8981,6 +9125,17 @@ pub mod processor {
                     && oi_any;
                 let accrual_active = funding_active || price_move_active;
                 let can_finish = !accrual_active || gap <= max_step_per_call;
+
+                if !crate::policy::account_free_catchup_allows_accrual(
+                    engine.oi_eff_long_q,
+                    engine.oi_eff_short_q,
+                    engine.last_oracle_price,
+                    fresh_price,
+                    funding_rate_e9_pre,
+                    engine.fund_px_last,
+                ) {
+                    return Err(PercolatorError::CatchupRequired.into());
+                }
 
                 if can_finish {
                     // COMPLETE: chunk to clock.slot using stored P_last

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -28,6 +28,7 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::oracle::{clamp_oracle_price, clamp_toward_with_dt, restart_detected};
 use percolator_prog::policy::{
     abi_ok,
+    account_free_catchup_allows_accrual,
     admin_ok,
     cpi_trade_size,
     decide_admin_op,
@@ -41,23 +42,30 @@ use percolator_prog::policy::{
     decision_nonce,
     // Fee-weighted EWMA
     ewma_update,
+    // Account validation helpers
+    fee_sync_anchor_within_accrued_boundary,
     // New: InitMarket scale validation
     init_market_scale_ok,
     // New: Oracle inversion math
     invert_price_e6,
     len_at_least,
     len_ok,
+    market_idx_within_capacity,
     matcher_identity_ok,
     matcher_shape_ok,
+    no_oracle_fee_sync_anchor,
     nonce_on_failure,
     nonce_on_success,
     owner_ok,
     pda_key_matches,
     // New: Oracle unit scale math
     scale_price_e6,
-    // Account validation helpers
     signer_ok,
     slab_shape_ok,
+    target_lag_after_read,
+    target_lag_pending,
+    trade_cpi_allowed_after_oracle_read,
+    user_value_op_allowed_after_accrual,
     writable_ok,
     MatcherAccountsShape,
     // ABI validation from real inputs
@@ -3017,4 +3025,283 @@ fn kani_restart_detected_universal() {
         current > init,
         "restart_detected must return (current > init_restart_slot)"
     );
+}
+
+// =============================================================================
+// W. ACCOUNT-FREE CATCHUP POLICY (3 proofs)
+// =============================================================================
+
+/// Prove: account-free catchup rejects any exposed price move. Price movement
+/// is equity-active whenever any side has OI, so a public catchup instruction
+/// with no account touches must not install it.
+#[kani::proof]
+fn kani_account_free_catchup_rejects_exposed_price_move() {
+    let oi_long: u128 = kani::any();
+    let oi_short: u128 = kani::any();
+    let p_last: u64 = kani::any();
+    let fresh_price: u64 = kani::any();
+    let funding_rate: i128 = kani::any();
+    let fund_px_last: u64 = kani::any();
+
+    kani::assume(oi_long != 0 || oi_short != 0);
+    kani::assume(p_last > 0);
+    kani::assume(fresh_price != p_last);
+
+    assert!(
+        !account_free_catchup_allows_accrual(
+            oi_long,
+            oi_short,
+            p_last,
+            fresh_price,
+            funding_rate,
+            fund_px_last,
+        ),
+        "exposed account-free catchup must reject price movement"
+    );
+}
+
+/// Prove: account-free catchup rejects exposed funding transfer. Funding is
+/// equity-active only when both OI sides and fund_px_last are present.
+#[kani::proof]
+fn kani_account_free_catchup_rejects_exposed_funding() {
+    let oi_long: u128 = kani::any();
+    let oi_short: u128 = kani::any();
+    let p_last: u64 = kani::any();
+    let funding_rate: i128 = kani::any();
+    let fund_px_last: u64 = kani::any();
+
+    kani::assume(oi_long != 0);
+    kani::assume(oi_short != 0);
+    kani::assume(funding_rate != 0);
+    kani::assume(fund_px_last > 0);
+
+    assert!(
+        !account_free_catchup_allows_accrual(
+            oi_long,
+            oi_short,
+            p_last,
+            p_last,
+            funding_rate,
+            fund_px_last,
+        ),
+        "exposed account-free catchup must reject active funding"
+    );
+}
+
+/// Prove: account-free catchup still allows no-op exposed accrual and all flat
+/// market accrual, including flat price replacement.
+#[kani::proof]
+fn kani_account_free_catchup_allows_flat_or_exposed_noop() {
+    let oi_long: u128 = kani::any();
+    let oi_short: u128 = kani::any();
+    let p_last: u64 = kani::any();
+    let fresh_price: u64 = kani::any();
+    let funding_rate: i128 = kani::any();
+    let fund_px_last: u64 = kani::any();
+
+    assert!(
+        account_free_catchup_allows_accrual(0, 0, p_last, fresh_price, funding_rate, fund_px_last),
+        "flat market account-free catchup is allowed"
+    );
+
+    assert!(
+        account_free_catchup_allows_accrual(oi_long, oi_short, p_last, p_last, 0, fund_px_last),
+        "exposed account-free catchup is allowed when price and funding are no-op"
+    );
+}
+
+// =============================================================================
+// X. TARGET-LAG USER OP POLICY (4 proofs)
+// =============================================================================
+
+/// Prove: target_lag_pending is exactly "selected raw target is nonzero and
+/// differs from engine P_last" for both external-oracle and Hyperp modes.
+#[kani::proof]
+fn kani_target_lag_pending_universal() {
+    let is_hyperp: bool = kani::any();
+    let external_target: u64 = kani::any();
+    let hyperp_target: u64 = kani::any();
+    let engine_last_price: u64 = kani::any();
+
+    let selected_target = if is_hyperp {
+        hyperp_target
+    } else {
+        external_target
+    };
+
+    assert_eq!(
+        target_lag_pending(is_hyperp, external_target, hyperp_target, engine_last_price,),
+        selected_target != 0 && selected_target != engine_last_price,
+        "target lag must be exactly selected_target != 0 && selected_target != engine P_last"
+    );
+}
+
+/// Prove: after an oracle read, target lag is exactly "selected raw target is
+/// nonzero and differs from the effective price the wrapper is about to feed."
+#[kani::proof]
+fn kani_target_lag_after_read_universal() {
+    let is_hyperp: bool = kani::any();
+    let external_target: u64 = kani::any();
+    let hyperp_target: u64 = kani::any();
+    let effective_price: u64 = kani::any();
+
+    let selected_target = if is_hyperp {
+        hyperp_target
+    } else {
+        external_target
+    };
+
+    assert_eq!(
+        target_lag_after_read(is_hyperp, external_target, hyperp_target, effective_price),
+        selected_target != 0 && selected_target != effective_price,
+        "post-read target lag must compare selected target to effective price"
+    );
+}
+
+/// Prove: public user value-moving/risk-increasing operations are admitted iff
+/// no raw-target/effective-price lag remains after accrual.
+#[kani::proof]
+fn kani_user_value_op_allowed_iff_no_target_lag() {
+    let is_hyperp: bool = kani::any();
+    let external_target: u64 = kani::any();
+    let hyperp_target: u64 = kani::any();
+    let engine_last_price: u64 = kani::any();
+
+    let lag = target_lag_pending(is_hyperp, external_target, hyperp_target, engine_last_price);
+    let allowed = user_value_op_allowed_after_accrual(
+        is_hyperp,
+        external_target,
+        hyperp_target,
+        engine_last_price,
+    );
+
+    assert_eq!(
+        allowed, !lag,
+        "user value/risk operation must be allowed iff target lag is absent"
+    );
+}
+
+/// Prove: TradeCpi's pre-CPI policy admits matcher invocation iff the raw
+/// target has already caught up to the effective price returned by the read.
+#[kani::proof]
+fn kani_trade_cpi_pre_cpi_allowed_iff_no_post_read_lag() {
+    let is_hyperp: bool = kani::any();
+    let external_target: u64 = kani::any();
+    let hyperp_target: u64 = kani::any();
+    let effective_price: u64 = kani::any();
+
+    let lag = target_lag_after_read(is_hyperp, external_target, hyperp_target, effective_price);
+    let allowed = trade_cpi_allowed_after_oracle_read(
+        is_hyperp,
+        external_target,
+        hyperp_target,
+        effective_price,
+    );
+
+    assert_eq!(
+        allowed, !lag,
+        "TradeCpi must invoke matcher only when post-read target lag is absent"
+    );
+}
+
+// =============================================================================
+// Y. CONFIGURED ACCOUNT CAPACITY (1 proof)
+// =============================================================================
+
+/// Prove: a wrapper account index is accepted only when it is inside both the
+/// compiled slab capacity and the market's configured max_accounts.
+#[kani::proof]
+fn kani_market_idx_within_capacity_universal() {
+    let idx: usize = kani::any();
+    let market_max_accounts: u64 = kani::any();
+
+    assert_eq!(
+        market_idx_within_capacity(idx, market_max_accounts),
+        idx < percolator::MAX_ACCOUNTS && (idx as u64) < market_max_accounts,
+        "market index capacity must enforce both hard cap and configured max_accounts"
+    );
+
+    if market_idx_within_capacity(idx, market_max_accounts) {
+        assert!(idx < percolator::MAX_ACCOUNTS);
+        assert!((idx as u64) < market_max_accounts);
+    }
+}
+
+// =============================================================================
+// Z. FEE-SYNC ANCHOR POLICY (3 proofs)
+// =============================================================================
+
+/// Prove: live fee-sync anchors are admitted exactly when they do not run past
+/// the already-accrued live market slot.
+#[kani::proof]
+fn kani_live_fee_sync_anchor_boundary_universal() {
+    let anchor_slot: u64 = kani::any();
+    let last_market_slot: u64 = kani::any();
+    let resolved_slot: u64 = kani::any();
+
+    assert_eq!(
+        fee_sync_anchor_within_accrued_boundary(
+            false,
+            anchor_slot,
+            last_market_slot,
+            resolved_slot,
+        ),
+        anchor_slot <= last_market_slot,
+        "live fee sync anchor must be bounded by last_market_slot"
+    );
+}
+
+/// Prove: resolved fee-sync anchors are admitted exactly when they do not run
+/// past the immutable resolved slot.
+#[kani::proof]
+fn kani_resolved_fee_sync_anchor_boundary_universal() {
+    let anchor_slot: u64 = kani::any();
+    let last_market_slot: u64 = kani::any();
+    let resolved_slot: u64 = kani::any();
+
+    assert_eq!(
+        fee_sync_anchor_within_accrued_boundary(true, anchor_slot, last_market_slot, resolved_slot,),
+        anchor_slot <= resolved_slot,
+        "resolved fee sync anchor must be bounded by resolved_slot"
+    );
+}
+
+/// Prove: no-oracle fee sync either returns no anchor or returns an anchor that
+/// is capped by wallclock, capped by last_market_slot, and not behind either
+/// engine current_slot or the account's fee cursor.
+#[kani::proof]
+fn kani_no_oracle_fee_sync_anchor_universal() {
+    let wallclock_slot: u64 = kani::any();
+    let last_market_slot: u64 = kani::any();
+    let current_slot: u64 = kani::any();
+    let account_last_fee_slot: u64 = kani::any();
+
+    let result = no_oracle_fee_sync_anchor(
+        wallclock_slot,
+        last_market_slot,
+        current_slot,
+        account_last_fee_slot,
+    );
+    let expected_anchor = if wallclock_slot < last_market_slot {
+        wallclock_slot
+    } else {
+        last_market_slot
+    };
+    let expected = if expected_anchor < current_slot || expected_anchor < account_last_fee_slot {
+        None
+    } else {
+        Some(expected_anchor)
+    };
+
+    assert_eq!(
+        result, expected,
+        "no-oracle fee sync anchor must be min(wallclock, last_market) unless stale"
+    );
+
+    if let Some(anchor) = result {
+        assert!(anchor <= wallclock_slot);
+        assert!(anchor <= last_market_slot);
+        assert!(anchor >= current_slot);
+        assert!(anchor >= account_last_fee_slot);
+    }
 }

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -4806,13 +4806,15 @@ fn test_liquidation_fee_goes_to_insurance() {
     );
 }
 
-/// Verify insurance fund absorbs losses when an account goes bankrupt.
-/// After liquidation with deficit, insurance decreases, not vault.
+/// Verify account-touching price catchup liquidates before bankruptcy.
+/// The old account-free catchup path could defer touches until the LP was
+/// bankrupt; the compliant path cranks/touches during the price walk and
+/// credits liquidation fees to insurance instead of draining it.
 #[test]
-fn test_insurance_absorbs_bankruptcy_loss() {
+fn test_account_touching_crank_prevents_bankruptcy_insurance_loss() {
     program_path();
     let mut env = TestEnv::new();
-    env.init_market_with_invert(0);
+    env.init_market_with_cap(0, 2_000);
 
     let lp = Keypair::new();
     let lp_idx = env.init_lp(&lp);
@@ -4823,7 +4825,7 @@ fn test_insurance_absorbs_bankruptcy_loss() {
     env.deposit(&user, user_idx, 15_000_000_000);
 
     // User goes long, so the LP takes the short side. A large cap-respecting
-    // price rally bankrupts the LP and leaves a deficit for insurance.
+    // price rally would bankrupt the LP if no account-touching path ran.
     env.trade(&user, &lp, lp_idx, user_idx, 1_000_000_000);
 
     // Large insurance to absorb the deficit
@@ -4833,22 +4835,12 @@ fn test_insurance_absorbs_bankruptcy_loss() {
     let ins_before = env.read_insurance_balance();
     let vault_before = env.vault_balance();
 
-    // Price rally: LP's short loss exceeds capital and leaves a deficit. Use
-    // real intermediate oracle observations rather than the helper's crank walk,
-    // because this test must leave liquidation to the explicit call below.
-    for step in 1..=30u64 {
-        let slot = 100 + step * 50;
-        let price = 138_000_000i64 + (207_000_000i64 - 138_000_000i64) * step as i64 / 30;
-        env.set_slot_and_price_raw_no_walk(slot, price);
-        env.try_catchup_accrue()
-            .expect("price path must stay inside the engine envelope");
-    }
-    let result = env.try_liquidate(lp_idx);
-    assert!(
-        result.is_ok(),
-        "Bankrupt liquidation should succeed: {:?}",
-        result
-    );
+    // Price rally: LP's short loss exceeds capital and leaves a deficit. Walk
+    // through the account-touching crank path; account-free CatchupAccrue is
+    // intentionally not allowed to move exposed markets through equity-active
+    // price changes.
+    env.set_slot_and_price(1_500, 207_000_000);
+    env.crank();
 
     let ins_after = env.read_insurance_balance();
     let vault_after = env.vault_balance();
@@ -4856,8 +4848,8 @@ fn test_insurance_absorbs_bankruptcy_loss() {
 
     assert_eq!(lp_pos, 0, "Bankrupt account position must be liquidated");
     assert!(
-        ins_after < ins_before,
-        "Bankrupt liquidation must consume insurance net of fees: before={} after={}",
+        ins_after >= ins_before,
+        "account-touching crank should avoid insurance depletion: before={} after={}",
         ins_before,
         ins_after
     );

--- a/tests/test_security.rs
+++ b/tests/test_security.rs
@@ -13370,6 +13370,39 @@ fn setup_max_risk_probe(
     (env, lp, lp_idx, actors)
 }
 
+#[test]
+fn test_attack_issue33_account_free_catchup_cannot_move_exposed_market() {
+    program_path();
+
+    let (mut env, _lp, _lp_idx, _actors) = setup_max_risk_probe(1, 1);
+    let slot_before = env.read_last_market_slot();
+    let insurance_before = env.read_insurance_balance();
+    let price = max_risk_next_clamped_price(MAX_RISK_P0_E6, -1, MAX_RISK_ATTACK_SLOTS as u64);
+
+    env.set_slot_and_price_raw_no_walk(
+        MAX_RISK_ATTACK_START_SLOT + MAX_RISK_ATTACK_SLOTS as u64,
+        price as i64,
+    );
+
+    let err = env
+        .try_catchup_accrue()
+        .expect_err("account-free catchup must reject exposed price movement");
+    assert!(
+        err.contains("0x1d"),
+        "expected CatchupRequired for exposed account-free catchup, got: {err}",
+    );
+    assert_eq!(
+        env.read_last_market_slot(),
+        slot_before,
+        "rejected account-free catchup must not advance the market slot",
+    );
+    assert_eq!(
+        env.read_insurance_balance(),
+        insurance_before,
+        "rejected account-free catchup must not mutate insurance",
+    );
+}
+
 fn max_risk_candidate_indices(lp_idx: u16, actors: &[MaxRiskActor]) -> Vec<u16> {
     let mut candidates = Vec::with_capacity(actors.len() + 1);
     candidates.push(lp_idx);


### PR DESCRIPTION
## Summary

Issue/PR #33 is already closed as superseded. This branch does not merge it; it carries the current wrapper-boundary proof work and regression coverage.

## Changelist

- Added pure wrapper policy helpers for:
  - account-free catchup admission on exposed vs flat markets
  - raw target / effective price lag checks for user value ops and pre-CPI TradeCpi
  - configured `max_accounts` index capacity checks
  - live/resolved/no-oracle fee-sync anchor boundaries
- Routed runtime wrapper checks through those helpers:
  - user value ops reject when raw target and effective engine price still diverge
  - TradeCpi rejects target lag before invoking the matcher
  - index checks respect both compiled `MAX_ACCOUNTS` and market `params.max_accounts`
  - normal fee sync refuses anchors past the accrued boundary
  - no-oracle fee sync caps to `min(wallclock_slot, last_market_slot)` and no-ops if that would move backward
- Added/updated regression coverage for account-free catchup on exposed markets and account-touching crank liquidation behavior.

## Proofs

Verified these Kani harnesses on the formatted tree:

- `kani_target_lag_pending_universal`
- `kani_target_lag_after_read_universal`
- `kani_user_value_op_allowed_iff_no_target_lag`
- `kani_trade_cpi_pre_cpi_allowed_iff_no_post_read_lag`
- `kani_market_idx_within_capacity_universal`
- `kani_live_fee_sync_anchor_boundary_universal`
- `kani_resolved_fee_sync_anchor_boundary_universal`
- `kani_no_oracle_fee_sync_anchor_universal`

Each returned `VERIFICATION:- SUCCESSFUL`.

## Validation

- `cargo build-sbf`
- `cargo test --release --test test_basic test_fee_sync_does_not_erase_market_accrual_interval -- --nocapture`
- `cargo test --release --test test_basic test_fee_sync_anchor_accepts_future_now_slot_for_every_path -- --nocapture`
- `cargo test --release --test test_basic test_deposit_fee_credits_rejects_overpayment -- --nocapture`
- `cargo test --release --test test_basic test_per_account_maintenance_fee_not_back_charged_to_new_user -- --nocapture`
- `cargo test --release --test test_basic test_keeper_crank_reward_pays_half_of_swept_fees_to_non_permissionless_caller -- --nocapture`
- `cargo test --release --test test_security test_attack_funding_large_dt_gap -- --nocapture`

Full suite was not rerun in this commit; this PR records the targeted proof and regression pass for the boundary changes.