### PR TITLE
Security test sweep: 9 LoF/DoS regression tests + 1 fix (mismatched-decimals collateral)

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8848,6 +8848,23 @@ pub mod processor {
         expect_key(secondary_mint_ai, &secondary_key)?;
         verify_mint(primary_mint_ai)?;
         verify_mint(secondary_mint_ai)?;
+        // Both collateral mints denominate the SAME base unit 1:1: deposits are primary-only,
+        // withdrawals pay EITHER mint, and SwapSecondaryForPrimary moves atoms 1:1 — none of these
+        // paths rescale by decimals. If the two mints had different decimals, one atom of each would
+        // carry different value, so a holder could deposit the higher-value mint and withdraw the same
+        // atom count in the lower-value mint (LoF), or drain the vault via the favorable direction.
+        // Pin the pair to equal decimals so even marketauth cannot install a value-asymmetric pair
+        // (bounded-admin: the admin must not be able to reach a user's collateral).
+        let primary_decimals = spl_token::state::Mint::unpack(&primary_mint_ai.try_borrow_data()?)
+            .map_err(|_| PercolatorError::InvalidMint)?
+            .decimals;
+        let secondary_decimals =
+            spl_token::state::Mint::unpack(&secondary_mint_ai.try_borrow_data()?)
+                .map_err(|_| PercolatorError::InvalidMint)?
+                .decimals;
+        if primary_decimals != secondary_decimals {
+            return Err(PercolatorError::InvalidMint.into());
+        }
 
         let mut data = market_ai.try_borrow_mut_data()?;
         let mut cfg = {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28318,6 +28318,51 @@ fn v16_attack_swap_secondary_conserves_and_mints_nothing() {
     );
 }
 
+// LoF/safety sweep — SwapSecondaryForPrimary rejects on a single-mint market (no secondary configured).
+// The swap reads `secondary_collateral_mint(&cfg)?`, which returns InvalidMint when
+// cfg.secondary_collateral_mint == [0;32] (the default until UpdateBaseUnitMints installs a pair). This
+// rejection happens BEFORE any token account is validated or moved, so a market that never configured a
+// secondary collateral cannot be tricked into a swap (which would otherwise need to interpret a zero/
+// absent mint). Every existing swap test installs a secondary first; the single-mint reject is uncovered.
+#[test]
+fn v16_attack_swap_on_single_mint_market_rejects_no_secondary() {
+    let mut env = V16CuEnv::new(); // single-mint market: no UpdateBaseUnitMints, secondary stays [0;32]
+    let admin = env.admin.insecure_clone();
+
+    // Real, existing accounts for the 4 token slots (content is irrelevant: the cfg check rejects first).
+    let a = env.token_account(admin.pubkey(), 100);
+    let b = env.token_account(admin.pubkey(), 0);
+    let src_before = env.token_amount(a);
+    let vault_before = env.token_amount(env.vault);
+
+    env.svm.expire_blockhash();
+    let r = env.send(
+        ProgInstruction::SwapSecondaryForPrimary { amount: 100 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(a, false),         // primary_source
+            AccountMeta::new(env.vault, false), // primary_vault
+            AccountMeta::new(b, false),         // secondary_dest (placeholder)
+            AccountMeta::new(a, false),         // secondary_vault (placeholder)
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        r.is_err(),
+        "SwapSecondaryForPrimary on a market with no configured secondary mint must reject"
+    );
+    assert!(
+        r.unwrap_err().contains("Custom(10)"),
+        "no-secondary swap must reject as InvalidMint (Custom 10)"
+    );
+    // Nothing moved: the rejection is before any transfer.
+    assert_eq!(env.token_amount(a), src_before, "no primary pulled by the rejected swap");
+    assert_eq!(env.token_amount(env.vault), vault_before, "primary vault unchanged");
+}
+
 // security.md sweep — SwapSecondaryForPrimary authority + balance bounds (#6/#33/#44): the 1:1 par
 // collateral swap is base_unit_authority-gated and bounded by the secondary vault's balance. Attacker
 // goals: (a) a non-authority drains the secondary reserve, (b) the authority over-swaps beyond the

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -35721,6 +35721,94 @@ fn v16_attack_deposit_primary_only_withdraw_either() {
     );
 }
 
+// LoF sweep — dual-mint shared credit (SOL-002 state asymmetry): a deposit credits ONE mint-agnostic
+// engine capital field (`PortfolioV16::header.capital`). The wrapper lets a holder withdraw EITHER the
+// primary or secondary collateral mint 1:1, so the danger is that a single N deposit funds TWO N
+// withdrawals — one per mint — printing collateral out of thin air. This drives that exact double-spend:
+// deposit N primary, fully withdraw N in primary (capital -> 0), then ATTEMPT to withdraw N again in the
+// secondary mint against a fully-funded secondary reserve. The engine MUST reject the second withdraw
+// (capital is exhausted, not per-mint), the secondary reserve must be untouched, and the holder must net
+// exactly N tokens out of an N deposit — never 2N. Complements `deposit_primary_only_withdraw_either`,
+// which only proves each mint is individually withdrawable while credit still remains; it never drives the
+// cross-mint exhaustion boundary where the double-withdraw would actually mint value.
+#[test]
+fn v16_attack_dual_mint_shared_credit_no_double_withdraw() {
+    let mut env = V16CuEnv::new();
+    let market = env.market;
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint();
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 1_000); // single PRIMARY deposit -> engine capital == 1_000.
+
+    // Seed the secondary reserve so the ONLY thing standing between the attacker and a 2x drain is the
+    // shared engine credit (not a thin token balance). 1_000 secondary is sitting in the canonical vault.
+    let sec_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            sec_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 1_000),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    // First withdraw drains the FULL deposit in the primary mint: engine capital 1_000 -> 0.
+    let (primary_dest, _) = env.withdraw_with_cu(&owner, p, 1_000);
+    assert_eq!(
+        env.token_amount(primary_dest),
+        1_000,
+        "full primary withdrawal delivered the entire deposit"
+    );
+
+    // Second withdraw asks for the SAME 1_000 again, now in the secondary mint. If the engine tracked
+    // credit per-mint (or skipped the debit on secondary), this would mint a free 1_000 from the seeded
+    // reserve. It must be rejected: capital is shared and already zero.
+    let sec_dest = env.token_account_for_mint(secondary, owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let r_double = env.send(
+        ProgInstruction::Withdraw { amount: 1_000 },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(sec_dest, false),
+            AccountMeta::new(sec_vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        r_double.is_err(),
+        "second cross-mint withdraw of an already-exhausted credit MUST reject (no free mint)"
+    );
+    assert_eq!(
+        env.token_amount(sec_dest),
+        0,
+        "rejected secondary withdraw delivered nothing"
+    );
+    assert_eq!(
+        env.token_amount(sec_vault),
+        1_000,
+        "secondary reserve is byte-identical after the rejected double-withdraw"
+    );
+
+    // Net conservation: one N deposit yielded exactly N tokens out across BOTH mints, never 2N.
+    assert_eq!(
+        env.token_amount(primary_dest) + env.token_amount(sec_dest),
+        1_000,
+        "holder netted exactly the deposit, not double"
+    );
+}
+
 // security.md sweep — base-unit mints changeable only when empty (#5 / README L127): the base-unit
 // authority may (re)set the primary/secondary mints ONLY while the market holds no value; once funded,
 // the change is rejected so live collateral can never be re-denominated out from under holders.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21866,6 +21866,62 @@ fn v16_attack_rebalance_reduce_owner_gated() {
         "OI still balanced"
     );
 }
+
+// LoF/safety sweep — RebalanceReduce is reduce-ONLY: an over-sized reduce_q cannot flip a position into
+// opposite-side risk. The engine clamps `reduce_q = reduce_q.min(leg.basis_pos_q.unsigned_abs())`, so a
+// reduce can at most take the position to FLAT, never past zero into the other side. Without that clamp,
+// the "reduce" tool would be a backdoor to OPEN fresh opposite-side exposure (a long of N reduced by 2N
+// would become a short of N) — risk creation disguised as risk reduction, bypassing the initial-margin
+// gate that real opens must pass. The existing owner-gated test reduces by EXACTLY the position size
+// (flat either way, so the clamp is never exercised); this drives reduce_q far beyond the position and
+// asserts the result is exactly flat with the sign never inverted, and OI/senior conservation intact.
+#[test]
+fn v16_attack_rebalance_reduce_overshoot_clamps_to_flat_no_flip() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 5_000, 10_000, 1_000);
+    let la = Keypair::new();
+    let pa = env.create_portfolio(&la);
+    let lb = Keypair::new();
+    let pb = env.create_portfolio(&lb);
+    env.deposit(&la, pa, 1_000_000);
+    env.deposit(&lb, pb, 1_000_000);
+    // la opens a LONG of POS_SCALE vs lb's short.
+    env.trade_asset_with_cu(0, &la, pa, &lb, pb, POS_SCALE as i128, 100, 0);
+    let basis0 = env.portfolio_state(pa).legs[0].basis_pos_q;
+    assert!(basis0 > 0, "la opened a long position of POS_SCALE");
+
+    // The owner force-reduces with reduce_q FAR larger than the position (3x). The clamp must cap the
+    // reduction at the position size, landing exactly flat — never flipping the long into a short.
+    env.svm.expire_blockhash();
+    let r = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: 0,
+            reduce_q: 3 * POS_SCALE,
+        },
+        vec![
+            AccountMeta::new(la.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(pa, false),
+        ],
+        &[&la],
+    );
+    assert!(r.is_ok(), "over-sized owner reduce should succeed (clamped): {r:?}");
+
+    let after = env.portfolio_state(pa).legs[0].basis_pos_q;
+    assert_eq!(
+        after, 0,
+        "over-reduce clamps to FLAT (0), never flips the long into a short"
+    );
+    // Defense-in-depth: the sign was never inverted (no opposite-side risk opened).
+    assert!(after >= 0, "position must not become negative (no backdoor short open)");
+
+    let (_, g1) = env.market_state();
+    assert_eq!(
+        g1.assets[0].oi_eff_long_q, g1.assets[0].oi_eff_short_q,
+        "OI still balanced after the clamped reduce"
+    );
+    assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation holds");
+}
+
 // security.md sweep — RefineResolvedUnreceiptedBound gating (#6/#30): this wind-down tool (decreases
 // the unreceipted resolved claim bound) is admin-only and resolved-mode-only. A non-admin must
 // reject, and it must reject in Live mode — no tampering with the resolved payout accounting.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -27174,6 +27174,103 @@ fn v16_attack_withdraw_insurance_domain_budget_cannot_be_overdrawn() {
     conserve(&env);
 }
 
