### PR TITLE
test(matcher_abi): regression for partial-fill FLAG_PARTIAL_OK requirement

### DIFF
--- a/tests/test_validate_matcher_return_partial_fill.rs
+++ b/tests/test_validate_matcher_return_partial_fill.rs
@@ -1,0 +1,80 @@
+//! Regression tests for `validate_matcher_return` partial-fill `FLAG_PARTIAL_OK` requirement.
+//!
+//! Context: see issue #73 — earlier deployed builds (commit `06f86fb`) only required
+//! `FLAG_PARTIAL_OK` for zero-fills (`exec_size == 0`). Genuine partial fills
+//! (`0 < exec_size.unsigned_abs() < req_size.unsigned_abs()`) bypassed the flag check.
+//! Commit `482b648` added the missing check at `src/percolator.rs:1511-1515`.
+//!
+//! These tests pin the post-fix behavior so any regression of `482b648` is caught.
+//! All four matcher-fill states are exercised:
+//!
+//!   * partial fill, no `FLAG_PARTIAL_OK`  → MUST be rejected (the C-16 fix)
+//!   * partial fill, with `FLAG_PARTIAL_OK` → MUST be accepted
+//!   * full fill,    no `FLAG_PARTIAL_OK`  → MUST be accepted (flag not required)
+//!   * zero fill,    no `FLAG_PARTIAL_OK`  → MUST be rejected (pre-existing check)
+
+use percolator_prog::constants::MATCHER_ABI_VERSION;
+use percolator_prog::matcher_abi::{
+    validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_VALID,
+};
+
+const LP_ACCOUNT_ID: u64 = 42;
+const ORACLE_PRICE_E6: u64 = 138_000_000;
+const REQ_SIZE: i128 = 1_000_000;
+const REQ_ID: u64 = 99;
+
+fn ret(exec_size: i128, flags: u32) -> MatcherReturn {
+    MatcherReturn {
+        abi_version: MATCHER_ABI_VERSION,
+        flags,
+        exec_price_e6: ORACLE_PRICE_E6,
+        exec_size,
+        req_id: REQ_ID,
+        lp_account_id: LP_ACCOUNT_ID,
+        oracle_price_e6: ORACLE_PRICE_E6,
+        reserved: 0,
+    }
+}
+
+fn check(r: &MatcherReturn) -> Result<(), solana_program::program_error::ProgramError> {
+    validate_matcher_return(r, LP_ACCOUNT_ID, ORACLE_PRICE_E6, REQ_SIZE, REQ_ID)
+}
+
+#[test]
+fn partial_fill_without_flag_partial_ok_is_rejected() {
+    // Pre-`482b648` deployed builds accepted this; post-fix builds must reject it.
+    let r = ret(1, FLAG_VALID);
+    assert!(
+        check(&r).is_err(),
+        "partial fill (exec={} < req={}) without FLAG_PARTIAL_OK must be rejected; \
+         regression of fix at src/percolator.rs:1511-1515",
+        r.exec_size,
+        REQ_SIZE
+    );
+}
+
+#[test]
+fn partial_fill_with_flag_partial_ok_is_accepted() {
+    let r = ret(1, FLAG_VALID | FLAG_PARTIAL_OK);
+    assert!(check(&r).is_ok(), "partial fill with FLAG_PARTIAL_OK must be accepted");
+}
+
+#[test]
+fn full_fill_without_flag_partial_ok_is_accepted() {
+    // exec_size == req_size is not a partial fill, so the flag is not required.
+    let r = ret(REQ_SIZE, FLAG_VALID);
+    assert!(
+        check(&r).is_ok(),
+        "full fill (exec_size == req_size) without FLAG_PARTIAL_OK must be accepted"
+    );
+}
+
+#[test]
+fn zero_fill_without_flag_partial_ok_is_rejected() {
+    // Sanity: pre-existing check at the top of validate_matcher_return.
+    let r = ret(0, FLAG_VALID);
+    assert!(
+        check(&r).is_err(),
+        "zero fill without FLAG_PARTIAL_OK must be rejected (pre-existing check)"
+    );
+}


### PR DESCRIPTION
Pin the post-[`482b648`](https://github.com/aeyakovenko/percolator-prog/commit/482b648) behavior of `validate_matcher_return` so any regression of the partial-fill `FLAG_PARTIAL_OK` check at `src/percolator.rs:1511-1515` is caught.

## Why

Earlier deployed builds (commit `06f86fb`) only required the flag for zero fills (`exec_size == 0`); genuine partial fills with `0 < exec_size.unsigned_abs() < req_size.unsigned_abs()` bypassed the flag check entirely. Commit `482b648` ("Fix init canonicalization and CPI lag checks", 2026-04-24) added the missing rejection.

This PR adds a small unit-level regression that exercises the four matcher-fill states directly through the public `validate_matcher_return` API. No `cargo build-sbf` / LiteSVM dependency.

## Tests

| Case | exec_size | flags | expected |
|------|-----------|-------|----------|
| partial fill, no `FLAG_PARTIAL_OK`   | 1            | `FLAG_VALID`                       | reject |
| partial fill, with `FLAG_PARTIAL_OK` | 1            | `FLAG_VALID \| FLAG_PARTIAL_OK`    | accept |
| full fill, no `FLAG_PARTIAL_OK`      | `req_size` | `FLAG_VALID`                       | accept |
| zero fill, no `FLAG_PARTIAL_OK`      | 0            | `FLAG_VALID`                       | reject |

Run locally with:

```
cargo test --release --test test_validate_matcher_return_partial_fill -- --nocapture
```

All four pass on current main HEAD.

## Refs

- Issue #73 (the gap report against the deployed binary)

## Notes

- Adding `MATCHER_ABI_VERSION` import via the existing `percolator_prog::constants` re-export.
- File placed alongside other `tests/test_*.rs` integration tests; no changes to existing tests.
- 80-line additions, single new file.