### PR TITLE
Persist hybrid mark fields across both partial-restore writebacks

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -766,6 +766,17 @@ pub mod policy {
         pub oracle_target_publish_time: i64,
         pub fee_sweep_cursor_word: u64,
         pub fee_sweep_cursor_bit: u64,
+        // Hybrid-after-hours mark sync: `read_price_and_stamp` snaps these
+        // to the freshly-accepted external price on every successful read
+        // in hybrid mode (`prog/src/percolator.rs:4276-4290`, added by
+        // commit 40d9024). Persisting them across partial-catchup writeback
+        // is required to enforce the invariant the snap exists for:
+        // regular-hours duplicate cranks must not create artificial
+        // mark/index funding divergence before after-hours fallback has
+        // actually started.
+        pub hyperp_mark_e6: u64,
+        pub mark_ewma_e6: u64,
+        pub mark_ewma_last_slot: u64,
     }
 
     /// Partial crank catchup preserves fresh target/liveness data, the
@@ -786,6 +797,9 @@ pub mod policy {
             oracle_target_publish_time: after_read_and_sweep.oracle_target_publish_time,
             fee_sweep_cursor_word: after_read_and_sweep.fee_sweep_cursor_word,
             fee_sweep_cursor_bit: after_read_and_sweep.fee_sweep_cursor_bit,
+            hyperp_mark_e6: after_read_and_sweep.hyperp_mark_e6,
+            mark_ewma_e6: after_read_and_sweep.mark_ewma_e6,
+            mark_ewma_last_slot: after_read_and_sweep.mark_ewma_last_slot,
         }
     }
 
@@ -5020,6 +5034,9 @@ pub mod processor {
             oracle_target_publish_time: config.oracle_target_publish_time,
             fee_sweep_cursor_word: config.fee_sweep_cursor_word,
             fee_sweep_cursor_bit: config.fee_sweep_cursor_bit,
+            hyperp_mark_e6: config.hyperp_mark_e6,
+            mark_ewma_e6: config.mark_ewma_e6,
+            mark_ewma_last_slot: config.mark_ewma_last_slot,
         }
     }
 
