### PR TITLE
[codex] Add public-interface authority isolation tests

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8848,6 +8848,16 @@ pub mod processor {
         expect_key(secondary_mint_ai, &secondary_key)?;
         verify_mint(primary_mint_ai)?;
         verify_mint(secondary_mint_ai)?;
+        let primary_decimals = spl_token::state::Mint::unpack(&primary_mint_ai.try_borrow_data()?)
+            .map_err(|_| PercolatorError::InvalidMint)?
+            .decimals;
+        let secondary_decimals =
+            spl_token::state::Mint::unpack(&secondary_mint_ai.try_borrow_data()?)
+                .map_err(|_| PercolatorError::InvalidMint)?
+                .decimals;
+        if primary_decimals != secondary_decimals {
+            return Err(PercolatorError::InvalidMint.into());
+        }
 
         let mut data = market_ai.try_borrow_mut_data()?;
         let mut cfg = {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26670,6 +26670,138 @@ fn v16_attack_backing_fee_policy_authority_gated() {
     );
 }
 
+// full-interface sweep: fee-policy authority must follow the current asset-0 insurance authority,
+// not stale marketauth or asset-admin privilege. This is a real role-boundary test: the old
+// marketauth remains live for market-wide admin policy, but cannot mutate the insurance-authority-
+// gated backing/trade fee policies after asset-0 insurance is rotated.
+#[test]
+fn v16_attack_asset0_insurance_rotation_rekeys_fee_policy_authority() {
+    let mut env = V16CuEnv::new();
+    let old_marketauth = env.admin.insecure_clone();
+    let new_insurance = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &old_marketauth,
+        Some(&new_insurance),
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+        new_insurance.pubkey().to_bytes(),
+    )
+    .expect("asset-0 admin rotates asset-0 insurance authority");
+
+    let cfg_before = env.market_state().0;
+    let profile0 =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+            .unwrap();
+    assert_eq!(
+        profile0.insurance_authority,
+        new_insurance.pubkey().to_bytes(),
+        "test precondition: asset-0 insurance authority is rotated away from marketauth"
+    );
+
+    env.svm.expire_blockhash();
+    let market_admin_still_live = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps: 123 },
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        market_admin_still_live.is_ok(),
+        "old marketauth remains a valid market-admin role after asset-0 insurance rotation"
+    );
+
+    let stale_backing = env.send(
+        ProgInstruction::UpdateBackingFeePolicy {
+            domain: 0,
+            fee_bps: 77,
+            insurance_share_bps: 5_000,
+        },
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        stale_backing.is_err(),
+        "stale marketauth must not retain asset-0 backing-fee authority"
+    );
+    let stale_trade = env.send(
+        ProgInstruction::UpdateTradeFeePolicy {
+            trade_fee_base_bps: 88,
+        },
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        stale_trade.is_err(),
+        "stale marketauth must not retain asset-0 trade-fee authority"
+    );
+
+    let cfg_after_rejects = env.market_state().0;
+    assert_eq!(
+        cfg_after_rejects.backing_trade_fee_bps_long,
+        cfg_before.backing_trade_fee_bps_long,
+        "rejected stale backing-fee update leaves the fee unchanged"
+    );
+    assert_eq!(
+        cfg_after_rejects.trade_fee_base_bps,
+        cfg_before.trade_fee_base_bps,
+        "rejected stale trade-fee update leaves the fee unchanged"
+    );
+
+    env.svm.expire_blockhash();
+    let backing_ok = env.send(
+        ProgInstruction::UpdateBackingFeePolicy {
+            domain: 0,
+            fee_bps: 77,
+            insurance_share_bps: 5_000,
+        },
+        vec![
+            AccountMeta::new(new_insurance.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&new_insurance],
+    );
+    assert!(
+        backing_ok.is_ok(),
+        "current asset-0 insurance authority can update backing-fee policy: {backing_ok:?}"
+    );
+    env.svm.expire_blockhash();
+    let trade_ok = env.send(
+        ProgInstruction::UpdateTradeFeePolicy {
+            trade_fee_base_bps: 88,
+        },
+        vec![
+            AccountMeta::new(new_insurance.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&new_insurance],
+    );
+    assert!(
+        trade_ok.is_ok(),
+        "current asset-0 insurance authority can update trade-fee policy: {trade_ok:?}"
+    );
+
+    let cfg_after = env.market_state().0;
+    assert_eq!(cfg_after.backing_trade_fee_bps_long, 77);
+    assert_eq!(cfg_after.backing_trade_fee_insurance_share_bps_long, 5_000);
+    assert_eq!(cfg_after.trade_fee_base_bps, 88);
+    assert_eq!(
+        cfg_after.fee_redirect_to_market_0_bps, 123,
+        "market-admin policy update and insurance-authority fee updates affect distinct fields"
+    );
+}
+
 // security.md sweep - permissionless asset authority isolation (#6/#33): the creator of asset N owns
 // that asset's local domain authorities, but must not be able to mutate market-wide knobs or market 0
 // policies. Discriminating control: the same creator CAN update asset N's own backing-fee domain.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20487,6 +20487,139 @@ fn v16_attack_update_authority_handoff_revokes_old_marketauth_admin_paths() {
     );
 }
 
+// full-interface sweep: the market-wide handoff also owns base-unit reserve swaps. A stale former
+// marketauth must not keep a value-moving `SwapSecondaryForPrimary` path after rotation, or it could
+// drain the secondary reserve by providing primary collateral under its own control.
+#[test]
+fn v16_attack_update_authority_handoff_rekeys_secondary_swap_authority() {
+    let mut env = V16CuEnv::new();
+    let old_marketauth = env.admin.insecure_clone();
+    let new_marketauth = Keypair::new();
+    env.ensure_signer_account(new_marketauth.pubkey());
+
+    let secondary_mint = env.create_mint();
+    env.update_base_unit_mints_with_cu(env.mint, secondary_mint);
+    let secondary_vault = canonical_vault_ata(env.vault_authority, secondary_mint);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary_mint, env.vault_authority, 40),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let stale_primary_source =
+        env.token_account_for_mint(env.mint, old_marketauth.pubkey(), 20);
+    let stale_secondary_dest =
+        env.token_account_for_mint(secondary_mint, old_marketauth.pubkey(), 0);
+    let fresh_primary_source =
+        env.token_account_for_mint(env.mint, new_marketauth.pubkey(), 20);
+    let fresh_secondary_dest =
+        env.token_account_for_mint(secondary_mint, new_marketauth.pubkey(), 0);
+
+    env.update_asset_authority_with_cu(&new_marketauth);
+    assert_eq!(
+        env.market_state().0.marketauth,
+        new_marketauth.pubkey().to_bytes(),
+        "market authority rotated to the new signer"
+    );
+
+    let market_before_stale = env.svm.get_account(&env.market).unwrap().data;
+    let primary_vault_before = env.token_amount(env.vault);
+    let secondary_vault_before = env.token_amount(secondary_vault);
+    env.svm.expire_blockhash();
+    let stale_swap = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::SwapSecondaryForPrimary { amount: 20 },
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(stale_primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(stale_secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        stale_swap.is_err(),
+        "stale marketauth must not retain the value-moving secondary-swap path"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap().data,
+        market_before_stale,
+        "rejected stale swap does not rewrite market config"
+    );
+    assert_eq!(
+        env.token_amount(stale_primary_source),
+        20,
+        "stale signer primary source is not debited"
+    );
+    assert_eq!(
+        env.token_amount(stale_secondary_dest),
+        0,
+        "stale signer receives no secondary collateral"
+    );
+    assert_eq!(
+        env.token_amount(env.vault),
+        primary_vault_before,
+        "primary vault unchanged after stale swap"
+    );
+    assert_eq!(
+        env.token_amount(secondary_vault),
+        secondary_vault_before,
+        "secondary reserve unchanged after stale swap"
+    );
+
+    env.svm.expire_blockhash();
+    let fresh_swap = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::SwapSecondaryForPrimary { amount: 20 },
+        vec![
+            AccountMeta::new(new_marketauth.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(fresh_primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(fresh_secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&new_marketauth],
+    );
+    assert!(
+        fresh_swap.is_ok(),
+        "new marketauth can execute the value-moving secondary swap after handoff: {fresh_swap:?}"
+    );
+    assert_eq!(env.token_amount(fresh_primary_source), 0);
+    assert_eq!(
+        env.token_amount(env.vault),
+        primary_vault_before + 20,
+        "new authority's primary collateral lands in the primary vault"
+    );
+    assert_eq!(
+        env.token_amount(fresh_secondary_dest),
+        20,
+        "new authority receives secondary collateral"
+    );
+    assert_eq!(
+        env.token_amount(secondary_vault),
+        secondary_vault_before - 20,
+        "secondary reserve debited exactly once"
+    );
+}
+
 // regression (security.md sweep): round-trip recovery under the junior-pnl model. A price round-trip
 // (100->110->100) leaves the drawdown-first trader's recovery as JUNIOR pnl (realized losses are
 // senior/immediate, recoveries park as junior pnl that is not liquid in Live mode). Value is fully

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9639,6 +9639,137 @@ fn v16_bpf_failed_terminal_insurance_withdraw_rolls_back_market_and_ledger() {
     assert_eq!(env.token_amount(dest), 0);
 }
 
+// security.md sweep - terminal insurance vault custody (#33/#44/#48): terminal WithdrawInsurance
+// debits resolved insurance and the optional ledger before validating token custody. A canonical vault
+// that carries a delegate is still unsafe; rejection must roll back market and ledger accounting.
+#[test]
+fn v16_attack_terminal_insurance_withdraw_rejects_delegated_vault_without_debiting_budget() {
+    let mut env = V16CuEnv::new();
+    env.top_up_insurance(100);
+    env.resolve();
+    let ledger = env.insurance_ledger_account();
+    let dest = env.token_account(env.admin.pubkey(), 0);
+
+    let mut delegated_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 100,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 100,
+            close_authority: COption::None,
+        },
+        &mut delegated_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let ledger_before = env.svm.get_account(&ledger).unwrap();
+    let dest_before = env.svm.get_account(&dest).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawInsurance { amount: 40 },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
+        ],
+        &[&env.admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "terminal WithdrawInsurance must reject a delegated canonical vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "delegated-vault terminal insurance withdraw must not debit market budgets"
+    );
+    assert_eq!(
+        env.svm.get_account(&ledger).unwrap(),
+        ledger_before,
+        "delegated-vault terminal insurance withdraw must not rewrite the ledger"
+    );
+    assert_eq!(
+        env.svm.get_account(&dest).unwrap(),
+        dest_before,
+        "destination receives nothing through the delegated vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "delegated vault remains byte-identical"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(group.insurance, 100);
+    assert_eq!(group.vault, 100);
+
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 100),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let ok = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawInsurance { amount: 40 },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
+        ],
+        &[&env.admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "terminal WithdrawInsurance succeeds once the vault is restored clean: {ok:?}"
+    );
+    assert_eq!(env.token_amount(dest), 40);
+    let (_, group) = env.market_state();
+    assert_eq!(group.insurance, 60);
+    assert_eq!(group.vault, 60);
+    let ledger_state =
+        state::read_insurance_ledger(&env.svm.get_account(&ledger).unwrap().data).unwrap();
+    assert_eq!(ledger_state.total_withdrawn_atoms, 40);
+    assert_eq!(ledger_state.last_observed_insurance_atoms, 60);
+}
+
 #[test]
 fn v16_bpf_failed_backing_withdraw_transfer_rolls_back_bucket_and_ledger() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38934,3 +38934,142 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
         "control push moved the EWMA mark"
     );
 }
+
+// Per-asset oracle-authority isolation for oracle reconfiguration entrypoints. A valid asset-1
+// oracle_authority must not be able to reset asset 0's oracle mode/anchor, which would let it steer
+// asset-0 marks before liquidations or settlement.
+#[test]
+fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_oracle() {
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100); // asset 0 oracle_authority = admin
+
+    let a1 = Keypair::new();
+    env.ensure_signer_account(a1.pubkey());
+    env.activate_asset_with_authorities(
+        1,
+        1,
+        100,
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+    );
+
+    // Non-vacuous control: a1 really is accepted for asset 1 oracle reconfiguration.
+    env.svm.expire_blockhash();
+    let own_asset = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 1,
+            now_slot: 1,
+            initial_mark_e6: 125,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        own_asset.is_ok(),
+        "asset-1's own oracle_authority configures asset-1 auth mark: {own_asset:?}"
+    );
+
+    let (cfg_before, group_before) = env.market_state();
+    assert_eq!(
+        cfg_before.oracle_mode,
+        percolator_prog::constants::ORACLE_MODE_AUTH_MARK,
+        "asset-0 starts on auth-mark mode"
+    );
+    assert_eq!(cfg_before.oracle_target_price_e6, 100);
+
+    // ATTACK 1: the valid asset-1 oracle_authority tries to re-anchor asset 0 as EWMA.
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    let ewma_attack = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: 0,
+            now_slot: 2,
+            initial_mark_e6: 9_000,
+            mark_ewma_halflife_slots: 10,
+            mark_min_fee: 0,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        ewma_attack.is_err(),
+        "asset-1 oracle_authority must not configure asset-0 EWMA"
+    );
+    assert_eq!(
+        env.market_state().0.oracle_mode,
+        cfg_before.oracle_mode,
+        "failed EWMA reconfiguration leaves asset-0 mode unchanged"
+    );
+    assert_eq!(
+        env.market_state().0.oracle_target_price_e6,
+        cfg_before.oracle_target_price_e6,
+        "failed EWMA reconfiguration leaves asset-0 target unchanged"
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        group_before.assets[0].effective_price,
+        "failed EWMA reconfiguration leaves asset-0 engine mark unchanged"
+    );
+
+    // ATTACK 2: the same cross-asset authority tries the auth-mark reconfiguration path too.
+    env.svm.expire_blockhash();
+    let auth_attack = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            initial_mark_e6: 8_000,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        auth_attack.is_err(),
+        "asset-1 oracle_authority must not configure asset-0 auth mark"
+    );
+    assert_eq!(
+        env.market_state().0.oracle_target_price_e6,
+        cfg_before.oracle_target_price_e6,
+        "failed auth reconfiguration leaves asset-0 target unchanged"
+    );
+
+    // CONTROL: asset 0's own authority can still reconfigure asset 0.
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    let ok = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            initial_mark_e6: 150,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(ok.is_ok(), "asset-0 authority reconfigures asset-0: {ok:?}");
+    assert_eq!(env.market_state().0.oracle_target_price_e6, 150);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21639,6 +21639,113 @@ fn v16_attack_live_asset_insurance_withdraw_uses_operator_not_authority() {
     );
 }
 