+// LoF sweep — dual-mint domain-insurance shared budget (SOL-002 state asymmetry, protocol funds).
+// `TopUpInsuranceDomain` is funded PRIMARY-only, but `WithdrawInsuranceAsset` (via
+// verify_domain_withdrawal_preflight -> verify_withdrawable_token_accounts) pays out in EITHER the
+// primary or the secondary collateral mint. The danger: a single domain insurance budget of N funds TWO
+// N withdrawals — one per mint — draining the protocol insurance backstop at 2x. This drives that exact
+// double-spend on PROTOCOL funds: top a domain budget to N, withdraw the full N in primary (budget -> 0),
+// then attempt a second N in the secondary mint against a fully-seeded secondary reserve. The engine MUST
+// reject (the domain budget is one mint-agnostic counter, already 0), the reserve must be untouched, and
+// no more than N may ever leave. This is the insurance-path analogue of the user-capital double-withdraw:
+// a DIFFERENT handler (handle_withdraw_insurance_asset), a DIFFERENT counter (insurance_domain_budget),
+// and higher severity (the insurance pool backstops every trader's bad debt). No existing insurance or
+// backing test exercises the dual-mint payout path at all.
+#[test]
+fn v16_attack_dual_mint_domain_insurance_no_double_withdraw() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint();
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    // Fund asset-0's long-side domain (domain 0) insurance budget = 300, in PRIMARY.
+    env.top_up_insurance_domain_with_authority(&admin, 0, 300);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0], 300,
+        "domain-0 budget funded"
+    );
+
+    // Seed the SECONDARY reserve generously so the ONLY barrier to a second payout is the shared
+    // mint-agnostic budget, never a thin token balance (a donation mints no insurance).
+    let sec_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            sec_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 1_000),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    // First payout: drain the FULL asset-0 budget in the PRIMARY mint. budget -> 0.
+    let (primary_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&admin, 0, 300)
+        .expect("asset-0 operator withdraws its domain insurance in primary");
+    assert_eq!(env.token_amount(primary_dest), 300, "primary payout delivered the full budget");
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0], 0,
+        "domain-0 budget fully drained by the primary payout"
+    );
+
+    // Second payout: ask for the SAME 300 again, now in the SECONDARY mint. If the budget were tracked
+    // per-mint (or the debit skipped on the secondary route), this would mint a free 300 of protocol
+    // insurance from the seeded reserve. It must reject: the budget is shared and already zero.
+    let sec_dest = env.token_account_for_mint(secondary, admin.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let r_double = env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            amount: 300,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(sec_dest, false),
+            AccountMeta::new(sec_vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        r_double.is_err(),
+        "second cross-mint insurance payout of an exhausted budget MUST reject (no free protocol mint)"
+    );
+    assert_eq!(env.token_amount(sec_dest), 0, "rejected secondary payout delivered nothing");
+    assert_eq!(
+        env.token_amount(sec_vault),
+        1_000,
+        "secondary insurance reserve is byte-identical after the rejected double-withdraw"
+    );
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0], 0,
+        "budget stays zero; the rejected attempt did not resurrect or double it"
+    );
+
+    // Net conservation: one N budget paid out exactly N across BOTH mints, never 2N.
+    assert_eq!(
+        env.token_amount(primary_dest) + env.token_amount(sec_dest),
+        300,
+        "protocol insurance paid exactly the funded budget, not double"
+    );
+}
+
 // security.md sweep — uniform live insurance API (#6/#23/#57): asset 0 and permissionless assets 1..N
 // both withdraw through the same asset-indexed tag. The signer must be that asset's insurance_operator,
 // and the withdrawal is bounded to that asset's own long+short insurance budget.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7522,6 +7522,55 @@ fn v16_bpf_sync_maintenance_fee_with_cranker_share_is_bounded() {
     assert_domain_budget_remaining_total_consistent(&group, "maintenance fee with cranker share");
 }
 
+// LoF/conservation sweep — maintenance cranker share at the 100% boundary (cranker_share_bps == 10_000).
+// The policy validation rejects > 10_000 but ALLOWS exactly 10_000, so a market can route the ENTIRE
+// maintenance fee to the cranker. The fee passes THROUGH insurance: sync credits the full charged fee to
+// insurance, then `reward = charged * share / 10_000` is moved out to the cranker, with `retained =
+// charged - reward` staying. At 100% share reward == charged, so the cranker takes the whole fee and
+// insurance nets ZERO — the extreme where a regression could underflow insurance (reward > available) or
+// lose/double the fee. Proves conservation holds at the boundary: payer pays exactly the fee, the cranker
+// receives all of it, insurance is unchanged, and the domain-budget total stays consistent. The existing
+// `_is_bounded` test only exercises a 40% share, never the 100% edge.
+#[test]
+fn v16_attack_sync_maintenance_full_cranker_share_conserves_no_insurance_underflow() {
+    let mut env = V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(
+        1, 10_000, 10_000, 10_000, 58,
+    );
+    let payer_owner = Keypair::new();
+    let cranker_owner = Keypair::new();
+    let payer_portfolio = env.create_portfolio(&payer_owner);
+    let cranker_portfolio = env.create_portfolio(&cranker_owner);
+    env.deposit(&payer_owner, payer_portfolio, 100_000_000);
+    env.update_maintenance_fee_policy_with_cu(10_000); // 100% cranker share — the boundary
+
+    let insurance_before = env.market_state().1.insurance;
+
+    env.svm.warp_to_slot(10);
+    env.sync_maintenance_fee_with_cu(payer_portfolio, Some(cranker_portfolio), 10);
+
+    let (_, group) = env.market_state();
+    let payer = env.portfolio_state(payer_portfolio);
+    let cranker = env.portfolio_state(cranker_portfolio);
+
+    // Same fee as the 40%-share test (the fee does not depend on the share): 580.
+    let fee = 100_000_000 - payer.capital;
+    assert_eq!(fee, 580, "maintenance fee charged is the same regardless of share");
+    // 100% share -> the cranker receives the ENTIRE fee...
+    assert_eq!(cranker.capital, 580, "cranker receives the full fee at 100% share");
+    // ...and NOTHING is retained to insurance (and no underflow: insurance is unchanged, not negative).
+    assert_eq!(
+        group.insurance, insurance_before,
+        "at 100% share nothing is retained to insurance (no underflow, no double-credit)"
+    );
+    // Conservation: the payer's debit equals exactly what the cranker received (insurance net zero).
+    assert_eq!(
+        cranker.capital + (group.insurance - insurance_before),
+        fee,
+        "fee fully conserved: cranker reward + retained insurance == charged"
+    );
+    assert_domain_budget_remaining_total_consistent(&group, "100% maintenance cranker share");
+}
+
 #[test]
 fn v16_attack_sync_maintenance_bad_cranker_rolls_back_fee() {
     let mut env = V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34845,6 +34845,83 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
     );
 }
 
