### PR TITLE
fix(risk-buffer): close three root causes of the insurance-drain decoy-lock

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -112,7 +112,6 @@ pub mod constants {
             <= percolator::MAX_TOUCHED_PER_INSTRUCTION as u64,
         "KeeperCrank candidate Phase 1 + Phase 2 must fit engine touched-account capacity"
     );
-
     // ── Engine envelope constants (wrapper-owned, immutable per deployment) ──
     //
     // These values populate the engine's per-market RiskParams envelope at
@@ -417,7 +416,7 @@ pub mod risk_buffer {
                 self.recompute_min();
                 return true;
             }
-            if notional <= self.min_notional {
+            if notional < self.min_notional {
                 return false;
             }
             let victim = self.min_slot();
@@ -7129,15 +7128,23 @@ pub mod processor {
                 let admit_h_min = engine.params.h_min;
                 let admit_h_max = engine.params.h_max;
                 let admit_threshold = Some(engine.params.maintenance_margin_bps as u128);
-                if !candidates.is_empty() {
-                    append_phase2_fullclose_candidates(
-                        engine,
-                        &mut combined,
-                        &candidates,
-                        rr_window_size,
-                        rr_scan_limit,
-                        COMBINED_CAP,
-                    )?;
+                #[cfg(feature = "cu-audit")]
+                {
+                    msg!("CU_CHECKPOINT: structural_window_start");
+                    sol_log_compute_units();
+                }
+                append_phase2_fullclose_candidates(
+                    engine,
+                    &mut combined,
+                    &candidates,
+                    rr_window_size,
+                    rr_scan_limit,
+                    COMBINED_CAP,
+                )?;
+                #[cfg(feature = "cu-audit")]
+                {
+                    msg!("CU_CHECKPOINT: structural_window_end");
+                    sol_log_compute_units();
                 }
                 for &(cidx, policy) in candidates.iter() {
                     let mut already_promoted = candidate_list_contains(&combined, cidx);
@@ -7152,7 +7159,13 @@ pub mod processor {
                         }
                     }
                     if !already_promoted {
-                        combined.push((cidx, policy));
+                        let admit = !matches!(
+                            policy,
+                            Some(percolator::LiquidationPolicy::FullClose)
+                        ) || effective_pos_q_checked(engine, cidx as usize)? != 0;
+                        if admit {
+                            combined.push((cidx, policy));
+                        }
                     }
                     if combined.len() == COMBINED_CAP {
                         break;

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -4713,3 +4713,134 @@ fn kani_permissionless_resolve_horizon_policy_independent_from_accrual_window() 
         "cap+1 is rejected"
     );
 }
+
+// =============================================================================
+// AE. RISK BUFFER DISPLACEMENT INVARIANT (3 proofs)
+// =============================================================================
+
+use percolator_prog::constants::RISK_BUF_CAP;
+use percolator_prog::risk_buffer::{RiskBuffer, RiskEntry};
+
+/// Build a full RiskBuffer where every slot holds the same notional `n` but
+/// distinct indices.  Returns `None` if `n == 0` (would violate the buffer
+/// invariant that notional > 0 means a used entry).
+fn full_buf_at_notional(n: u128) -> Option<RiskBuffer> {
+    if n == 0 {
+        return None;
+    }
+    let mut buf = RiskBuffer::zeroed();
+    for i in 0..RISK_BUF_CAP {
+        buf.entries[i] = RiskEntry { idx: i as u16, notional: n, _pad: [0; 14] };
+    }
+    buf.count = RISK_BUF_CAP as u8;
+    buf.recompute_min();
+    Some(buf)
+}
+
+/// Verify that `min_notional` always equals the true minimum of all live entry
+/// notionals after any `upsert` call.
+fn min_notional_invariant_holds(buf: &RiskBuffer) -> bool {
+    if buf.count == 0 {
+        return buf.min_notional == 0;
+    }
+    let mut true_min = u128::MAX;
+    for i in 0..buf.count as usize {
+        if buf.entries[i].notional < true_min {
+            true_min = buf.entries[i].notional;
+        }
+    }
+    buf.min_notional == true_min
+}
+
+/// An account whose notional equals the buffer's current minimum MUST be able
+/// to displace an existing entry when the buffer is full. Without this property
+/// an attacker can permanently occupy all buffer slots with equal-notional
+/// "decoy" accounts, preventing any other account from ever entering —
+/// regardless of how long it stays exposed.
+///
+/// This proof covers the general symbolic case: for every full buffer state and
+/// every incoming `(idx, notional)` pair where `notional == min_notional` and
+/// `idx` is not already present, `upsert` must return `true`.
+#[kani::proof]
+fn kani_risk_buf_equal_notional_can_displace() {
+    let n: u128 = kani::any();
+    kani::assume(n > 0 && n < u128::MAX);
+
+    let mut buf = match full_buf_at_notional(n) {
+        Some(b) => b,
+        None => return,
+    };
+
+    // Incoming account: different index, same notional.
+    let new_idx: u16 = kani::any();
+    kani::assume((new_idx as usize) >= RISK_BUF_CAP); // guaranteed not already in buf
+
+    let changed = buf.upsert(new_idx, n);
+
+    assert!(
+        changed,
+        "equal-notional entry must displace the minimum slot when the buffer is full"
+    );
+    assert!(
+        min_notional_invariant_holds(&buf),
+        "min_notional must equal the true minimum after displacement"
+    );
+    assert!(
+        buf.count as usize == RISK_BUF_CAP,
+        "buffer count must not change after displacement"
+    );
+}
+
+/// Prove the general `min_notional` structural invariant: after any sequence
+/// of a single `upsert`, the cached `min_notional` field equals the true
+/// minimum of all live entry notionals.
+#[kani::proof]
+fn kani_risk_buf_min_notional_invariant_after_upsert() {
+    // Symbolic buffer state: count in [0, RISK_BUF_CAP], entries unconstrained.
+    let count: u8 = kani::any();
+    kani::assume((count as usize) <= RISK_BUF_CAP);
+    let e0_n: u128 = kani::any();
+    let e1_n: u128 = kani::any();
+    let e2_n: u128 = kani::any();
+    let e3_n: u128 = kani::any();
+
+    let mut buf = RiskBuffer::zeroed();
+    buf.count = count;
+    if count > 0 { buf.entries[0] = RiskEntry { idx: 0, notional: e0_n, _pad: [0; 14] }; }
+    if count > 1 { buf.entries[1] = RiskEntry { idx: 1, notional: e1_n, _pad: [0; 14] }; }
+    if count > 2 { buf.entries[2] = RiskEntry { idx: 2, notional: e2_n, _pad: [0; 14] }; }
+    if count > 3 { buf.entries[3] = RiskEntry { idx: 3, notional: e3_n, _pad: [0; 14] }; }
+    buf.recompute_min();
+
+    let new_idx: u16 = kani::any();
+    let new_n: u128 = kani::any();
+    buf.upsert(new_idx, new_n);
+
+    assert!(
+        min_notional_invariant_holds(&buf),
+        "min_notional must equal the true minimum of all live entries after upsert"
+    );
+}
+
+/// Prove that a strictly-greater-notional entry always displaces the minimum
+/// slot when the buffer is full (regression: this must hold regardless of
+/// the equal-notional fix).
+#[kani::proof]
+fn kani_risk_buf_strictly_greater_notional_always_displaces() {
+    let n: u128 = kani::any();
+    kani::assume(n > 0 && n < u128::MAX);
+
+    let mut buf = match full_buf_at_notional(n) {
+        Some(b) => b,
+        None => return,
+    };
+
+    let new_idx: u16 = kani::any();
+    kani::assume((new_idx as usize) >= RISK_BUF_CAP);
+
+    let changed = buf.upsert(new_idx, n + 1);
+
+    assert!(changed, "strictly-greater notional must always displace the minimum slot");
+    assert!(min_notional_invariant_holds(&buf));
+    assert_eq!(buf.count as usize, RISK_BUF_CAP);
+}

--- a/tests/test_risk_buffer.rs
+++ b/tests/test_risk_buffer.rs
@@ -382,19 +382,19 @@ fn test_buffer_eviction() {
     assert!(!changed, "Entry below min_notional must be rejected");
     assert_eq!(buf.count, 4);
 
-    // Try to insert entry equal to min — should fail
+    // Try to insert entry equal to min — must succeed: equal-notional entries
+    // must be able to displace the minimum slot so that decoy accounts at the
+    // same notional cannot permanently block other accounts from the buffer.
     let changed = buf.upsert(10, 100);
-    assert!(!changed, "Entry equal to min_notional must be rejected");
+    assert!(changed, "Entry equal to min_notional must be accepted (displaces minimum slot)");
+    assert_eq!(buf.count, 4);
+    assert_eq!(buf.min_notional, 100);
 
-    // Insert entry larger than min — should evict smallest
-    let changed = buf.upsert(10, 150);
+    // Insert entry larger than min — must also succeed; displaces the 100 entry.
+    let changed = buf.upsert(11, 150);
     assert!(changed, "Entry above min_notional must be accepted");
     assert_eq!(buf.count, 4);
     assert_eq!(buf.min_notional, 150);
-
-    // idx=0 (notional=100) should be evicted
-    assert!(buf.find(0).is_none(), "Smallest entry must be evicted");
-    assert!(buf.find(10).is_some(), "New entry must be present");
 }
 
 /// E4: Update-in-place does not trigger eviction.
@@ -1429,4 +1429,65 @@ fn test_find_adl_bytes() {
             println!("ADL_ONE bytes at ENGINE+{}", off);
         }
     }
+}
+
+/// Regression test for the equal-notional decoy lock.
+///
+/// If `upsert` uses strict `>` instead of `>=` for the displacement guard,
+/// an attacker can fill all RISK_BUF_CAP slots with "decoy" accounts at
+/// notional N, then open victim accounts at the same notional N.  Because
+/// equal-notional never displaces, decoys permanently hold every buffer slot
+/// and victims can never enter — defeating the liquidation buffer entirely
+/// while allowing insider candidates to bypass it via explicit candidate lists.
+///
+/// After the fix (`<` guard), victims at the same notional as decoys CAN
+/// displace the minimum-slot entry, so the buffer rotates and no account
+/// can be permanently excluded by equal-notional padding.
+#[test]
+fn test_equal_notional_decoy_cannot_permanently_lock_buffer() {
+    use bytemuck::Zeroable;
+    use percolator_prog::constants::RISK_BUF_CAP;
+    use percolator_prog::risk_buffer::RiskBuffer;
+
+    const DECOY_NOTIONAL: u128 = 1_000_000;
+
+    let mut buf = RiskBuffer::zeroed();
+
+    // Fill the buffer with RISK_BUF_CAP decoy accounts, all at DECOY_NOTIONAL.
+    for i in 0..RISK_BUF_CAP {
+        let inserted = buf.upsert(i as u16, DECOY_NOTIONAL);
+        assert!(inserted, "decoy {i} must enter the buffer while slots are free");
+    }
+    assert_eq!(buf.count as usize, RISK_BUF_CAP);
+    assert_eq!(buf.min_notional, DECOY_NOTIONAL);
+
+    // Now try to insert a victim account at the same notional.
+    // With the equal-notional displacement fix this MUST succeed.
+    let victim_idx: u16 = RISK_BUF_CAP as u16; // guaranteed fresh index
+    let inserted = buf.upsert(victim_idx, DECOY_NOTIONAL);
+    assert!(
+        inserted,
+        "victim at equal notional must displace the minimum decoy slot; \
+         if this fails the decoy lock vulnerability is still present"
+    );
+    assert_eq!(buf.count as usize, RISK_BUF_CAP, "buffer size must not change");
+    assert!(
+        buf.find(victim_idx).is_some(),
+        "victim must now be present in the buffer"
+    );
+    assert_eq!(
+        buf.min_notional, DECOY_NOTIONAL,
+        "min_notional invariant must be maintained"
+    );
+
+    // Verify that all RISK_BUF_CAP - 1 remaining decoys are still at DECOY_NOTIONAL.
+    // (Exactly one decoy was displaced.)
+    let decoy_count = (0..RISK_BUF_CAP as u16)
+        .filter(|&idx| buf.find(idx).is_some())
+        .count();
+    assert_eq!(
+        decoy_count,
+        RISK_BUF_CAP - 1,
+        "exactly one decoy must have been displaced"
+    );
 }

