### PR TITLE
Persist per-leg oracle ratchet across TradeCpi zero-fill writeback

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -8405,6 +8405,22 @@ pub mod processor {
                     restored.oracle_target_price_e6 = config.oracle_target_price_e6;
                     restored.oracle_target_publish_time = config.oracle_target_publish_time;
                     restored.last_hyperp_index_slot = config.last_hyperp_index_slot;
+                    // Per-leg ratchet (`oracle_leg_publish_times` /
+                    // `oracle_leg_prices_e6`) is the documented
+                    // anti-replay defense for composite oracles
+                    // (`MarketConfig::oracle_leg_publish_times` doc-
+                    // comment). `read_external_price_e6` only writes
+                    // these arrays when `publish_time > prev_time`
+                    // (rejecting rollback) and rejects same-timestamp
+                    // disagreement, so the post-read state is a
+                    // validated monotonic advance. Carry it forward
+                    // alongside the other oracle/index state above —
+                    // otherwise the per-leg ratchet de-advances on
+                    // disk while `oracle_target_price_e6` advances,
+                    // and the next composite read admits a stale
+                    // leg paired with a fresh one.
+                    restored.oracle_leg_publish_times = config.oracle_leg_publish_times;
+                    restored.oracle_leg_prices_e6 = config.oracle_leg_prices_e6;
                     state::write_config(&mut data, &restored);
                     state::write_req_nonce(&mut data, req_id);
                     return Ok(());


### PR DESCRIPTION
Closes #95.

## Problem

The `TradeCpi` handler's zero-fill (`exec_size == 0`) branch in `src/percolator.rs` open-codes a `MarketConfig` rollback. It forwards six oracle/index fields from the post-oracle-read `config` and reverts everything else to a `config_pre_oracle` snapshot.

Two `MarketConfig` fields populated by `oracle::read_external_price_e6` are not in that forwarded list:

- `oracle_leg_publish_times: [i64; ORACLE_LEG_CAP]`
- `oracle_leg_prices_e6:     [u64; ORACLE_LEG_CAP]`

Both arrays were added by commit `d40edb5` ("Add TOTO oracle legs and Hyperp dynamic fees") and serve as the per-leg anti-replay ratchet documented at the `MarketConfig::oracle_leg_publish_times` doc-comment:

> Composite reads reject per-leg rollback, so a caller cannot pair a fresh leg with an older already-observed leg to manufacture a cross.

`read_external_price_e6` rejects per-leg rollback (`publish_time < prev_time`) and same-timestamp price disagreement. The check is non-load-bearing whenever the zero-fill writeback runs: the per-leg arrays revert to `config_pre_oracle` while `oracle_target_price_e6`, `last_oracle_publish_time`, `last_effective_price_e6`, and the other whitelisted fields advance to their post-call values.

Net effect on disk after one zero-fill: target/baseline/liveness fields advance; per-leg ratchet de-advances. The next composite read admits a leg whose `publish_time` exceeds the pre-bug ratchet — including snapshots stale relative to wallclock but newer than the rolled-back ledger — and the resulting cross feeds into `engine.last_oracle_price` via `accrue_market_to`.

Full root-cause analysis, source-line trace, and reproducer in #95 (LiteSVM tests against deployed BPF sha256 `cb6f9c96…545`).

## Cause

The TOTO commit `d40edb5` added the two `MarketConfig` fields and the matching mutations in `read_external_price_e6` but did not extend the open-coded `restored = config_pre_oracle` writeback inside the TradeCpi zero-fill branch. The same omission exists at the partial-catchup `KeeperCrank` writeback (`policy::PartialCrankConfigFields` whitelist at `src/percolator.rs:769-783`) and is addressed by PR #94 (issue #93). The two writeback sites are independent code paths.

## Fix

Carry both per-leg arrays forward from `config` alongside the existing six fields. Two assignment statements added to the open-coded forwarding list, plus a comment explaining the rationale.

The fields are validated by `read_external_price_e6` (rejecting rollback, rejecting same-timestamp disagreement) before they reach the writeback. Persisting the post-read values cannot inject an unvalidated observation — only validated monotonic advances. This matches the source choice for every other oracle-state field already in the forwarded list (`oracle_target_price_e6`, `oracle_target_publish_time`, `last_oracle_publish_time`, `last_effective_price_e6`, `last_good_oracle_slot`).

## Behavioral impact

- **Composite markets (`oracle_leg_count >= 2`):** per-leg ratchet now persists across TradeCpi zero-fill commits, restoring the documented rollback invariant. Real-fill (`exec_size != 0`) paths are unchanged — they already commit the post-read config in full via the regular trade path.
- **Single-leg external markets (`oracle_leg_count == 1`):** `read_external_price_e6` writes only leg index 0; legs 1-2 stay zero across both snapshots, so carry-forward is observationally equivalent to revert. No behavior change.
- **Hyperp markets:** `read_external_price_e6` is not invoked (the Hyperp branch in `get_engine_oracle_price_e6` is taken instead). Per-leg arrays remain zero across the call. No behavior change.
- **ABI / serialization:** no changes to any on-chain layout. Same `MarketConfig` struct as before.
- **Compute cost:** two additional fixed-size array copies per zero-fill writeback (48 bytes total). Negligible.

## Verification

```
cargo check --release
  # clean (only pre-existing solana-client v1.18.26 future-incompat warning)

cargo build-sbf
  # clean (with this branch's wrapper compiled)

cargo test --release --test test_bounty4_tradecpi_zerofill -- --nocapture
  # against the patched wrapper, the four PoC tests from #95
  # invert: the staircase stalls at step 2 with `OracleStale` (per-leg
  # ratchet now rejects the cherry-picked replay), drift stays at 0,
  # and the BOUNTY-WIN panic does NOT fire.

cargo test --release --test unit bug_tradecpi_zerofill -- --nocapture
  # the three host-side companion tests from #95 also flip from
  # pass-as-bug-confirmed to fail-as-bug-closed once this fix lands.
```

The PoC tests from #95 are intentionally not added to this PR — their assertions encode the pre-fix state and would flip once this fix lands. The forward-looking regression-prevention proof would be a Kani harness over the TradeCpi zero-fill writeback (no such harness currently exists at this site, mirroring the Kani coverage gap noted in #95's "Why this wasn't caught" section).

## Coordination with PR #94

PR #94 adds `oracle_leg_publish_times` and `oracle_leg_prices_e6` to `policy::PartialCrankConfigFields` and the matching read/write helpers. Its scope is the partial-catchup `KeeperCrank` writeback (`prog/src/percolator.rs:769-783, 4838-4849`). The TradeCpi zero-fill rollback this PR fixes is open-coded and uses none of the helpers PR #94 modifies (verified: `grep -n "partial_crank_config_to_write\|PartialCrankConfigFields\|apply_partial_crank_config_fields" src/percolator.rs` returns no hits inside the zero-fill branch).

The two PRs are independent and both safe to merge; they fix different code paths.