+// LoF sweep — oracle-authority rotation actually transfers control (revokes old, grants new). Rotating an
+// asset's oracle authority via UpdateAssetAuthority must REVOKE the previous holder's mark-push power and
+// GRANT it to the new key. If rotation only updated state cosmetically (old key still able to push), a
+// rotated-out / compromised key could keep injecting marks to manipulate settlement (LoF); if the new key
+// could not push, the asset's oracle would be bricked (DoS). Drives the functional transfer end-to-end:
+// admin (the bootstrapped oracle authority) pushes once, the asset_admin rotates the oracle authority to a
+// fresh key, then the OLD key's push rejects (Unauthorized) while the NEW key's push succeeds. The
+// existing rotation test checks state-level isolation/burnability, not the functional push transfer.
+#[test]
+fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100); // admin bootstraps as asset 0's oracle authority; mark = 100
+    let admin = env.admin.insecure_clone();
+
+    // Baseline: the current oracle authority (admin) can push a mark.
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    let r0 = env.send(
+        ProgInstruction::PushAuthMark { asset_index: 0, now_slot: 2, mark_e6: 110 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(r0.is_ok(), "admin (oracle authority) can push before rotation: {r0:?}");
+
+    // Rotate the ORACLE authority admin -> newauth. admin signs as asset_admin; newauth co-signs (proves
+    // control of the incoming key).
+    let newauth = Keypair::new();
+    env.ensure_signer_account(newauth.pubkey());
+    env.svm.expire_blockhash();
+    let rot = env.send(
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: 0,
+            kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
+            new_pubkey: newauth.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(newauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin, &newauth],
+    );
+    assert!(rot.is_ok(), "asset_admin rotates the oracle authority: {rot:?}");
+
+    env.svm.warp_to_slot(3);
+    // OLD authority (admin) is now REVOKED: its push must reject as Unauthorized.
+    env.svm.expire_blockhash();
+    let r_old = env.send(
+        ProgInstruction::PushAuthMark { asset_index: 0, now_slot: 3, mark_e6: 120 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(r_old.is_err(), "the OLD oracle authority must be revoked after rotation");
+    assert!(
+        r_old.unwrap_err().contains("Custom(8)"),
+        "revoked old authority push must be Unauthorized (Custom 8)"
+    );
+
+    // NEW authority can push: rotation GRANTED control.
+    env.svm.expire_blockhash();
+    let r_new = env.send(
+        ProgInstruction::PushAuthMark { asset_index: 0, now_slot: 3, mark_e6: 120 },
+        vec![
+            AccountMeta::new(newauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&newauth],
+    );
+    assert!(r_new.is_ok(), "the NEW oracle authority can push after rotation: {r_new:?}");
+}
+
 // security.md sweep - oracle reconfiguration authority (#6/#37): changing oracle MODE/anchor is as
 // sensitive as pushing a mark. A non-oracle-authority must not switch an empty market between EWMA,
 // AUTH_MARK, or HYBRID modes and thereby seize future price control before users arrive.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -19386,6 +19386,82 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     assert_eq!(env.token_amount(earnings_dest), 0);
 }
 
+// LoF sweep — deposit must pin the vault to the canonical ATA (F-VAULT-FRAG, SOL-007). Deposit credits
+// engine collateral and moves tokens into `vault_token`, while withdrawals pull from the CANONICAL vault
+// (the ATA of vault_authority+mint). If deposit accepted ANY vault_authority-owned token account, a
+// deposit could be routed into a NON-canonical account: the engine credits capital, but the tokens land
+// in a vault the protocol never reads for withdrawals -> the canonical vault is undercollateralized and
+// the depositor's tokens are stranded (liquidity fragmentation). verify_vault_token_account pins the key
+// to canonical_vault_address, so a fragmented deposit must reject. The F-VAULT-FRAG pinning is tested for
+// withdraw / backing / insurance / domain-topups, but NOT for the deposit path.
+#[test]
+fn v16_attack_deposit_to_noncanonical_vault_rejected() {
+    let mut env = V16CuEnv::new();
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+
+    let user = Keypair::new();
+    let p = env.create_portfolio(&user);
+
+    // A legit user-owned source funded with 1_000 primary.
+    let source = env.token_account_for_mint(primary, user.pubkey(), 1_000);
+
+    // A FRAGMENTED vault: a valid token account OWNED BY vault_authority for the right mint, but NOT the
+    // canonical ATA (random address). Same owner + mint as the real vault — only the address differs.
+    let fragmented_vault = Pubkey::new_unique();
+    assert_ne!(
+        fragmented_vault,
+        canonical_vault_ata(vault_authority, primary),
+        "fragmented vault is deliberately not the canonical ATA"
+    );
+    env.svm
+        .set_account(
+            fragmented_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(primary, vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    // ATTACK: deposit routed into the fragmented vault. Must reject (InvalidVaultAccount, Custom 12) —
+    // the engine must NOT credit capital against a vault withdrawals will never read.
+    env.svm.expire_blockhash();
+    let r = env.send(
+        ProgInstruction::Deposit { amount: 1_000 },
+        vec![
+            AccountMeta::new(user.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(fragmented_vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&user],
+    );
+    assert!(r.is_err(), "deposit into a non-canonical vault must reject");
+    assert!(
+        r.unwrap_err().contains("Custom(12)"),
+        "fragmented vault must be InvalidVaultAccount (Custom 12)"
+    );
+    // Atomic: nothing pulled, nothing credited.
+    assert_eq!(env.token_amount(source), 1_000, "rejected deposit pulled no tokens");
+    assert_eq!(env.token_amount(fragmented_vault), 0, "fragmented vault received nothing");
+    assert_eq!(env.portfolio_state(p).capital, 0, "no engine capital credited to a fragmented deposit");
+
+    // CONTROL: the SAME deposit into the CANONICAL vault succeeds and credits capital — proving the
+    // rejection above was the canonical-vault pin, not an unrelated failure.
+    env.deposit(&user, p, 1_000);
+    assert_eq!(
+        env.portfolio_state(p).capital,
+        1_000,
+        "deposit into the canonical vault credits capital normally"
+    );
+}
+
 // security.md sweep — deposit source confusion (#35/#44): the deposit source must be a token account
 // owned by the depositor. Passing the VAULT (or any non-owned account) as the source must reject —
 // otherwise a vault->vault no-op transfer could credit capital for free (mint capital from nothing).

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12618,6 +12618,77 @@ fn v16_regression_profit_withdraw_no_value_printed() {
     );
 }
 
+// security.md sweep — privilege/injection (#19/#39): the permissionless crank's LIQUIDATION fee is
+// config-pinned, not caller-injectable. For action=1 (Liquidate) the wrapper builds the engine request
+// with `fee_bps: config.liquidation_fee_bps` (ignoring the caller's fee_bps) AND requires the caller's
+// fee_bps == 0 (`action == 1 && fee_bps != 0 -> InvalidInstruction`). Without that gate a liquidator could
+// pass an inflated fee_bps to over-extract from the liquidated account (or 0 it out). The funding-rate
+// injection test covers funding_rate_e9 / recovery_reason (via action=0), but never the action=1 fee_bps
+// gate. This proves a Liquidate crank with a nonzero caller fee_bps rejects at the top of the handler
+// (InvalidInstruction, Custom 9), while the same crank with fee_bps==0 passes the gate (failing later for
+// an unrelated reason on a healthy account — NOT Custom 9).
+#[test]
+fn v16_attack_crank_liquidation_fee_bps_not_caller_injectable() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 1_000); // a flat, healthy (non-liquidatable) account
+
+    // ATTACK: a Liquidate crank (action=1) supplying a nonzero fee_bps must reject on the parameter gate.
+    env.svm.expire_blockhash();
+    let r_fee = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 1,
+            funding_rate_e9: 0,
+            close_q: 1,
+            fee_bps: 5_000, // caller-injected liquidation fee — must be rejected
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+        ],
+        &[],
+    );
+    assert!(r_fee.is_err(), "Liquidate crank with a caller-supplied fee_bps must reject");
+    assert!(
+        r_fee.unwrap_err().contains("Custom(9)"),
+        "caller fee_bps injection must reject as InvalidInstruction (Custom 9), the parameter gate"
+    );
+
+    // CONTROL: the SAME crank with fee_bps == 0 passes the parameter gate and reaches the engine, which
+    // rejects for an unrelated reason (the account is healthy / not liquidatable) — crucially NOT Custom 9.
+    env.svm.expire_blockhash();
+    let r_zero = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 1,
+            funding_rate_e9: 0,
+            close_q: 1,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+        ],
+        &[],
+    );
+    assert!(
+        r_zero.is_err(),
+        "liquidating a healthy account still fails (nothing to liquidate)"
+    );
+    assert!(
+        !r_zero.unwrap_err().contains("Custom(9)"),
+        "fee_bps==0 must PASS the parameter gate and fail downstream (not the Custom 9 gate)"
+    );
+}
+
 // security.md sweep — privilege/injection (#19/#39): the permissionless crank's funding_rate_e9
 // and recovery_reason are CALLER-supplied. Attacker tries to inject arbitrary funding to drain the
 // counterparty. Gate (v16_program.rs:10092) must reject any nonzero caller value; the real rate is

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33205,6 +33205,72 @@ fn v16_attack_pyth_partial_verification_rejected() {
     );
 }
 
+// LoF sweep — Pyth account header validation: discriminator + minimum length (SOL-019 type confusion).
+// read_pyth_price_e6 rejects an account whose first 8 bytes are not the PriceUpdateV2 anchor discriminator
+// (OracleInvalid) and one shorter than PRICE_UPDATE_V2_MIN_LEN (InvalidAccountData), BEFORE deserializing
+// the price. Combined with the owner check, this stops a Pyth-RECEIVER-owned account that is NOT a
+// PriceUpdateV2 (a different Pyth account type, or a crafted blob) from being parsed as a price feed --
+// type confusion that could inject an arbitrary mark (LoF). No existing test corrupts the Pyth
+// discriminator or truncates the account (make_pyth_data always writes the correct 134-byte header).
+#[test]
+fn v16_attack_pyth_bad_discriminator_or_short_account_rejected() {
+    let feed = [0x55u8; 32];
+    let configure = |mutate: &dyn Fn(&mut Vec<u8>)| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let mut data = make_pyth_data(&feed, 200_000, -6, 0, 100);
+        mutate(&mut data);
+        let acct = Pubkey::new_unique();
+        env.svm
+            .set_account(
+                acct,
+                Account {
+                    lamports: 1_000_000_000,
+                    data,
+                    owner: oracle_v16::PYTH_RECEIVER_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[acct],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // Control: an untouched (valid header) Pyth account configures.
+    let (ok, ok_err) = configure(&|_d| {});
+    assert!(ok, "a well-formed Pyth account configures: {ok_err:?}");
+
+    // Corrupted anchor discriminator -> rejected before the price is parsed (type confusion blocked).
+    let (disc_ok, disc_err) = configure(&|d| d[0] ^= 0xff);
+    assert!(!disc_ok, "a Pyth account with a wrong discriminator must reject");
+    assert!(
+        disc_err.unwrap().contains("Custom(26)"),
+        "bad Pyth discriminator must be OracleInvalid (Custom 26)"
+    );
+
+    // Truncated account (below PRICE_UPDATE_V2_MIN_LEN) -> rejected on the length gate, no out-of-bounds.
+    let (short_ok, short_err) = configure(&|d| d.truncate(100));
+    assert!(!short_ok, "a too-short Pyth account must reject");
+    let short_msg = short_err.unwrap_or_default();
+    assert!(
+        short_msg.contains("InvalidAccountData") || short_msg.contains("Custom"),
+        "a too-short Pyth account must reject cleanly (no panic / OOB read): {short_msg}"
+    );
+}
+
 // LoF/DoS sweep — Chainlink oracle source end-to-end (SOL-014/SOL-024, previously ZERO coverage). The
 // `CHAINLINK_STORE_PROGRAM_ID` owner branch of `read_oracle_price_e6` -> `read_chainlink_price_e6` is a
 // full production oracle path that nothing exercised: discriminator/version/round/live-length gates,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -270,12 +270,16 @@ fn encode_matcher_init_passive_with_spread(
 }
 
 fn make_mint_data() -> Vec<u8> {
+    make_mint_data_with_decimals(0)
+}
+
+fn make_mint_data_with_decimals(decimals: u8) -> Vec<u8> {
     let mut data = vec![0u8; Mint::LEN];
     Mint::pack(
         Mint {
             mint_authority: COption::None,
             supply: 0,
-            decimals: 0,
+            decimals,
             is_initialized: true,
             freeze_authority: COption::None,
         },
@@ -36078,6 +36082,98 @@ fn v16_attack_dual_mint_shared_credit_no_double_withdraw() {
         env.token_amount(primary_dest) + env.token_amount(sec_dest),
         1_000,
         "holder netted exactly the deposit, not double"
+    );
+}
+
+// LoF sweep — base-unit mints must share decimals (bounded-admin, SOL-002 value asymmetry). The two
+// collateral mints denominate the same base unit 1:1: deposits are primary-only, withdrawals pay EITHER
+// mint, and SwapSecondaryForPrimary moves atoms 1:1 — none rescale by decimals. If marketauth could pair
+// a primary mint with a secondary mint of different decimals, one atom of each would carry different
+// value: a holder could deposit the higher-value mint and withdraw the same atom count in the lower-value
+// mint (LoF), or drain the vault via the favorable direction. UpdateBaseUnitMints must reject a
+// mismatched-decimals pair so even the admin cannot install a value-asymmetric collateral pair.
+// GREEN regression: the wrapper now compares Mint.decimals on both accounts and rejects on mismatch.
+#[test]
+fn v16_attack_base_unit_mints_must_share_decimals() {
+    // Primary (env.mint) is a 0-decimals mint. A SECONDARY with matching decimals configures...
+    let mut env = V16CuEnv::new();
+    let primary = env.mint;
+
+    let matched = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            matched,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_mint_data_with_decimals(0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let r_ok = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: matched.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(matched, false),
+        ],
+        &[&env.admin.insecure_clone()],
+    );
+    assert!(
+        r_ok.is_ok(),
+        "an equal-decimals secondary mint must configure: {r_ok:?}"
+    );
+
+    // ...but a SECONDARY with different decimals (6 vs primary's 0) is the value-asymmetric pair and
+    // must be rejected as InvalidMint (Custom 10) — the admin cannot mint a 1:1 atom asymmetry.
+    let mismatched = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            mismatched,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_mint_data_with_decimals(6),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let r_bad = env.send(
+        ProgInstruction::UpdateBaseUnitMints {
+            primary_mint: primary.to_bytes(),
+            secondary_mint: mismatched.to_bytes(),
+        },
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(primary, false),
+            AccountMeta::new_readonly(mismatched, false),
+        ],
+        &[&env.admin.insecure_clone()],
+    );
+    assert!(
+        r_bad.is_err(),
+        "a mismatched-decimals secondary mint must reject (value-asymmetric 1:1 atom pair)"
+    );
+    assert!(
+        r_bad.unwrap_err().contains("Custom(10)"),
+        "mismatched decimals must be InvalidMint (Custom 10)"
+    );
+
+    // The rejected attempt did not stick: config still carries the matched secondary.
+    let (cfg, _) = env.market_state();
+    assert_eq!(
+        cfg.secondary_collateral_mint,
+        matched.to_bytes(),
+        "rejected mismatched-decimals update must not overwrite the configured secondary mint"
     );
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33140,6 +33140,71 @@ fn v16_attack_oracle_pyth_exponent_bounds_enforced() {
     );
 }
 