@@ -5035,6 +5052,9 @@ pub mod processor {
         config.oracle_target_publish_time = fields.oracle_target_publish_time;
         config.fee_sweep_cursor_word = fields.fee_sweep_cursor_word;
         config.fee_sweep_cursor_bit = fields.fee_sweep_cursor_bit;
+        config.hyperp_mark_e6 = fields.hyperp_mark_e6;
+        config.mark_ewma_e6 = fields.mark_ewma_e6;
+        config.mark_ewma_last_slot = fields.mark_ewma_last_slot;
     }
 
     fn partial_crank_config_to_write(
@@ -8425,6 +8445,21 @@ pub mod processor {
                     restored.oracle_target_price_e6 = config.oracle_target_price_e6;
                     restored.oracle_target_publish_time = config.oracle_target_publish_time;
                     restored.last_hyperp_index_slot = config.last_hyperp_index_slot;
+                    // Hybrid-after-hours mark sync: `read_price_and_stamp`
+                    // snaps these to the freshly-accepted external price on
+                    // every successful read in hybrid mode (see :4276-4290,
+                    // added by commit 40d9024). Carry them forward so the
+                    // mark/index funding-divergence invariant the snap
+                    // exists for survives the zero-fill rollback —
+                    // otherwise repeated zero-fill TradeCpi calls leave
+                    // `mark_ewma_e6` pinned at the pre-call value while
+                    // `last_effective_price_e6` advances, and
+                    // `compute_current_funding_rate_e9` (:5410-5419) reads
+                    // both fields and saturates the per-slot rate at the
+                    // engine cap.
+                    restored.hyperp_mark_e6 = config.hyperp_mark_e6;
+                    restored.mark_ewma_e6 = config.mark_ewma_e6;
+                    restored.mark_ewma_last_slot = config.mark_ewma_last_slot;
                     state::write_config(&mut data, &restored);
                     state::write_req_nonce(&mut data, req_id);
                     return Ok(());

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1872,3 +1872,351 @@ fn test_nonce_overflow_does_not_reopen_request_id_space() {
         "u64::MAX-1 should advance to u64::MAX"
     );
 }
+
+// =============================================================================
+// Bounty 4 disclosure: hybrid-after-hours mark fields dropped by both
+// partial-restore writebacks (host-side companion tests).
+//
+// Source citation:
+//   `prog/src/percolator.rs:4276-4290` (commit 40d9024) — `read_price_and_stamp`
+//     snaps `hyperp_mark_e6`, `mark_ewma_e6`, `mark_ewma_last_slot` to the
+//     freshly-accepted external price on every successful read in
+//     hybrid-after-hours markets.
+//   `prog/src/percolator.rs:760-790` — `policy::PartialCrankConfigFields` +
+//     `partial_crank_config_fields_to_write` — 8-field whitelist; none of the
+//     three mark fields are present.
+//   `prog/src/percolator.rs:8421-8428` — TradeCpi zero-fill rollback's
+//     open-coded six-field forwarding; none of the three mark fields are
+//     present.
+//
+// The three tests below build a hybrid-after-hours `MarketConfig`, simulate
+// the in-memory snap, simulate the relevant writeback, and assert the
+// post-writeback on-disk state. The funding-rate consequence test consumes
+// the post-writeback state through `policy::funding_rate_e9_from_mark_index`
+// directly. No LiteSVM, no BPF.
+// =============================================================================
+
+/// Build a hybrid-after-hours `MarketConfig` with sane test defaults: mark
+/// pinned at `mark_old`, effective at `eff_old`, snap on, funding params from
+/// the wrapper's `append_default_extended_tail_for(non_hyperp = false)`.
+fn build_hybrid_test_config(mark_old: u64, eff_old: u64, slot_old: u64) -> state::MarketConfig {
+    let mut cfg = state::MarketConfig::zeroed();
+    cfg.trade_fee_mode = percolator_prog::constants::TRADE_FEE_MODE_HYBRID_AFTER_HOURS;
+    // Non-Hyperp: index_feed_id is non-zero (any non-zero pattern works for
+    // `is_hybrid_after_hours_mode`, which only checks `index_feed_id != [0;32]
+    // && trade_fee_mode == HYBRID_AFTER_HOURS`).
+    cfg.index_feed_id = [1u8; 32];
+    cfg.last_effective_price_e6 = eff_old;
+    cfg.mark_ewma_e6 = mark_old;
+    cfg.hyperp_mark_e6 = mark_old;
+    cfg.mark_ewma_last_slot = slot_old;
+    cfg.last_oracle_publish_time = slot_old as i64;
+    cfg.oracle_target_price_e6 = eff_old;
+    cfg.oracle_target_publish_time = slot_old as i64;
+    cfg.last_good_oracle_slot = slot_old;
+    // Funding params from the wrapper's default test tail
+    // (`append_default_extended_tail_for`, `tests/common/mod.rs:213`).
+    cfg.funding_horizon_slots = 500;
+    cfg.funding_k_bps = 100;
+    cfg.funding_max_premium_bps = 500;
+    cfg.funding_max_e9_per_slot = 1_000;
+    cfg
+}
+
+/// Mirror the snap at `prog:4276-4290` — `read_price_and_stamp` writes these
+/// three mark fields to the freshly-accepted effective price on every
+/// successful read in hybrid-after-hours markets. `read_price_and_stamp` is a
+/// private wrapper helper, but the snap logic is small and self-contained;
+/// re-implement it here with the public oracle gate.
+fn simulate_hybrid_mark_snap(cfg: &mut state::MarketConfig, price: u64, clock_slot: u64) {
+    let advanced = price != cfg.last_effective_price_e6
+        || cfg.mark_ewma_e6 != price
+        || cfg.hyperp_mark_e6 != price;
+    if oracle::is_hybrid_after_hours_mode(cfg) && advanced {
+        cfg.hyperp_mark_e6 = price;
+        cfg.mark_ewma_e6 = price;
+        cfg.mark_ewma_last_slot = clock_slot;
+    }
+}
+
+/// Mirror the OLD (pre-fix) writeback shape at `prog:5040-5051` and
+/// `prog:760-790` — partial-catchup restores `before_read` and overlays only
+/// the original 8 fields. Implemented as a direct copy here (NOT through
+/// `policy::partial_crank_config_fields_to_write`) so the test reproduces the
+/// pre-fix behavior even on a tree where the fix has extended the helper to
+/// also forward the three mark fields.
+fn simulate_partial_crank_writeback_buggy(
+    before_read: state::MarketConfig,
+    after_read: state::MarketConfig,
+) -> state::MarketConfig {
+    let mut restored = before_read;
+    restored.last_effective_price_e6 = after_read.last_effective_price_e6;
+    restored.last_hyperp_index_slot = after_read.last_hyperp_index_slot;
+    restored.last_good_oracle_slot = after_read.last_good_oracle_slot;
+    restored.last_oracle_publish_time = after_read.last_oracle_publish_time;
+    restored.oracle_target_price_e6 = after_read.oracle_target_price_e6;
+    restored.oracle_target_publish_time = after_read.oracle_target_publish_time;
+    restored.fee_sweep_cursor_word = after_read.fee_sweep_cursor_word;
+    restored.fee_sweep_cursor_bit = after_read.fee_sweep_cursor_bit;
+    restored
+}
+
+/// Mirror the FIXED partial-catchup writeback — extends the original 8-field
+/// forwarding to include `hyperp_mark_e6`, `mark_ewma_e6`, and
+/// `mark_ewma_last_slot`. Used by the post-fix assertion below to demonstrate
+/// the proposed patch closes the bug.
+fn simulate_partial_crank_writeback_fixed(
+    before_read: state::MarketConfig,
+    after_read: state::MarketConfig,
+) -> state::MarketConfig {
+    let mut restored = simulate_partial_crank_writeback_buggy(before_read, after_read);
+    restored.hyperp_mark_e6 = after_read.hyperp_mark_e6;
+    restored.mark_ewma_e6 = after_read.mark_ewma_e6;
+    restored.mark_ewma_last_slot = after_read.mark_ewma_last_slot;
+    restored
+}
+
+/// Mirror the TradeCpi zero-fill rollback at `prog:8421-8428` — restores
+/// `config_pre_oracle` and overlays exactly six oracle/index fields.
+fn simulate_zerofill_writeback(
+    before_read: state::MarketConfig,
+    after_read: state::MarketConfig,
+) -> state::MarketConfig {
+    let mut restored = before_read;
+    restored.last_good_oracle_slot = after_read.last_good_oracle_slot;
+    restored.last_effective_price_e6 = after_read.last_effective_price_e6;
+    restored.last_oracle_publish_time = after_read.last_oracle_publish_time;
+    restored.oracle_target_price_e6 = after_read.oracle_target_price_e6;
+    restored.oracle_target_publish_time = after_read.oracle_target_publish_time;
+    restored.last_hyperp_index_slot = after_read.last_hyperp_index_slot;
+    restored
+}
+
+#[test]
+fn bug_partial_catchup_drops_hybrid_mark_fields() {
+    // Hybrid-after-hours config: mark pinned at $100, effective at $100,
+    // both at slot 100.
+    let mark_old: u64 = 100_000_000;
+    let eff_old: u64 = 100_000_000;
+    let slot_old: u64 = 100;
+    let before = build_hybrid_test_config(mark_old, eff_old, slot_old);
+
+    // Sanity: the snap is gated on hybrid-after-hours mode.
+    assert!(
+        oracle::is_hybrid_after_hours_mode(&before),
+        "test config must be in hybrid-after-hours mode"
+    );
+
+    // Simulate the in-memory state after a read advances the effective price
+    // to $110 in slot 110: `read_price_and_stamp` snaps mark fields to the
+    // new price (4276-4290).
+    let new_price: u64 = 110_000_000;
+    let new_slot: u64 = 110;
+    let mut after = before;
+    after.last_effective_price_e6 = new_price;
+    after.last_oracle_publish_time = new_slot as i64;
+    after.oracle_target_price_e6 = new_price;
+    after.oracle_target_publish_time = new_slot as i64;
+    after.last_good_oracle_slot = new_slot;
+    simulate_hybrid_mark_snap(&mut after, new_price, new_slot);
+
+    // Confirm the in-memory snap fired.
+    assert_eq!(after.mark_ewma_e6, new_price, "snap should set mark_ewma_e6");
+    assert_eq!(
+        after.hyperp_mark_e6, new_price,
+        "snap should set hyperp_mark_e6"
+    );
+    assert_eq!(
+        after.mark_ewma_last_slot, new_slot,
+        "snap should set mark_ewma_last_slot"
+    );
+
+    // Run the partial-catchup writeback. On disk after the writeback:
+    let restored = simulate_partial_crank_writeback_buggy(before, after);
+
+    // Effective + target survived (whitelisted):
+    assert_eq!(
+        restored.last_effective_price_e6, new_price,
+        "last_effective_price_e6 is whitelisted; should advance"
+    );
+    assert_eq!(
+        restored.oracle_target_price_e6, new_price,
+        "oracle_target_price_e6 is whitelisted; should advance"
+    );
+    assert_eq!(
+        restored.last_oracle_publish_time, new_slot as i64,
+        "last_oracle_publish_time is whitelisted; should advance"
+    );
+
+    // Mark fields reverted (NOT whitelisted) — this is the bug:
+    assert_eq!(
+        restored.mark_ewma_e6, mark_old,
+        "BUG: mark_ewma_e6 must REVERT to pre-call value (not in PartialCrankConfigFields whitelist)"
+    );
+    assert_eq!(
+        restored.hyperp_mark_e6, mark_old,
+        "BUG: hyperp_mark_e6 must REVERT to pre-call value (not in whitelist)"
+    );
+    assert_eq!(
+        restored.mark_ewma_last_slot, slot_old,
+        "BUG: mark_ewma_last_slot must REVERT to pre-call value (not in whitelist)"
+    );
+
+    println!("  partial-catchup BUG REPRODUCED: mark_ewma_e6 reverted to ${} (pre-call), while last_effective_price_e6 advanced to ${}", mark_old / 1_000_000, new_price / 1_000_000);
+}
+
+#[test]
+fn bug_tradecpi_zerofill_drops_hybrid_mark_fields() {
+    // Same setup as the partial-catchup test, but exercising the TradeCpi
+    // zero-fill open-coded rollback at `prog:8421-8428`.
+    let mark_old: u64 = 100_000_000;
+    let eff_old: u64 = 100_000_000;
+    let slot_old: u64 = 100;
+    let before = build_hybrid_test_config(mark_old, eff_old, slot_old);
+
+    let new_price: u64 = 95_000_000;
+    let new_slot: u64 = 110;
+    let mut after = before;
+    after.last_effective_price_e6 = new_price;
+    after.last_oracle_publish_time = new_slot as i64;
+    after.oracle_target_price_e6 = new_price;
+    after.oracle_target_publish_time = new_slot as i64;
+    after.last_good_oracle_slot = new_slot;
+    simulate_hybrid_mark_snap(&mut after, new_price, new_slot);
+
+    assert_eq!(after.mark_ewma_e6, new_price);
+
+    let restored = simulate_zerofill_writeback(before, after);
+
+    assert_eq!(
+        restored.last_effective_price_e6, new_price,
+        "last_effective_price_e6 is in the zero-fill forwarded set; should advance"
+    );
+    assert_eq!(
+        restored.mark_ewma_e6, mark_old,
+        "BUG: mark_ewma_e6 must REVERT (not in TradeCpi zero-fill forwarded set)"
+    );
+    assert_eq!(
+        restored.hyperp_mark_e6, mark_old,
+        "BUG: hyperp_mark_e6 must REVERT (not in TradeCpi zero-fill forwarded set)"
+    );
+    assert_eq!(
+        restored.mark_ewma_last_slot, slot_old,
+        "BUG: mark_ewma_last_slot must REVERT (not in TradeCpi zero-fill forwarded set)"
+    );
+
+    println!("  tradecpi-zerofill BUG REPRODUCED: mark_ewma_e6 reverted to ${} (pre-call), while last_effective_price_e6 advanced to ${}", mark_old / 1_000_000, new_price / 1_000_000);
+}
+
+#[test]
+fn bug_funding_rate_diverges_after_hybrid_mark_revert() {
+    // Walk the bug end-to-end into the funding rate computation. After a
+    // sequence of zero-fill TradeCpi calls the on-disk state is
+    // `mark_ewma_e6 = mark_old` (reverted) and `last_effective_price_e6 =
+    // eff_new` (advanced). `compute_current_funding_rate_e9` reads both and
+    // produces a saturated negative per-slot rate even though no genuine
+    // mark/index divergence exists.
+    let mark_old: u64 = 100_000_000;
+    let eff_new: u64 = 110_000_000;
+    let slot_old: u64 = 100;
+    let mut config = build_hybrid_test_config(mark_old, eff_new, slot_old);
+    // Force the post-bug shape directly: mark stayed at $100, effective
+    // walked to $110.
+    config.mark_ewma_e6 = mark_old;
+
+    // Funding rate as compute_current_funding_rate_e9 would compute it
+    // (`prog:5410-5419`): direct call to the public policy helper.
+    let rate = policy::funding_rate_e9_from_mark_index(
+        config.mark_ewma_e6,
+        config.last_effective_price_e6,
+        config.funding_horizon_slots,
+        config.funding_k_bps,
+        config.funding_max_premium_bps,
+        config.funding_max_e9_per_slot,
+    )
+    .expect("funding rate must compute");
+
+    assert!(
+        rate < 0,
+        "funding rate must be negative when mark < effective (got {})",
+        rate
+    );
+    assert_eq!(
+        rate, -(config.funding_max_e9_per_slot as i128),
+        "with mark $100 vs effective $110 (10% gap, premium cap = 500 bps = 5%), \
+         per-slot rate must saturate at -funding_max_e9_per_slot"
+    );
+
+    // Sanity: an honest (no-bug) state has mark == effective and rate = 0.
+    let rate_honest = policy::funding_rate_e9_from_mark_index(
+        eff_new,
+        eff_new,
+        config.funding_horizon_slots,
+        config.funding_k_bps,
+        config.funding_max_premium_bps,
+        config.funding_max_e9_per_slot,
+    )
+    .unwrap();
+    assert_eq!(
+        rate_honest, 0,
+        "honest mark==effective state must produce zero funding rate"
+    );
+
+    println!("  bug-state funding rate = {} e9/slot (saturated negative)", rate);
+    println!("  honest-state funding rate = {} e9/slot", rate_honest);
+    println!("  divergence is FABRICATED — no real mark/index gap, just a writeback drop");
+}
+
+#[test]
+fn fix_partial_catchup_carries_hybrid_mark_fields_forward() {
+    // Mirror image of `bug_partial_catchup_drops_hybrid_mark_fields`, but
+    // running the proposed fix's writeback (which forwards the three mark
+    // fields from `after_read_and_sweep`). Asserts that the post-writeback
+    // state has mark==effective, leaving zero funding-rate divergence.
+    let mark_old: u64 = 100_000_000;
+    let eff_old: u64 = 100_000_000;
+    let slot_old: u64 = 100;
+    let before = build_hybrid_test_config(mark_old, eff_old, slot_old);
+
+    let new_price: u64 = 110_000_000;
+    let new_slot: u64 = 110;
+    let mut after = before;
+    after.last_effective_price_e6 = new_price;
+    after.last_oracle_publish_time = new_slot as i64;
+    after.oracle_target_price_e6 = new_price;
+    after.oracle_target_publish_time = new_slot as i64;
+    after.last_good_oracle_slot = new_slot;
+    simulate_hybrid_mark_snap(&mut after, new_price, new_slot);
+
+    let restored = simulate_partial_crank_writeback_fixed(before, after);
+
+    assert_eq!(
+        restored.last_effective_price_e6, new_price,
+        "fix preserves whitelisted last_effective_price_e6 advance"
+    );
+    assert_eq!(
+        restored.mark_ewma_e6, new_price,
+        "FIX: mark_ewma_e6 carried forward to match effective"
+    );
+    assert_eq!(
+        restored.hyperp_mark_e6, new_price,
+        "FIX: hyperp_mark_e6 carried forward"
+    );
+    assert_eq!(
+        restored.mark_ewma_last_slot, new_slot,
+        "FIX: mark_ewma_last_slot carried forward"
+    );
+
+    let rate = policy::funding_rate_e9_from_mark_index(
+        restored.mark_ewma_e6,
+        restored.last_effective_price_e6,
+        restored.funding_horizon_slots,
+        restored.funding_k_bps,
+        restored.funding_max_premium_bps,
+        restored.funding_max_e9_per_slot,
+    )
+    .unwrap();
+    assert_eq!(rate, 0, "post-fix funding rate must be zero (no fabricated divergence)");
+
+    println!("  POST-FIX: mark_ewma_e6 = ${} == last_effective_price_e6 = ${}, funding rate = {} e9/slot", restored.mark_ewma_e6 / 1_000_000, restored.last_effective_price_e6 / 1_000_000, rate);
+}


### PR DESCRIPTION
Closes #97.

## Problem

Commit `40d9024` ("Keep hybrid mark aligned during oracle staircase") taught `read_price_and_stamp` to snap three trade-derived mark fields to the freshly-accepted external price on every successful read in hybrid-after-hours markets (`src/percolator.rs:4276-4290`):

- `hyperp_mark_e6`
- `mark_ewma_e6`
- `mark_ewma_last_slot`

Both partial-restore writeback paths silently dropped those mutations:

1. **Partial-catchup KeeperCrank writeback** through `policy::PartialCrankConfigFields` whitelist + apply helper at `src/percolator.rs:760-790` and `:5025-5052`. The whitelist had 8 fields; none of the three mark fields were present.
2. **TradeCpi zero-fill rollback's** open-coded six-field forwarding at `src/percolator.rs:8421-8428`. None of the three mark fields were forwarded either.

After either writeback, on-disk state ended up with `mark_ewma_e6` pinned at the pre-call value while `last_effective_price_e6` (whitelisted) advanced to the new external price. `compute_current_funding_rate_e9` (`src/percolator.rs:5410-5419`) reads both fields; the fabricated divergence saturated `funding_rate_e9_from_mark_index` at the engine cap `funding_max_e9_per_slot`, transferring funding from the loss-side counterparty to the favored side every accrual interval.

This was the invariant `40d9024` exists to prevent — the inline comment at `:4279-4286` names the exact attack class ("regular-hours duplicate cranks can create artificial mark/index funding divergence before after-hours fallback has actually started"). The in-memory snap was correct; the writebacks just dropped it on the way to disk.

Full root-cause analysis and reproducer in #97.

## Cause

The `40d9024` commit added the three field mutations in `read_price_and_stamp` but did not extend either of the two partial-restore writebacks to cover them. Same omission shape as `d40edb5` (the TOTO commit) which added `oracle_leg_publish_times` / `oracle_leg_prices_e6` without extending the same writebacks — fixed by PR #94 (#93's site) and PR #96 (#95's site).

This is a strict superset of those fixes: same two writeback sites, additional three fields. Each writeback site needs its own field extension; PR #94 and PR #96 do not cover this finding.

## Fix

Extend both writeback sites to forward the three mark fields from `after_read_and_sweep`:

| Symbol | Edit |
|---|---|
| `policy::PartialCrankConfigFields` (struct, `src/percolator.rs:760-769`) | Add `hyperp_mark_e6: u64`, `mark_ewma_e6: u64`, `mark_ewma_last_slot: u64` |
| `policy::partial_crank_config_fields_to_write` (whitelist, `:776-790`) | Source the three new fields from `after_read_and_sweep` |
| `processor::partial_crank_config_fields` (read helper, `:5025-5038`) | Read the three new fields from `MarketConfig` |
| `processor::apply_partial_crank_config_fields` (write helper, `:5040-5052`) | Write the three new fields back to `MarketConfig` |
| TradeCpi zero-fill rollback (open-coded, `:8421-8428`) | Add `restored.hyperp_mark_e6 = config.hyperp_mark_e6;` etc. |

Total diff: +35 lines src + 348 lines test, no deletions, no other paths touched.

## Why `after_read_and_sweep`

The snap that populates these fields runs only when `is_hybrid_after_hours_mode(config)` is true and either `advanced` or `mark_ewma_e6 != price` or `hyperp_mark_e6 != price` holds (`src/percolator.rs:4276-4290`). The post-read values are validated monotonic alignments to the external effective price, not arbitrary user input. Sourcing from `before_read` (the current behavior) actively erases that alignment.

This matches the source choice for every other oracle-state field already in the forwarded list (`oracle_target_price_e6`, `oracle_target_publish_time`, `last_oracle_publish_time`, `last_effective_price_e6`, `last_good_oracle_slot`, plus the per-leg arrays added by PR #94's analog).

## Behavioral impact

- **Hybrid-after-hours markets (`config.trade_fee_mode == TRADE_FEE_MODE_HYBRID_AFTER_HOURS`):** the snap now persists across both writebacks, restoring the documented mark/index alignment invariant. No fabricated funding divergence.
- **Non-hybrid external markets (default `trade_fee_mode == TRADE_FEE_MODE_STATIC`):** the snap doesn't fire (`is_hybrid_after_hours_mode` returns false). Mark fields stay zero across both snapshots, so carry-forward is observationally equivalent to revert. No behavior change.
- **Hyperp markets:** `read_price_and_stamp` is not invoked (the Hyperp branch in `get_engine_oracle_price_e6` is taken instead). Per-call mark fields not touched in this path. No behavior change.
- **TradeCpi real-fill (non-zero-fill):** writes the post-read `MarketConfig` in full via `state::write_config`; doesn't go through the zero-fill rollback. Unaffected.
- **ABI / serialization:** no changes to any on-chain layout. Same `MarketConfig` struct as before.
- **Compute cost:** three additional `u64` copies per partial-catchup writeback and per zero-fill writeback. Negligible.

## Verification

Four host-side tests added in commit `7281f16` (one commit before the fix in `1a04248`). They use only public crate symbols and the `bytemuck::Zeroable` constructor for `MarketConfig`; no LiteSVM, no BPF.

```sh
cargo test --release --test unit -- --nocapture bug_partial_catchup_drops_hybrid_mark_fields bug_tradecpi_zerofill_drops_hybrid_mark_fields bug_funding_rate_diverges fix_partial_catchup_carries
```

Captured output (against this PR's branch, fix applied):

```
running 4 tests
  bug-state funding rate = -1000 e9/slot (saturated negative)
  honest-state funding rate = 0 e9/slot
  divergence is FABRICATED — no real mark/index gap, just a writeback drop
  partial-catchup BUG REPRODUCED: mark_ewma_e6 reverted to \$100 (pre-call), while last_effective_price_e6 advanced to \$110
  tradecpi-zerofill BUG REPRODUCED: mark_ewma_e6 reverted to \$100 (pre-call), while last_effective_price_e6 advanced to \$95
  POST-FIX: mark_ewma_e6 = \$110 == last_effective_price_e6 = \$110, funding rate = 0 e9/slot
test bug_funding_rate_diverges_after_hybrid_mark_revert ... ok
test bug_partial_catchup_drops_hybrid_mark_fields ... ok
test bug_tradecpi_zerofill_drops_hybrid_mark_fields ... ok
test fix_partial_catchup_carries_hybrid_mark_fields_forward ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 33 filtered out; finished in 0.00s
```

Tests 1-3 reproduce the bug by explicitly simulating the OLD (pre-fix) writeback shape — they pass on this branch AND on unmodified upstream/main, demonstrating the bug structurally regardless of which `PartialCrankConfigFields` shape the tree currently has. Test 4 demonstrates the proposed fix's writeback closes the funding-rate divergence at the source.

Full unit suite still passes (`cargo test --release --test unit`): 35 passed, 0 failed, 2 ignored.

A Kani harness extension over the new fields would be a natural follow-up but is out of scope for this PR; no Kani harness exists over the TradeCpi zero-fill writeback at all (mirrored coverage gap noted in #97's "Why this wasn't caught" — same observation as PR #94's coverage of the partial-catchup site).

## Coordination with PRs #94 and #96

| PR | Closes | Adds to whitelist | Site |
|---|---|---|---|
| #94 (0x-SquidSol) | #93 | `oracle_leg_publish_times`, `oracle_leg_prices_e6` | partial-catchup |
| #96 (this submitter) | #95 | same two leg arrays | TradeCpi zero-fill |
| #98 (this PR) | #97 | `hyperp_mark_e6`, `mark_ewma_e6`, `mark_ewma_last_slot` | both sites |

The three PRs are mutually independent. Both writeback sites need both extensions (leg arrays and mark fields). Merging this PR alongside #94 and #96 leaves both sites covered for both classes of fields.