### PR TITLE
Fix: UpdateBaseUnitMints must reject mismatched-decimals collateral pair (LoF)

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8848,6 +8848,23 @@ pub mod processor {
         expect_key(secondary_mint_ai, &secondary_key)?;
         verify_mint(primary_mint_ai)?;
         verify_mint(secondary_mint_ai)?;
+        // Both collateral mints denominate the SAME base unit 1:1: deposits are primary-only,
+        // withdrawals pay EITHER mint, and SwapSecondaryForPrimary moves atoms 1:1 — none of these
+        // paths rescale by decimals. If the two mints had different decimals, one atom of each would
+        // carry different value, so a holder could deposit the higher-value mint and withdraw the same
+        // atom count in the lower-value mint (LoF), or drain the vault via the favorable direction.
+        // Pin the pair to equal decimals so even marketauth cannot install a value-asymmetric pair
+        // (bounded-admin: the admin must not be able to reach a user's collateral).
+        let primary_decimals = spl_token::state::Mint::unpack(&primary_mint_ai.try_borrow_data()?)
+            .map_err(|_| PercolatorError::InvalidMint)?
+            .decimals;
+        let secondary_decimals =
+            spl_token::state::Mint::unpack(&secondary_mint_ai.try_borrow_data()?)
+                .map_err(|_| PercolatorError::InvalidMint)?
+                .decimals;
+        if primary_decimals != secondary_decimals {
+            return Err(PercolatorError::InvalidMint.into());
+        }
 
         let mut data = market_ai.try_borrow_mut_data()?;
         let mut cfg = {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -270,12 +270,16 @@ fn encode_matcher_init_passive_with_spread(
 }
 
 fn make_mint_data() -> Vec<u8> {
+    make_mint_data_with_decimals(0)
+}
+
+fn make_mint_data_with_decimals(decimals: u8) -> Vec<u8> {
     let mut data = vec![0u8; Mint::LEN];
     Mint::pack(
         Mint {
             mint_authority: COption::None,
             supply: 0,
-            decimals: 0,
+            decimals,
             is_initialized: true,
             freeze_authority: COption::None,
         },
@@ -35718,6 +35722,98 @@ fn v16_attack_deposit_primary_only_withdraw_either() {
         env.token_amount(sec_dest),
         300,
         "secondary withdrawal delivered 1:1"
+    );
+}
+
+// LoF sweep — base-unit mints must share decimals (bounded-admin, SOL-002 value asymmetry). The two
+// collateral mints denominate the same base unit 1:1: deposits are primary-only, withdrawals pay EITHER
+// mint, and SwapSecondaryForPrimary moves atoms 1:1 — none rescale by decimals. If marketauth could pair
+// a primary mint with a secondary mint of different decimals, one atom of each would carry different
+// value: a holder could deposit the higher-value mint and withdraw the same atom count in the lower-value
+// mint (LoF), or drain the vault via the favorable direction. UpdateBaseUnitMints must reject a
+// mismatched-decimals pair so even the admin cannot install a value-asymmetric collateral pair.
+// GREEN regression: the wrapper now compares Mint.decimals on both accounts and rejects on mismatch.
+#[test]
+fn v16_attack_base_unit_mints_must_share_decimals() {
+    // Primary (env.mint) is a 0-decimals mint. A SECONDARY with matching decimals configures...
+    let mut env = V16CuEnv::new();
+    let primary = env.mint;
+
+    let matched = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            matched,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_mint_data_with_decimals(0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let r_ok = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: matched.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(matched, false),
+        ],
+        &[&env.admin.insecure_clone()],
+    );
+    assert!(
+        r_ok.is_ok(),
+        "an equal-decimals secondary mint must configure: {r_ok:?}"
+    );
+
+    // ...but a SECONDARY with different decimals (6 vs primary's 0) is the value-asymmetric pair and
+    // must be rejected as InvalidMint (Custom 12) — the admin cannot mint a 1:1 atom asymmetry.
+    let mismatched = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            mismatched,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_mint_data_with_decimals(6),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let r_bad = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: mismatched.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(mismatched, false),
+        ],
+        &[&env.admin.insecure_clone()],
+    );
+    assert!(
+        r_bad.is_err(),
+        "a mismatched-decimals secondary mint must reject (value-asymmetric 1:1 atom pair)"
+    );
+    assert!(
+        r_bad.unwrap_err().contains("Custom(10)"),
+        "mismatched decimals must be InvalidMint (Custom 10)"
+    );
+
+    // The rejected attempt did not stick: config still carries the matched secondary.
+    let (cfg, _) = env.market_state();
+    assert_eq!(
+        cfg.secondary_collateral_mint,
+        matched.to_bytes(),
+        "rejected mismatched-decimals update must not overwrite the configured secondary mint"
     );
 }
 


### PR DESCRIPTION
## Summary

**This PR changes program behavior** (a one-line-class validation) plus a regression test. The dual-mint collateral feature had a missing invariant that lets `marketauth` install a value-asymmetric collateral pair, enabling user/protocol loss-of-funds.

## The bug (LoF — bounded-admin violation / SOL-002)

The two collateral mints denominate the **same base unit 1:1**:
- `Deposit` is primary-only,
- `Withdraw` pays out in **either** mint,
- `SwapSecondaryForPrimary` moves atoms 1:1.

None of these paths rescale by token decimals — they move raw atoms. But `handle_update_base_unit_mints` validated each mint (`verify_mint`) **without ever comparing their decimals**. So `marketauth` could pair, e.g., a 6-decimals primary with a 9-decimals secondary. Then one atom of each carries different real value, and a holder can:
- deposit the higher-value mint and withdraw the **same atom count** in the lower-value mint (**user LoF**), or
- run the favorable direction to **drain the vault** at the expense of other users.

This violates the README's stated bounded-admin guarantee ("even the asset-0 admin … cannot reach into … a user's collateral").

## The fix

After `verify_mint`, unpack both `Mint.decimals` and reject on mismatch (`InvalidMint`). The check runs only at (re)configuration, which is already gated to an empty market, so no live market is affected.

## Test

`v16_attack_base_unit_mints_must_share_decimals`:
- equal-decimals secondary → configures;
- mismatched-decimals (6 vs primary's 0) → rejects `Custom(10)` (InvalidMint);
- the rejected update does **not** overwrite the configured secondary mint.

Verified the test **fails without the guard** (the asymmetric pair was previously accepted), confirming a real vulnerability rather than a tautology. Existing `v16_attack_base_unit_mints_changeable_only_when_empty`, `..._guarded`, and `deposit_primary_only_withdraw_either` (all use matched 0-decimals mints) still pass.

## Note for reviewers

If mismatched-decimals pairs were ever intended (with out-of-band normalization), this guard would need revisiting — but no decimals normalization exists anywhere in deposit/withdraw/swap, so par-1:1 is the clear design intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)