+// LoF sweep — Pyth price updates must be FULLY verified (SOL-024 oracle integrity). read_pyth_price_e6
+// rejects unless data[OFF_VERIFICATION_LEVEL] == PYTH_VERIFICATION_FULL_TAG (1). The Pyth Solana Receiver
+// can write a PriceUpdateV2 at a PARTIAL verification level (fewer guardian signatures verified); trusting
+// such a partially-verified price as the settlement mark would accept oracle data the receiver itself did
+// not fully validate — a manipulation/mispricing vector (LoF). Drives the gate: a FULL price configures,
+// while partial (0) and any other non-FULL level reject as OracleInvalid. No existing test varies the
+// Pyth verification level (make_pyth_data hardcodes FULL).
+#[test]
+fn v16_attack_pyth_partial_verification_rejected() {
+    let feed = [0x55u8; 32];
+    let configure = |verification_level: u8| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let mut data = make_pyth_data(&feed, 200_000, -6, 0, 100); // well-formed, fresh, in-bounds price
+        data[40] = verification_level; // OFF_VERIFICATION_LEVEL
+        let acct = Pubkey::new_unique();
+        env.svm
+            .set_account(
+                acct,
+                Account {
+                    lamports: 1_000_000_000,
+                    data,
+                    owner: oracle_v16::PYTH_RECEIVER_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[acct],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // FULL verification (1) -> configures (proves the price is otherwise valid, isolating the gate).
+    let (full_ok, full_err) = configure(1);
+    assert!(full_ok, "a FULLY-verified Pyth price configures: {full_err:?}");
+
+    // PARTIAL verification (0) -> reject: the price was not fully verified by the Pyth receiver.
+    let (partial_ok, partial_err) = configure(0);
+    assert!(!partial_ok, "a partially-verified Pyth price must reject");
+    assert!(
+        partial_err.unwrap().contains("Custom(26)"),
+        "partial-verification Pyth price must be OracleInvalid (Custom 26)"
+    );
+
+    // Any other non-FULL tag (2) -> also reject (only the exact FULL tag is accepted).
+    let (other_ok, other_err) = configure(2);
+    assert!(!other_ok, "a non-FULL verification tag must reject");
+    assert!(
+        other_err.unwrap().contains("Custom(26)"),
+        "non-FULL verification tag must be OracleInvalid (Custom 26)"
+    );
+}
+
 // LoF/DoS sweep — Chainlink oracle source end-to-end (SOL-014/SOL-024, previously ZERO coverage). The
 // `CHAINLINK_STORE_PROGRAM_ID` owner branch of `read_oracle_price_e6` -> `read_chainlink_price_e6` is a
 // full production oracle path that nothing exercised: discriminator/version/round/live-length gates,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -16938,6 +16938,59 @@ fn v16_attack_cure_and_cancel_close_owner_gated() {
     );
 }
 
+// LoF/idempotency sweep — CureAndCancelClose cannot be replayed against an already-cured close ledger.
+// A cure leaves the close ledger in the `canceled` (inert) state and escrows the deposit; the preflight
+// rejects any ledger that is not `active` (`!active || canceled || finalized || has_irreversible_progress
+// -> LockActive`). Without that, a second cure could re-run the cancel/escrow path on a stale ledger,
+// double-processing a deposit or resurrecting a settled close. This drives the replay: seed a cancellable
+// close, cure it once (success -> canceled), then attempt a SECOND cure with a funded deposit — which must
+// reject (EngineLockActive) WITHOUT pulling the second deposit. Existing cure tests cover gating, exact
+// deposit, and cross-market rejection, but never the double-cure / canceled-ledger replay.
+#[test]
+fn v16_attack_cure_cannot_be_replayed_on_canceled_close_ledger() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 100);
+    env.seed_cancellable_close_progress(p);
+
+    // First cure (flat account, no extra deposit needed) succeeds and leaves the ledger `canceled`.
+    let src0 = env.token_account(owner.pubkey(), 0);
+    env.cure_and_cancel_close_with_cu(&owner, p, src0, 0);
+
+    // ATTACK: replay the cure with a FUNDED deposit against the now-canceled ledger. Must reject
+    // (EngineLockActive, Custom 21) and must NOT pull the second deposit (no double-escrow).
+    let src1 = env.token_account(owner.pubkey(), 50);
+    env.svm.expire_blockhash();
+    let r_replay = env.send(
+        ProgInstruction::CureAndCancelClose {
+            optional_deposit: 50,
+        },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(src1, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        r_replay.is_err(),
+        "a second cure of an already-canceled close ledger must reject (no replay)"
+    );
+    assert!(
+        r_replay.unwrap_err().contains("Custom(21)"),
+        "double-cure must reject as EngineLockActive (Custom 21)"
+    );
+    assert_eq!(
+        env.token_amount(src1),
+        50,
+        "rejected replay must not pull the second deposit (no double-escrow)"
+    );
+}
+
 // full-interface sweep (cron29): CureAndCancelClose validates token accounts before the engine cure
 // and transfers after the engine mutation. A market-A portfolio must not be curable through market B
 // with a valid market-B vault, or the source transfer could fund one market while canceling and

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -15198,6 +15198,74 @@ fn v16_attack_convert_then_withdraw_pays_exactly_backed_amount() {
     );
 }
 