+// full-interface sweep: live asset-0 insurance withdrawal must follow the current hot
+// insurance_operator, not stale marketauth/asset-admin privilege. This is value-moving: after the
+// operator is rekeyed, the old market authority must not drain the funded asset-0 insurance domain.
+#[test]
+fn v16_attack_asset0_operator_rotation_rekeys_live_insurance_withdraw() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let new_operator = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&new_operator),
+        0,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+        new_operator.pubkey().to_bytes(),
+    )
+    .expect("asset-0 admin rotates the live insurance operator");
+    env.top_up_insurance_domain_with_authority(&admin, 0, 500);
+
+    let (_, group_before) = env.market_state();
+    assert_eq!(
+        group_before.insurance_domain_budget[0], 500,
+        "funded asset-0 insurance domain makes the stale-operator attempt non-vacuous"
+    );
+    let stale_dest = env.token_account(admin.pubkey(), 0);
+    let stale_dest_before = env.svm.get_account(&stale_dest).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+
+    env.svm.expire_blockhash();
+    let stale_admin = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            amount: 100,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(stale_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        stale_admin.is_err(),
+        "stale marketauth/asset-admin must not retain live asset-0 insurance-operator power"
+    );
+    assert_eq!(
+        env.svm.get_account(&stale_dest).unwrap(),
+        stale_dest_before,
+        "stale operator attempt pays no tokens"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "stale operator attempt does not debit the vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "stale operator attempt leaves market state unchanged"
+    );
+
+    let operator_dest = env.token_account(new_operator.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let operator_withdraw = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            amount: 100,
+        },
+        vec![
+            AccountMeta::new(new_operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(operator_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&new_operator],
+    );
+    assert!(
+        operator_withdraw.is_ok(),
+        "current asset-0 insurance_operator can withdraw live insurance: {operator_withdraw:?}"
+    );
+    assert_eq!(
+        env.token_amount(operator_dest),
+        100,
+        "current operator receives the withdrawal"
+    );
+    let (_, group_after) = env.market_state();
+    assert_eq!(group_after.insurance_domain_budget[0], 400);
+    assert_eq!(group_after.insurance, group_before.insurance - 100);
+    assert_eq!(
+        env.token_amount(env.vault),
+        group_after.vault as u64,
+        "engine vault accounting matches SPL vault after rekeyed-operator withdrawal"
+    );
+}
+
 // security.md sweep — RebalanceReduce owner gating (#6/#46): RebalanceReduce is OWNER-gated
 // self-service risk reduction (with_one_portfolio_view enforces owner signs + matches the portfolio).
 // A non-owner must NOT be able to force-reduce a victim's position (griefing); the owner may reduce

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20359,6 +20359,134 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
     );
 }
 
+// full-interface sweep: UpdateAuthority is a market-wide handoff, not just a config write. Once the
+// marketauth rotates, the old key must lose downstream admin power everywhere, especially policy
+// mutation and ResolveMarket. A stale resolve is a real DoS/LoF vector because it can freeze a live,
+// funded market while users still hold withdrawable capital.
+#[test]
+fn v16_attack_update_authority_handoff_revokes_old_marketauth_admin_paths() {
+    let mut env = V16CuEnv::new();
+    let old_marketauth = env.admin.insecure_clone();
+    let new_marketauth = Keypair::new();
+    env.ensure_signer_account(new_marketauth.pubkey());
+
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    env.deposit(&owner, portfolio, 1_000_000);
+    assert_eq!(
+        env.market_state().1.mode,
+        percolator::MarketModeV16::Live,
+        "precondition: funded market is live"
+    );
+
+    env.update_asset_authority_with_cu(&new_marketauth);
+    assert_eq!(
+        env.market_state().0.marketauth,
+        new_marketauth.pubkey().to_bytes(),
+        "market authority rotated to the new signer"
+    );
+
+    let market_before_stale = env.svm.get_account(&env.market).unwrap().data;
+    let vault_before_stale = env.svm.get_account(&env.vault).unwrap().data;
+
+    env.svm.expire_blockhash();
+    let stale_policy = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps: 777 },
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        stale_policy.is_err(),
+        "old marketauth must not retain fee-policy mutation power after handoff"
+    );
+
+    env.svm.expire_blockhash();
+    let stale_resolve = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ResolveMarket,
+        vec![
+            AccountMeta::new(old_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&old_marketauth],
+    );
+    assert!(
+        stale_resolve.is_err(),
+        "old marketauth must not retain ResolveMarket DoS power after handoff"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap().data,
+        market_before_stale,
+        "stale admin attempts leave market state byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap().data,
+        vault_before_stale,
+        "stale admin attempts do not touch real custody"
+    );
+
+    // Non-vacuous liveness check: the stale key did not resolve/freeze the market; the owner can
+    // still withdraw capital before the new marketauth intentionally exercises the admin path.
+    let (owner_dest, _) = env.withdraw_with_cu(&owner, portfolio, 250_000);
+    assert_eq!(
+        env.token_amount(owner_dest),
+        250_000,
+        "funded market remains live and withdrawable after stale-admin attempts"
+    );
+
+    env.svm.expire_blockhash();
+    let new_policy = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps: 777 },
+        vec![
+            AccountMeta::new(new_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&new_marketauth],
+    );
+    assert!(
+        new_policy.is_ok(),
+        "new marketauth can mutate market-wide policy after handoff: {new_policy:?}"
+    );
+    assert_eq!(
+        env.market_state().0.fee_redirect_to_market_0_bps,
+        777,
+        "new authority owns the market-wide policy path"
+    );
+
+    env.svm.expire_blockhash();
+    let new_resolve = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ResolveMarket,
+        vec![
+            AccountMeta::new(new_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&new_marketauth],
+    );
+    assert!(
+        new_resolve.is_ok(),
+        "new marketauth can intentionally resolve the market after handoff: {new_resolve:?}"
+    );
+    assert_eq!(
+        env.market_state().1.mode,
+        percolator::MarketModeV16::Resolved,
+        "resolve authority moved to the new signer"
+    );
+}
+
 // regression (security.md sweep): round-trip recovery under the junior-pnl model. A price round-trip
 // (100->110->100) leaves the drawdown-first trader's recovery as JUNIOR pnl (realized losses are
 // senior/immediate, recoveries park as junior pnl that is not liquid in Live mode). Value is fully

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -31858,6 +31858,143 @@ fn v16_attack_liquidation_cranker_reward_cannot_alias_liquidated_account() {
     );
 }
 
+// security.md sweep - liquidation cranker reward owner isolation (#3/#44): the optional reward
+// portfolio is a public tail account. A caller must not be able to mutate another same-market
+// portfolio by naming it as the cranker reward target without that portfolio owner's signature.
+// Rejection must roll back the liquidated account, reward portfolio, and market; the rightful
+// reward owner remains the positive control.
+#[test]
+fn v16_attack_liquidation_cranker_reward_requires_reward_owner_signature() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.update_liquidation_fee_policy_with_cu(5_000);
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+    let lo = Keypair::new();
+    let l = env.create_portfolio(&lo);
+    let so = Keypair::new();
+    let s = env.create_portfolio(&so);
+    let co = Keypair::new();
+    let c = env.create_portfolio(&co);
+    let mallory = Keypair::new();
+    env.ensure_signer_account(mallory.pubkey());
+    env.deposit(&lo, l, 100_000_000);
+    env.deposit(&so, s, 100_000);
+    env.deposit(&co, c, 1_000);
+    env.trade_asset_with_cu(0, &lo, l, &so, s, POS_SCALE as i128, 1_000_000, 0);
+    for slot in 1..=30u64 {
+        env.svm.warp_to_slot(slot);
+        let _ = env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                action: 0,
+                asset_index: 0,
+                now_slot: slot,
+                funding_rate_e9: 0,
+                close_q: 0,
+                fee_bps: 0,
+                recovery_reason: 0,
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(s, false),
+            ],
+            &[],
+        );
+    }
+    assert!(
+        env.portfolio_state(s).health_cert.certified_liq_deficit != 0,
+        "short is liquidatable before the unauthorized reward-owner attempt"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let short_before = env.svm.get_account(&s).unwrap();
+    let cranker_before = env.svm.get_account(&c).unwrap();
+    let cranker_cap_before = env.portfolio_state(c).capital;
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 30,
+            funding_rate_e9: 0,
+            close_q: POS_SCALE,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(mallory.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(s, false),
+            AccountMeta::new(c, false),
+        ],
+        &[&mallory],
+    );
+    assert!(
+        rejected.is_err(),
+        "cranker reward portfolio must require its own owner signer"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "wrong-owner reward rejection leaves market byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&s).unwrap(),
+        short_before,
+        "wrong-owner reward rejection leaves liquidated account byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&c).unwrap(),
+        cranker_before,
+        "wrong-owner reward rejection leaves reward portfolio byte-identical"
+    );
+    assert_eq!(
+        env.portfolio_state(c).capital,
+        cranker_cap_before,
+        "no unsolicited reward credit lands in another user's portfolio"
+    );
+
+    env.svm.expire_blockhash();
+    let accepted = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 30,
+            funding_rate_e9: 0,
+            close_q: POS_SCALE,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(co.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(s, false),
+            AccountMeta::new(c, false),
+        ],
+        &[&co],
+    );
+    assert!(
+        accepted.is_ok(),
+        "reward-owner-signed liquidation succeeds: {:?}",
+        accepted
+    );
+    assert!(
+        env.portfolio_state(c).capital > cranker_cap_before,
+        "positive control: rightful reward owner receives a real cranker reward"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(
+        group.vault as u64,
+        env.token_amount(env.vault),
+        "accounting == real vault"
+    );
+    assert!(
+        group.vault >= group.c_tot + group.insurance,
+        "senior conservation"
+    );
+}
+
 // security.md sweep — liquidation cranker reward market binding (#3/#44): when cranker rewards are
 // enabled, the reward portfolio must belong to the same market as the liquidated account. A foreign
 // market portfolio can otherwise try to receive value from this market's insurance while validating under

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34617,6 +34617,154 @@ fn v16_attack_chainlink_oracle_key_owner_binding_enforced() {
 }
 
 #[test]
+fn v16_attack_non_pyth_oracle_freshness_and_confidence_enforced() {
+    type OracleAttempt = (bool, Option<String>, bool, u64);
+
+    let configure_switchboard =
+        |publish_time: i64, std_dev_e6: u64, conf_filter_bps: u16| -> OracleAttempt {
+            let mut env = V16CuEnv::new();
+            set_test_clock(&mut env, 1, 1000);
+            let feed = Pubkey::new_unique();
+            env.svm
+                .set_account(
+                    feed,
+                    Account {
+                        lamports: 1_000_000_000,
+                        data: make_switchboard_data(200_000, std_dev_e6, publish_time),
+                        owner: oracle_v16::SWITCHBOARD_ON_DEMAND_MAINNET_PROGRAM_ID,
+                        executable: false,
+                        rent_epoch: 0,
+                    },
+                )
+                .unwrap();
+            let before = env.svm.get_account(&env.market).unwrap().data;
+            let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+                0,
+                1,
+                0,
+                [feed.to_bytes(), [0u8; 32], [0u8; 32]],
+                &[feed],
+                1,
+                1000,
+                0,
+                0,
+                100,
+                conf_filter_bps,
+            );
+            let ok = r.is_ok();
+            let price = if ok {
+                env.market_state().1.assets[0].raw_oracle_target_price
+            } else {
+                0
+            };
+            let after = env.svm.get_account(&env.market).unwrap().data;
+            (ok, r.err(), before == after, price)
+        };
+
+    let (fresh_ok, _, _, fresh_price) = configure_switchboard(940, 1_000, 200);
+    assert!(
+        fresh_ok,
+        "a fresh Switchboard feed with tight std-dev configures"
+    );
+    assert_eq!(
+        fresh_price, 200_000,
+        "fresh Switchboard feed configures the expected e6 mark"
+    );
+
+    let (stale_ok, stale_err, stale_unchanged, _) = configure_switchboard(939, 0, 200);
+    assert!(
+        !stale_ok,
+        "a Switchboard feed one second past max staleness must reject"
+    );
+    let err = stale_err.unwrap();
+    assert!(
+        err.contains("Custom(27)"),
+        "stale Switchboard feed should reject as OracleStale (Custom 27), got: {err}"
+    );
+    assert!(
+        stale_unchanged,
+        "rejected stale Switchboard feed must not mutate the market"
+    );
+
+    let (wide_ok, wide_err, wide_unchanged, _) = configure_switchboard(940, 100_000, 200);
+    assert!(
+        !wide_ok,
+        "a Switchboard feed with std-dev wider than the configured confidence filter must reject"
+    );
+    let err = wide_err.unwrap();
+    assert!(
+        err.contains("Custom(28)"),
+        "wide-confidence Switchboard feed should reject as OracleConfTooWide (Custom 28), got: {err}"
+    );
+    assert!(
+        wide_unchanged,
+        "rejected wide-confidence Switchboard feed must not mutate the market"
+    );
+
+    let configure_chainlink = |publish_time: u32| -> OracleAttempt {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 1000);
+        let feed = Pubkey::new_unique();
+        env.svm
+            .set_account(
+                feed,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: make_chainlink_data(20_000_000, 8, publish_time),
+                    owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let before = env.svm.get_account(&env.market).unwrap().data;
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed.to_bytes(), [0u8; 32], [0u8; 32]],
+            &[feed],
+            1,
+            1000,
+            0,
+            0,
+            100,
+            200,
+        );
+        let ok = r.is_ok();
+        let price = if ok {
+            env.market_state().1.assets[0].raw_oracle_target_price
+        } else {
+            0
+        };
+        let after = env.svm.get_account(&env.market).unwrap().data;
+        (ok, r.err(), before == after, price)
+    };
+
+    let (fresh_ok, _, _, fresh_price) = configure_chainlink(940);
+    assert!(fresh_ok, "a fresh Chainlink feed configures");
+    assert_eq!(
+        fresh_price, 200_000,
+        "fresh Chainlink feed configures the expected e6 mark"
+    );
+
+    let (stale_ok, stale_err, stale_unchanged, _) = configure_chainlink(939);
+    assert!(
+        !stale_ok,
+        "a Chainlink feed one second past max staleness must reject"
+    );
+    let err = stale_err.unwrap();
+    assert!(
+        err.contains("Custom(27)"),
+        "stale Chainlink feed should reject as OracleStale (Custom 27), got: {err}"
+    );
+    assert!(
+        stale_unchanged,
+        "rejected stale Chainlink feed must not mutate the market"
+    );
+}
+
+#[test]
 fn v16_attack_crank_oracle_feed_id_mismatch_rejects_without_mutation() {
     let mut env = V16CuEnv::new();
     set_test_clock(&mut env, 1, 100);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12306,6 +12306,158 @@ fn v16_attack_resolved_payout_topup_bad_dest_does_not_burn_receipt() {
     assert_eq!(env.market_state().1.vault, 0);
 }
 
+// security.md sweep - resolved top-up vault custody (#33/#44/#48): ClaimResolvedPayoutTopup is
+// unsigned and updates the pending receipt before validating the vault token account. A delegated
+// canonical vault must reject atomically, without burning the remaining receipt or moving custody.
+#[test]
+fn v16_attack_claim_resolved_topup_rejects_delegated_vault_without_burning_receipt() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    {
+        let mut market_account = env.svm.get_account(&env.market).expect("market account");
+        let mut portfolio_account = env.svm.get_account(&portfolio).expect("portfolio account");
+        let (cfg, mut group) = state::read_market(&market_account.data).unwrap();
+        let mut account = state::read_portfolio(&portfolio_account.data).unwrap();
+        group.mode = MarketModeV16::Resolved;
+        group.resolved_slot = 1;
+        group.current_slot = 1;
+        group.vault = 60;
+        group.payout_snapshot_captured = true;
+        group.payout_snapshot = 100;
+        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
+            snapshot_residual: 100,
+            terminal_claim_exact_receipts_num: 100 * BOUND_SCALE,
+            terminal_claim_bound_unreceipted_num: 0,
+            current_payout_rate_num: 100 * BOUND_SCALE,
+            current_payout_rate_den: 100 * BOUND_SCALE,
+            snapshot_slot: 1,
+            payout_halted: false,
+            finalized: false,
+        };
+        account.resolved_payout_receipt = ResolvedPayoutReceiptV16 {
+            present: true,
+            prior_bound_contribution_num: 100 * BOUND_SCALE,
+            live_released_face_at_receipt: 0,
+            terminal_positive_claim_face: 100,
+            paid_effective: 40,
+            finalized: false,
+        };
+        state::write_market(&mut market_account.data, &cfg, &group).unwrap();
+        state::write_portfolio(&mut portfolio_account.data, &account).unwrap();
+        env.svm.set_account(env.market, market_account).unwrap();
+        env.svm.set_account(portfolio, portfolio_account).unwrap();
+    }
+
+    let mut delegated_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 60,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 60,
+            close_authority: COption::None,
+        },
+        &mut delegated_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let dest = env.token_account_for_mint(env.mint, owner.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::ClaimResolvedPayoutTopup,
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "ClaimResolvedPayoutTopup must reject a delegated canonical vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected delegated-vault top-up must not mutate market payout accounting"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before,
+        "rejected delegated-vault top-up must not burn the pending receipt"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "delegated vault remains untouched"
+    );
+    assert_eq!(
+        env.svm.get_account(&dest).unwrap(),
+        dest_before,
+        "destination receives nothing on rejected delegated-vault top-up"
+    );
+    let account = env.portfolio_state(portfolio);
+    assert_eq!(account.resolved_payout_receipt.paid_effective, 40);
+    assert!(
+        !account.resolved_payout_receipt.finalized,
+        "receipt remains claimable after delegated-vault rejection"
+    );
+
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 60),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let cu = env.claim_resolved_payout_topup_with_cu(owner.pubkey(), portfolio, dest);
+    assert_cu_within(
+        "ClaimResolvedPayoutTopup delegated-vault rollback",
+        cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.token_amount(dest),
+        60,
+        "same top-up succeeds after the vault is restored clean"
+    );
+    let account = env.portfolio_state(portfolio);
+    assert_eq!(account.resolved_payout_receipt.paid_effective, 100);
+    assert!(account.resolved_payout_receipt.finalized);
+    assert_eq!(env.market_state().1.vault, 0);
+}
+
 // regression (security.md sweep): MTM settlement under a price move (§6.1 loss->capital,
 // §6.2 profit->pnl warmup). After full winner->loser->winner cranking, total equity is
 // conserved, the winner's +PnL is backed by the loser's realized-loss residual, and senior

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -32453,6 +32453,133 @@ fn v16_attack_liquidation_cranker_reward_requires_reward_owner_signature() {
     );
 }
 
