### PR TITLE
[codex] Gate maintenance sync live portfolio closure

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8826,7 +8826,7 @@ pub mod processor {
         }
         let authenticated_now_slot = authenticated_slot_or_fallback(now_slot);
 
-        let close_payer_portfolio = {
+        let sync_result = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
             if group.header.mode == 0 {
@@ -8931,13 +8931,9 @@ pub mod processor {
                     .map_err(map_v16_error)?;
             }
 
-            let close_payer_portfolio =
-                deregister_materialized_portfolio_if_empty(&mut group, &portfolio)?;
-            close_payer_portfolio
+            Ok::<(), ProgramError>(())
         };
-        if close_payer_portfolio {
-            close_portfolio_account_to_market_slab(portfolio_ai, market_ai)?;
-        }
+        sync_result?;
         Ok(())
     }
 
@@ -11163,17 +11159,6 @@ pub mod processor {
     ) -> ProgramResult {
         ensure_trade_portfolio_current_for_requests_view(group, account_a, requests)?;
         ensure_trade_portfolio_current_for_requests_view(group, account_b, requests)
-    }
-
-    fn deregister_materialized_portfolio_if_empty(
-        group: &mut state::MarketViewMutV16<'_>,
-        portfolio: &percolator::PortfolioV16ViewMut<'_>,
-    ) -> Result<bool, ProgramError> {
-        match group.deregister_empty_materialized_portfolio_not_atomic(&portfolio.as_view()) {
-            Ok(()) => Ok(true),
-            Err(percolator::V16Error::LockActive) => Ok(false),
-            Err(err) => Err(map_v16_error(err)),
-        }
     }
 
     fn close_portfolio_account_to_market_slab(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -49344,6 +49344,54 @@ fn v16_attack_maintenance_fee_spam_cannot_overdrain() {
     );
 }
 
+// security.md sweep - public maintenance sync must not bypass the live ClosePortfolio owner gate.
+// A flat but initialized portfolio is user-owned state; ClosePortfolio rejects a non-owner in live
+// mode, so the unsigned SyncMaintenanceFee path must not dematerialize it as a side effect.
+#[test]
+fn v16_attack_sync_maintenance_cannot_close_empty_live_victim_portfolio() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        1,
+        "empty initialized portfolio is materialized before the attack"
+    );
+
+    env.svm.expire_blockhash();
+    let sync = env.send(
+        ProgInstruction::SyncMaintenanceFee { now_slot: 0 },
+        vec![
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[],
+    );
+    assert!(
+        sync.is_ok(),
+        "public SyncMaintenanceFee may refresh an empty live portfolio but must not close it: {sync:?}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "empty maintenance sync must not decrement materialized count or absorb rent"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before,
+        "empty maintenance sync must leave the victim portfolio alive"
+    );
+
+    env.close_portfolio_with_cu(&owner, portfolio);
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        0,
+        "owner ClosePortfolio remains the live dematerialization path"
+    );
+}
+
 // Fresh InitMarket is a public bootstrap boundary: an attacker or misconfigured launcher should not be
 // able to burn a newly allocated market account into a half-written, unusable slab with grief params.
 #[test]


### PR DESCRIPTION
## Summary

- Stops `SyncMaintenanceFee` from dematerializing/closing the payer portfolio as an unsigned side effect in live mode.
- Adds a LiteSVM regression proving an empty live portfolio remains alive after public maintenance sync, and that owner `ClosePortfolio` remains the live dematerialization path.

## Root Cause

`handle_sync_maintenance_fee` called `deregister_materialized_portfolio_if_empty` after syncing fees. Because `SyncMaintenanceFee` is permissionless and has no owner signer, any caller could close a flat initialized live portfolio and move its rent into the market slab, bypassing the existing live `ClosePortfolio` owner gate.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_sync_maintenance -- --nocapture`
- `cargo test --test v16_cu v16_attack_non_owner_cannot_close_flat_portfolio -- --nocapture`
- `cargo test --test v16_cu v16_attack_abandoned_empty_portfolio_cannot_block_slab_close -- --nocapture`
- `cargo test --test v16_cu v16_bpf_sync_maintenance_fee_with_cranker_share_is_bounded -- --nocapture`
- `cargo test --test v16_cu v16_attack_maintenance_fee_spam_cannot_overdrain -- --nocapture`
- `git diff --check`

Note: `cargo fmt --check` on `main` wants to reformat large pre-existing sections of `tests/v16_cu.rs`; no formatting churn is included here.