+// LoF sweep — deposit/withdraw amount > u64::MAX must reject, never truncate (SOL-014). The instruction
+// `amount` is u128 but SPL token balances are u64: the wrapper credits the ENGINE `amount` (u128) while
+// transferring `amount_to_u64(amount)` tokens. `amount_to_u64` is `u64::try_from`, so amounts above
+// u64::MAX reject. If it instead used `amount as u64`, a deposit of `u64::MAX + 1` would credit the engine
+// ~1.8e19 base units while transferring `(u64::MAX+1) as u64 == 0` tokens — minting collateral from
+// nothing (drain). This drives the boundary: deposit and withdraw with amount == u64::MAX + 1 both reject
+// (InvalidInstruction) with the engine vault/c_tot and the user balances untouched. The existing
+// `large_amount_deposit_withdraw_exact` only exercises the TVL cap (~1e16, far below u64::MAX).
+#[test]
+fn v16_attack_deposit_withdraw_amount_over_u64_max_rejects_no_truncation() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 1_000); // a normal funded position to withdraw against
+
+    let over: u128 = u64::MAX as u128 + 1; // (over as u64) == 0 — the truncation trap
+    let (_, g0) = env.market_state();
+    let cap0 = env.portfolio_state(p).capital;
+
+    // DEPOSIT over u64::MAX: must reject before any engine credit / token pull.
+    let src = env.token_account(owner.pubkey(), 1_000);
+    env.svm.expire_blockhash();
+    let r_dep = env.send(
+        ProgInstruction::Deposit { amount: over },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(src, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(r_dep.is_err(), "deposit of amount > u64::MAX must reject (no truncation credit)");
+    assert!(
+        r_dep.unwrap_err().contains("Custom(9)"),
+        "over-u64 deposit must be InvalidInstruction (Custom 9)"
+    );
+    assert_eq!(env.token_amount(src), 1_000, "rejected over-u64 deposit pulled no tokens");
+    assert_eq!(env.portfolio_state(p).capital, cap0, "no engine credit minted by truncation");
+    assert_eq!(env.market_state().1.c_tot, g0.c_tot, "c_tot unchanged");
+
+    // WITHDRAW over u64::MAX: must also reject before any engine debit / token transfer.
+    let dest = env.token_account(owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let r_wd = env.send(
+        ProgInstruction::Withdraw { amount: over },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    );
+    assert!(r_wd.is_err(), "withdraw of amount > u64::MAX must reject (no truncation debit)");
+    assert!(
+        r_wd.unwrap_err().contains("Custom(9)"),
+        "over-u64 withdraw must be InvalidInstruction (Custom 9)"
+    );
+    assert_eq!(env.token_amount(dest), 0, "rejected over-u64 withdraw delivered nothing");
+    assert_eq!(env.portfolio_state(p).capital, cap0, "capital unchanged by rejected over-u64 withdraw");
+}
+
 // security.md sweep — zero-amount input validation (#39): zero-amount operations must reject or be
 // clean no-ops across deposit/withdraw/trade/topup — never corrupt state or conservation.
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -32222,6 +32222,80 @@ fn v16_attack_oracle_negative_or_zero_price_rejected() {
     );
 }
 
+// LoF/DoS sweep — Pyth exponent bound + extreme-scale arithmetic (SOL-001/SOL-014). The wrapper scales a
+// Pyth price by `10^(exponent+6)`: `read_pyth_price_e6` does `price_u.checked_mul(10u128.pow(scale))` when
+// scale>=0 and `price_u / 10u128.pow(-scale)` when scale<0. Without the `|exponent| <= MAX_EXPO_ABS(18)`
+// guard, a feed reporting an extreme exponent drives `10u128.pow(huge)` past u128 -> overflow PANIC (a
+// crank/refresh that touches the feed aborts every time = liveness DoS), or scales the mark to a wildly
+// wrong value (mispriced positions = LoF). This drives the boundary directly: an out-of-bounds exponent
+// MUST reject gracefully (OracleInvalid, never panic), and an in-bounds-but-extreme exponent must be
+// handled by the post-scale bounds check (over-MAX or floor-to-0 -> OracleInvalid) without overflow.
+// Complements `oracle_negative_or_zero_price_rejected` (varies price at a FIXED expo=-6, never the
+// exponent) and `oracle_composite_over_max_price_rejects` (the multi-leg compose path, not single-leg
+// Pyth exponent scaling).
+#[test]
+fn v16_attack_oracle_pyth_exponent_bounds_enforced() {
+    let configure = |price: i64, expo: i32| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let feed = [0x55u8; 32];
+        let acct = env.set_pyth_price_with_conf(&feed, price, expo, 0, 100);
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[acct],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // Sanity: a normal in-bounds exponent (-6) with a sane price configures.
+    let (ok, _) = configure(200_000, -6);
+    assert!(ok, "a normal expo=-6 Pyth price configures");
+
+    // MAX_EXPO_ABS == 18. The exponent bound (read_pyth_price_e6, v16_program.rs L4091) rejects
+    // |exponent| > 18 BEFORE any pow() is evaluated, so the overflow can never be reached.
+    let (over_ok, over_err) = configure(200_000, 19);
+    assert!(!over_ok, "exponent 19 (> MAX_EXPO_ABS) must reject, never overflow");
+    assert!(
+        over_err.unwrap().contains("Custom(26)"),
+        "out-of-bounds positive exponent must be OracleInvalid (Custom 26), a graceful error not a panic"
+    );
+    let (under_ok, under_err) = configure(200_000, -19);
+    assert!(!under_ok, "exponent -19 (< -MAX_EXPO_ABS) must reject, never overflow");
+    assert!(
+        under_err.unwrap().contains("Custom(26)"),
+        "out-of-bounds negative exponent must be OracleInvalid (Custom 26)"
+    );
+
+    // In-bounds extreme +18 -> scale = 24 -> 10^24 (fits u128, ~1e24 << 3.4e38). With a large mantissa
+    // the scaled price blows past MAX_ORACLE_PRICE; checked_mul succeeds and the post-scale bounds check
+    // rejects it cleanly. The point: no overflow panic on the largest legal exponent.
+    let (max_ok, max_err) = configure(1_000_000, 18);
+    assert!(!max_ok, "expo=+18 with a large mantissa overshoots MAX_ORACLE_PRICE and must reject");
+    assert!(
+        max_err.unwrap().contains("Custom(26)"),
+        "in-bounds max exponent that overshoots must be OracleInvalid, handled without panic"
+    );
+
+    // In-bounds extreme -18 -> scale = -12 -> price / 10^12. A small mantissa floors to 0 and is rejected
+    // by the `out == 0` guard. The point: the divide path also handles the largest legal magnitude
+    // without panic and never yields a zero mark.
+    let (min_ok, min_err) = configure(200_000, -18);
+    assert!(!min_ok, "expo=-18 with a small mantissa floors to 0 and must reject");
+    assert!(
+        min_err.unwrap().contains("Custom(26)"),
+        "in-bounds min exponent that floors to 0 must be OracleInvalid (no zero mark)"
+    );
+}
+
 // security.md sweep — oracle feed account owner validation (#37/#44): a Pyth feed account must be owned
 // by the Pyth receiver program. Attacker goal: substitute a self-owned account holding crafted "Pyth"
 // data to inject an arbitrary oracle price (full oracle spoof). Protection: the wrapper rejects a feed

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -340,6 +340,25 @@ fn make_pyth_data(
     data
 }
 
+// Craft a Chainlink OCR2 Transmissions (store) account (mirrors read_chainlink_price_e6 / CL_* offsets
+// in src/v16_program.rs). Layout: 8-byte anchor discriminator + 192-byte header + transmission record.
+// The wrapper binds the feed by ACCOUNT KEY (not a data field), so the account must be created AT the
+// configured feed pubkey.
+fn make_chainlink_data(decimals: u8, answer: i128, publish_time: i64) -> Vec<u8> {
+    // CHAINLINK_FEED_MIN_LEN = 8 + 192 + 48
+    let mut data = vec![0u8; 8 + 192 + 48];
+    data[0..8].copy_from_slice(&[96, 179, 69, 66, 128, 129, 73, 117]); // discriminator
+    data[8] = 1; // CL_OFF_VERSION (must be != 0)
+    data[138] = decimals; // CL_OFF_DECIMALS
+    data[143..147].copy_from_slice(&1u32.to_le_bytes()); // CL_OFF_LATEST_ROUND_ID (!= 0)
+    data[148..152].copy_from_slice(&1u32.to_le_bytes()); // CL_OFF_LIVE_LENGTH (must == 1)
+    let tx = 8 + 192; // CL_OFF_TRANSMISSION
+    data[tx..tx + 8].copy_from_slice(&1u64.to_le_bytes()); // CL_TRANS_OFF_SLOT (!= 0)
+    data[tx + 8..tx + 12].copy_from_slice(&(publish_time as u32).to_le_bytes()); // CL_TRANS_OFF_TIMESTAMP
+    data[tx + 16..tx + 32].copy_from_slice(&answer.to_le_bytes()); // CL_TRANS_OFF_ANSWER (i128)
+    data
+}
+
 fn cu_ix() -> Instruction {
     ComputeBudgetInstruction::set_compute_unit_limit(1_400_000)
 }
@@ -32293,6 +32312,88 @@ fn v16_attack_oracle_pyth_exponent_bounds_enforced() {
     assert!(
         min_err.unwrap().contains("Custom(26)"),
         "in-bounds min exponent that floors to 0 must be OracleInvalid (no zero mark)"
+    );
+}
+
+// LoF/DoS sweep — Chainlink oracle source end-to-end (SOL-014/SOL-024, previously ZERO coverage). The
+// `CHAINLINK_STORE_PROGRAM_ID` owner branch of `read_oracle_price_e6` -> `read_chainlink_price_e6` is a
+// full production oracle path that nothing exercised: discriminator/version/round/live-length gates,
+// freshness, feed-by-account-key binding, and the `scale_decimal_to_e6(answer, decimals)` scaling. The
+// `decimals` byte is read straight from feed data; `scale_decimal_to_e6` rejects `decimals > MAX_EXPO_ABS
+// (18)` BEFORE `10u128.pow()` runs, so a feed reporting a huge `decimals` cannot overflow the pow into a
+// panic (crank/refresh DoS) or scale the mark to a wrong value (LoF). This proves the happy path reads a
+// crafted Chainlink feed AND that the boundary rejects gracefully. No existing test touches Chainlink.
+#[test]
+fn v16_attack_chainlink_oracle_read_and_bounds_enforced() {
+    // feed binds by account KEY (read_chainlink_price_e6: price_ai.key == expected_feed_key), so create
+    // the feed account AT the configured feed pubkey.
+    let feed = [0x44u8; 32];
+    let feed_key = Pubkey::new_from_array(feed);
+    let configure = |answer: i128, decimals: u8, corrupt_disc: bool| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let mut data = make_chainlink_data(decimals, answer, 100);
+        if corrupt_disc {
+            data[0] ^= 0xff; // break the anchor discriminator
+        }
+        env.svm
+            .set_account(
+                feed_key,
+                Account {
+                    lamports: 1_000_000_000,
+                    data,
+                    owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[feed_key],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // Happy path: a well-formed Chainlink feed (8 decimals, sane answer) reads and configures. This is
+    // the FIRST end-to-end exercise of the Chainlink parse path (discriminator, version, round id,
+    // live_length, freshness, key binding, decimal scaling all on the success route).
+    let (ok, ok_err) = configure(2_000_000_00, 8, false); // 2.0e8 raw / 10^(8-6) = 2_000_000 e6
+    assert!(ok, "a well-formed Chainlink feed must configure: {ok_err:?}");
+
+    // decimals > MAX_EXPO_ABS(18): scale_decimal_to_e6 rejects before any pow(), so the overflow panic
+    // is unreachable. Graceful OracleInvalid, never a DoS panic / mispriced mark.
+    let (over_ok, over_err) = configure(2_000_000, 19, false);
+    assert!(!over_ok, "decimals=19 (> MAX_EXPO_ABS) must reject, never overflow");
+    assert!(
+        over_err.unwrap().contains("Custom(26)"),
+        "out-of-range decimals must be OracleInvalid (Custom 26), a graceful error not a panic"
+    );
+
+    // Negative answer -> OracleInvalid (no sign-flipped / underflowed mark).
+    let (neg_ok, neg_err) = configure(-2_000_000, 8, false);
+    assert!(!neg_ok, "a negative Chainlink answer must reject");
+    assert!(
+        neg_err.unwrap().contains("Custom(26)"),
+        "negative answer must be OracleInvalid (Custom 26)"
+    );
+
+    // Wrong discriminator -> rejected before any field is trusted (anti-spoof: a Chainlink-owned account
+    // that is not actually a Transmissions store cannot inject a price).
+    let (disc_ok, disc_err) = configure(2_000_000, 8, true);
+    assert!(!disc_ok, "a bad Chainlink discriminator must reject");
+    assert!(
+        disc_err.unwrap().contains("Custom(26)"),
+        "bad discriminator must be OracleInvalid (Custom 26)"
     );
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -27728,6 +27728,86 @@ fn v16_attack_unexposed_target_move_cannot_grief_live_insurance_withdrawals() {
     );
 }
 
+// LoF sweep — SwapSecondaryForPrimary mints nothing / is accounting-neutral (SOL-002). A SUCCESSFUL swap
+// is a pure 1:1 token exchange between the authority and the vault (primary in, secondary out); it makes
+// NO engine call, so it must not change the engine's collateral accounting (vault / c_tot / insurance) —
+// only the vault's physical mint composition rebalances. If a swap leaked into engine accounting it would
+// mint or destroy protocol collateral (a solvency break). The sibling test
+// swap_secondary_unauthorized_and_bounded only drives REJECTION paths; nothing exercises a successful
+// swap's conservation. Drives a live deposit (nonzero engine vault/c_tot), then a real swap, asserting:
+// engine counters are byte-identical, the two physical vaults move +N/-N, and total tokens are conserved.
+#[test]
+fn v16_attack_swap_secondary_conserves_and_mints_nothing() {
+    let mut env = V16CuEnv::new();
+    let primary = env.mint;
+    let vault_authority = env.vault_authority;
+    let secondary = env.create_mint(); // 0-decimals, matches primary (post equal-decimals guard)
+    env.update_base_unit_mints_with_cu(primary, secondary);
+
+    // A user deposits 1_000 primary so the engine carries real collateral (vault == c_tot == 1_000).
+    let user = Keypair::new();
+    let p = env.create_portfolio(&user);
+    env.deposit(&user, p, 1_000);
+
+    // Seed the secondary reserve with 400 (a donation: mints no engine collateral).
+    let secondary_vault = canonical_vault_ata(vault_authority, secondary);
+    env.svm
+        .set_account(
+            secondary_vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(secondary, vault_authority, 400),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let admin = env.admin.insecure_clone();
+    let admin_primary = env.token_account_for_mint(primary, admin.pubkey(), 300); // authority pays in primary
+    let admin_secondary = env.token_account_for_mint(secondary, admin.pubkey(), 0); // receives secondary
+
+    // Snapshot engine accounting + physical balances BEFORE the swap.
+    let g_before = env.market_state().1;
+    let primary_vault_before = env.token_amount(env.vault);
+    let sec_vault_before = env.token_amount(secondary_vault);
+    let admin_primary_before = env.token_amount(admin_primary);
+    let total_vault_tokens_before = primary_vault_before + sec_vault_before;
+
+    // Authority swaps 250: pays 250 primary into the vault, receives 250 secondary out.
+    env.swap_secondary_for_primary_with_cu(admin_primary, env.vault, admin_secondary, secondary_vault, 250);
+
+    let g_after = env.market_state().1;
+    // (1) Engine collateral accounting is byte-identical — the swap minted/destroyed NO protocol value.
+    assert_eq!(g_after.vault, g_before.vault, "engine vault counter unchanged by swap");
+    assert_eq!(g_after.c_tot, g_before.c_tot, "engine c_tot unchanged by swap");
+    assert_eq!(g_after.insurance, g_before.insurance, "engine insurance unchanged by swap");
+    assert_eq!(g_before.vault, 1_000, "sanity: engine vault reflects the live deposit only");
+
+    // (2) Physical mint composition rebalanced exactly +250 primary / -250 secondary.
+    assert_eq!(
+        env.token_amount(env.vault),
+        primary_vault_before + 250,
+        "primary vault received the swapped-in 250"
+    );
+    assert_eq!(
+        env.token_amount(secondary_vault),
+        sec_vault_before - 250,
+        "secondary vault released exactly 250"
+    );
+    assert_eq!(env.token_amount(admin_primary), admin_primary_before - 250, "authority paid 250 primary");
+    assert_eq!(env.token_amount(admin_secondary), 250, "authority received 250 secondary");
+
+    // (3) Total custodied tokens across BOTH vaults are conserved (1:1 par, equal decimals): the swap
+    // moved value between mints, never created or destroyed it.
+    assert_eq!(
+        env.token_amount(env.vault) + env.token_amount(secondary_vault),
+        total_vault_tokens_before,
+        "total vault tokens conserved across the swap"
+    );
+}
+
 // security.md sweep — SwapSecondaryForPrimary authority + balance bounds (#6/#33/#44): the 1:1 par
 // collateral swap is base_unit_authority-gated and bounded by the secondary vault's balance. Attacker
 // goals: (a) a non-authority drains the secondary reserve, (b) the authority over-swaps beyond the

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -31017,6 +31017,95 @@ fn v16_attack_liquidation_cranker_reward_bounded_by_fee() {
     );
 }
 
+// LoF/conservation sweep — liquidation cranker share at the 100% boundary (liquidation_cranker_fee_share_
+// bps == 10_000). Unlike the maintenance-fee share (routed through insurance), the liquidation fee is
+// charged to the LIQUIDATED account's collateral and split between the cranker and insurance. At 100%
+// share the cranker takes the ENTIRE fee and insurance gets ZERO — the extreme where a regression could
+// over-pay the cranker beyond the fee (mint) or leak to insurance. Proves: cranker_reward == total_fee,
+// insurance delta == 0, the reward never exceeds the fee, and the fee mints no vault tokens (internal
+// transfer only). The existing bounded test only exercises a 50% share (exact cranker/insurance split).
+#[test]
+fn v16_attack_liquidation_full_cranker_share_takes_whole_fee_no_mint() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.update_liquidation_fee_policy_with_cu(10_000); // 100% cranker share — the boundary
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+    let lo = Keypair::new();
+    let l = env.create_portfolio(&lo);
+    let so = Keypair::new();
+    let s = env.create_portfolio(&so);
+    let co = Keypair::new();
+    let c = env.create_portfolio(&co); // cranker
+    env.deposit(&lo, l, 100_000_000);
+    env.deposit(&so, s, 100_000); // thin short -> insolvent on a price doubling
+    env.deposit(&co, c, 1_000);
+    env.trade_asset_with_cu(0, &lo, l, &so, s, POS_SCALE as i128, 1_000_000, 0);
+    for slot in 1..=30u64 {
+        env.svm.warp_to_slot(slot);
+        let _ = env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                action: 0,
+                asset_index: 0,
+                now_slot: slot,
+                funding_rate_e9: 0,
+                close_q: 0,
+                fee_bps: 0,
+                recovery_reason: 0,
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(s, false),
+            ],
+            &[],
+        );
+    }
+    let c0 = env.portfolio_state(c).capital;
+    let (_, g0) = env.market_state();
+
+    // Liquidate the insolvent short, crediting the cranker portfolio.
+    env.svm.expire_blockhash();
+    let r = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PermissionlessCrank {
+            action: 1,
+            asset_index: 0,
+            now_slot: 30,
+            funding_rate_e9: 0,
+            close_q: POS_SCALE,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(co.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(s, false),
+            AccountMeta::new(c, false),
+        ],
+        &[&co],
+    );
+    assert!(r.is_ok(), "liquidation with a fee should proceed: {r:?}");
+
+    let (_, g1) = env.market_state();
+    let cranker_reward = env.portfolio_state(c).capital as i128 - c0 as i128;
+    let ins_delta = g1.insurance as i128 - g0.insurance as i128;
+    let total_fee = cranker_reward + ins_delta;
+
+    assert!(cranker_reward > 0, "cranker received a real reward (non-vacuous): {cranker_reward}");
+    assert!(total_fee > 0, "a liquidation fee was charged");
+    // 100% share: the cranker takes the ENTIRE fee; insurance gets nothing.
+    assert_eq!(ins_delta, 0, "100%% share: no liquidation fee retained to insurance");
+    assert_eq!(cranker_reward, total_fee, "100%% share: cranker reward == the whole fee");
+    // The reward never exceeds the fee (no profit/mint beyond what was charged).
+    assert!(cranker_reward <= total_fee, "cranker reward bounded by the fee");
+    // The fee is internal (liquidated account -> cranker), minting no vault tokens.
+    assert_eq!(g1.vault, g0.vault, "liquidation fee mints no vault tokens");
+    assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation through 100%-share liquidation");
+}
+
 // security.md sweep — liquidation cranker reward account aliasing (#3/#44): when cranker rewards are
 // enabled, the optional reward portfolio must be distinct from the portfolio being liquidated. Otherwise
 // a liquidated account could receive part of its own liquidation fee back in the same crank.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -25606,6 +25606,59 @@ fn v16_attack_self_crank_maintenance_fee_conserves() {
     );
 }
 