+// full-interface sweep: a liquidation crank can carry both a hybrid-oracle tail and an optional
+// program-owned cranker reward tail. A malformed reward tail must not let the valid oracle update
+// partially persist before the later reward-account validation fails.
+#[test]
+fn v16_attack_hybrid_liquidation_bad_reward_tail_rolls_back_oracle_update() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.update_liquidation_fee_policy_with_cu(5_000);
+    set_test_clock(&mut env, 1, 100);
+    let feed = [0xa9u8; 32];
+    let initial_oracle = env.set_pyth_price_with_conf(&feed, 1_000_000, -6, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[initial_oracle],
+        1,
+        100,
+        0,
+        0,
+        10,
+        0,
+    )
+    .expect("configure hybrid oracle");
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 100_000_000);
+    env.deposit(&short_owner, short, 100_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+
+    set_test_clock(&mut env, 2, 101);
+    let fresh_oracle = env.set_pyth_price_with_conf(&feed, 2_000_000, -6, 0, 101);
+    let malformed_reward = env.program_account(env.portfolio_account_len);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let short_before = env.svm.get_account(&short).unwrap();
+    let malformed_before = env.svm.get_account(&malformed_reward).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 2,
+            funding_rate_e9: 0,
+            close_q: POS_SCALE,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short, false),
+            AccountMeta::new_readonly(fresh_oracle, false),
+            AccountMeta::new(malformed_reward, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "malformed program-owned reward tail must reject even with a valid hybrid oracle tail"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected mixed-tail crank must not persist the fresh oracle target or liquidation state"
+    );
+    assert_eq!(
+        env.svm.get_account(&short).unwrap(),
+        short_before,
+        "rejected mixed-tail crank must not mutate the liquidated portfolio"
+    );
+    assert_eq!(
+        env.svm.get_account(&malformed_reward).unwrap(),
+        malformed_before,
+        "rejected mixed-tail crank must not mutate the malformed reward account"
+    );
+
+    let payer_owner = env.payer.insecure_clone();
+    let valid_reward = env.create_portfolio(&payer_owner);
+    let reward_cap_before = env.portfolio_state(valid_reward).capital;
+    env.svm.expire_blockhash();
+    let accepted = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 2,
+            funding_rate_e9: 0,
+            close_q: POS_SCALE,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(payer_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short, false),
+            AccountMeta::new_readonly(fresh_oracle, false),
+            AccountMeta::new(valid_reward, false),
+        ],
+        &[&payer_owner],
+    );
+    assert!(
+        accepted.is_ok(),
+        "same hybrid liquidation succeeds with a valid reward portfolio: {accepted:?}"
+    );
+    assert!(
+        env.portfolio_state(valid_reward).capital > reward_cap_before,
+        "valid reward portfolio receives the cranker reward"
+    );
+    let (cfg, group) = env.market_state();
+    assert_eq!(
+        cfg.last_good_oracle_slot, 2,
+        "valid control persists the fresh hybrid oracle update"
+    );
+    assert_eq!(group.assets[0].raw_oracle_target_price, 2_000_000);
+}
+
 // security.md sweep — liquidation cranker reward market binding (#3/#44): when cranker rewards are
 // enabled, the reward portfolio must belong to the same market as the liquidated account. A foreign
 // market portfolio can otherwise try to receive value from this market's insurance while validating under

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34563,6 +34563,61 @@ fn v16_attack_oracle_negative_or_zero_price_rejected() {
     );
 }
 
+#[test]
+fn v16_attack_oracle_pyth_exponent_bounds_enforced() {
+    let configure = |price: i64, expo: i32| -> (bool, Option<String>, bool, u64) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let feed = [0x55u8; 32];
+        let acct = env.set_pyth_price_with_conf(&feed, price, expo, 0, 100);
+        let before = env.svm.get_account(&env.market).unwrap().data;
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[acct],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        let ok = r.is_ok();
+        let price_after = if ok {
+            env.market_state().1.assets[0].raw_oracle_target_price
+        } else {
+            0
+        };
+        let after = env.svm.get_account(&env.market).unwrap().data;
+        (ok, r.err(), before == after, price_after)
+    };
+
+    let (ok, _, _, price_after) = configure(200_000, -6);
+    assert!(ok, "control: a normal Pyth exponent configures");
+    assert_eq!(price_after, 200_000, "control: expo -6 scales to e6");
+
+    for (label, price, expo) in [
+        ("positive exponent above bound", 200_000, 19),
+        ("negative exponent below bound", 200_000, -19),
+        ("max exponent overshoots price bound", 1_000_000, 18),
+        ("min exponent floors to zero", 200_000, -18),
+    ] {
+        let (ok, err, unchanged, _) = configure(price, expo);
+        assert!(!ok, "{label}: Pyth exponent edge must reject");
+        let err = err.unwrap();
+        assert!(
+            err.contains("Custom(26)"),
+            "{label}: exponent edge should reject as OracleInvalid (Custom 26), got {err}"
+        );
+        assert!(
+            unchanged,
+            "{label}: rejected exponent edge must leave market bytes unchanged"
+        );
+    }
+}
+
 // security.md sweep — oracle feed account owner validation (#37/#44): a Pyth feed account must be owned
 // by the Pyth receiver program. Attacker goal: substitute a self-owned account holding crafted "Pyth"
 // data to inject an arbitrary oracle price (full oracle spoof). Protection: the wrapper rejects a feed

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33632,6 +33632,117 @@ fn v16_attack_deposit_wrong_mint_source_rejects() {
     );
 }
 
+// security.md sweep — deposit rejects a vault with a delegate (#44 defense-in-depth): inbound custody
+// must use the same hardened vault checks as withdraw. Otherwise a user deposit could be credited into a
+// canonical vault token account that a delegate can drain out-of-band. The rejected deposit must not pull
+// source tokens or credit portfolio capital; a clean vault control then succeeds.
+#[test]
+fn v16_attack_deposit_vault_with_delegate_rejected() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    let source = env.token_account_for_mint(env.mint, owner.pubkey(), 1_000);
+    let (_, group_before) = env.market_state();
+    let cap_before = env.portfolio_state(portfolio).capital;
+
+    let attacker = Pubkey::new_unique();
+    let mut delegated = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: env.token_amount(env.vault),
+            delegate: COption::Some(attacker),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 1_000,
+            close_authority: COption::None,
+        },
+        &mut delegated,
+    )
+    .unwrap();
+    let mut tainted_vault = env.svm.get_account(&env.vault).unwrap();
+    tainted_vault.data = delegated;
+    env.svm.set_account(env.vault, tainted_vault).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::Deposit { amount: 500 },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        rejected.is_err(),
+        "deposit through a delegated vault must reject before crediting capital"
+    );
+    assert_eq!(
+        env.token_amount(source),
+        1_000,
+        "rejected delegated-vault deposit does not pull source tokens"
+    );
+    assert_eq!(
+        env.portfolio_state(portfolio).capital,
+        cap_before,
+        "rejected delegated-vault deposit does not credit capital"
+    );
+    let (_, group_after_reject) = env.market_state();
+    assert_eq!(
+        group_after_reject.vault, group_before.vault,
+        "rejected delegated-vault deposit leaves accounting vault unchanged"
+    );
+    assert_eq!(
+        group_after_reject.c_tot, group_before.c_tot,
+        "rejected delegated-vault deposit leaves c_tot unchanged"
+    );
+
+    let mut clean = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: env.token_amount(env.vault),
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::None,
+        },
+        &mut clean,
+    )
+    .unwrap();
+    let mut clean_vault = env.svm.get_account(&env.vault).unwrap();
+    clean_vault.data = clean;
+    env.svm.set_account(env.vault, clean_vault).unwrap();
+
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::Deposit { amount: 500 },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(ok.is_ok(), "deposit through a clean vault works: {ok:?}");
+    assert_eq!(env.token_amount(source), 500);
+    assert_eq!(
+        env.portfolio_state(portfolio).capital,
+        cap_before + 500,
+        "clean vault deposit credits capital"
+    );
+}
+
 // security.md sweep — withdraw rejects a vault with a delegate/close_authority (#44 defense-in-depth):
 // verify_withdrawable_token_accounts rejects the vault if it has a delegate or close_authority set
 // (such a vault could be drained/closed out-of-band by that authority). Attacker goal: route withdrawals

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21611,6 +21611,105 @@ fn v16_attack_close_slab_bad_primary_dest_is_atomic() {
     );
 }
 
+// security.md sweep - CloseSlab terminal custody hardening (#44/#48): even when the primary
+// vault is the canonical market vault, a close_authority on that token account makes terminal
+// reclaim unsafe. CloseSlab must reject before transferring dust or zeroing the market slab.
+#[test]
+fn v16_attack_close_slab_rejects_closable_primary_vault_before_reclaim() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.resolve();
+
+    let attacker_close_authority = Pubkey::new_unique();
+    let mut closable_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 7,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::Some(attacker_close_authority),
+        },
+        &mut closable_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: closable_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let dest = env.token_account(admin.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&dest).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "CloseSlab must reject a primary vault with close_authority set"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected closable-vault CloseSlab must not zero the market"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected closable-vault CloseSlab must not move or close the vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&dest).unwrap(),
+        dest_before,
+        "rejected closable-vault CloseSlab must not pay primary dust"
+    );
+
+    env.set_token_account_amount(env.vault, env.mint, env.vault_authority, 7);
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "same canonical vault closes once close_authority is removed: {ok:?}"
+    );
+    assert_eq!(env.token_amount(dest), 7);
+    let closed_market = env.svm.get_account(&env.market).unwrap();
+    assert_eq!(closed_market.lamports, 0);
+    assert!(closed_market.data.iter().all(|b| *b == 0));
+}
+
 // full-interface sweep (cron31): CloseSlab must pin the primary vault to the current market's vault
 // PDA before transferring dust, closing token accounts, or zeroing the slab. A canonical vault for a
 // different market must reject atomically; otherwise a final cleanup could close or drain foreign

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28548,6 +28548,129 @@ fn v16_attack_swap_secondary_rejects_foreign_market_vault() {
     assert_eq!(env.token_amount(secondary_vault_b), 70);
 }
 
