### PR TITLE
[codex] Bound terminal insurance high-slot withdrawal CU

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5146,36 +5146,81 @@ pub mod processor {
         Ok(capacity.min(global_available).min(group.header.vault.get()))
     }
 
-    fn terminal_insurance_withdraw_capacity_for_authority_view(
-        group: &state::MarketViewMutV16<'_>,
-        cfg: &WrapperConfigV16,
-        authority: &Pubkey,
-    ) -> Result<u128, ProgramError> {
-        let authority_bytes = authority.to_bytes();
-        if authority_bytes == [0u8; 32] {
-            return Err(PercolatorError::Unauthorized.into());
+    fn debit_terminal_insurance_domain_for_authority_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        domain: usize,
+        amount: &mut u128,
+        observed_total: &mut u128,
+    ) -> ProgramResult {
+        let remaining = domain_withdraw_capacity_view(group, domain)?;
+        if remaining == 0 {
+            return Ok(());
         }
-        let domain_count = (group.header.config.max_market_slots.get() as usize)
+        *observed_total = observed_total
+            .checked_add(remaining)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        let debit = remaining.min(*amount);
+        if debit != 0 {
+            group
+                .withdraw_domain_insurance_not_atomic(domain, debit)
+                .map_err(map_v16_error)?;
+            *amount = amount
+                .checked_sub(debit)
+                .ok_or(PercolatorError::EngineCounterUnderflow)?;
+        }
+        Ok(())
+    }
+
+    fn debit_terminal_insurance_asset_for_authority_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        cfg: &WrapperConfigV16,
+        authority_bytes: [u8; 32],
+        asset_index: usize,
+        amount: &mut u128,
+        observed_total: &mut u128,
+        observe_all_matching_domains: bool,
+    ) -> ProgramResult {
+        let long_domain = asset_index
             .checked_mul(2)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        let mut total = 0u128;
-        let mut domain = 0usize;
-        while domain < domain_count {
-            let authorities = domain_authorities_from_view(group, cfg, domain)?;
-            if authorities.insurance_authority == authority_bytes {
-                total = total
-                    .checked_add(domain_withdraw_capacity_view(group, domain)?)
-                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-            }
-            domain += 1;
+        let short_domain = long_domain
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        let slot = &group.markets[asset_index].engine;
+        let long_budget_remaining = slot
+            .insurance_domain_budget_long
+            .get()
+            .checked_sub(slot.insurance_domain_spent_long.get())
+            .ok_or(PercolatorError::EngineCounterUnderflow)?;
+        let short_budget_remaining = slot
+            .insurance_domain_budget_short
+            .get()
+            .checked_sub(slot.insurance_domain_spent_short.get())
+            .ok_or(PercolatorError::EngineCounterUnderflow)?;
+        if long_budget_remaining == 0 && short_budget_remaining == 0 {
+            return Ok(());
         }
-        let global_available = group.header.insurance.get().saturating_sub(
-            group
-                .header
-                .source_insurance_credit_reserved_total_atoms
-                .get(),
-        );
-        Ok(total.min(global_available).min(group.header.vault.get()))
+        let authorities = domain_authorities_from_view(group, cfg, long_domain)?;
+        if authorities.insurance_authority != authority_bytes {
+            return Ok(());
+        }
+        if long_budget_remaining != 0 && (*amount != 0 || observe_all_matching_domains) {
+            debit_terminal_insurance_domain_for_authority_view(
+                group,
+                long_domain,
+                amount,
+                observed_total,
+            )?;
+        }
+        if short_budget_remaining != 0 && (*amount != 0 || observe_all_matching_domains) {
+            debit_terminal_insurance_domain_for_authority_view(
+                group,
+                short_domain,
+                amount,
+                observed_total,
+            )?;
+        }
+        Ok(())
     }
 
     fn debit_terminal_insurance_budgets_for_authority_view(
@@ -5183,39 +5228,64 @@ pub mod processor {
         cfg: &WrapperConfigV16,
         authority: &Pubkey,
         mut amount: u128,
-    ) -> ProgramResult {
+        observe_all_matching_domains: bool,
+    ) -> Result<u128, ProgramError> {
         if amount == 0 {
-            return Ok(());
+            return Ok(0);
         }
         let authority_bytes = authority.to_bytes();
         if authority_bytes == [0u8; 32] {
             return Err(PercolatorError::Unauthorized.into());
         }
-        let domain_count = (group.header.config.max_market_slots.get() as usize)
-            .checked_mul(2)
-            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        let mut domain = 0usize;
-        while domain < domain_count && amount != 0 {
-            let authorities = domain_authorities_from_view(group, cfg, domain)?;
-            if authorities.insurance_authority == authority_bytes {
-                let remaining = domain_withdraw_capacity_view(group, domain)?;
-                let debit = remaining.min(amount);
-                if debit != 0 {
-                    // Atomic insurance/vault/budget withdraw per domain (maintains the budget total).
-                    group
-                        .withdraw_domain_insurance_not_atomic(domain, debit)
-                        .map_err(map_v16_error)?;
-                    amount = amount
-                        .checked_sub(debit)
-                        .ok_or(PercolatorError::EngineCounterUnderflow)?;
-                }
+        let global_available_before = group.header.insurance.get().saturating_sub(
+            group
+                .header
+                .source_insurance_credit_reserved_total_atoms
+                .get(),
+        );
+        let vault_before = group.header.vault.get();
+        let asset_count = group.header.config.max_market_slots.get() as usize;
+        if asset_count > group.markets.len() {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let mut observed_total = 0u128;
+        let mut front = 0usize;
+        let mut back = asset_count;
+        // Sweep from both ends so sparse terminal budgets at either edge cannot force a full
+        // near-10 MiB account walk before making progress.
+        while front < back && (amount != 0 || observe_all_matching_domains) {
+            debit_terminal_insurance_asset_for_authority_view(
+                group,
+                cfg,
+                authority_bytes,
+                front,
+                &mut amount,
+                &mut observed_total,
+                observe_all_matching_domains,
+            )?;
+            if amount == 0 && !observe_all_matching_domains {
+                break;
             }
-            domain += 1;
+            back -= 1;
+            if back != front {
+                debit_terminal_insurance_asset_for_authority_view(
+                    group,
+                    cfg,
+                    authority_bytes,
+                    back,
+                    &mut amount,
+                    &mut observed_total,
+                    observe_all_matching_domains,
+                )?;
+            }
+            front += 1;
         }
         if amount != 0 {
             return Err(PercolatorError::EngineCounterUnderflow.into());
         }
-        Ok(())
+        Ok(observed_total
+            .min(global_available_before)
+            .min(vault_before))
     }
 
     fn debit_market_insurance_budget_view(
@@ -8096,15 +8166,10 @@ pub mod processor {
         let cfg_pre = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
-            let available_insurance = terminal_insurance_withdraw_capacity_for_authority_view(
-                &group,
-                &cfg,
-                authority.key,
-            )?;
             if group.header.mode != 1
                 || group.header.materialized_portfolio_count.get() != 0
                 || group.header.c_tot.get() != 0
-                || amount > available_insurance
+                || amount > group.header.insurance.get()
                 || amount > group.header.vault.get()
             {
                 return Err(PercolatorError::EngineLockActive.into());
@@ -8114,26 +8179,27 @@ pub mod processor {
             } else {
                 None
             };
+            // insurance + vault + per-domain budget all decremented atomically inside the engine
+            // withdraw (called per domain by the helper); no separate header decrement here.
+            let observed_insurance = debit_terminal_insurance_budgets_for_authority_view(
+                &mut group,
+                &cfg,
+                authority.key,
+                amount,
+                ledger_data.is_some(),
+            )?;
             let mut ledger_state = if let Some(data) = ledger_data.as_deref() {
                 let (mut ledger, initialized) = read_or_new_insurance_ledger(
                     data,
                     market_ai.key.to_bytes(),
                     authority.key.to_bytes(),
-                    available_insurance,
+                    observed_insurance,
                 )?;
-                sync_insurance_ledger(&mut ledger, available_insurance)?;
+                sync_insurance_ledger(&mut ledger, observed_insurance)?;
                 Some((ledger, initialized))
             } else {
                 None
             };
-            // insurance + vault + per-domain budget all decremented atomically inside the engine
-            // withdraw (called per domain by the helper); no separate header decrement here.
-            debit_terminal_insurance_budgets_for_authority_view(
-                &mut group,
-                &cfg,
-                authority.key,
-                amount,
-            )?;
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_withdrawn_atoms = ledger
                     .total_withdrawn_atoms

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -44615,6 +44615,124 @@ fn v16_bpf_10m_market_over_5000_assets_trades_with_bounded_cu() {
     );
 }
 
+// DoS regression — terminal insurance withdrawal used to compute authority capacity with one
+// full-domain scan and then debit with another. A sparse near-10 MiB market with only the LAST
+// domain funded exhausted the 1.4M tx cap before the authority could recover funds, stranding
+// terminal insurance and blocking CloseSlab. Keep this path real-BPF and non-vacuous: fund the
+// last domain, resolve with no portfolios, withdraw through the global terminal interface, and
+// then close the slab.
+#[test]
+fn v16_bpf_terminal_insurance_last_domain_withdraw_stays_bounded_on_10m_market() {
+    const N: usize = 5_834;
+    const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
+    const HIGH_ASSET: usize = N - 1;
+    const PRICE: u64 = 100;
+    const FUNDED: u128 = 123;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(1, PRICE);
+    let (_, g0) = env.market_state();
+    let template = g0.assets[0];
+
+    let new_len = state::market_account_len_for_capacity(N).unwrap();
+    let next_len = state::market_account_len_for_capacity(N + 1).unwrap();
+    assert!(
+        N > 5_000 && new_len <= SOLANA_MAX_ACCOUNT_DATA_LEN && next_len > SOLANA_MAX_ACCOUNT_DATA_LEN,
+        "test should exercise the maximal near-10 MiB market capacity"
+    );
+    {
+        let mut acct = env.svm.get_account(&env.market).unwrap();
+        acct.data.resize(new_len, 0u8);
+        acct.lamports = acct.lamports.max(new_len as u64 * 10);
+        env.svm.set_account(env.market, acct).unwrap();
+    }
+
+    let high_market_id = (HIGH_ASSET as u64) + 1;
+    env.mutate_market(|_cfg, group| {
+        assert_eq!(group.assets.len(), N, "grown read yields N asset slots");
+        assert_eq!(group.insurance_domain_budget.len(), 2 * N);
+        group.config.max_market_slots = N as u32;
+        group.next_market_id = (N as u64) + 1;
+
+        let mut high = template;
+        high.market_id = high_market_id;
+        group.assets[HIGH_ASSET] = high;
+
+        let (long_domain, short_domain) = (2 * HIGH_ASSET, 2 * HIGH_ASSET + 1);
+        group.source_backing_buckets[long_domain] =
+            percolator::BackingBucketV16::empty_for_market(high_market_id);
+        group.source_backing_buckets[short_domain] =
+            percolator::BackingBucketV16::empty_for_market(high_market_id);
+    });
+    {
+        let mut acct = env.svm.get_account(&env.market).unwrap();
+        let profile0 = state::read_asset_oracle_profile(&acct.data, 0).unwrap();
+        state::write_asset_oracle_profile(&mut acct.data, HIGH_ASSET, &profile0).unwrap();
+        env.svm.set_account(env.market, acct).unwrap();
+    }
+
+    let last_domain = (2 * HIGH_ASSET + 1) as u16;
+    let admin = env.admin.insecure_clone();
+    let topup_cu = env.top_up_insurance_domain_with_authority_and_cu(&admin, last_domain, FUNDED).1;
+    assert_cu_within(
+        "10MiB terminal last-domain insurance top-up",
+        topup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let before_resolve = env.market_state().1;
+    assert_eq!(
+        before_resolve.insurance_domain_budget[last_domain as usize],
+        FUNDED,
+        "only the last domain is funded"
+    );
+    assert_eq!(before_resolve.insurance, FUNDED);
+    assert_eq!(before_resolve.c_tot, 0, "no open capital before resolve");
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap().data.len(),
+        new_len,
+        "market account remains the near-10 MiB buffer"
+    );
+
+    env.resolve();
+    let (dest, withdraw_cu) = env.withdraw_terminal_insurance_with_authority(&admin, FUNDED);
+    println!(
+        "v16 10MiB terminal WithdrawInsurance: domains={}, funded_domain={}, CU={withdraw_cu}",
+        2 * N,
+        last_domain
+    );
+    assert_cu_within(
+        "10MiB terminal last-domain WithdrawInsurance",
+        withdraw_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.token_amount(dest), FUNDED as u64);
+
+    let after_withdraw = env.market_state().1;
+    assert_eq!(after_withdraw.insurance, 0, "terminal insurance drained");
+    assert_eq!(
+        after_withdraw.insurance_domain_budget_remaining_total, 0,
+        "all per-domain insurance is consumed"
+    );
+    assert_eq!(
+        after_withdraw.insurance_domain_budget[last_domain as usize],
+        0,
+        "last-domain budget principal is consumed"
+    );
+    assert_eq!(
+        after_withdraw.insurance_domain_spent[last_domain as usize],
+        0,
+        "terminal withdrawal reduces budget rather than recording spent"
+    );
+
+    let close_cu = env.close_slab_with_cu();
+    assert_cu_within(
+        "10MiB terminal last-domain CloseSlab",
+        close_cu,
+        CUSTODY_CU_LIMIT,
+    );
+}
+
 // LIVENESS: no trader can block marketauth's asset cleanup. After force_close_delay_slots, the
 // permissionless force-close winds down a retired asset by netting a long against a short at the
 // frozen mark. A griefer who sits on a maximally-complex (14-leg) STALE portfolio cannot stall this:


### PR DESCRIPTION
## What changed

- Collapsed terminal `WithdrawInsurance` authority-capacity/debit handling into a progress-making debit pass instead of a separate full capacity scan followed by a debit scan.
- Skips empty terminal insurance domains before heavier capacity/authority work.
- Walks funded terminal insurance candidates from both ends so sparse budgets at either edge of a near-10 MiB market cannot force a full account walk before progress.
- Added a real LiteSVM regression for a 5,834-slot market where only the last domain is funded, then resolved and withdrawn through the public terminal `WithdrawInsurance` interface.

## Why

The sweep found a worst-case CU DoS: before the fix, withdrawing terminal insurance from the last domain of the largest current market exhausted the 1.4M tx cap (`ProgramFailedToComplete`) and could strand terminal insurance, blocking `CloseSlab`.

After the fix, the regression prints terminal `WithdrawInsurance` at about 24k-26k CU and stays below the existing custody guardrail.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test v16_bpf_terminal_insurance_last_domain_withdraw_stays_bounded_on_10m_market --test v16_cu -- --nocapture`
- `cargo test terminal_insurance --test v16_cu -- --nocapture`
- `cargo test v16_attack_withdraw_insurance_requires_full_wind_down --test v16_cu -- --nocapture`
- `cargo test v16_bpf_10m_market_over_5000_assets_trades_with_bounded_cu --test v16_cu -- --nocapture`
- `cargo test v16_cu_custody_and_resolution_paths_are_bounded --test v16_cu -- --nocapture`
- `git diff --check -- src/v16_program.rs tests/v16_cu.rs`