+// DoS/safety sweep — permissionless SettleB (PermissionlessCrank action=2) cannot corrupt or drain a
+// healthy account. SettleB is the bankrupt-account chunk-settlement crank; it is PERMISSIONLESS (anyone
+// may target any portfolio) and, unlike Liquidate (action=1), pays NO cranker reward. The existing crank
+// tests only exercise action=0 (Refresh) and action=1 (Liquidate) — the action=2 dispatch is otherwise
+// untested end-to-end. A SettleB on a flat, solvent account has nothing to settle, so it MUST be a safe
+// no-op for value: the account's capital and the market's vault/c_tot are conserved, no reward is minted,
+// and the owner can still withdraw in full afterward (no fund-trap). Guards the untested permissionless
+// dispatch against being abused to corrupt, drain, or freeze an unrelated healthy account.
+#[test]
+fn v16_attack_permissionless_settle_b_on_healthy_account_is_safe_noop() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 1_000); // flat, solvent — nothing to settle
+
+    let (_, g0) = env.market_state();
+    let cap0 = env.portfolio_state(p).capital;
+    assert_eq!(cap0, 1_000, "account funded and flat");
+
+    // A third party permissionlessly cranks SettleB (action=2) against the healthy account.
+    env.svm.warp_to_slot(5);
+    env.svm.expire_blockhash();
+    let _ = env.send(
+        ProgInstruction::PermissionlessCrank {
+            action: 2,
+            asset_index: 0,
+            now_slot: 5,
+            funding_rate_e9: 0,
+            close_q: 0,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true), // arbitrary cranker
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+        ],
+        &[],
+    );
+    // Whether the engine treats "nothing to settle" as a no-op (Ok) or NonProgress (Err), the invariant is
+    // the same: NO value moved and NO state corruption.
+    let (_, g1) = env.market_state();
+    assert_eq!(env.portfolio_state(p).capital, cap0, "SettleB must not touch a healthy account's capital");
+    assert_eq!(g1.vault, g0.vault, "SettleB must not move the market vault");
+    assert_eq!(g1.c_tot, g0.c_tot, "SettleB must not move c_tot");
+    assert_eq!(g1.insurance, g0.insurance, "SettleB must not mint/burn insurance (no cranker reward)");
+
+    // Liveness: the owner can still withdraw their full capital — the permissionless SettleB did not
+    // freeze or trap the account.
+    let (dest, _) = env.withdraw_with_cu(&owner, p, 1_000);
+    assert_eq!(env.token_amount(dest), 1_000, "account fully withdrawable after a permissionless SettleB");
+}
+
 // security.md sweep — per-asset crank isolation (#32/#22): cranking one asset must not alter another
 // asset's state. A crank+price-move on asset 0 must leave asset 1's effective_price and OI unchanged
 // (no cross-asset corruption).

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33415,6 +33415,74 @@ fn v16_attack_chainlink_oracle_freshness_enforced() {
     );
 }
 