+// full-interface sweep (cron35): the secondary collateral reserve is a real value-bearing vault, so it
+// must inherit the same delegate/close-authority hardening as the primary vault. A canonical secondary
+// vault with a delegate could be drained out-of-band; SwapSecondaryForPrimary must reject it before
+// pulling primary collateral or paying secondary collateral.
+#[test]
+fn v16_attack_swap_secondary_rejects_delegated_secondary_vault() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let secondary_mint = env.create_mint();
+    env.update_base_unit_mints_with_cu(env.mint, secondary_mint);
+
+    let secondary_vault = canonical_vault_ata(env.vault_authority, secondary_mint);
+    let mut delegated_reserve = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: secondary_mint,
+            owner: env.vault_authority,
+            amount: 50,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 50,
+            close_authority: COption::None,
+        },
+        &mut delegated_reserve,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_reserve,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let primary_source = env.token_account_for_mint(env.mint, admin.pubkey(), 10);
+    let secondary_dest = env.token_account_for_mint(secondary_mint, admin.pubkey(), 0);
+    let primary_vault_before = env.svm.get_account(&env.vault).unwrap();
+    let secondary_vault_before = env.svm.get_account(&secondary_vault).unwrap();
+    let source_before = env.svm.get_account(&primary_source).unwrap();
+    let dest_before = env.svm.get_account(&secondary_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::SwapSecondaryForPrimary { amount: 10 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "SwapSecondaryForPrimary must reject a delegated secondary reserve"
+    );
+    assert_eq!(
+        env.svm.get_account(&primary_source).unwrap(),
+        source_before,
+        "rejected delegated-reserve swap must not pull primary collateral"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_dest).unwrap(),
+        dest_before,
+        "rejected delegated-reserve swap must not pay secondary collateral"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        primary_vault_before,
+        "rejected delegated-reserve swap must not credit the primary vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_vault).unwrap(),
+        secondary_vault_before,
+        "delegated secondary reserve remains untouched and recoverable"
+    );
+
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary_mint, env.vault_authority, 50),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::SwapSecondaryForPrimary { amount: 10 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "same canonical secondary reserve works once delegate is removed: {ok:?}"
+    );
+    assert_eq!(env.token_amount(primary_source), 0);
+    assert_eq!(env.token_amount(secondary_dest), 10);
+    assert_eq!(env.token_amount(secondary_vault), 40);
+}
+
 // security.md sweep — CloseSlab with secondary collateral (#44/#48): if a secondary collateral mint is
 // configured, closing the slab must not zero the market after closing only the primary vault. Any
 // secondary reserve must be recovered atomically in the same close, or the PDA-held reserve is stranded.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33037,6 +33037,110 @@ fn v16_attack_crank_oracle_feed_id_mismatch_rejects_without_mutation() {
     assert_eq!(group.assets[0].raw_oracle_target_price, 210_000);
 }
 
+// security.md sweep — oracle same-publish-time replay guard (#37/#44): after a hybrid feed update is
+// accepted, a later oracle account with the SAME publish_time but a DIFFERENT price must reject. Without
+// this monotonicity check, a mutable feed account could rewrite price at a fixed timestamp and drive the
+// mark without a fresh oracle update. A later publish_time with the same feed id still cranks normally.
+#[test]
+fn v16_attack_crank_oracle_same_publish_time_price_rewrite_rejected() {
+    let mut env = V16CuEnv::new();
+    set_test_clock(&mut env, 1, 100);
+    let feed = [0x79u8; 32];
+    let initial = env.set_pyth_price_with_conf(&feed, 200_000, -6, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[initial],
+        1,
+        100,
+        0,
+        0,
+        10,
+        0,
+    )
+    .expect("configure matching one-leg hybrid oracle");
+
+    let keeper_owner = Keypair::new();
+    let keeper_portfolio = env.create_portfolio(&keeper_owner);
+    set_test_clock(&mut env, 2, 101);
+    let rewritten_same_time = env.set_pyth_price_with_conf(&feed, 500_000, -6, 0, 100);
+    let market_before = env.svm.get_account(&env.market).unwrap().data;
+    let portfolio_before = env.svm.get_account(&keeper_portfolio).unwrap().data;
+
+    env.svm.expire_blockhash();
+    let bad = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 0,
+            asset_index: 0,
+            now_slot: 2,
+            funding_rate_e9: 0,
+            close_q: 0,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(keeper_portfolio, false),
+            AccountMeta::new_readonly(rewritten_same_time, false),
+        ],
+        &[],
+    );
+    assert!(
+        bad.is_err(),
+        "same-publish-time feed with a changed price must reject"
+    );
+    let err = bad.err().unwrap();
+    assert!(
+        err.contains("Custom(26)"),
+        "same-time price rewrite should reject as OracleInvalid (Custom 26), got: {err}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap().data,
+        market_before,
+        "rejected same-time price rewrite must not update oracle profile or market state"
+    );
+    assert_eq!(
+        env.svm.get_account(&keeper_portfolio).unwrap().data,
+        portfolio_before,
+        "rejected same-time price rewrite must not mutate the cranked portfolio"
+    );
+
+    let (cfg_after_bad, group_after_bad) = env.market_state();
+    assert_eq!(cfg_after_bad.oracle_leg_prices_e6[0], 200_000);
+    assert_eq!(cfg_after_bad.oracle_leg_publish_times[0], 100);
+    assert_eq!(
+        group_after_bad.assets[0].raw_oracle_target_price, 200_000,
+        "stale rewrite did not move the target mark"
+    );
+
+    let later = env.set_pyth_price_with_conf(&feed, 210_000, -6, 0, 101);
+    env.svm.expire_blockhash();
+    env.crank_with_oracle_tail(
+        keeper_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            action: 0,
+            asset_index: 0,
+            now_slot: 2,
+            funding_rate_e9: 0,
+            close_q: 0,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        &[later],
+    );
+    let (cfg, group) = env.market_state();
+    assert_eq!(cfg.oracle_leg_prices_e6[0], 210_000);
+    assert_eq!(cfg.oracle_leg_publish_times[0], 101);
+    assert_eq!(cfg.last_good_oracle_slot, 2);
+    assert_eq!(
+        group.assets[0].raw_oracle_target_price, 210_000,
+        "later publish_time with the same feed id cranks normally"
+    );
+}
+
 // security.md sweep — malformed oracle config rejects cleanly (#37/#44 robustness): a hybrid oracle
 // declaring N legs but supplied with fewer oracle accounts must reject WITHOUT partially configuring or
 // corrupting the market (no out-of-bounds read, no half-written oracle profile). Protection: the runtime

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -27534,6 +27534,48 @@ fn v16_attack_no_fee_liquidation_cranker_gets_nothing() {
     assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation");
 }
 
+#[test]
+fn v16_attack_asset_append_cannot_freeze_flat_withdrawal() {
+    let mut env = V16CuEnv::new();
+
+    let victim = Keypair::new();
+    let portfolio = env.create_portfolio(&victim);
+    env.deposit(&victim, portfolio, 1_000);
+    let epoch_before = env.market_state().1.asset_set_epoch;
+
+    env.update_market_init_fee_policy_with_cu(10);
+    let attacker = Keypair::new();
+    let attacker_key = attacker.pubkey();
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        1,
+        100,
+        attacker_key,
+        attacker_key,
+        attacker_key,
+        attacker_key,
+        10,
+    );
+    let epoch_after = env.market_state().1.asset_set_epoch;
+    assert!(
+        epoch_after > epoch_before,
+        "permissionless asset append must advance the market asset epoch"
+    );
+
+    let (dest, _) = env.withdraw_with_cu(&victim, portfolio, 1_000);
+    assert_eq!(
+        env.token_amount(dest),
+        1_000,
+        "flat withdrawal must survive a third party asset epoch bump"
+    );
+    assert_eq!(
+        env.portfolio_state(portfolio).capital,
+        0,
+        "flat victim capital fully exits after the epoch bump"
+    );
+}
+
 // security.md sweep — withdraw requires flat account (#19/#46): withdraw_not_atomic requires the
 // account to be FLAT (active_bitmap empty) — ANY open position blocks withdrawal, regardless of how
 // small the position or how large the capital. After closing, the full capital is recoverable (no

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38793,6 +38793,95 @@ fn v16_attack_deposit_primary_only_withdraw_either() {
     );
 }
 
+#[test]
+fn v16_attack_dual_mint_shared_credit_no_double_withdraw() {
+    let mut env = V16CuEnv::new();
+    let market = env.market;
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint();
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    env.deposit(&owner, portfolio, 1_000);
+
+    let secondary_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 1_000),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let (primary_dest, _) = env.withdraw_with_cu(&owner, portfolio, 1_000);
+    assert_eq!(
+        env.token_amount(primary_dest),
+        1_000,
+        "primary withdrawal consumed the whole shared credit"
+    );
+    assert_eq!(
+        env.portfolio_state(portfolio).capital,
+        0,
+        "primary withdrawal exhausted the portfolio capital"
+    );
+
+    let market_before = env.svm.get_account(&market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    let secondary_vault_before = env.svm.get_account(&secondary_vault).unwrap();
+
+    let secondary_dest = env.token_account_for_mint(secondary, owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let double_withdraw = env.send(
+        ProgInstruction::Withdraw { amount: 1_000 },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        double_withdraw.is_err(),
+        "exhausted shared credit must not withdraw again through the secondary mint"
+    );
+    assert_eq!(
+        env.svm.get_account(&market).unwrap(),
+        market_before,
+        "rejected cross-mint double-withdraw leaves market bytes unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before,
+        "rejected cross-mint double-withdraw leaves portfolio bytes unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_vault).unwrap(),
+        secondary_vault_before,
+        "rejected cross-mint double-withdraw leaves secondary reserve unchanged"
+    );
+    assert_eq!(
+        env.token_amount(secondary_dest),
+        0,
+        "rejected secondary withdraw delivered nothing"
+    );
+    assert_eq!(
+        env.token_amount(primary_dest) + env.token_amount(secondary_dest),
+        1_000,
+        "one primary deposit paid out once across both collateral mints"
+    );
+}
+
 // full-interface sweep: base-unit mints are treated as the same unit at 1:1 atom parity across
 // deposits, withdrawals, and SwapSecondaryForPrimary. A mismatched-decimals secondary mint would make
 // that 1:1 accounting value-asymmetric, so even marketauth must not be able to install it.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28896,6 +28896,143 @@ fn v16_attack_swap_secondary_rejects_delegated_secondary_vault() {
     assert_eq!(env.token_amount(secondary_vault), 40);
 }
 
+// full-interface sweep: SwapSecondaryForPrimary validates two distinct vault legs before either SPL
+// transfer. The secondary reserve is covered above; the primary vault must also reject if it carries a
+// delegate, otherwise the market authority could receive secondary collateral while depositing primary
+// into custody that can be drained out-of-band.
+#[test]
+fn v16_attack_swap_secondary_rejects_delegated_primary_vault() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let secondary_mint = env.create_mint();
+    env.update_base_unit_mints_with_cu(env.mint, secondary_mint);
+
+    let secondary_vault = canonical_vault_ata(env.vault_authority, secondary_mint);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary_mint, env.vault_authority, 50),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let mut delegated_primary_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 0,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 10,
+            close_authority: COption::None,
+        },
+        &mut delegated_primary_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_primary_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let primary_source = env.token_account_for_mint(env.mint, admin.pubkey(), 10);
+    let secondary_dest = env.token_account_for_mint(secondary_mint, admin.pubkey(), 0);
+    let primary_vault_before = env.svm.get_account(&env.vault).unwrap();
+    let secondary_vault_before = env.svm.get_account(&secondary_vault).unwrap();
+    let source_before = env.svm.get_account(&primary_source).unwrap();
+    let dest_before = env.svm.get_account(&secondary_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::SwapSecondaryForPrimary { amount: 10 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "SwapSecondaryForPrimary must reject a delegated primary vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&primary_source).unwrap(),
+        source_before,
+        "rejected delegated-primary swap must not pull primary collateral"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        primary_vault_before,
+        "rejected delegated-primary swap must not credit unsafe primary custody"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_dest).unwrap(),
+        dest_before,
+        "rejected delegated-primary swap must not pay secondary collateral"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_vault).unwrap(),
+        secondary_vault_before,
+        "rejected delegated-primary swap must not debit the secondary reserve"
+    );
+
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::SwapSecondaryForPrimary { amount: 10 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(primary_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "same primary vault works once delegate is removed: {ok:?}"
+    );
+    assert_eq!(env.token_amount(primary_source), 0);
+    assert_eq!(env.token_amount(env.vault), 10);
+    assert_eq!(env.token_amount(secondary_dest), 10);
+    assert_eq!(env.token_amount(secondary_vault), 40);
+}
+
 // security.md sweep — CloseSlab with secondary collateral (#44/#48): if a secondary collateral mint is
 // configured, closing the slab must not zero the market after closing only the primary vault. Any
 // secondary reserve must be recovered atomically in the same close, or the PDA-held reserve is stranded.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -42516,6 +42516,93 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
     );
 }
 
+#[test]
+fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
+    let mut env = V16CuEnv::new();
+    set_test_clock(&mut env, 1, 100);
+
+    let feed = [0x55u8; 32];
+    let acct = env.set_pyth_price_with_conf(&feed, 200_000, -6, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[acct],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    )
+    .expect("hybrid external-oracle configuration succeeds");
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let mark_before = env.market_state().1.assets[0].effective_price;
+    assert!(mark_before > 0, "external oracle seeded a real mark");
+
+    let admin = env.admin.insecure_clone();
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    let auth_push = env.send(
+        ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 9_999_999,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        auth_push.is_err(),
+        "correct authority must not PushAuthMark over a hybrid oracle asset"
+    );
+    assert!(
+        auth_push.unwrap_err().contains("Custom(8)"),
+        "wrong-mode PushAuthMark should reject as Unauthorized"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected PushAuthMark leaves hybrid market bytes unchanged"
+    );
+
+    env.svm.expire_blockhash();
+    let ewma_push = env.send(
+        ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 9_999_999,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ewma_push.is_err(),
+        "correct authority must not PushEwmaMark over a hybrid oracle asset"
+    );
+    assert!(
+        ewma_push.unwrap_err().contains("Custom(8)"),
+        "wrong-mode PushEwmaMark should reject as Unauthorized"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected PushEwmaMark leaves hybrid market bytes unchanged"
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        mark_before,
+        "external-oracle mark was not overridden by rejected manual pushes"
+    );
+}
+
 // Per-asset oracle-authority isolation for oracle reconfiguration entrypoints. A valid asset-1
 // oracle_authority must not be able to reset asset 0's oracle mode/anchor, which would let it steer
 // asset-0 marks before liquidations or settlement.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -39205,3 +39205,168 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_oracle
     assert!(ok.is_ok(), "asset-0 authority reconfigures asset-0: {ok:?}");
     assert_eq!(env.market_state().0.oracle_target_price_e6, 150);
 }
