### PR TITLE
Persist per-leg oracle ratchet across partial-catchup writeback

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -759,6 +759,8 @@ pub mod policy {
         pub oracle_target_publish_time: i64,
         pub fee_sweep_cursor_word: u64,
         pub fee_sweep_cursor_bit: u64,
+        pub oracle_leg_publish_times: [i64; crate::constants::ORACLE_LEG_CAP],
+        pub oracle_leg_prices_e6: [u64; crate::constants::ORACLE_LEG_CAP],
     }
 
     /// Partial crank catchup preserves fresh target/liveness data, the
@@ -779,6 +781,8 @@ pub mod policy {
             oracle_target_publish_time: after_read_and_sweep.oracle_target_publish_time,
             fee_sweep_cursor_word: after_read_and_sweep.fee_sweep_cursor_word,
             fee_sweep_cursor_bit: after_read_and_sweep.fee_sweep_cursor_bit,
+            oracle_leg_publish_times: after_read_and_sweep.oracle_leg_publish_times,
+            oracle_leg_prices_e6: after_read_and_sweep.oracle_leg_prices_e6,
         }
     }
 
@@ -4818,6 +4822,8 @@ pub mod processor {
             oracle_target_publish_time: config.oracle_target_publish_time,
             fee_sweep_cursor_word: config.fee_sweep_cursor_word,
             fee_sweep_cursor_bit: config.fee_sweep_cursor_bit,
+            oracle_leg_publish_times: config.oracle_leg_publish_times,
+            oracle_leg_prices_e6: config.oracle_leg_prices_e6,
         }
     }
 