+// LoF sweep — Chainlink round-header field validation (SOL-019/SOL-024). read_chainlink_price_e6 rejects
+// (OracleInvalid) when version == 0, latest_round_id == 0, live_length != 1, result_slot == 0, or
+// publish_time <= 0. Notably live_length != 1: the reader reads the transmission at a FIXED offset, so a
+// multi-round feed (live_length > 1, where the latest round lives elsewhere in the ring buffer) MUST be
+// rejected rather than misread off the stale first slot -- otherwise positions would settle against an
+// outdated round (LoF). The earlier Chainlink tests only used a well-formed single-round header; none of
+// these individual field gates is exercised.
+#[test]
+fn v16_attack_chainlink_round_header_fields_validated() {
+    let feed = [0x47u8; 32];
+    let feed_key = Pubkey::new_from_array(feed);
+    let configure = |mutate: &dyn Fn(&mut Vec<u8>)| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100);
+        let mut data = make_chainlink_data(8, 2_000_000_00, 100); // valid single-round header
+        mutate(&mut data);
+        env.svm
+            .set_account(
+                feed_key,
+                Account {
+                    lamports: 1_000_000_000,
+                    data,
+                    owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[feed_key],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // Control: the untouched single-round header configures.
+    let (ok, ok_err) = configure(&|_d| {});
+    assert!(ok, "a well-formed single-round Chainlink feed configures: {ok_err:?}");
+
+    // Each field gate, individually, must reject as OracleInvalid (Custom 26).
+    let cases: [(&str, &dyn Fn(&mut Vec<u8>)); 5] = [
+        ("version == 0", &|d: &mut Vec<u8>| d[8] = 0),
+        ("latest_round_id == 0", &|d: &mut Vec<u8>| d[143..147].copy_from_slice(&0u32.to_le_bytes())),
+        ("live_length != 1 (multi-round)", &|d: &mut Vec<u8>| {
+            d[148..152].copy_from_slice(&2u32.to_le_bytes())
+        }),
+        ("result_slot == 0", &|d: &mut Vec<u8>| d[200..208].copy_from_slice(&0u64.to_le_bytes())),
+        ("publish_time <= 0", &|d: &mut Vec<u8>| d[208..212].copy_from_slice(&0u32.to_le_bytes())),
+    ];
+    for (label, mutate) in cases {
+        let (cfg_ok, cfg_err) = configure(mutate);
+        assert!(!cfg_ok, "Chainlink feed with {label} must reject");
+        assert!(
+            cfg_err.unwrap().contains("Custom(26)"),
+            "Chainlink {label} must be OracleInvalid (Custom 26)"
+        );
+    }
+}
+
 // security.md sweep — oracle feed account owner validation (#37/#44): a Pyth feed account must be owned
 // by the Pyth receiver program. Attacker goal: substitute a self-owned account holding crafted "Pyth"
 // data to inject an arbitrary oracle price (full oracle spoof). Protection: the wrapper rejects a feed

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26221,6 +26221,51 @@ fn v16_attack_no_fee_liquidation_cranker_gets_nothing() {
     assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation");
 }
 
+// DoS sweep — epoch-grief isolation: a third party cannot trap a flat depositor's funds (SOL-021).
+// Appending a permissionless asset advances the market-wide `asset_set_epoch`, which invalidates the
+// health certificate of EVERY portfolio in the market (a cert binds cert_asset_set_epoch == current).
+// If withdrawal were gated on a fresh certificate, an attacker could append assets every slot to keep
+// all victims' certs perpetually stale and freeze their withdrawals (a cheap-to-trigger, market-wide
+// fund-trap). withdraw_not_atomic gates only on flatness (active_bitmap empty), NOT on cert freshness,
+// so a flat holder is immune. This drives the attack: a flat victim, then an unrelated attacker appends
+// an asset (epoch bumps, victim's would-be cert is stale), and the victim still withdraws in full. Guards
+// against a regression that adds a cert-freshness check to the flat-withdraw path and reopens the DoS.
+#[test]
+fn v16_attack_third_party_asset_append_cannot_freeze_flat_withdrawal() {
+    let mut env = V16CuEnv::new();
+
+    // Victim deposits and stays FLAT (no positions).
+    let victim = Keypair::new();
+    let vp = env.create_portfolio(&victim);
+    env.deposit(&victim, vp, 1_000);
+    let epoch_before = env.market_state().1.asset_set_epoch;
+
+    // Unrelated attacker permissionlessly appends a new asset — advancing the market-wide
+    // asset_set_epoch and thereby staling every portfolio's health certificate.
+    env.update_market_init_fee_policy_with_cu(10);
+    let attacker = Keypair::new();
+    let ak = attacker.pubkey();
+    env.activate_permissionless_asset_with_fee(&attacker, 1, 1, 100, ak, ak, ak, ak, 10);
+    let epoch_after = env.market_state().1.asset_set_epoch;
+    assert!(
+        epoch_after > epoch_before,
+        "sanity: permissionless append must advance asset_set_epoch (the grief lever)"
+    );
+
+    // The flat victim must still withdraw their full capital — the epoch bump cannot trap their funds.
+    let (dest, _) = env.withdraw_with_cu(&victim, vp, 1_000);
+    assert_eq!(
+        env.token_amount(dest),
+        1_000,
+        "flat withdrawal must survive a third party's asset_set_epoch bump (no fund-trap DoS)"
+    );
+    assert_eq!(
+        env.portfolio_state(vp).capital,
+        0,
+        "victim's capital fully withdrawn despite the staled certificate"
+    );
+}
+
 // security.md sweep — withdraw requires flat account (#19/#46): withdraw_not_atomic requires the
 // account to be FLAT (active_bitmap empty) — ANY open position blocks withdrawal, regardless of how
 // small the position or how large the capital. After closing, the full capital is recoverable (no

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -39015,6 +39015,57 @@ fn v16_attack_init_portfolio_cannot_use_market_as_portfolio_account() {
     assert_eq!(initialized.capital, 0);
 }
 
+// DoS sweep — re-init cannot inflate materialized_portfolio_count (SOL-010 / SOL-022 counter inflation).
+// InitPortfolio registers the new (empty) portfolio: materialized_portfolio_count += 1. CloseSlab requires
+// that count == 0 (full wind-down). If an already-initialized EMPTY portfolio could be re-initialized, it
+// would register a SECOND time, leaving a phantom count that never decrements -> the market can NEVER be
+// closed/wound down (a permanent, cheap-to-trigger slab-close DoS). The is_initialized guard rejects the
+// re-init BEFORE the register, so the count cannot be inflated. This is distinct from the funded-reinit
+// test (which protects victim capital/ownership) and from the close-side counter test (rejected close
+// doesn't decrement): this guards the INIT-side counter integrity that keeps slab close reachable.
+#[test]
+fn v16_attack_empty_portfolio_reinit_cannot_inflate_materialized_count() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner); // InitPortfolio: count -> 1 (empty, never deposited)
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        1,
+        "one init registers exactly one materialized portfolio"
+    );
+
+    // ATTACK: re-init the SAME already-initialized empty portfolio to register it a second time.
+    env.svm.expire_blockhash();
+    let r = env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(p, false),
+        ],
+        &[&owner],
+    );
+    assert!(r.is_err(), "re-init of an initialized portfolio must reject");
+    assert!(
+        r.unwrap_err().contains("Custom(2)"),
+        "re-init must be AlreadyInitialized (Custom 2)"
+    );
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        1,
+        "rejected re-init must NOT inflate materialized_portfolio_count (no phantom count)"
+    );
+
+    // The count is accurate: closing the single real portfolio drives it to 0, so the market remains
+    // wind-down-able (the rejected re-init left no phantom blocking slab close).
+    env.close_portfolio_with_cu(&owner, p);
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        0,
+        "count reaches 0 after the one real portfolio closes -> slab close stays reachable"
+    );
+}
+
 // SOL-010 (reinitialization): InitPortfolio targets a program-owned account and SETS its owner. An
 // attacker could try to re-init a VICTIM's already-funded portfolio -- which would reset its capital
 // and reassign ownership, a severe LOF (victim's vaulted tokens orphaned). The is_initialized guard

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33832,6 +33832,93 @@ fn v16_attack_marketauth_renounce_rejected_even_with_fallback() {
     );
 }
 