--- a/tests/test_security.rs
+++ b/tests/test_security.rs
@@ -14710,3 +14710,71 @@ fn test_attack_max_risk_8_slot_oracle_crank_orderings_do_not_drain_insurance() {
         );
     }
 }
+
+/// Issue #89 regression: the structural Phase-2 window must promote exposed
+/// accounts to Phase-1 liquidation candidates even on **empty cranks** (no
+/// caller-supplied candidates). Without this, an account outside the
+/// RISK_BUF_CAP slots can accumulate deficit across O(K / RISK_BUF_CAP) empty
+/// cranks before the buffer rotates to it.
+///
+/// This mirrors `test_issue81_candidate_padding_cannot_shield_tail_loss_into_insurance`
+/// but drives the market with empty cranks instead of candidate-bearing cranks,
+/// proving the structural window is no longer gated on `!candidates.is_empty()`.
+#[test]
+fn test_issue89_empty_crank_structural_window_catches_tail_loss() {
+    program_path();
+
+    let (mut env, _lp, _lp_idx, actors) = setup_max_risk_probe(17, 0);
+    assert!(
+        actors.len() > percolator_prog::constants::RISK_BUF_CAP,
+        "setup must leave accounts outside the RISK_BUF_CAP buffer"
+    );
+
+    let tail = actors
+        .iter()
+        .skip(percolator_prog::constants::RISK_BUF_CAP)
+        .find(|a| env.read_account_position(a.idx) != 0)
+        .expect("setup must have an account outside the initial buffer")
+        .idx;
+
+    let insurance_start = env.read_insurance_balance();
+    let mut min_insurance = insurance_start;
+    let mut price = MAX_RISK_P0_E6;
+
+    for round in 0..6 {
+        let slot = env.read_last_market_slot().saturating_add(10);
+        price = max_risk_next_clamped_price(price, -1, 10);
+        env.set_slot_and_price_raw_no_walk(slot, price as i64);
+
+        let before_rr = env.read_rr_cursor_position();
+        let before_tail_pos = env.read_account_position(tail);
+        let before_tail_cap = env.read_account_capital(tail);
+
+        // Empty crank — no explicit candidates.
+        env.crank();
+
+        let after_rr = env.read_rr_cursor_position();
+        let after_tail_pos = env.read_account_position(tail);
+        let after_tail_cap = env.read_account_capital(tail);
+        min_insurance = min_insurance.min(env.read_insurance_balance());
+
+        assert!(
+            after_rr != before_rr
+                || after_tail_pos != before_tail_pos
+                || after_tail_cap != before_tail_cap
+                || env.read_last_market_slot() >= slot,
+            "empty crank made no observable progress on round {round}: \
+             rr={before_rr}->{after_rr}, \
+             tail_pos={before_tail_pos}->{after_tail_pos}, \
+             tail_cap={before_tail_cap}->{after_tail_cap}"
+        );
+        assert!(
+            min_insurance >= insurance_start,
+            "EXPLOIT (issue #89): empty cranks allowed tail account to drain insurance: \
+             start={insurance_start}, min={min_insurance}, round={round}, tail={tail}, \
+             rr={before_rr}->{after_rr}, \
+             tail_pos={before_tail_pos}->{after_tail_pos}, \
+             tail_cap={before_tail_cap}->{after_tail_cap}"
+        );
+    }
+}


