### PR TITLE
[codex] Use clamped no-CPI price for mark fees

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6173,20 +6173,18 @@ pub mod processor {
             } else {
                 size_q.unsigned_abs()
             };
-            // F-TRADENOCPI-FEE: the position enters/settles at the asset mark (effective_price), NOT at
-            // the caller-supplied exec_price. The engine uses request.exec_price ONLY as the fee notional
-            // basis (fee = size_q*exec_price/POS_SCALE * fee_bps), so without pinning it two cooperating
-            // accounts could declare a tiny exec_price to pay an arbitrarily small fee on a full
-            // mark-valued trade. Bill the fee on the mark (the price the trade actually settles at),
-            // mirroring TradeCpi where the matcher's exec_price_e6 must equal the oracle price.
-            // NOTE: the ORIGINAL caller exec_price is still passed to update_hybrid_mark_after_trade_view
-            // below — in hybrid mode that is the reported trade price that drives mark discovery (bounded
-            // by the EWMA/clamp), a distinct role from the fee basis.
-            let fee_basis_price = group.markets[asset_index as usize]
-                .engine
-                .asset
-                .effective_price
-                .get();
+            // F-TRADENOCPI-FEE / F-NOCPI-MARK-FEE: request.exec_price is used by the engine only as
+            // fee notional. In price-managed EWMA/stale-hybrid modes, the caller's reported print is
+            // also the mark-discovery input, so first normalize it to the same per-asset dt price
+            // envelope the engine will accept. Use that accepted print consistently for dynamic fee
+            // sizing, engine fee notional, and the EWMA update. Modes without trade-driven mark
+            // discovery fall back to the current effective mark.
+            let fee_basis_price = accepted_reported_trade_price_view(
+                &oracle_profile,
+                &group,
+                asset_index as usize,
+                exec_price,
+            )?;
             let fee_bps = hybrid_trade_fee_bps_view(
                 &cfg,
                 &oracle_profile,
@@ -6264,7 +6262,7 @@ pub mod processor {
                 &mut oracle_profile,
                 &group,
                 asset_index as usize,
-                exec_price,
+                fee_basis_price,
                 outcome
                     .fee_a
                     .checked_add(outcome.fee_b)
@@ -6408,11 +6406,12 @@ pub mod processor {
             expect_portfolio_view_owner(&account_a, account_a_owner_key)?;
             expect_portfolio_view_owner(&account_b, account_b_owner_key)?;
 
-            // Pre-pass: per leg, read its oracle profile, pin the fee basis to the asset mark, and
-            // build the SIGNED engine request. Reject duplicate assets (one leg per asset per batch).
+            // Pre-pass: per leg, read its oracle profile, normalize the reported print to the
+            // wrapper-accepted fee/mark basis, and build the SIGNED engine request. Reject duplicate
+            // assets (one leg per asset per batch).
             let mut requests: Vec<TradeRequestV16> = Vec::with_capacity(legs.len());
-            // (asset_index, oracle_profile, reported_exec_price, fee_basis_price, fee_bps_eff, abs_size)
-            let mut leg_ctx: Vec<(usize, state::AssetOracleProfileV16, u64, u64, u64, u128)> =
+            // (asset_index, oracle_profile, fee_basis_price, fee_bps_eff, abs_size)
+            let mut leg_ctx: Vec<(usize, state::AssetOracleProfileV16, u64, u64, u128)> =
                 Vec::with_capacity(legs.len());
             for leg in legs {
                 let asset_index = leg.asset_index as usize;
@@ -6429,11 +6428,12 @@ pub mod processor {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
                 let abs_size = leg.size_q.unsigned_abs();
-                let fee_basis_price = group.markets[asset_index]
-                    .engine
-                    .asset
-                    .effective_price
-                    .get();
+                let fee_basis_price = accepted_reported_trade_price_view(
+                    &oracle_profile,
+                    &group,
+                    asset_index,
+                    leg.exec_price,
+                )?;
                 let fee_bps_eff = hybrid_trade_fee_bps_view(
                     &cfg,
                     &oracle_profile,
@@ -6452,7 +6452,6 @@ pub mod processor {
                 leg_ctx.push((
                     asset_index,
                     oracle_profile,
-                    leg.exec_price,
                     fee_basis_price,
                     fee_bps_eff,
                     abs_size,
@@ -6480,14 +6479,8 @@ pub mod processor {
             // aggregate or we refuse the batch (no silent mis-accounting).
             let mut reconstructed_total: u128 = 0;
             let mut cfg_dirty = false;
-            for (
-                asset_index,
-                oracle_profile,
-                reported_price,
-                fee_basis_price,
-                fee_bps_eff,
-                abs_size,
-            ) in leg_ctx.iter_mut()
+            for (asset_index, oracle_profile, fee_basis_price, fee_bps_eff, abs_size) in
+                leg_ctx.iter_mut()
             {
                 let fee_leg = batch_leg_fee(*abs_size, *fee_basis_price, *fee_bps_eff)?;
                 credit_trade_fees_to_market_budgets_view(
@@ -6507,7 +6500,7 @@ pub mod processor {
                     oracle_profile,
                     &group,
                     *asset_index,
-                    *reported_price,
+                    *fee_basis_price,
                     total_fee_leg,
                 )?;
                 write_oracle_profile_to_view(&mut group, *asset_index, oracle_profile)?;
@@ -11462,13 +11455,52 @@ pub mod processor {
         ))
     }
 
+    fn profile_updates_mark_from_trade_view(
+        profile: &state::AssetOracleProfileV16,
+        now_slot: u64,
+    ) -> bool {
+        oracle_v16::profile_is_ewma_mark(profile)
+            || (oracle_v16::profile_is_hybrid(profile)
+                && oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot))
+    }
+
+    fn accepted_reported_trade_price_view(
+        profile: &state::AssetOracleProfileV16,
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        reported_exec_price: u64,
+    ) -> Result<u64, ProgramError> {
+        ensure_valid_reported_trade_price(reported_exec_price)?;
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let effective_price = group.markets[asset_index]
+            .engine
+            .asset
+            .effective_price
+            .get();
+        let now_slot = authenticated_market_slot_or_fallback_view(group);
+        if !profile_updates_mark_from_trade_view(profile, now_slot) {
+            return Ok(effective_price);
+        }
+        let dt_slots = core::cmp::max(1, asset_segment_dt_view(group, asset_index, now_slot)?);
+        Ok(oracle_v16::clamp_toward_engine_dt(
+            effective_price,
+            reported_exec_price,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt_slots,
+        ))
+    }
+
     fn hybrid_trade_fee_bps_view(
         cfg: &WrapperConfigV16,
         profile: &state::AssetOracleProfileV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
         size_q_abs: u128,
-        exec_price: u64,
+        accepted_exec_price: u64,
         caller_fee_bps: u64,
     ) -> Result<u64, ProgramError> {
         let base = core::cmp::max(caller_fee_bps, cfg.trade_fee_base_bps);
@@ -11495,13 +11527,7 @@ pub mod processor {
         }
         let asset = group.markets[asset_index].engine.asset;
         let effective_price = asset.effective_price.get();
-        let trade_notional = trade_notional_floor(size_q_abs, exec_price)?;
-        let clamped_exec = oracle_v16::clamp_toward_engine_dt(
-            effective_price,
-            exec_price,
-            group.header.config.max_price_move_bps_per_slot.get(),
-            1,
-        );
+        let trade_notional = trade_notional_floor(size_q_abs, accepted_exec_price)?;
         let max_side_oi_q = core::cmp::max(asset.oi_eff_long_q.get(), asset.oi_eff_short_q.get());
         let max_side_notional = risk_notional_ceil(max_side_oi_q, effective_price)?;
         let mark_externality_notional = core::cmp::max(max_side_notional, trade_notional)
@@ -11522,7 +11548,7 @@ pub mod processor {
         let required = policy_v16::dynamic_fee_bps_with_externality_floor(
             base,
             profile.mark_ewma_e6,
-            clamped_exec,
+            accepted_exec_price,
             profile.mark_ewma_halflife_slots,
             profile.mark_ewma_last_slot,
             now_slot,
@@ -11662,34 +11688,24 @@ pub mod processor {
         profile: &mut state::AssetOracleProfileV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
-        exec_price: u64,
+        accepted_exec_price: u64,
         fee_paid: u128,
     ) -> Result<(), ProgramError> {
         let now_slot = authenticated_market_slot_or_fallback_view(group);
-        let ewma_updates_from_trade = oracle_v16::profile_is_ewma_mark(profile)
-            || (oracle_v16::profile_is_hybrid(profile)
-                && oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot));
+        let ewma_updates_from_trade = profile_updates_mark_from_trade_view(profile, now_slot);
         if !ewma_updates_from_trade
             || asset_index >= group.header.config.max_market_slots.get() as usize
         {
             return Ok(());
         }
+        if accepted_exec_price == 0 || accepted_exec_price > percolator::MAX_ORACLE_PRICE {
+            return Err(PercolatorError::OracleInvalid.into());
+        }
         let fee_paid = u64::try_from(fee_paid).unwrap_or(u64::MAX);
-        let effective_price = group.markets[asset_index]
-            .engine
-            .asset
-            .effective_price
-            .get();
-        let clamped_exec = oracle_v16::clamp_toward_engine_dt(
-            effective_price,
-            exec_price,
-            group.header.config.max_price_move_bps_per_slot.get(),
-            1,
-        );
         let old = profile.mark_ewma_e6;
         let new_mark = policy_v16::ewma_update(
             old,
-            clamped_exec,
+            accepted_exec_price,
             profile.mark_ewma_halflife_slots,
             profile.mark_ewma_last_slot,
             now_slot,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -35332,6 +35332,100 @@ fn v16_attack_nocpi_zero_reported_price_cannot_drive_ewma_or_hybrid_mark() {
     }
 }
 
+fn ewma_no_cpi_fee_and_mark_for_reported_price(
+    path: NoCpiReportedPricePath,
+    reported_price: u64,
+) -> (u128, u64) {
+    const MARK: u64 = 1_000_000;
+    const CAP_BPS: u64 = 50;
+    const TRADE_SLOT: u64 = 5;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: MARK,
+        h_max: 20,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        trade_fee_base_bps: 100,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(1);
+    env.configure_ewma_mark_with_cu(1, MARK, 1, 0);
+    let (_, configured_group) = env.market_state();
+    assert_eq!(configured_group.assets[0].effective_price, MARK);
+    assert_eq!(configured_group.assets[0].slot_last, 1);
+
+    env.svm.warp_to_slot(TRADE_SLOT);
+    let (owner_a, account_a, owner_b, account_b) =
+        funded_no_cpi_reported_price_pair(&mut env, 3_000_000_000);
+    let insurance_before = env.market_state().1.insurance;
+    let size_q = (1000u128 * POS_SCALE) as i128;
+    env.svm.expire_blockhash();
+    try_no_cpi_reported_price_trade_with_cu(
+        &mut env,
+        path,
+        &owner_a,
+        account_a,
+        &owner_b,
+        account_b,
+        size_q,
+        reported_price,
+        0,
+    )
+    .unwrap_or_else(|err| {
+        panic!("{path:?}: no-CPI EWMA trade with reported_price={reported_price} failed: {err}")
+    });
+    let (cfg, group) = env.market_state();
+    (group.insurance - insurance_before, cfg.mark_ewma_e6)
+}
+
+// No-CPI reported-price manipulation follow-up: an epsilon reported price is valid, so rejecting
+// zero is insufficient. The wrapper must first bound the reported print to the same per-asset dt
+// envelope the engine will accept, then use that accepted print consistently for fee notional,
+// dynamic mark-movement fees, and EWMA movement. Otherwise epsilon can either under-pay fees or
+// drive a different mark than the charged price justified.
+#[test]
+fn v16_attack_nocpi_epsilon_reported_price_uses_dt_clamped_fee_and_ewma_price() {
+    const MARK: u64 = 1_000_000;
+    const CAP_BPS: u64 = 50;
+    const DT: u64 = 4;
+    let dt_clamped_epsilon = oracle_v16::clamp_toward_engine_dt(MARK, 1, CAP_BPS, DT);
+    assert_eq!(
+        dt_clamped_epsilon, 980_000,
+        "test setup must exercise a multi-slot engine dt clamp"
+    );
+
+    for path in [
+        NoCpiReportedPricePath::Single,
+        NoCpiReportedPricePath::Batch,
+    ] {
+        let epsilon = ewma_no_cpi_fee_and_mark_for_reported_price(path, 1);
+        let clamped = ewma_no_cpi_fee_and_mark_for_reported_price(path, dt_clamped_epsilon);
+        let at_mark = ewma_no_cpi_fee_and_mark_for_reported_price(path, MARK);
+
+        assert_eq!(
+            epsilon, clamped,
+            "{path:?}: epsilon report must be normalized to the accepted dt-clamped price for fee and EWMA"
+        );
+        assert_ne!(
+            epsilon.0, at_mark.0,
+            "{path:?}: non-vacuous fee assertion; the accepted below-mark print must not be billed as old mark"
+        );
+        assert_ne!(
+            epsilon.1, at_mark.1,
+            "{path:?}: non-vacuous EWMA assertion; the accepted below-mark print must move the mark"
+        );
+        assert!(
+            epsilon.0 < at_mark.0,
+            "{path:?}: lower accepted print should charge lower notional fee than at-mark"
+        );
+        assert!(
+            epsilon.1 < at_mark.1,
+            "{path:?}: lower accepted print should move EWMA below at-mark control"
+        );
+    }
+}
+
 // security.md sweep — phantom collateral via un-backed positive PnL (#9/#22/#33): an account whose
 // counterparty went insolvent carries a large positive PnL figure that is NOT backed (residual is
 // pinned at the counterparty's recovered capital). Attacker goal: have that face-value paper profit


### PR DESCRIPTION
## Summary

- normalize no-CPI reported trade prices to the wrapper-accepted per-asset dt-clamped print for EWMA/stale-hybrid mark discovery
- use that same accepted print for dynamic mark-movement fee sizing, engine fee notional, and EWMA updates
- add a LiteSVM regression covering both TradeNoCpi and BatchTradeNoCpi epsilon reports against the dt-clamped accepted price

## Root Cause

The zero-price guard rejected the sentinel bypass, but valid epsilon prices still reached price-managed no-CPI paths with split semantics: fees were billed on the old effective mark while EWMA movement used a separately clamped reported price. The wrapper now computes the accepted print once and uses it consistently.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test v16_attack_nocpi_epsilon_reported_price_uses_dt_clamped_fee_and_ewma_price --test v16_cu -- --nocapture --test-threads=1`
- `cargo test nocpi --test v16_cu -- --nocapture --test-threads=1`
- `git diff --check`

`cargo fmt --check` still reports broad pre-existing formatting drift in `tests/v16_cu.rs`, so I did not apply unrelated format churn.