+// LoF sweep — pushed marks cannot override an EXTERNAL-oracle asset (oracle bypass / price manipulation).
+// PushAuthMark/PushEwmaMark are the manual-mark paths for AuthMark/EwmaMark-mode assets. An asset priced
+// by a real external oracle (Pyth/Switchboard/Chainlink, i.e. hybrid mode) must NOT accept a pushed mark,
+// or the asset's own oracle authority could bypass the external feed and set ANY settlement price —
+// inducing liquidations / printing PnL against traders (LoF). The handlers gate on the asset's mode
+// (profile_is_auth_mark / profile_is_ewma_mark) and reject a mismatch with Unauthorized, BEFORE the
+// authority or slot checks. This drives the bypass with the GENUINE oracle authority (admin) on a
+// hybrid-configured asset and asserts both pushes reject and the externally-seeded mark is unchanged.
+// The existing push-mark tests cover the authority gate / clamp / freshness, never the MODE gate.
+#[test]
+fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
+    let mut env = V16CuEnv::new();
+    set_test_clock(&mut env, 1, 100);
+
+    // Configure asset 0 to be priced by a real EXTERNAL Pyth oracle (hybrid mode). admin is the
+    // oracle authority (ConfigureHybridOracle requires + binds it).
+    let feed = [0x55u8; 32];
+    let acct = env.set_pyth_price_with_conf(&feed, 200_000, -6, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[acct],
+        1,
+        100,
+        0,
+        0,
+        100,
+        0,
+    )
+    .expect("hybrid (external-oracle) configuration of asset 0");
+    let mark_before = env.market_state().1.assets[0].effective_price;
+    assert!(mark_before > 0, "asset 0 seeded from the external oracle");
+
+    let admin = env.admin.insecure_clone();
+    env.svm.warp_to_slot(2);
+
+    // ATTACK 1: the genuine oracle authority pushes an arbitrary AuthMark to OVERRIDE the external feed.
+    // Mode gate (profile_is_auth_mark) rejects it as Unauthorized -- a hybrid asset is not mark-pushable.
+    env.svm.expire_blockhash();
+    let r_auth = env.send(
+        ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 9_999_999,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(r_auth.is_err(), "PushAuthMark on an external-oracle asset must reject");
+    assert!(
+        r_auth.unwrap_err().contains("Custom(8)"),
+        "wrong-mode push must be Unauthorized (Custom 8), not silently applied"
+    );
+
+    // ATTACK 2: same via PushEwmaMark (profile_is_ewma_mark gate) -> also Unauthorized.
+    env.svm.expire_blockhash();
+    let r_ewma = env.send(
+        ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 9_999_999,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(r_ewma.is_err(), "PushEwmaMark on an external-oracle asset must reject");
+    assert!(
+        r_ewma.unwrap_err().contains("Custom(8)"),
+        "wrong-mode push must be Unauthorized (Custom 8)"
+    );
+
+    // The externally-priced mark was never overridden by either rejected push.
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        mark_before,
+        "external-oracle mark unchanged by the rejected manual pushes"
+    );
+}
+
 // security.md sweep — auth-mark push is authority-gated (#6/#37): pushing the settlement mark requires
 // the signer to be the asset's oracle/mark authority (expect_live_authority(authorities.oracle_authority,
 // signer), src/v16_program.rs:9868). Attacker goal: a non-authority pushes an extreme mark to manipulate

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -16923,6 +16923,45 @@ fn v16_attack_tradecpi_self_trade_rejected() {
     assert_eq!(g1.c_tot, g0.c_tot, "c_tot unchanged");
 }
 
+// LoF sweep — a cure deposit is not stranded in escrow; it is fully recoverable. CureAndCancelClose
+// escrows the optional_deposit into `cancel_deposit_escrow`, then on completion folds the escrow into
+// `capital` and zeroes the escrow (cure_and_cancel_close_with_cert_not_atomic). If that release were
+// dropped, the cure deposit would sit in escrow forever — withdraw only pays out `capital`, so the user's
+// cure funds would be permanently locked (LoF). This drives the full round-trip: cure WITH a nonzero
+// deposit, then withdraw the ENTIRE cured capital (original + cure deposit) back out. cure_deposit_exact_
+// and_atomic only asserts the capital credit (never withdraws it); the audit withdraw-after-cure test
+// cures with a ZERO deposit (no escrow to release). This proves the escrowed deposit round-trips out.
+#[test]
+fn v16_attack_cure_deposit_is_recoverable_not_stranded_in_escrow() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let p = env.create_portfolio(&owner);
+    env.deposit(&owner, p, 100);
+    env.seed_cancellable_close_progress(p);
+
+    // Cure WITH a 50 deposit: the escrow is folded into capital (100 + 50 = 150) and zeroed.
+    let src = env.token_account_for_mint(env.mint, owner.pubkey(), 50);
+    env.cure_and_cancel_close_with_cu(&owner, p, src, 50);
+    assert_eq!(
+        env.portfolio_state(p).capital,
+        150,
+        "cure deposit folded into capital (escrow released, not stranded)"
+    );
+
+    // Recover EVERYTHING — including the escrowed cure deposit — via a normal withdraw.
+    let (dest, _) = env.withdraw_with_cu(&owner, p, 150);
+    assert_eq!(
+        env.token_amount(dest),
+        150,
+        "the full cured capital (original 100 + cure deposit 50) is withdrawable"
+    );
+    assert_eq!(
+        env.portfolio_state(p).capital,
+        0,
+        "no residue stranded in capital/escrow after recovering the cure deposit"
+    );
+}
+
 // security.md sweep — CureAndCancelClose deposit accounting (#35/#48): the cure's optional_deposit
 // must credit capital EXACTLY once matching the token transfer (no free-mint), and reject atomically
 // if the source is underfunded. Finding E covered withdraw-after-cure; this covers the deposit leg.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33222,6 +33222,68 @@ fn v16_attack_chainlink_oracle_read_and_bounds_enforced() {
     );
 }
 
+// LoF sweep — Chainlink oracle freshness (SOL-024). read_chainlink_price_e6 computes
+// age = now_unix_ts - publish_time and rejects (OracleStale) if `age < 0 || age > max_staleness_secs`.
+// A stale price (too old) consumed as the mark would let positions settle/liquidate against an outdated
+// price (LoF); a FUTURE-dated price (age < 0) is equally invalid and must not be trusted. The earlier
+// Chainlink test only used a fresh (publish_time == now) feed, so the freshness gate was never exercised;
+// Switchboard freshness is tested but Chainlink's is not. Configure uses now_unix_ts=100, max_staleness=60.
+#[test]
+fn v16_attack_chainlink_oracle_freshness_enforced() {
+    let feed = [0x46u8; 32];
+    let feed_key = Pubkey::new_from_array(feed);
+    let configure = |publish_time: i64| -> (bool, Option<String>) {
+        let mut env = V16CuEnv::new();
+        set_test_clock(&mut env, 1, 100); // now_unix_ts = 100
+        env.svm
+            .set_account(
+                feed_key,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: make_chainlink_data(8, 2_000_000_00, publish_time),
+                    owner: oracle_v16::CHAINLINK_STORE_PROGRAM_ID,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let r = env.try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            1,
+            0,
+            [feed, [0u8; 32], [0u8; 32]],
+            &[feed_key],
+            1,
+            100,
+            0,
+            0,
+            100,
+            0,
+        );
+        (r.is_ok(), r.err())
+    };
+
+    // Fresh (publish_time == now) configures — the freshness gate passes.
+    let (fresh_ok, fresh_err) = configure(100);
+    assert!(fresh_ok, "a fresh Chainlink feed (age 0) configures: {fresh_err:?}");
+
+    // Stale: publish_time=1, now=100, max_staleness=60 -> age 99 > 60 -> OracleStale (Custom 27).
+    let (stale_ok, stale_err) = configure(1);
+    assert!(!stale_ok, "a stale Chainlink feed (age 99 > 60) must reject");
+    assert!(
+        stale_err.unwrap().contains("Custom(27)"),
+        "an over-stale Chainlink price must be OracleStale (Custom 27)"
+    );
+
+    // Future-dated: publish_time=200 > now=100 -> age = -100 < 0 -> OracleStale (no trusting future prices).
+    let (future_ok, future_err) = configure(200);
+    assert!(!future_ok, "a future-dated Chainlink feed (age < 0) must reject");
+    assert!(
+        future_err.unwrap().contains("Custom(27)"),
+        "a future-dated Chainlink price must be OracleStale (Custom 27)"
+    );
+}
+
 // security.md sweep — oracle feed account owner validation (#37/#44): a Pyth feed account must be owned
 // by the Pyth receiver program. Attacker goal: substitute a self-owned account holding crafted "Pyth"
 // data to inject an arbitrary oracle price (full oracle spoof). Protection: the wrapper rejects a feed


### PR DESCRIPTION
Aggregates the security-loop output into one branch. Each commit is a self-contained litesvm end-to-end test (real BPF) targeting a loss-of-funds (LoF) or denial-of-service (DoS) vector with no prior coverage, plus one behavior fix. All 10 new tests pass; existing suite unaffected.

## The fix (behavior change — review carefully)

**`UpdateBaseUnitMints` must reject a mismatched-decimals collateral pair.** Deposit/withdraw/`SwapSecondaryForPrimary` move atoms 1:1 with no decimals rescaling, so pairing a primary mint with a different-decimals secondary lets a holder deposit the higher-value mint and withdraw the same atom count in the lower-value mint (LoF) — or drain the vault via the favorable direction. The handler now compares `Mint.decimals` and rejects on mismatch. Verified the regression test fails without the guard.

## The tests

1. **dual-mint shared credit** — one deposit can't be withdrawn once per mint (2× collateral mint).
2. **Pyth exponent bound** — `|exponent| ≤ 18` prevents `10^huge` overflow panic (crank DoS) / mispricing.
3. **Chainlink oracle source end-to-end** — first coverage of the Chainlink reader (discriminator/round/freshness/key-binding + decimals bound); adds a `make_chainlink_data` fixture.
4. **dual-mint domain insurance** — per-domain insurance budget can't be double-withdrawn across mints (protocol-fund LoF).
5. **base-unit mints share decimals** — green regression for the fix above.
6. **swap accounting-neutral** — a successful `SwapSecondaryForPrimary` mints no engine collateral; only physical composition rebalances.
7. **epoch-grief flat withdrawal** — a third-party asset append (advancing `asset_set_epoch`) can't freeze a flat holder's withdrawal (market-wide fund-trap DoS).
8. **pushed-mark mode guard** — `PushAuthMark`/`PushEwmaMark` can't override an external-oracle (hybrid) asset's price (manipulation).
9. **deposit canonical-vault pin** — deposit into a non-canonical vault rejects (F-VAULT-FRAG; liquidity fragmentation / undercollateralization).
10. **empty-portfolio re-init** — re-init can't inflate `materialized_portfolio_count` (slab-close DoS).

Supersedes the individual PRs #115–#124 (closed in favor of this aggregate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)