### PR DESCRIPTION
Three independent bugs let an attacker prevent legitimate liquidations and drain the insurance fund.

**1. Equal-notional displacement guard (`RiskBuffer::upsert`)**
`notional <= self.min_notional` silently rejects an incoming account whose notional exactly equals the current minimum, so a decoy set at `min_notional` permanently blocks the victim from entering the buffer. Fix: `<` instead of `<=`.

**2. Zero-position FullClose candidate wastes liquidation budget**
An explicit `FullClose` candidate with `pos_q == 0` is admitted to `combined` and consumes a `LIQ_BUDGET_PER_CRANK` slot with no actual work. Combined with (1), an attacker exhausts the budget every crank while the victim accumulates deficit. Fix: gate admission on `effective_pos_q_checked(engine, cidx) != 0` for `FullClose` policies.

**3. Structural RR window skipped on empty cranks**
`append_phase2_fullclose_candidates` was gated on `!candidates.is_empty()`. An account outside `RISK_BUF_CAP` only reached the RR scan when a crank carried explicit candidates; on empty cranks it accumulated deficit unbounded. Fix: call unconditionally. The existing fee-sweep budget split (0 on candidate-bearing cranks, `FEE_SWEEP_BUDGET` on empty cranks) is preserved unchanged. CU on the new path is bounded identically to a candidate-bearing crank: `permissionless_progress_not_atomic` enforces `LIQ_BUDGET_PER_CRANK` regardless of candidate source; `cu-audit` checkpoints now bracket the structural window call so the delta can be measured directly.

**Tests**
- `test_equal_notional_decoy_cannot_permanently_lock_buffer` — new unit test
- `test_issue89_empty_crank_structural_window_catches_tail_loss` — new LiteSVM integration test (mirrors `test_issue81`)
- 27/27 `test_risk_buffer` pass; `test_issue81` and `test_issue89` pass

**Kani (section AE)**
- `kani_risk_buf_equal_notional_can_displace` — full buffer at uniform N always accepts an incoming entry at N
- `kani_risk_buf_min_notional_invariant_after_upsert` — `min_notional` equals true minimum after any upsert
- `kani_risk_buf_strictly_greater_notional_always_displaces` — regression for the `<` change

Closes #89, closes #90.