+
+// Per-asset oracle-authority isolation for the external-feed ConfigureHybridOracle path. The no-feed
+// EWMA/Auth reconfiguration handlers are covered above; Hybrid has its own oracle-account tail and feed
+// validation, so a valid asset-1 oracle_authority must not be able to use a real feed account to reset
+// asset 0's oracle mode/anchor.
+#[test]
+fn v16_attack_cross_asset_oracle_authority_cannot_configure_other_asset_hybrid() {
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100); // asset 0 oracle_authority = admin
+
+    let a1 = Keypair::new();
+    env.ensure_signer_account(a1.pubkey());
+    env.activate_asset_with_authorities(
+        1,
+        1,
+        100,
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+    );
+
+    set_test_clock(&mut env, 2, 100);
+    let own_feed = [0x31u8; 32];
+    let own_pyth = env.set_pyth_price_with_conf(&own_feed, 175, -6, 0, 100);
+    let mut own_feeds = [[0u8; 32]; percolator_prog::constants::ORACLE_LEG_CAP];
+    own_feeds[0] = own_feed;
+    env.svm.expire_blockhash();
+    let own_asset_hybrid = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 1,
+            now_slot: 2,
+            now_unix_ts: 100,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 3,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: own_feeds,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(own_pyth, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        own_asset_hybrid.is_ok(),
+        "asset-1's own oracle_authority configures asset-1 Hybrid mode: {own_asset_hybrid:?}"
+    );
+    assert_eq!(
+        env.market_state().1.assets[1].effective_price,
+        175,
+        "control hybrid configuration moved asset 1 to the Pyth feed price"
+    );
+
+    let market_before_attack = env.svm.get_account(&env.market).unwrap();
+    let (cfg_before_attack, group_before_attack) = env.market_state();
+    assert_eq!(
+        cfg_before_attack.oracle_mode,
+        percolator_prog::constants::ORACLE_MODE_AUTH_MARK,
+        "asset 0 remains on auth-mark before the cross-asset hybrid attempt"
+    );
+    assert_eq!(cfg_before_attack.oracle_target_price_e6, 100);
+
+    set_test_clock(&mut env, 3, 101);
+    let attack_feed = [0x32u8; 32];
+    let attack_pyth = env.set_pyth_price_with_conf(&attack_feed, 9_000, -6, 0, 101);
+    let mut attack_feeds = [[0u8; 32]; percolator_prog::constants::ORACLE_LEG_CAP];
+    attack_feeds[0] = attack_feed;
+    env.svm.expire_blockhash();
+    let hybrid_attack = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 0,
+            now_slot: 3,
+            now_unix_ts: 101,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 3,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: attack_feeds,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(attack_pyth, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        hybrid_attack.is_err(),
+        "asset-1 oracle_authority must not configure asset-0 Hybrid mode"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_attack,
+        "failed cross-asset Hybrid configuration leaves the whole market account unchanged"
+    );
+    assert_eq!(
+        env.market_state().0.oracle_target_price_e6,
+        cfg_before_attack.oracle_target_price_e6,
+        "failed cross-asset Hybrid configuration leaves asset-0 target unchanged"
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        group_before_attack.assets[0].effective_price,
+        "failed cross-asset Hybrid configuration leaves asset-0 engine mark unchanged"
+    );
+
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    let own_asset0_hybrid = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 0,
+            now_slot: 3,
+            now_unix_ts: 101,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 3,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: attack_feeds,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(attack_pyth, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        own_asset0_hybrid.is_ok(),
+        "asset-0's own oracle_authority can configure asset-0 Hybrid mode: {own_asset0_hybrid:?}"
+    );
+    let (cfg_after, group_after) = env.market_state();
+    assert_eq!(
+        cfg_after.oracle_mode,
+        percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS
+    );
+    assert_eq!(cfg_after.oracle_target_price_e6, 9_000);
+    assert_eq!(group_after.assets[0].effective_price, 9_000);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -29355,6 +29355,95 @@ fn v16_attack_swap_secondary_unauthorized_and_bounded() {
     );
 }
 
+#[test]
+fn v16_attack_swap_secondary_conserves_and_mints_nothing() {
+    let mut env = V16CuEnv::new();
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint();
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    let user = Keypair::new();
+    let portfolio = env.create_portfolio(&user);
+    env.deposit(&user, portfolio, 1_000);
+
+    let secondary_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 400),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let admin = env.admin.insecure_clone();
+    let admin_primary = env.token_account_for_mint(primary, admin.pubkey(), 300);
+    let admin_secondary = env.token_account_for_mint(secondary, admin.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let group_before = env.market_state().1;
+    let primary_vault_before = env.token_amount(env.vault);
+    let secondary_vault_before = env.token_amount(secondary_vault);
+    let admin_primary_before = env.token_amount(admin_primary);
+    let total_vault_tokens_before = primary_vault_before + secondary_vault_before;
+
+    env.swap_secondary_for_primary_with_cu(
+        admin_primary,
+        env.vault,
+        admin_secondary,
+        secondary_vault,
+        250,
+    );
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "successful secondary swap must not mutate engine market state"
+    );
+    let group_after = env.market_state().1;
+    assert_eq!(
+        group_after.vault, group_before.vault,
+        "engine vault accounting unchanged by physical mint rebalance"
+    );
+    assert_eq!(
+        group_after.c_tot, group_before.c_tot,
+        "engine c_tot unchanged by physical mint rebalance"
+    );
+    assert_eq!(
+        group_after.insurance, group_before.insurance,
+        "engine insurance unchanged by physical mint rebalance"
+    );
+    assert_eq!(
+        env.token_amount(env.vault),
+        primary_vault_before + 250,
+        "primary vault received the swapped-in primary collateral"
+    );
+    assert_eq!(
+        env.token_amount(secondary_vault),
+        secondary_vault_before - 250,
+        "secondary reserve released the same atom count"
+    );
+    assert_eq!(
+        env.token_amount(admin_primary),
+        admin_primary_before - 250,
+        "base-unit authority paid primary collateral"
+    );
+    assert_eq!(
+        env.token_amount(admin_secondary),
+        250,
+        "base-unit authority received secondary collateral"
+    );
+    assert_eq!(
+        env.token_amount(env.vault) + env.token_amount(secondary_vault),
+        total_vault_tokens_before,
+        "total custodied base-unit atoms conserved across the swap"
+    );
+}
+
 // full-interface sweep (cron30): SwapSecondaryForPrimary must pin the secondary reserve to the
 // current market's vault PDA. A valid secondary-mint token account owned by another market's vault PDA
 // must not be usable as the reserve, or one market's base-unit authority could drain another market's

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28665,6 +28665,97 @@ fn v16_attack_withdraw_insurance_domain_budget_cannot_be_overdrawn() {
     conserve(&env);
 }
 
+#[test]
+fn v16_attack_dual_mint_domain_insurance_no_double_withdraw() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint();
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    env.top_up_insurance_domain_with_authority(&admin, 0, 300);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0],
+        300,
+        "domain-0 insurance budget funded"
+    );
+
+    let secondary_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 1_000),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let (primary_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&admin, 0, 300)
+        .expect("asset-0 operator withdraws funded insurance budget");
+    assert_eq!(
+        env.token_amount(primary_dest),
+        300,
+        "primary insurance payout delivered the funded budget"
+    );
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0],
+        0,
+        "primary payout exhausted the shared domain budget"
+    );
+
+    let secondary_dest = env.token_account_for_mint(secondary, admin.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let secondary_vault_before = env.svm.get_account(&secondary_vault).unwrap();
+    let secondary_dest_before = env.svm.get_account(&secondary_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let double_withdraw = env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            amount: 300,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        double_withdraw.is_err(),
+        "exhausted insurance budget must not withdraw again through the secondary mint"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected cross-mint insurance double-withdraw leaves market bytes unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_vault).unwrap(),
+        secondary_vault_before,
+        "rejected cross-mint insurance double-withdraw leaves secondary reserve unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_dest).unwrap(),
+        secondary_dest_before,
+        "rejected cross-mint insurance double-withdraw leaves destination unchanged"
+    );
+    assert_eq!(
+        env.token_amount(primary_dest) + env.token_amount(secondary_dest),
+        300,
+        "one domain budget paid out once across both collateral mints"
+    );
+}
+
 // security.md sweep — uniform live insurance API (#6/#23/#57): asset 0 and permissionless assets 1..N
 // both withdraw through the same asset-indexed tag. The signer must be that asset's insurance_operator,
 // and the withdrawal is bounded to that asset's own long+short insurance budget.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -340,6 +340,34 @@ fn make_pyth_data(
     data
 }
 
+fn make_switchboard_data(price_e6: u64, std_dev_e6: u64, publish_time: i64) -> Vec<u8> {
+    let mut data = vec![0u8; 3_208];
+    data[0..8].copy_from_slice(&[196, 27, 108, 196, 10, 215, 219, 40]);
+    data[2_120..2_152].copy_from_slice(&[0x5a; 32]);
+    data[2_215] = 1;
+    data[2_216..2_224].copy_from_slice(&publish_time.to_le_bytes());
+    let value = (price_e6 as i128) * 1_000_000_000_000i128;
+    data[2_264..2_280].copy_from_slice(&value.to_le_bytes());
+    let std_dev = (std_dev_e6 as i128) * 1_000_000_000_000i128;
+    data[2_280..2_296].copy_from_slice(&std_dev.to_le_bytes());
+    data[2_360] = 1;
+    data[2_368..2_376].copy_from_slice(&1u64.to_le_bytes());
+    data
+}
+
+fn make_chainlink_data(price: i128, decimals: u8, publish_time: u32) -> Vec<u8> {
+    let mut data = vec![0u8; 248];
+    data[0..8].copy_from_slice(&[96, 179, 69, 66, 128, 129, 73, 117]);
+    data[8] = 1;
+    data[138] = decimals;
+    data[143..147].copy_from_slice(&1u32.to_le_bytes());
+    data[148..152].copy_from_slice(&1u32.to_le_bytes());
+    data[200..208].copy_from_slice(&1u64.to_le_bytes());
+    data[208..212].copy_from_slice(&publish_time.to_le_bytes());
+    data[216..232].copy_from_slice(&price.to_le_bytes());
+    data
+}
+
 fn cu_ix() -> Instruction {
     ComputeBudgetInstruction::set_compute_unit_limit(1_400_000)
 }