@@ -4833,6 +4839,8 @@ pub mod processor {
         config.oracle_target_publish_time = fields.oracle_target_publish_time;
         config.fee_sweep_cursor_word = fields.fee_sweep_cursor_word;
         config.fee_sweep_cursor_bit = fields.fee_sweep_cursor_bit;
+        config.oracle_leg_publish_times = fields.oracle_leg_publish_times;
+        config.oracle_leg_prices_e6 = fields.oracle_leg_prices_e6;
     }
 
     fn partial_crank_config_to_write(

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -4295,6 +4295,8 @@ fn kani_partial_crank_config_write_field_sources() {
         oracle_target_publish_time: kani::any(),
         fee_sweep_cursor_word: kani::any(),
         fee_sweep_cursor_bit: kani::any(),
+        oracle_leg_publish_times: [kani::any(), kani::any(), kani::any()],
+        oracle_leg_prices_e6: [kani::any(), kani::any(), kani::any()],
     };
     let after = PartialCrankConfigFields {
         last_effective_price_e6: kani::any(),
@@ -4305,6 +4307,8 @@ fn kani_partial_crank_config_write_field_sources() {
         oracle_target_publish_time: kani::any(),
         fee_sweep_cursor_word: kani::any(),
         fee_sweep_cursor_bit: kani::any(),
+        oracle_leg_publish_times: [kani::any(), kani::any(), kani::any()],
+        oracle_leg_prices_e6: [kani::any(), kani::any(), kani::any()],
     };
 
     let out = partial_crank_config_fields_to_write(before, after);
@@ -4320,6 +4324,8 @@ fn kani_partial_crank_config_write_field_sources() {
     );
     assert_eq!(out.fee_sweep_cursor_word, after.fee_sweep_cursor_word);
     assert_eq!(out.fee_sweep_cursor_bit, after.fee_sweep_cursor_bit);
+    assert_eq!(out.oracle_leg_publish_times, after.oracle_leg_publish_times);
+    assert_eq!(out.oracle_leg_prices_e6, after.oracle_leg_prices_e6);
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #93.

## Problem

`policy::partial_crank_config_fields_to_write` (`src/percolator.rs:769-783`) returns the 8-field whitelist that `processor::partial_crank_config_to_write` (lines 4838-4849) overlays onto a `before_read` snapshot when committing a partial-catchup `KeeperCrank`.

Two `MarketConfig` fields populated by `oracle::read_external_price_e6` — `oracle_leg_prices_e6: [u64; ORACLE_LEG_CAP]` (line 2808) and `oracle_leg_publish_times: [i64; ORACLE_LEG_CAP]` (line 2812) — are **not** in that whitelist. They are written at lines 3642-3646 as the per-leg replay-defense ratchet documented at lines 3595-3597 ("a caller cannot pair a fresh leg with an older already-observed leg to manufacture a cross").

On partial catchup, those mutations are silently dropped at writeback. `let mut restored = before_read; apply_partial_crank_config_fields(&mut restored, fields);` (lines 4846-4847) restores the per-leg arrays to their pre-call values while the freshly-computed `oracle_target_price_e6` (in the whitelist at line 778) is preserved. The per-leg rollback check at lines 3634-3640 is non-load-bearing whenever `oversized_crank_catchup_target` (lines 710-748) returns `Target(...)`.

Full root-cause analysis and reproducer in #93.

## Cause

The TOTO commit `d40edb5` added the two `MarketConfig` fields and the matching mutations in `read_external_price_e6` but did not extend `policy::PartialCrankConfigFields` or `policy::partial_crank_config_fields_to_write`. `kani_partial_crank_config_write_field_sources` (`tests/kani.rs`) verifies the source choice for each whitelisted field; it does not constrain the set of whitelist members, so the gap did not produce a counterexample.

## Fix

Add both per-leg arrays to the carry-forward whitelist, sourced from `after_read_and_sweep`. Four edits in `src/percolator.rs`, one extension in `tests/kani.rs`:

| Symbol | Edit |
|---|---|
| `policy::PartialCrankConfigFields` (struct, lines 753-762) | Add `oracle_leg_publish_times: [i64; ORACLE_LEG_CAP]` and `oracle_leg_prices_e6: [u64; ORACLE_LEG_CAP]` |
| `policy::partial_crank_config_fields_to_write` (whitelist, lines 769-783) | Source both new fields from `after_read_and_sweep` |
| `processor::partial_crank_config_fields` (read helper, lines 4809-4822) | Read both new fields from `MarketConfig` |
| `processor::apply_partial_crank_config_fields` (write helper, lines 4824-4836) | Write both new fields back to `MarketConfig` |
| `kani_partial_crank_config_write_field_sources` (`tests/kani.rs`) | `kani::any()` over the new fields and assert carry-forward equals `after.*` |

Total diff: +14 lines, no deletions, no other paths touched.

## Why `after_read_and_sweep`

`read_external_price_e6` writes the per-leg arrays only when `publish_time > prev_time` for that leg (line 3642) and rejects same-timestamp price changes (lines 3634-3640). The writes are monotonic advances of a ratchet that the function has already validated. Persisting `after_read_and_sweep` cannot inject an unvalidated observation. Sourcing from `before_read` (current behavior) actively erases the validated advance.

This matches the source choice for every other whitelist member written by the same call path (`oracle_target_price_e6`, `oracle_target_publish_time`, `last_oracle_publish_time`, `last_effective_price_e6`, `last_good_oracle_slot`), all already sourced from `after_read_and_sweep`.

## Behavioral impact

- **Composite markets (`oracle_leg_count >= 2`):** per-leg ratchet now persists across partial-catchup commits, restoring the documented rollback invariant. Full-crank (non-partial) paths are unchanged — they already commit the whole post-read config.
- **Single-leg external markets (`oracle_leg_count == 1`):** `read_external_price_e6` writes only leg index 0; legs 1-2 stay zero across both snapshots, so carry-forward is observationally equivalent to revert. No behavior change.
- **Hyperp markets:** `read_external_price_e6` is not invoked (the Hyperp branch in `get_engine_oracle_price_e6` is taken instead). Per-leg arrays remain zero across the call. No behavior change.
- **ABI / serialization:** `PartialCrankConfigFields` is an internal policy struct, not part of any on-chain layout. Struct growth has no on-chain impact.
- **Compute cost:** two additional fixed-size array copies per partial-catchup writeback (48 bytes total). Negligible.

## Verification

Release build against this branch:

```
cargo check --release --tests
  # clean (no errors; only pre-existing warnings unrelated to this change)

cargo test --release --test unit
  # test result: ok. 29 passed; 0 failed; 2 ignored

cargo test --release --test unit test_three_leg_external_oracle
  # test result: ok. 5 passed; 0 failed         (TOTO regression suite intact)

cargo test --release --test test_bounty4_cross_leg_skew
  # test result: ok. 3 passed; 0 failed
```

The Kani extension can be checked with `cargo kani --harness kani_partial_crank_config_write_field_sources`. The harness additions are mechanical mirrors of the existing per-field pattern; I did not run Kani locally.

The PoC reproducer from #93 (`tests/test_bounty4_partial_crank_leg_ledger.rs`) is intentionally not included in this PR — its assertions encode the pre-fix state and would flip from pass-as-bug-confirmed to fail-as-bug-closed once the fix lands. The forward-looking regression-prevention proof is the extended Kani harness.