### PR TITLE
Fix oversized trade-size panic in `TradeNoCpi`/`TradeCpi`

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -6813,6 +6813,9 @@ pub mod processor {
                 if size == 0 || size == i128::MIN {
                     return Err(ProgramError::InvalidInstructionData);
                 }
+                if size.unsigned_abs() > percolator::MAX_TRADE_SIZE_Q {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
 
                 let mut data = state::slab_data_mut(a_slab)?;
                 slab_guard(program_id, a_slab, &data)?;

--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -3833,6 +3833,30 @@ pub mod processor {
         )
     }
 
+    fn checked_wide_mul_div_floor_u128(a: u128, b: u128, d: u128) -> Option<u128> {
+        if d == 0 {
+            return None;
+        }
+        percolator::wide_math::mul_div_floor_u256(
+            percolator::wide_math::U256::from_u128(a),
+            percolator::wide_math::U256::from_u128(b),
+            percolator::wide_math::U256::from_u128(d),
+        )
+        .try_into_u128()
+    }
+
+    fn checked_wide_mul_div_ceil_u128(a: u128, b: u128, d: u128) -> Option<u128> {
+        if d == 0 {
+            return None;
+        }
+        percolator::wide_math::checked_mul_div_ceil_u256(
+            percolator::wide_math::U256::from_u128(a),
+            percolator::wide_math::U256::from_u128(b),
+            percolator::wide_math::U256::from_u128(d),
+        )
+        .and_then(|v| v.try_into_u128())
+    }
+
     fn current_trade_fee_paid_cap(
         size: i128,
         exec_price: u64,
@@ -3841,16 +3865,18 @@ pub mod processor {
         if trading_fee_bps == 0 || size == 0 {
             return Ok(0);
         }
-        let notional = percolator::wide_math::mul_div_floor_u128(
+        let notional = checked_wide_mul_div_floor_u128(
             size.unsigned_abs(),
             exec_price as u128,
             percolator::POS_SCALE,
-        );
+        )
+        .ok_or_else(|| ProgramError::from(PercolatorError::EngineOverflow))?;
         if notional == 0 {
             return Ok(0);
         }
         let one_side_fee =
-            percolator::wide_math::mul_div_ceil_u128(notional, trading_fee_bps as u128, 10_000);
+            checked_wide_mul_div_ceil_u128(notional, trading_fee_bps as u128, 10_000)
+                .ok_or_else(|| ProgramError::from(PercolatorError::EngineOverflow))?;
         one_side_fee
             .checked_mul(2)
             .ok_or_else(|| PercolatorError::EngineOverflow.into())

--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -7099,6 +7099,9 @@ pub mod processor {
                 if size == 0 || size == i128::MIN {
                     return Err(ProgramError::InvalidInstructionData);
                 }
+                if size.unsigned_abs() > percolator::MAX_TRADE_SIZE_Q {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
                 if lp_idx == user_idx {
                     return Err(ProgramError::InvalidInstructionData);
                 }
@@ -7550,6 +7553,9 @@ pub mod processor {
                     }
 
                     let trade_size = crate::policy::cpi_trade_size(ret.exec_size, size);
+                    if trade_size.unsigned_abs() > percolator::MAX_TRADE_SIZE_Q {
+                        return Err(PercolatorError::EngineOverflow.into());
+                    }
                     let current_fee_paid_cap = current_trade_fee_paid_cap(
                         trade_size,
                         exec_price,

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1612,6 +1612,72 @@ fn test_comprehensive_margin_limit_enforcement() {
     );
 }
 
+#[test]
+fn test_trade_nocpi_oversized_size_rejected_with_error() {
+    program_path();
+
+    let mut env = TestEnv::new();
+    env.init_market_with_trading_fee(10);
+
+    let lp = Keypair::new();
+    let lp_idx = env.init_lp(&lp);
+    env.deposit(&lp, lp_idx, 100_000_000_000);
+
+    let user = Keypair::new();
+    let user_idx = env.init_user(&user);
+    env.deposit(&user, user_idx, 10_000_000_000);
+
+    let user_cap_before = env.read_account_capital(user_idx);
+    let lp_cap_before = env.read_account_capital(lp_idx);
+    let user_pos_before = env.read_account_position(user_idx);
+    let lp_pos_before = env.read_account_position(lp_idx);
+    let vault_before = env.read_engine_vault();
+    let c_tot_before = env.read_c_tot();
+    let insurance_before = env.read_insurance_balance();
+    let used_before = env.read_num_used_accounts();
+    println!(
+        "oversized TradeNoCpi setup: request_size={} trading_fee_bps=10",
+        i128::MAX
+    );
+
+    let result = env.try_trade(&user, &lp, lp_idx, user_idx, i128::MAX);
+    let err = result.expect_err("oversized TradeNoCpi must be rejected");
+    println!("oversized TradeNoCpi rejection: {err}");
+    println!(
+        "oversized TradeNoCpi post-state: vault={} c_tot={} insurance={} user_pos={} lp_pos={} used={}",
+        env.read_engine_vault(),
+        env.read_c_tot(),
+        env.read_insurance_balance(),
+        env.read_account_position(user_idx),
+        env.read_account_position(lp_idx),
+        env.read_num_used_accounts()
+    );
+
+    assert_eq!(env.read_account_capital(user_idx), user_cap_before);
+    assert_eq!(env.read_account_capital(lp_idx), lp_cap_before);
+    assert_eq!(env.read_account_position(user_idx), user_pos_before);
+    assert_eq!(env.read_account_position(lp_idx), lp_pos_before);
+    assert_eq!(env.read_engine_vault(), vault_before);
+    assert_eq!(env.read_c_tot(), c_tot_before);
+    assert_eq!(env.read_insurance_balance(), insurance_before);
+    assert_eq!(env.read_num_used_accounts(), used_before);
+    assert!(env.read_engine_vault() >= env.read_c_tot() + env.read_insurance_balance());
+    assert_eq!(
+        env.read_account_position(user_idx) + env.read_account_position(lp_idx),
+        0
+    );
+    assert!(
+        !err.contains("panicked")
+            && !err.contains("mul_div_floor_u128: a*b overflow")
+            && !err.contains("SBF program panicked"),
+        "TradeNoCpi panicked before the engine size-bound rejection: {err}"
+    );
+    assert!(
+        err.contains("InvalidInstructionData") || err.contains("invalid instruction data"),
+        "TradeNoCpi oversized size must reject at wrapper entry, got: {err}"
+    );
+}
+
 /// Test 10: Funding accrual - multiple cranks succeed over time
 #[test]
 fn test_comprehensive_funding_accrual() {

--- a/tests/test_tradecpi.rs
+++ b/tests/test_tradecpi.rs
@@ -2959,6 +2959,207 @@ fn test_attack_extreme_position_size() {
     );
 }
 
+fn init_lp_with_matcher_max_fill(
+    env: &mut TradeCpiTestEnv,
+    owner: &Keypair,
+    matcher_prog: &Pubkey,
+    max_fill_abs: u128,
+) -> (u16, Pubkey) {
+    let idx = env.account_count;
+    env.svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+    let ata = env.create_ata(&owner.pubkey(), DEFAULT_INIT_PAYMENT);
+
+    let lp_bytes = idx.to_le_bytes();
+    let (lp_pda, _) =
+        Pubkey::find_program_address(&[b"lp", env.slab.as_ref(), &lp_bytes], &env.program_id);
+
+    let ctx = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 10_000_000,
+                data: vec![0u8; MATCHER_CONTEXT_LEN],
+                owner: *matcher_prog,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let init_ix = Instruction {
+        program_id: *matcher_prog,
+        accounts: vec![
+            AccountMeta::new_readonly(lp_pda, false),
+            AccountMeta::new(ctx, false),
+        ],
+        data: encode_init_vamm(MatcherMode::Passive, 5, 10, 200, 0, 0, max_fill_abs, 0),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[cu_ix(), init_ix],
+        Some(&owner.pubkey()),
+        &[owner],
+        env.svm.latest_blockhash(),
+    );
+    env.svm
+        .send_transaction(tx)
+        .expect("init oversized matcher context failed");
+
+    let ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.slab, false),
+            AccountMeta::new(ata, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new_readonly(sysvar::clock::ID, false),
+        ],
+        data: encode_init_lp(matcher_prog, &ctx, DEFAULT_INIT_PAYMENT),
+    };
+
+    let tx = Transaction::new_signed_with_payer(
+        &[cu_ix(), ix],
+        Some(&owner.pubkey()),
+        &[owner],
+        env.svm.latest_blockhash(),
+    );
+    env.svm
+        .send_transaction(tx)
+        .expect("init oversized-fill lp failed");
+    env.account_count += 1;
+    (idx, ctx)
+}
+
+/// BUG REPRO: TradeCpi must reject an oversized matcher fill before fee math.
+///
+/// The matcher context shape allows an LP to configure `max_fill_abs` above the
+/// engine's trade-size bound. If the wrapper accepts that ABI-valid fill, the
+/// fee-cap precheck must still return an error, not panic in narrow u128 math.
+#[test]
+fn test_tradecpi_oversized_matcher_fill_rejected_with_error() {
+    let mut env = TradeCpiTestEnv::new();
+
+    init_hyperp_with_fee_weighting(&mut env, 1_000_000, 10, 0);
+
+    let admin = Keypair::from_bytes(&env.payer.to_bytes()).unwrap();
+    let matcher_prog = env.matcher_program_id;
+    env.try_set_oracle_authority(&admin, &admin.pubkey())
+        .unwrap();
+    env.try_push_oracle_price(&admin, 1_000_000, 1000).unwrap();
+
+    let lp = Keypair::new();
+    let (lp_idx, matcher_ctx) =
+        init_lp_with_matcher_max_fill(&mut env, &lp, &matcher_prog, i128::MAX as u128);
+    env.deposit(&lp, lp_idx, 100_000_000_000);
+
+    let user = Keypair::new();
+    let user_idx = env.init_user(&user);
+    env.deposit(&user, user_idx, 10_000_000_000);
+
+    env.set_slot(100);
+    env.crank();
+
+    let user_cap_before = env.read_account_capital(user_idx);
+    let lp_cap_before = env.read_account_capital(lp_idx);
+    let user_pos_before = env.read_account_position(user_idx);
+    let lp_pos_before = env.read_account_position(lp_idx);
+    let vault_before = env.read_vault();
+    let c_tot_before = env.read_c_tot();
+    let insurance_before = env.read_insurance_balance();
+    let used_before = env.read_num_used_accounts();
+    println!(
+        "oversized matcher fill setup: request_size={} max_fill_abs={} trading_fee_bps=10 oracle_price_e6=1000000",
+        i128::MAX,
+        i128::MAX as u128
+    );
+
+    let result = env.try_trade_cpi(
+        &user,
+        &lp.pubkey(),
+        lp_idx,
+        user_idx,
+        i128::MAX,
+        &matcher_prog,
+        &matcher_ctx,
+    );
+
+    let err = result.expect_err("oversized matcher fill must be rejected");
+    println!("oversized matcher fill rejection: {err}");
+    println!(
+        "oversized matcher fill post-state: vault={} c_tot={} insurance={} user_pos={} lp_pos={} used={}",
+        env.read_vault(),
+        env.read_c_tot(),
+        env.read_insurance_balance(),
+        env.read_account_position(user_idx),
+        env.read_account_position(lp_idx),
+        env.read_num_used_accounts()
+    );
+
+    assert_eq!(
+        env.read_account_capital(user_idx),
+        user_cap_before,
+        "Rejected oversized fill must not change user capital"
+    );
+    assert_eq!(
+        env.read_account_capital(lp_idx),
+        lp_cap_before,
+        "Rejected oversized fill must not change LP capital"
+    );
+    assert_eq!(
+        env.read_account_position(user_idx),
+        user_pos_before,
+        "Rejected oversized fill must not change user position"
+    );
+    assert_eq!(
+        env.read_account_position(lp_idx),
+        lp_pos_before,
+        "Rejected oversized fill must not change LP position"
+    );
+    assert_eq!(
+        env.read_vault(),
+        vault_before,
+        "Rejected oversized fill must not change engine vault"
+    );
+    assert_eq!(
+        env.read_c_tot(),
+        c_tot_before,
+        "Rejected oversized fill must not change c_tot"
+    );
+    assert_eq!(
+        env.read_insurance_balance(),
+        insurance_before,
+        "Rejected oversized fill must not change insurance"
+    );
+    assert_eq!(
+        env.read_num_used_accounts(),
+        used_before,
+        "Rejected oversized fill must not change used accounts"
+    );
+    assert!(
+        env.read_vault() >= env.read_c_tot() + env.read_insurance_balance(),
+        "Rejected oversized fill must preserve conservation post-state"
+    );
+    assert_eq!(
+        env.read_account_position(user_idx) + env.read_account_position(lp_idx),
+        0,
+        "Rejected oversized fill must preserve OI symmetry post-state"
+    );
+    assert!(
+        !err.contains("panicked")
+            && !err.contains("mul_div_floor_u128: a*b overflow")
+            && !err.contains("SBF program panicked"),
+        "TradeCpi panicked before the engine size-bound rejection: {err}"
+    );
+    assert!(
+        err.contains("InvalidInstructionData")
+            || err.contains("invalid instruction data")
+            || err.contains("EngineOverflow")
+            || err.contains("0x2"),
+        "TradeCpi oversized size must reject cleanly, got: {err}"
+    );
+}
+
 /// ATTACK: Try to trade with i128::MIN position size (negative extreme).
 #[test]
 fn test_attack_extreme_negative_position_size() {


### PR DESCRIPTION
# Summary

Closes #70

This PR fixes the oversized trade-size production panic in `TradeNoCpi` and `TradeCpi`.

- `373acbab64f3df5fce082fe867de77f0e89e311b` bounds `TradeNoCpi` entry size before fee-cap math.
- `233c66f71f588a78e047ee25978ee14a522150f6` bounds `TradeCpi` entry size and the matcher-selected returned trade size before fee-cap math.
- `909c37cedaa338f19ffb670976af6124039e83f4` replaces the fee-cap helper's panic-on-overflow narrow math with checked wide helpers that return `EngineOverflow`.

The load-bearing fix is the pre-fee `MAX_TRADE_SIZE_Q` validation. The checked fee-cap helper is defense in depth so this path returns an error rather than reaching an SBF panic if future callers miss a bound.

## Verification

Commands run:

```sh
cargo test --release --test test_basic test_trade_nocpi_oversized_size_rejected_with_error -- --exact --nocapture
cargo test --release --test test_tradecpi test_tradecpi_oversized_matcher_fill_rejected_with_error -- --exact --nocapture
cargo test --release --test test_basic -- --nocapture
cargo test --release --test test_tradecpi -- --nocapture
cargo test --release --test test_security -- --nocapture
cargo test --release --test test_conservation -- --nocapture
cargo build-sbf
cargo fmt --check
git diff --check
```

Relevant output:

```text
test test_trade_nocpi_oversized_size_rejected_with_error ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 147 filtered out; finished in 0.02s

test test_tradecpi_oversized_matcher_fill_rejected_with_error ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 87 filtered out; finished in 0.03s

test result: ok. 146 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 21.43s
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.71s
test result: ok. 245 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 145.49s
test result: ok. 35 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 70.02s
warning: `percolator-prog` (lib) generated 2 warnings
    Finished `release` profile [optimized] target(s) in 1.37s
```

`cargo fmt --check` and `git diff --check` are clean.