@@ -34295,6 +34323,296 @@ fn v16_attack_oracle_feed_id_mismatch_rejected() {
         ok.is_ok(),
         "the matching configured feed id configures: {:?}",
         ok
+    );
+}
+
+#[test]
+fn v16_attack_switchboard_oracle_key_owner_binding_enforced() {
+    let valid_feed = Pubkey::new_unique();
+    let mut valid_env = V16CuEnv::new();
+    set_test_clock(&mut valid_env, 1, 100);
+    valid_env
+        .svm
+        .set_account(
+            valid_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_switchboard_data(200_000, 0, 100),
+                owner: oracle_v16::SWITCHBOARD_ON_DEMAND_MAINNET_PROGRAM_ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let ok = valid_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [valid_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[valid_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(ok.is_ok(), "a valid Switchboard feed configures: {ok:?}");
+    assert_eq!(
+        valid_env.market_state().1.assets[0].raw_oracle_target_price,
+        200_000,
+        "valid Switchboard parse should set the expected e6 mark"
+    );
+
+    let expected_feed = Pubkey::new_unique();
+    let wrong_feed = Pubkey::new_unique();
+    let mut wrong_key_env = V16CuEnv::new();
+    set_test_clock(&mut wrong_key_env, 1, 100);
+    wrong_key_env
+        .svm
+        .set_account(
+            wrong_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_switchboard_data(500_000, 0, 100),
+                owner: oracle_v16::SWITCHBOARD_ON_DEMAND_MAINNET_PROGRAM_ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let before = wrong_key_env
+        .svm
+        .get_account(&wrong_key_env.market)
+        .unwrap()
+        .data;
+    let bad = wrong_key_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [expected_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[wrong_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(
+        bad.is_err(),
+        "a Switchboard account at the wrong key must reject"
+    );
+    let err = bad.err().unwrap();
+    assert!(
+        err.contains("Custom(29)"),
+        "wrong Switchboard feed key should reject as InvalidOracleKey (Custom 29), got: {err}"
+    );
+    assert_eq!(
+        wrong_key_env
+            .svm
+            .get_account(&wrong_key_env.market)
+            .unwrap()
+            .data,
+        before,
+        "rejected Switchboard key spoof must not mutate the market"
+    );
+
+    let mut wrong_owner_env = V16CuEnv::new();
+    set_test_clock(&mut wrong_owner_env, 1, 100);
+    wrong_owner_env
+        .svm
+        .set_account(
+            expected_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_switchboard_data(500_000, 0, 100),
+                owner: Pubkey::new_unique(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let before = wrong_owner_env
+        .svm
+        .get_account(&wrong_owner_env.market)
+        .unwrap()
+        .data;
+    let bad = wrong_owner_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [expected_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[expected_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(
+        bad.is_err(),
+        "a Switchboard-shaped account under a non-Switchboard owner must reject"
+    );
+    let err = bad.err().unwrap();
+    assert!(
+        err.contains("IllegalOwner"),
+        "wrong Switchboard owner should reject as IllegalOwner, got: {err}"
+    );
+    assert_eq!(
+        wrong_owner_env
+            .svm
+            .get_account(&wrong_owner_env.market)
+            .unwrap()
+            .data,
+        before,
+        "rejected Switchboard owner spoof must not mutate the market"
+    );
+}
+
+#[test]
+fn v16_attack_chainlink_oracle_key_owner_binding_enforced() {
+    let valid_feed = Pubkey::new_unique();
+    let mut valid_env = V16CuEnv::new();
+    set_test_clock(&mut valid_env, 1, 100);
+    valid_env
+        .svm
+        .set_account(
+            valid_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_chainlink_data(20_000_000, 8, 100),
+                owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let ok = valid_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [valid_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[valid_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(ok.is_ok(), "a valid Chainlink feed configures: {ok:?}");
+    assert_eq!(
+        valid_env.market_state().1.assets[0].raw_oracle_target_price,
+        200_000,
+        "valid Chainlink parse should set the expected e6 mark"
+    );
+
+    let expected_feed = Pubkey::new_unique();
+    let wrong_feed = Pubkey::new_unique();
+    let mut wrong_key_env = V16CuEnv::new();
+    set_test_clock(&mut wrong_key_env, 1, 100);
+    wrong_key_env
+        .svm
+        .set_account(
+            wrong_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_chainlink_data(50_000_000, 8, 100),
+                owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let before = wrong_key_env
+        .svm
+        .get_account(&wrong_key_env.market)
+        .unwrap()
+        .data;
+    let bad = wrong_key_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [expected_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[wrong_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(
+        bad.is_err(),
+        "a Chainlink account at the wrong key must reject"
+    );
+    let err = bad.err().unwrap();
+    assert!(
+        err.contains("Custom(29)"),
+        "wrong Chainlink feed key should reject as InvalidOracleKey (Custom 29), got: {err}"
+    );
+    assert_eq!(
+        wrong_key_env
+            .svm
+            .get_account(&wrong_key_env.market)
+            .unwrap()
+            .data,
+        before,
+        "rejected Chainlink key spoof must not mutate the market"
+    );
+
+    let mut wrong_owner_env = V16CuEnv::new();
+    set_test_clock(&mut wrong_owner_env, 1, 100);
+    wrong_owner_env
+        .svm
+        .set_account(
+            expected_feed,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_chainlink_data(50_000_000, 8, 100),
+                owner: Pubkey::new_unique(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let before = wrong_owner_env
+        .svm
+        .get_account(&wrong_owner_env.market)
+        .unwrap()
+        .data;
+    let bad = wrong_owner_env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [expected_feed.to_bytes(), [0u8; 32], [0u8; 32]],
+        &[expected_feed],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    );
+    assert!(
+        bad.is_err(),
+        "a Chainlink-shaped account under a non-Chainlink owner must reject"
+    );
+    let err = bad.err().unwrap();
+    assert!(
+        err.contains("IllegalOwner"),
+        "wrong Chainlink owner should reject as IllegalOwner, got: {err}"
+    );
+    assert_eq!(
+        wrong_owner_env
+            .svm
+            .get_account(&wrong_owner_env.market)
+            .unwrap()
+            .data,
+        before,
+        "rejected Chainlink owner spoof must not mutate the market"
     );
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -19881,6 +19881,176 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
     assert!(g.vault >= g.c_tot + g.insurance, "senior conservation");
 }
 
+// full-interface sweep: the value top-up handlers validate the canonical vault before they mutate
+// market accounting. A delegated canonical vault is unsafe custody even at the right address: donor
+// tokens could be pulled and then drained out-of-band. All top-up variants must reject atomically.
+#[test]
+fn v16_attack_value_topups_reject_delegated_canonical_vault() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+
+    let mut delegated_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 0,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 1_000,
+            close_authority: COption::None,
+        },
+        &mut delegated_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let assert_core_unchanged = |env: &V16CuEnv, label: &str| {
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before,
+            "{label}: market accounting unchanged"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.vault).unwrap(),
+            vault_before,
+            "{label}: delegated canonical vault unchanged"
+        );
+    };
+
+    let insurance_source = env.token_account_for_mint(env.mint, admin.pubkey(), 11);
+    let insurance_source_before = env.svm.get_account(&insurance_source).unwrap();
+    env.svm.expire_blockhash();
+    let insurance_reject = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::TopUpInsurance { amount: 11 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(insurance_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        insurance_reject.is_err(),
+        "TopUpInsurance must reject a delegated canonical vault"
+    );
+    assert_core_unchanged(&env, "TopUpInsurance");
+    assert_eq!(
+        env.svm.get_account(&insurance_source).unwrap(),
+        insurance_source_before,
+        "rejected insurance top-up must not pull donor tokens"
+    );
+
+    let domain_source = env.token_account_for_mint(env.mint, admin.pubkey(), 12);
+    let domain_source_before = env.svm.get_account(&domain_source).unwrap();
+    env.svm.expire_blockhash();
+    let domain_reject = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::TopUpInsuranceDomain {
+            domain: 0,
+            amount: 12,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(domain_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        domain_reject.is_err(),
+        "TopUpInsuranceDomain must reject a delegated canonical vault"
+    );
+    assert_core_unchanged(&env, "TopUpInsuranceDomain");
+    assert_eq!(
+        env.svm.get_account(&domain_source).unwrap(),
+        domain_source_before,
+        "rejected domain insurance top-up must not pull donor tokens"
+    );
+
+    let backing_source = env.token_account_for_mint(env.mint, admin.pubkey(), 13);
+    let backing_source_before = env.svm.get_account(&backing_source).unwrap();
+    env.svm.expire_blockhash();
+    let backing_reject = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::TopUpBackingBucket {
+            domain: 1,
+            amount: 13,
+            expiry_slot: 10_000,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        backing_reject.is_err(),
+        "TopUpBackingBucket must reject a delegated canonical vault"
+    );
+    assert_core_unchanged(&env, "TopUpBackingBucket");
+    assert_eq!(
+        env.svm.get_account(&backing_source).unwrap(),
+        backing_source_before,
+        "rejected backing top-up must not pull donor tokens"
+    );
+
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let (_insurance_ok_source, _) = env.top_up_insurance_with_cu(11);
+    let (_domain_ok_source, _) = env.top_up_insurance_domain_with_authority_and_cu(&admin, 0, 12);
+    let (_backing_ok_source, _) = env.top_up_backing_bucket_with_cu(1, 13, 10_000);
+    let (_, group_after) = env.market_state();
+    assert_eq!(group_after.insurance, 23);
+    assert_eq!(
+        group_after.source_backing_buckets[1].fresh_unliened_backing_num,
+        13 * BOUND_SCALE
+    );
+    assert_eq!(
+        env.token_amount(env.vault),
+        group_after.vault as u64,
+        "clean-vault controls leave accounting matched to custody"
+    );
+}
+
 // security.md sweep — domain-indexed public calls must reject domains outside the configured market
 // slots before touching accounting, ledgers, or SPL custody. On a one-asset market, domains 0/1 are
 // valid and domain 2 is out of range; a real market authority with valid token accounts still cannot

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -24675,6 +24675,117 @@ fn v16_attack_topup_backing_bucket_authority_gated() {
     assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation");
 }
 
+// full-interface sweep: WithdrawBackingBucket has a two-stage authority check where marketauth passes
+// preflight, but live withdrawal must still require the current backing_bucket_authority unless the
+// domain is in shutdown-drain. After asset-0 backing authority is rekeyed, stale marketauth must not
+// drain live provider backing.
+#[test]
+fn v16_attack_asset0_backing_rotation_rekeys_live_bucket_withdraw() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let new_backing = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&new_backing),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        new_backing.pubkey().to_bytes(),
+    )
+    .expect("asset-0 admin rotates the backing-bucket authority");
+    env.top_up_backing_bucket_with_authority(&new_backing, 0, 500, 100_000);
+
+    let (_, group_before) = env.market_state();
+    assert_eq!(
+        group_before.source_backing_buckets[0].fresh_unliened_backing_num,
+        500 * BOUND_SCALE,
+        "funded asset-0 backing bucket makes the stale-authority attempt non-vacuous"
+    );
+    let stale_dest = env.token_account(admin.pubkey(), 0);
+    let stale_dest_before = env.svm.get_account(&stale_dest).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+
+    env.svm.expire_blockhash();
+    let stale_admin = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 0,
+            amount: 100,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(stale_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        stale_admin.is_err(),
+        "stale marketauth must not drain live backing after asset-0 backing authority rotates"
+    );
+    assert_eq!(
+        env.svm.get_account(&stale_dest).unwrap(),
+        stale_dest_before,
+        "stale backing-withdraw attempt pays no tokens"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "stale backing-withdraw attempt does not debit the vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "stale backing-withdraw attempt leaves market state unchanged"
+    );
+
+    let backing_dest = env.token_account(new_backing.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let backing_withdraw = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 0,
+            amount: 100,
+        },
+        vec![
+            AccountMeta::new(new_backing.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&new_backing],
+    );
+    assert!(
+        backing_withdraw.is_ok(),
+        "current asset-0 backing authority can withdraw live backing: {backing_withdraw:?}"
+    );
+    assert_eq!(
+        env.token_amount(backing_dest),
+        100,
+        "current backing authority receives the withdrawal"
+    );
+    let (_, group_after) = env.market_state();
+    assert_eq!(
+        group_after.source_backing_buckets[0].fresh_unliened_backing_num,
+        400 * BOUND_SCALE
+    );
+    assert_eq!(
+        env.token_amount(env.vault),
+        group_after.vault as u64,
+        "engine vault accounting matches SPL vault after rekeyed backing withdrawal"
+    );
+}
+
 // security.md sweep — F-VAULT-FRAG fix on a WITHDRAW path: WithdrawBackingBucket transfers FROM the
 // vault; the canonical-ATA pin must apply here too. A withdrawal routed to a non-canonical
 // vault-authority-owned account must reject (no draining a fragment / fabricating an outbound path).

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21861,6 +21861,153 @@ fn v16_attack_permissionless_resolve_rejects_fresh_market() {
     );
 }
 
+// security.md sweep - stale-matured live entrypoint freeze (#30/#33/#48): once the market is
+// permissionless-resolve matured, ordinary live value-moving entrypoints must reject atomically until the
+// market is resolved. Otherwise users could race stale resolution by withdrawing/trading/topping up against
+// stale accounting. The same clock state must still allow ResolveStalePermissionless as the positive path.
+#[test]
+fn v16_attack_stale_matured_live_value_paths_reject_before_resolution() {
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+
+    let owner_a = Keypair::new();
+    let account_a = env.create_portfolio(&owner_a);
+    let owner_b = Keypair::new();
+    let account_b = env.create_portfolio(&owner_b);
+    env.deposit(&owner_a, account_a, 1_000_000);
+    env.deposit(&owner_b, account_b, 1_000_000);
+    let admin = env.admin.insecure_clone();
+    let withdraw_dest = env.token_account_for_mint(env.mint, owner_a.pubkey(), 0);
+    let deposit_source = env.token_account_for_mint(env.mint, owner_a.pubkey(), 50_000);
+    let topup_source = env.token_account_for_mint(env.mint, admin.pubkey(), 25_000);
+
+    env.svm.warp_to_slot(5);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let account_a_before = env.svm.get_account(&account_a).unwrap();
+    let account_b_before = env.svm.get_account(&account_b).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let withdraw_dest_before = env.svm.get_account(&withdraw_dest).unwrap();
+    let deposit_source_before = env.svm.get_account(&deposit_source).unwrap();
+    let topup_source_before = env.svm.get_account(&topup_source).unwrap();
+
+    env.svm.expire_blockhash();
+    let withdraw = env.send(
+        ProgInstruction::Withdraw { amount: 100_000 },
+        vec![
+            AccountMeta::new(owner_a.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+            AccountMeta::new(withdraw_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner_a],
+    );
+    assert!(
+        withdraw.is_err(),
+        "Withdraw must reject once stale resolution is matured"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&account_a).unwrap(), account_a_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(
+        env.svm.get_account(&withdraw_dest).unwrap(),
+        withdraw_dest_before,
+        "stale-matured withdraw pays no tokens"
+    );
+
+    env.svm.expire_blockhash();
+    let deposit = env.send(
+        ProgInstruction::Deposit { amount: 50_000 },
+        vec![
+            AccountMeta::new(owner_a.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+            AccountMeta::new(deposit_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner_a],
+    );
+    assert!(
+        deposit.is_err(),
+        "Deposit must reject once stale resolution is matured"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&account_a).unwrap(), account_a_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(
+        env.svm.get_account(&deposit_source).unwrap(),
+        deposit_source_before,
+        "stale-matured deposit pulls no source tokens"
+    );
+
+    env.svm.expire_blockhash();
+    let topup = env.send(
+        ProgInstruction::TopUpInsurance { amount: 25_000 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(topup_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        topup.is_err(),
+        "TopUpInsurance must reject once stale resolution is matured"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(
+        env.svm.get_account(&topup_source).unwrap(),
+        topup_source_before,
+        "stale-matured top-up pulls no source tokens"
+    );
+
+    env.svm.expire_blockhash();
+    let trade = env.send(
+        ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            size_q: POS_SCALE as i128,
+            exec_price: 100,
+            fee_bps: 0,
+        },
+        vec![
+            AccountMeta::new(owner_a.pubkey(), true),
+            AccountMeta::new(owner_b.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+            AccountMeta::new(account_b, false),
+        ],
+        &[&owner_a, &owner_b],
+    );
+    assert!(
+        trade.is_err(),
+        "TradeNoCpi must reject once stale resolution is matured"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&account_a).unwrap(), account_a_before);
+    assert_eq!(env.svm.get_account(&account_b).unwrap(), account_b_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 5 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "the same stale-matured clock state must still allow permissionless resolve: {resolve:?}"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(group.mode, percolator::MarketModeV16::Resolved);
+    assert_eq!(group.resolved_slot, 5);
+}
+
 // security.md sweep -- permissionless resolve slot spoof (#30 DoS): ResolveStalePermissionless is
 // public. A cranker must not be able to pass a far-future caller now_slot and resolve a still-fresh
 // market. The handler must authenticate against Clock; once the real Clock reaches the stale window,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20970,6 +20970,132 @@ fn v16_attack_close_resolved_dest_validation() {
     );
 }
 
+// full-interface sweep (cron40): CloseResolved computes and records the resolved payout before
+// validating the supplied vault account. A delegated canonical vault must reject atomically, without
+// finalizing/burning the user's payout state or moving custody.
+#[test]
+fn v16_attack_close_resolved_rejects_delegated_vault_without_burning_payout() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 1_000_000);
+    env.resolve();
+
+    let mut delegated_vault = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: env.mint,
+            owner: env.vault_authority,
+            amount: 1_000_000,
+            delegate: COption::Some(Pubkey::new_unique()),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 1_000_000,
+            close_authority: COption::None,
+        },
+        &mut delegated_vault,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: delegated_vault,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let dest = env.token_account_for_mint(env.mint, owner.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&p).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "CloseResolved must reject a delegated canonical payout vault"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected delegated-vault CloseResolved must not mutate market payout accounting"
+    );
+    assert_eq!(
+        env.svm.get_account(&p).unwrap(),
+        portfolio_before,
+        "rejected delegated-vault CloseResolved must not finalize or burn the payout"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "delegated vault remains untouched"
+    );
+    assert_eq!(
+        env.svm.get_account(&dest).unwrap(),
+        dest_before,
+        "destination receives nothing on rejected delegated-vault payout"
+    );
+
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 1_000_000),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        ok.is_ok(),
+        "same resolved payout succeeds after the vault is restored clean: {ok:?}"
+    );
+    assert_eq!(env.token_amount(dest), 1_000_000);
+    assert_eq!(
+        env.market_state().1.vault,
+        0,
+        "resolved payout fully drains accounted vault value"
+    );
+}
+
 // security.md sweep - resolved payout account aliasing (#26/#44/#48): CloseResolved and the unsigned
 // ClaimResolvedPayoutTopup are value-moving wind-down paths. Passing the market slab as the portfolio
 // account must reject atomically and must not burn the real user's payout state.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -37693,6 +37693,118 @@ fn v16_bpf_batch_trade_14_legs_under_tx_limit() {
     assert_eq!(percolator::active_bitmap_count_ones(t.active_bitmap), 14);
 }
 
+// SOL-011 / DoS boundary: BatchTradeNoCpi is a public variable-length instruction. It must not
+// accept a distinct-asset batch that exceeds the configured per-portfolio active-leg cap, even when
+// the market has more configured assets than one portfolio may hold.
+#[test]
+fn v16_attack_batch_nocpi_over_portfolio_leg_cap_rejects_atomically() {
+    const ASSETS: usize = 15;
+    let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
+        V16CuMarketParams {
+            max_portfolio_assets: 14,
+            maintenance_margin_bps: 1_000,
+            initial_margin_bps: 1_000,
+            max_price_move_bps_per_slot: 500,
+            ..V16CuMarketParams::default()
+        },
+        ASSETS,
+    );
+    env.activate_asset(14, 15, 100);
+    env.portfolio_account_len = state::portfolio_account_len_for_market_slots(ASSETS).unwrap();
+    env.svm.warp_to_slot(20);
+    for a in 0..ASSETS as u16 {
+        env.configure_auth_mark_for_asset_as_admin(a, 20, 100);
+    }
+    let (_, configured) = env.market_state();
+    assert_eq!(configured.config.max_market_slots as usize, ASSETS);
+    assert_eq!(configured.config.max_portfolio_assets, 14);
+
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 5_000_000);
+    env.deposit(&lp, la, 5_000_000);
+
+    let over_cap_legs: Vec<BatchTradeLeg> = (0..ASSETS as u16)
+        .map(|asset_index| BatchTradeLeg {
+            asset_index,
+            size_q: POS_SCALE as i128,
+            exec_price: 100,
+            fee_bps: 0,
+        })
+        .collect();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+
+    env.svm.expire_blockhash();
+    let over_cap = env.send(
+        ProgInstruction::BatchTradeNoCpi {
+            legs: over_cap_legs,
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(lp.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+        ],
+        &[&taker, &lp],
+    );
+    assert!(
+        over_cap.is_err(),
+        "15-leg BatchTradeNoCpi must reject against a 14-leg portfolio cap"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected over-cap batch must not mutate market accounting"
+    );
+    assert_eq!(
+        env.svm.get_account(&ta).unwrap(),
+        taker_before,
+        "rejected over-cap batch must not partially open taker legs"
+    );
+    assert_eq!(
+        env.svm.get_account(&la).unwrap(),
+        lp_before,
+        "rejected over-cap batch must not partially open LP legs"
+    );
+
+    let cap_legs: Vec<BatchTradeLeg> = (0..14u16)
+        .map(|asset_index| BatchTradeLeg {
+            asset_index,
+            size_q: POS_SCALE as i128,
+            exec_price: 100,
+            fee_bps: 0,
+        })
+        .collect();
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::BatchTradeNoCpi { legs: cap_legs },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(lp.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+        ],
+        &[&taker, &lp],
+    )
+    .expect("14-leg control batch still executes on the same 15-asset market");
+    let taker_after = env.portfolio_state(ta);
+    assert_eq!(
+        percolator::active_bitmap_count_ones(taker_after.active_bitmap),
+        14,
+        "control opens exactly the configured active-leg cap"
+    );
+    assert!(
+        !has_active_leg_for_asset(&taker_after, 14),
+        "the rejected 15th leg never leaked into the taker portfolio"
+    );
+}
+
 // BatchTradeCpi: a single batched matcher CPI fills a MIXED-direction spread (taker long asset 0,
 // short asset 1) against one LP, then both fills apply with one end-state margin check.
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -41852,6 +41852,56 @@ fn v16_attack_init_portfolio_cannot_use_market_as_portfolio_account() {
     assert_eq!(initialized.capital, 0);
 }
 
+#[test]
+fn v16_attack_empty_portfolio_reinit_cannot_inflate_materialized_count() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        1,
+        "initial empty portfolio increments the materialized count once"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    env.svm.expire_blockhash();
+    let reinit = env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        reinit.is_err(),
+        "re-init of an already initialized empty portfolio must reject"
+    );
+    assert!(
+        reinit.unwrap_err().contains("Custom(2)"),
+        "empty portfolio re-init should reject as AlreadyInitialized"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected empty re-init must not inflate market counters"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before,
+        "rejected empty re-init must not rewrite the portfolio"
+    );
+
+    env.close_portfolio_with_cu(&owner, portfolio);
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        0,
+        "one real empty portfolio closes back to zero materialized count"
+    );
+}
+
 // SOL-010 (reinitialization): InitPortfolio targets a program-owned account and SETS its owner. An
 // attacker could try to re-init a VICTIM's already-funded portfolio -- which would reset its capital
 // and reassign ownership, a severe LOF (victim's vaulted tokens orphaned). The is_initialized guard

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28926,6 +28926,133 @@ fn v16_attack_close_slab_requires_secondary_vault_recovery() {
     );
 }
 
+// full-interface sweep (cron38): the optional secondary reserve is validated before CloseSlab sweeps
+// primary dust. A canonical secondary vault with close_authority set must reject atomically; otherwise
+// terminal cleanup could partially reclaim the primary vault while leaving unsafe secondary custody.
+#[test]
+fn v16_attack_close_slab_rejects_closable_secondary_vault_before_reclaim() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let secondary_mint = env.create_mint();
+    env.update_base_unit_mints_with_cu(env.mint, secondary_mint);
+
+    env.set_token_account_amount(env.vault, env.mint, env.vault_authority, 7);
+    let secondary_vault = canonical_vault_ata(env.vault_authority, secondary_mint);
+    let mut closable_secondary = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: secondary_mint,
+            owner: env.vault_authority,
+            amount: 50,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::Some(Pubkey::new_unique()),
+        },
+        &mut closable_secondary,
+    )
+    .unwrap();
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: closable_secondary,
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.resolve();
+
+    let primary_dest = env.token_account(admin.pubkey(), 0);
+    let secondary_dest = env.token_account_for_mint(secondary_mint, admin.pubkey(), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let primary_vault_before = env.svm.get_account(&env.vault).unwrap();
+    let secondary_vault_before = env.svm.get_account(&secondary_vault).unwrap();
+    let primary_dest_before = env.svm.get_account(&primary_dest).unwrap();
+    let secondary_dest_before = env.svm.get_account(&secondary_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(primary_dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new(secondary_dest, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "CloseSlab must reject a secondary vault with close_authority set"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected closable-secondary CloseSlab must not zero the market"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        primary_vault_before,
+        "primary dust must not be swept before secondary vault validation"
+    );
+    assert_eq!(
+        env.svm.get_account(&secondary_vault).unwrap(),
+        secondary_vault_before,
+        "closable secondary reserve remains untouched and recoverable"
+    );
+    assert_eq!(env.svm.get_account(&primary_dest).unwrap(), primary_dest_before);
+    assert_eq!(
+        env.svm.get_account(&secondary_dest).unwrap(),
+        secondary_dest_before
+    );
+
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary_mint, env.vault_authority, 50),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(primary_dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(secondary_vault, false),
+            AccountMeta::new(secondary_dest, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "same secondary reserve closes once close_authority is removed: {ok:?}"
+    );
+    assert_eq!(env.token_amount(primary_dest), 7);
+    assert_eq!(env.token_amount(secondary_dest), 50);
+    let closed_market = env.svm.get_account(&env.market).unwrap();
+    assert_eq!(closed_market.lamports, 0);
+    assert!(closed_market.data.iter().all(|b| *b == 0));
+}
+
 // full-interface sweep (cron32): CloseSlab's optional secondary vault must be bound to the current
 // market's vault PDA, not merely be a valid token account for the configured secondary mint. A foreign
 // market's canonical secondary reserve must reject before primary dust is swept or either vault/market

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34748,6 +34748,117 @@ fn v16_attack_chainlink_oracle_key_owner_binding_enforced() {
 }
 
 #[test]
+fn v16_attack_chainlink_oracle_malformed_fields_reject_without_mutation() {
+    const CL_OFF_VERSION: usize = 8;
+    const CL_OFF_DECIMALS: usize = 138;
+    const CL_OFF_LATEST_ROUND_ID: usize = 143;
+    const CL_OFF_LIVE_LENGTH: usize = 148;
+    const CL_OFF_TRANSMISSION: usize = 8 + 192;
+    const CL_TRANS_OFF_SLOT: usize = 0;
+    const CL_TRANS_OFF_TIMESTAMP: usize = 8;
+    const CL_TRANS_OFF_ANSWER: usize = 16;
+
+    let configure = |data: Vec<u8>| -> (bool, Option<String>, bool, u64) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let feed = Pubkey::new_unique();
+        env.svm
+            .set_account(
+                feed,
+                Account {
+                    lamports: 1_000_000_000,
+                    data,
+                    owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let before = env.svm.get_account(&env.market).unwrap().data;
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed.to_bytes(), [0u8; 32], [0u8; 32]],
+            &[feed],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        let ok = r.is_ok();
+        let price = if ok {
+            env.market_state().1.assets[0].raw_oracle_target_price
+        } else {
+            0
+        };
+        let after = env.svm.get_account(&env.market).unwrap().data;
+        (ok, r.err(), before == after, price)
+    };
+
+    let (ok, _, _, price) = configure(make_chainlink_data(20_000_000, 8, 100));
+    assert!(ok, "control: a well-formed Chainlink feed configures");
+    assert_eq!(price, 200_000, "control: Chainlink scaling reaches e6");
+
+    let mut cases: Vec<(&str, Vec<u8>)> = Vec::new();
+    let mut bad_disc = make_chainlink_data(20_000_000, 8, 100);
+    bad_disc[0] ^= 0xff;
+    cases.push(("bad discriminator", bad_disc));
+
+    let mut version_zero = make_chainlink_data(20_000_000, 8, 100);
+    version_zero[CL_OFF_VERSION] = 0;
+    cases.push(("zero version", version_zero));
+
+    let mut round_zero = make_chainlink_data(20_000_000, 8, 100);
+    round_zero[CL_OFF_LATEST_ROUND_ID..CL_OFF_LATEST_ROUND_ID + 4]
+        .copy_from_slice(&0u32.to_le_bytes());
+    cases.push(("zero latest round", round_zero));
+
+    let mut live_length_two = make_chainlink_data(20_000_000, 8, 100);
+    live_length_two[CL_OFF_LIVE_LENGTH..CL_OFF_LIVE_LENGTH + 4]
+        .copy_from_slice(&2u32.to_le_bytes());
+    cases.push(("bad live length", live_length_two));
+
+    let mut slot_zero = make_chainlink_data(20_000_000, 8, 100);
+    slot_zero[CL_OFF_TRANSMISSION + CL_TRANS_OFF_SLOT
+        ..CL_OFF_TRANSMISSION + CL_TRANS_OFF_SLOT + 8]
+        .copy_from_slice(&0u64.to_le_bytes());
+    cases.push(("zero result slot", slot_zero));
+
+    let mut timestamp_zero = make_chainlink_data(20_000_000, 8, 100);
+    timestamp_zero[CL_OFF_TRANSMISSION + CL_TRANS_OFF_TIMESTAMP
+        ..CL_OFF_TRANSMISSION + CL_TRANS_OFF_TIMESTAMP + 4]
+        .copy_from_slice(&0u32.to_le_bytes());
+    cases.push(("zero publish time", timestamp_zero));
+
+    let mut decimals_too_large = make_chainlink_data(20_000_000, 8, 100);
+    decimals_too_large[CL_OFF_DECIMALS] = 19;
+    cases.push(("decimals above bound", decimals_too_large));
+
+    let mut negative_answer = make_chainlink_data(20_000_000, 8, 100);
+    negative_answer[CL_OFF_TRANSMISSION + CL_TRANS_OFF_ANSWER
+        ..CL_OFF_TRANSMISSION + CL_TRANS_OFF_ANSWER + 16]
+        .copy_from_slice(&(-20_000_000i128).to_le_bytes());
+    cases.push(("negative answer", negative_answer));
+
+    for (label, data) in cases {
+        let (ok, err, unchanged, _) = configure(data);
+        assert!(!ok, "{label}: malformed Chainlink feed must reject");
+        let err = err.unwrap();
+        assert!(
+            err.contains("Custom(26)"),
+            "{label}: malformed Chainlink feed should reject as OracleInvalid (Custom 26), got {err}"
+        );
+        assert!(
+            unchanged,
+            "{label}: rejected Chainlink feed must leave market bytes unchanged"
+        );
+    }
+}
+
+#[test]
 fn v16_attack_non_pyth_oracle_freshness_and_confidence_enforced() {
     type OracleAttempt = (bool, Option<String>, bool, u64);
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -36534,6 +36534,153 @@ fn v16_attack_permissionless_create_underfunded_fee_does_not_activate_or_credit(
     assert_domain_budget_remaining_total_consistent(&funded_group, "funded permissionless create");
 }
 
+// full-interface sweep (cron39): permissionless reuse of a retired slot is a separate
+// UpdateAssetLifecycle branch from append. An underfunded creator must not consume
+// free_market_slot_count, install fresh authorities into the retired slot, or credit asset-0
+// insurance before the fee transfer can really happen.
+#[test]
+fn v16_attack_permissionless_reuse_underfunded_fee_does_not_consume_slot() {
+    const FEE: u128 = 40;
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(FEE);
+
+    env.svm.warp_to_slot(1);
+    env.activate_asset(1, 1, 100);
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        2,
+        0,
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let (cfg_before, group_before) = env.market_state();
+    assert_eq!(
+        cfg_before.free_market_slot_count, 1,
+        "setup leaves exactly one retired reusable slot"
+    );
+    assert_eq!(
+        group_before.assets[1].lifecycle,
+        AssetLifecycleV16::Retired
+    );
+
+    let creator = Keypair::new();
+    env.ensure_signer_account(creator.pubkey());
+    let underfunded_source = env.token_account(creator.pubkey(), FEE as u64 - 1);
+    let source_before = env.svm.get_account(&underfunded_source).unwrap();
+
+    env.svm.warp_to_slot(3);
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::UpdateAssetLifecycle {
+            action: percolator_prog::processor::ASSET_ACTION_ACTIVATE,
+            asset_index: 1,
+            now_slot: 3,
+            initial_price: 250,
+            insurance_authority: creator.pubkey().to_bytes(),
+            insurance_operator: creator.pubkey().to_bytes(),
+            backing_bucket_authority: creator.pubkey().to_bytes(),
+            oracle_authority: creator.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(underfunded_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    );
+    assert!(
+        rejected.is_err(),
+        "underfunded permissionless slot reuse must reject"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected reuse did not consume the retired slot or install new authorities"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected reuse did not move vault tokens"
+    );
+    assert_eq!(
+        env.svm.get_account(&underfunded_source).unwrap(),
+        source_before,
+        "rejected reuse did not debit the creator"
+    );
+    let (cfg_after_reject, group_after_reject) = env.market_state();
+    assert_eq!(
+        cfg_after_reject.free_market_slot_count, 1,
+        "retired slot remains reusable after rejected underfunded reuse"
+    );
+    assert_eq!(
+        group_after_reject.assets[1].lifecycle,
+        AssetLifecycleV16::Retired,
+        "asset remains retired after rejected underfunded reuse"
+    );
+    assert_eq!(group_after_reject.insurance, group_before.insurance);
+    assert_eq!(group_after_reject.vault, group_before.vault);
+    assert_eq!(
+        group_after_reject.insurance_domain_budget,
+        group_before.insurance_domain_budget
+    );
+
+    let funded_source = env.token_account(creator.pubkey(), FEE as u64);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAssetLifecycle {
+            action: percolator_prog::processor::ASSET_ACTION_ACTIVATE,
+            asset_index: 1,
+            now_slot: 3,
+            initial_price: 250,
+            insurance_authority: creator.pubkey().to_bytes(),
+            insurance_operator: creator.pubkey().to_bytes(),
+            backing_bucket_authority: creator.pubkey().to_bytes(),
+            oracle_authority: creator.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(funded_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    )
+    .expect("funded permissionless slot reuse succeeds after rejected underfunded attempt");
+    let (cfg_after_funded, group_after_funded) = env.market_state();
+    assert_eq!(
+        cfg_after_funded.free_market_slot_count, 0,
+        "funded reuse consumes the retired slot"
+    );
+    assert_eq!(
+        group_after_funded.assets[1].lifecycle,
+        AssetLifecycleV16::Active
+    );
+    assert_eq!(
+        env.token_amount(funded_source),
+        0,
+        "funded reuse pulls the fee"
+    );
+    assert_eq!(
+        group_after_funded.vault - group_before.vault,
+        FEE,
+        "funded reuse credits the accounting vault exactly once"
+    );
+    assert_eq!(
+        group_after_funded.insurance - group_before.insurance,
+        FEE,
+        "funded reuse credits asset-0 insurance exactly once"
+    );
+    assert_domain_budget_remaining_total_consistent(
+        &group_after_funded,
+        "permissionless reuse funded after underfunded reject",
+    );
+}
+
 // security.md sweep - sparse append DoS: permissionless activation may append exactly the next
 // configured slot, or reuse a retired slot, but it must not accept sparse jumps. Otherwise a stranger
 // could force large market-account growth or create holes in the asset table.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38812,3 +38812,125 @@ fn v16_attack_push_ewma_mark_same_slot_does_not_compound() {
         "advancing a slot resumes EWMA movement: {m3} vs {m2}"
     );
 }
+
+// Per-asset oracle-authority isolation for the separate EWMA push handler. PushAuthMark has the same
+// boundary covered elsewhere, but PushEwmaMark is its own public entrypoint: a real oracle_authority for
+// asset 1 must not be able to steer asset 0's EWMA mark and cause cross-asset liquidations/LoF.
+#[test]
+fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
+    let mut env = V16CuEnv::new();
+    env.configure_ewma_mark_with_cu(0, 100, 10, 0); // asset 0 EWMA, oracle_authority = admin
+
+    // Activate asset 1 with a distinct real oracle_authority.
+    let a1 = Keypair::new();
+    env.ensure_signer_account(a1.pubkey());
+    env.activate_asset_with_authorities(
+        1,
+        1,
+        100,
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+        a1.pubkey(),
+    );
+
+    // Non-vacuous control: a1 is accepted as the real oracle_authority for asset 1.
+    env.svm.expire_blockhash();
+    let own_asset_config = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: 1,
+            now_slot: 1,
+            initial_mark_e6: 100,
+            mark_ewma_halflife_slots: 10,
+            mark_min_fee: 0,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        own_asset_config.is_ok(),
+        "asset-1's own oracle_authority configures asset-1 EWMA: {own_asset_config:?}"
+    );
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    let own_asset_push = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PushEwmaMark {
+            asset_index: 1,
+            now_slot: 2,
+            mark_e6: 150,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        own_asset_push.is_ok(),
+        "asset-1's own oracle_authority pushes asset-1 EWMA: {own_asset_push:?}"
+    );
+
+    // ATTACK: the same valid asset-1 oracle_authority pushes asset 0's EWMA mark -> reject.
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    let r = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 9_999_999,
+        },
+        vec![
+            AccountMeta::new(a1.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&a1],
+    );
+    assert!(
+        r.is_err(),
+        "asset-1's oracle_authority must not push asset-0's EWMA mark"
+    );
+    assert_eq!(
+        env.market_state().0.mark_ewma_e6,
+        100,
+        "asset-0 EWMA mark unchanged by cross-asset push"
+    );
+
+    // CONTROL: asset 0's own authority can push asset 0.
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    let ok = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 150,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        ok.is_ok(),
+        "asset-0's own authority pushes asset-0 EWMA mark: {ok:?}"
+    );
+    assert!(
+        env.market_state().0.mark_ewma_e6 > 100,
+        "control push moved the EWMA mark"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -270,12 +270,16 @@ fn encode_matcher_init_passive_with_spread(
 }
 
 fn make_mint_data() -> Vec<u8> {
+    make_mint_data_with_decimals(0)
+}
+
+fn make_mint_data_with_decimals(decimals: u8) -> Vec<u8> {
     let mut data = vec![0u8; Mint::LEN];
     Mint::pack(
         Mint {
             mint_authority: COption::None,
             supply: 0,
-            decimals: 0,
+            decimals,
             is_initialized: true,
             freeze_authority: COption::None,
         },
@@ -38633,6 +38637,79 @@ fn v16_attack_deposit_primary_only_withdraw_either() {
         env.token_amount(sec_dest),
         300,
         "secondary withdrawal delivered 1:1"
+    );
+}
+
+// full-interface sweep: base-unit mints are treated as the same unit at 1:1 atom parity across
+// deposits, withdrawals, and SwapSecondaryForPrimary. A mismatched-decimals secondary mint would make
+// that 1:1 accounting value-asymmetric, so even marketauth must not be able to install it.
+#[test]
+fn v16_attack_base_unit_mints_reject_mismatched_decimals() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let primary = env.mint;
+
+    let matched_secondary = env.create_mint();
+    env.svm.expire_blockhash();
+    let matched = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: matched_secondary.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(matched_secondary, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        matched.is_ok(),
+        "equal-decimals primary/secondary mints must still configure: {matched:?}"
+    );
+
+    let mismatched_secondary = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            mismatched_secondary,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_mint_data_with_decimals(6),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: mismatched_secondary.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(mismatched_secondary, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        rejected.is_err(),
+        "mismatched-decimals base-unit pair must reject"
+    );
+    assert!(
+        rejected.unwrap_err().contains("Custom(10)"),
+        "mismatched decimals must fail as InvalidMint"
+    );
+    let (cfg, _) = env.market_state();
+    assert_eq!(
+        cfg.secondary_collateral_mint,
+        matched_secondary.to_bytes(),
+        "rejected mismatched-decimals update must not overwrite the existing secondary mint"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds thirty-five LiteSVM adversarial tests plus one public-interface base-unit mint validation fix for public-interface authority isolation, oracle integrity, stale/live liveness, custody hardening, dual-mint/base-unit accounting, lifecycle rollback, liquidation reward isolation, terminal/recovery boundaries, and bounded batch paths.

- `PushEwmaMark` cross-asset isolation: asset-1's real oracle authority cannot push asset-0 EWMA state; asset 0's own authority still can.
- External-oracle push mode guard: the correct oracle authority cannot use `PushAuthMark` or `PushEwmaMark` to override a hybrid/Pyth-priced asset; rejected pushes leave market bytes unchanged.
- No-feed and hybrid oracle reconfiguration isolation: asset-1 oracle authority cannot reconfigure asset 0 through manual or hybrid oracle paths, with positive controls for the rightful authority.
- Non-Pyth oracle binding/freshness/confidence: Switchboard and Chainlink provider-shaped accounts bind by key/owner and reject stale or wide-confidence data without market mutation.
- Chainlink malformed-field parsing: bad discriminator, zero version/round/live-length/slot/timestamp, decimals above bound, and negative answer reject as `OracleInvalid` without mutation.
- Pyth exponent-bound parsing: out-of-bound and extreme in-bound Pyth exponents reject gracefully as `OracleInvalid`; a normal exponent configures.
- Hybrid liquidation reward-tail rollback: a valid hybrid oracle tail plus malformed reward tail rejects atomically without persisting oracle, liquidation, or reward-account mutation.
- Hybrid oracle timestamp replay: same-feed/same-publish-time price rewrites reject without mutating market or portfolio state.
- Stale-matured live-entrypoint freeze: `Withdraw`, `Deposit`, `TopUpInsurance`, and `TradeNoCpi` reject before permissionless stale resolution, while the resolution path still works.
- Asset append epoch-grief isolation: an unrelated permissionless asset append advances `asset_set_epoch` but cannot freeze a flat victim withdrawal.
- Market-authority handoff: stale marketauth cannot mutate admin paths or execute secondary swaps after rotation; the new key can.
- Secondary swap accounting neutrality: successful `SwapSecondaryForPrimary` on a funded market leaves engine market bytes/accounting unchanged while conserving total primary-plus-secondary vault atoms.
- Base-unit mint decimal parity: `UpdateBaseUnitMints` now rejects primary/secondary mint pairs with mismatched SPL decimals; equal-decimal config still works.
- Dual-mint shared-credit exhaustion: one primary deposit cannot withdraw once through primary and again through secondary; rejected second withdrawal leaves market, portfolio, and reserve unchanged.
- Dual-mint domain-insurance exhaustion: one funded domain budget cannot pay once through primary and again through secondary; rejected second payout leaves market, reserve, and destination unchanged.
- Custody hardening: delegated canonical vaults reject across deposit, top-up, CloseResolved payout, ClaimResolvedPayoutTopup, terminal WithdrawInsurance, and both secondary-swap vault legs.
- Liquidation cranker reward owner isolation: a liquidator cannot mutate another reward portfolio unless that portfolio owner signs.
- CloseSlab terminal custody: primary and secondary terminal reclaim reject closable canonical vault/reserve accounts before moving custody or zeroing the slab.
- Lifecycle retired-slot reuse rollback: underfunded permissionless reuse of a retired slot does not consume slot counters, install authorities, debit creator funds, or credit insurance.
- Empty portfolio reinit counter integrity: reinitializing an already initialized empty portfolio rejects as `AlreadyInitialized` without inflating `materialized_portfolio_count`; the one real portfolio still closes the count back to zero.
- Batch no-CPI leg-cap hardening: 15 configured assets reject atomically against the 14-leg portfolio cap; a 14-leg control succeeds.
- Asset-0 authority rekeys: rotated insurance, live insurance-withdraw, and backing-withdraw authorities revoke stale marketauth while preserving the remaining admin surface.

These are non-vacuous boundary cases, distinct from existing random non-authority tests, same-entrypoint happy paths, and engine-only unit coverage.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark --test v16_cu -- --nocapture`
- `cargo test v16_attack_pushed_mark_cannot_override_external_oracle_asset --test v16_cu -- --nocapture`
- `cargo test v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_oracle --test v16_cu -- --nocapture`
- `cargo test v16_attack_cross_asset_oracle_authority_cannot_configure_other_asset_hybrid --test v16_cu -- --nocapture`
- `cargo test v16_attack_switchboard_oracle_key_owner_binding_enforced --test v16_cu -- --nocapture`
- `cargo test v16_attack_chainlink_oracle_key_owner_binding_enforced --test v16_cu -- --nocapture`
- `cargo test v16_attack_non_pyth_oracle_freshness_and_confidence_enforced --test v16_cu -- --nocapture`
- `cargo test v16_attack_chainlink_oracle_malformed_fields_reject_without_mutation --test v16_cu -- --nocapture`
- `cargo test v16_attack_oracle_pyth_exponent_bounds_enforced --test v16_cu -- --nocapture`
- `cargo test v16_attack_hybrid_liquidation_bad_reward_tail_rolls_back_oracle_update --test v16_cu -- --nocapture`
- `cargo test v16_attack_crank_oracle_same_publish_time_price_rewrite_rejected --test v16_cu -- --nocapture`
- `cargo test v16_attack_stale_matured_live_value_paths_reject_before_resolution --test v16_cu -- --nocapture`
- `cargo test v16_attack_asset_append_cannot_freeze_flat_withdrawal --test v16_cu -- --nocapture`
- `cargo test v16_attack_update_authority_handoff_revokes_old_marketauth_admin_paths --test v16_cu -- --nocapture`
- `cargo test v16_attack_update_authority_handoff_rekeys_secondary_swap_authority --test v16_cu -- --nocapture`
- `cargo test v16_attack_swap_secondary_conserves_and_mints_nothing --test v16_cu -- --nocapture`
- `cargo test v16_attack_base_unit_mints_reject_mismatched_decimals --test v16_cu -- --nocapture`
- `cargo test v16_attack_dual_mint_shared_credit_no_double_withdraw --test v16_cu -- --nocapture`
- `cargo test v16_attack_dual_mint_domain_insurance_no_double_withdraw --test v16_cu -- --nocapture`
- `cargo test v16_attack_deposit_vault_with_delegate_rejected --test v16_cu -- --nocapture`
- `cargo test v16_attack_value_topups_reject_delegated_canonical_vault --test v16_cu -- --nocapture`
- `cargo test v16_attack_close_resolved_rejects_delegated_vault_without_burning_payout --test v16_cu -- --nocapture`
- `cargo test v16_attack_claim_resolved_topup_rejects_delegated_vault_without_burning_receipt --test v16_cu -- --nocapture`
- `cargo test v16_attack_terminal_insurance_withdraw_rejects_delegated_vault_without_debiting_budget --test v16_cu -- --nocapture`
- `cargo test v16_attack_swap_secondary_rejects_delegated_secondary_vault --test v16_cu -- --nocapture`
- `cargo test v16_attack_swap_secondary_rejects_delegated_primary_vault --test v16_cu -- --nocapture`
- `cargo test v16_attack_liquidation_cranker_reward_requires_reward_owner_signature --test v16_cu -- --nocapture`
- `cargo test v16_attack_close_slab_rejects_closable_primary_vault_before_reclaim --test v16_cu -- --nocapture`
- `cargo test v16_attack_close_slab_rejects_closable_secondary_vault_before_reclaim --test v16_cu -- --nocapture`
- `cargo test v16_attack_permissionless_reuse_underfunded_fee_does_not_consume_slot --test v16_cu -- --nocapture`
- `cargo test v16_attack_empty_portfolio_reinit_cannot_inflate_materialized_count --test v16_cu -- --nocapture`
- `cargo test v16_attack_batch_nocpi_over_portfolio_leg_cap_rejects_atomically --test v16_cu -- --nocapture`
- `cargo test v16_attack_asset0_insurance_rotation_rekeys_fee_policy_authority --test v16_cu -- --nocapture`
- `cargo test v16_attack_asset0_operator_rotation_rekeys_live_insurance_withdraw --test v16_cu -- --nocapture`
- `cargo test v16_attack_asset0_backing_rotation_rekeys_live_bucket_withdraw --test v16_cu -- --nocapture`
- `cargo test cross_asset_oracle_authority --test v16_cu -- --nocapture`
- `cargo test oracle_key_owner_binding --test v16_cu -- --nocapture`
- `cargo test chainlink_oracle --test v16_cu -- --nocapture`
- `cargo test non_pyth_oracle --test v16_cu -- --nocapture`
- `cargo test dual_mint --test v16_cu -- --nocapture`
- `cargo test base_unit_mints --test v16_cu -- --nocapture`
- `cargo test swap_secondary --test v16_cu -- --nocapture`
- `cargo test update_authority --test v16_cu -- --nocapture`
- `cargo test handoff --test v16_cu -- --nocapture`
- `git diff --check -- src/v16_program.rs tests/v16_cu.rs`

`cargo test fee_policy --test v16_cu -- --nocapture` was attempted after the fee-policy test was added; the four non-fixture fee-policy tests passed, but the filter also includes `v16_attack_batch_trades_reject_with_backing_fee_policy`, which is blocked in this isolated worktree by the missing `tests/fixtures/auth_matcher/target/deploy/auth_matcher.so` fixture.

`cargo test --test v16_cu` was also attempted earlier in the isolated worktree, but the full file is blocked there by missing external matcher fixture BPF artifacts (`auth_matcher.so`, `hostile_matcher.so`, and `/tmp/percolator-match/target/deploy/percolator_match.so`). The new tests above pass against a freshly built program SBF.