### PR TITLE
[codex] Freeze stale-window marketauth mutations

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9603,6 +9603,10 @@ pub mod processor {
         if !live_authority_matches(&cfg_pre.marketauth, authority.key) {
             return Err(PercolatorError::Unauthorized.into());
         }
+        let authenticated_slot = authenticated_slot_or_fallback(now_slot);
+        if oracle_v16::permissionless_stale_matured(&cfg_pre, authenticated_slot) {
+            return Err(PercolatorError::OracleStale.into());
+        }
 
         let cfg_after = {
             let mut data = market_ai.try_borrow_mut_data()?;
@@ -9624,7 +9628,6 @@ pub mod processor {
             if asset_index >= configured_slots {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
-            let authenticated_slot = authenticated_slot_or_fallback(now_slot);
             let mut reset_profile = None;
             match action {
                 ASSET_ACTION_ACTIVATE => {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10020,6 +10020,9 @@ pub mod processor {
         if mode != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
         }
+        if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
+            return Err(PercolatorError::OracleStale.into());
+        }
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51387,6 +51387,84 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     );
 }
 
+// security.md sweep - stale-resolve config drift (#30/#48): once the market is already old enough
+// for ResolveStalePermissionless, marketauth must not be able to move the resolve threshold forward.
+// Otherwise the fallback can be DoSed in the stale window by reconfiguring stale_slots before the
+// permissionless resolver captures the terminal snapshot.
+#[test]
+fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.configure_auth_mark_with_cu(0, 100);
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_with_cu(3, 100);
+
+    // Non-vacuous fresh control: before the stale boundary, marketauth can still tune the policy.
+    env.svm.warp_to_slot(4);
+    env.svm.expire_blockhash();
+    let fresh = env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 6,
+            force_close_delay_slots: 6,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        fresh.is_ok(),
+        "fresh ConfigurePermissionlessResolve remains reachable: {fresh:?}"
+    );
+    assert_eq!(env.market_state().0.permissionless_resolve_stale_slots, 6);
+
+    env.svm.warp_to_slot(40);
+    let (stale_cfg, stale_group) = env.market_state();
+    assert_eq!(stale_group.mode, MarketModeV16::Live);
+    assert!(
+        oracle_v16::permissionless_stale_matured(&stale_cfg, 40),
+        "test setup must be beyond the configured stale boundary"
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+
+    env.svm.expire_blockhash();
+    let stale = env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 1_000,
+            force_close_delay_slots: 1_000,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        stale.is_err(),
+        "ConfigurePermissionlessResolve must reject once the market is resolve-matured"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale reconfiguration leaves resolve policy unchanged"
+    );
+
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "permissionless resolve remains live after rejected stale reconfiguration: {resolve:?}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
 // Backing-withdrawal stress gate (the insurance path is tested by v16_attack_live_insurance_withdraw_rejects_
 // exposed_target_effective_lag 27623; the BACKING path uses the SAME live_domain_withdraw_health_or_shutdown_
 // view gate but was untested). Scenario the user flagged: an LP withdrawing (fresh) backing from an exposed,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -52505,6 +52505,134 @@ fn v16_attack_permissionless_asset_shutdown_rejects_when_resolve_matured() {
     assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
 }
 
+// security.md sweep - stale-resolve privileged lifecycle drift (#30/#35/#48): the market authority
+// can normally move an empty asset into DrainOnly or Retired without token movement. Once the base
+// market is resolve-matured, those live lifecycle mutations must freeze too; otherwise the terminal
+// snapshot and trader exit surface can be changed in the stale window before permissionless resolve.
+#[test]
+fn v16_attack_marketauth_lifecycle_actions_reject_when_resolve_matured() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.configure_auth_mark_with_cu(0, 100);
+
+    env.svm.warp_to_slot(1);
+    env.activate_asset(1, 1, 100);
+    env.svm.warp_to_slot(2);
+    env.activate_asset(2, 2, 100);
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_with_cu(3, 100);
+
+    // Non-vacuous fresh controls: marketauth lifecycle actions are reachable before stale maturity.
+    env.svm.warp_to_slot(4);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_DRAIN_ONLY,
+        1,
+        0,
+        0,
+    );
+    assert_eq!(
+        env.market_state().1.assets[1].lifecycle,
+        AssetLifecycleV16::DrainOnly,
+        "fresh marketauth DrainOnly path is reachable"
+    );
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        4,
+        0,
+    );
+    assert_eq!(
+        env.market_state().1.assets[1].lifecycle,
+        AssetLifecycleV16::Retired,
+        "fresh marketauth Retire path is reachable"
+    );
+
+    env.svm.warp_to_slot(40);
+    let (stale_cfg, stale_group) = env.market_state();
+    assert_eq!(stale_group.mode, MarketModeV16::Live);
+    assert!(
+        oracle_v16::permissionless_stale_matured(&stale_cfg, 40),
+        "test setup must be beyond the permissionless resolve stale boundary"
+    );
+    assert_eq!(stale_group.assets[2].lifecycle, AssetLifecycleV16::Active);
+
+    let before_drain = env.svm.get_account(&env.market).unwrap();
+    env.svm.expire_blockhash();
+    let stale_drain = env.send(
+        ProgInstruction::UpdateAssetLifecycle {
+            action: percolator_prog::processor::ASSET_ACTION_DRAIN_ONLY,
+            asset_index: 2,
+            now_slot: 0,
+            initial_price: 0,
+            insurance_authority: admin.pubkey().to_bytes(),
+            insurance_operator: admin.pubkey().to_bytes(),
+            backing_bucket_authority: admin.pubkey().to_bytes(),
+            oracle_authority: admin.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        stale_drain.is_err(),
+        "marketauth DrainOnly must reject once the base market is resolve-matured"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        before_drain,
+        "rejected stale DrainOnly leaves lifecycle state unchanged"
+    );
+
+    let before_retire = env.svm.get_account(&env.market).unwrap();
+    env.svm.expire_blockhash();
+    let stale_retire = env.send(
+        ProgInstruction::UpdateAssetLifecycle {
+            action: percolator_prog::processor::ASSET_ACTION_RETIRE,
+            asset_index: 2,
+            now_slot: 40,
+            initial_price: 0,
+            insurance_authority: admin.pubkey().to_bytes(),
+            insurance_operator: admin.pubkey().to_bytes(),
+            backing_bucket_authority: admin.pubkey().to_bytes(),
+            oracle_authority: admin.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        stale_retire.is_err(),
+        "marketauth Retire must reject once the base market is resolve-matured"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        before_retire,
+        "rejected stale Retire leaves lifecycle state unchanged"
+    );
+    assert_eq!(
+        env.market_state().1.assets[2].lifecycle,
+        AssetLifecycleV16::Active,
+        "stale marketauth lifecycle actions cannot alter the active asset"
+    );
+
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "permissionless resolve still succeeds after rejected stale lifecycle actions: {resolve:?}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
 // security.md sweep - stale-resolve oracle restart drift (#30/#37/#48): a permissionless
 // asset admin can restart its own Recovery asset and install a fresh per-asset oracle profile.
 // Once the base market is resolve-matured, that lifecycle/oracle restart must freeze; otherwise a


### PR DESCRIPTION
## Summary

Fixes two stale-resolution drift/DoS issues found during the LoF/DoS sweep. Once the base market is permissionless-resolve-matured but still `Live`, privileged marketauth paths could still mutate live state before the terminal snapshot was captured:

- `UpdateAssetLifecycle(DrainOnly|Retire)` could change an empty asset's lifecycle in the stale window.
- `ConfigurePermissionlessResolve` could push `stale_slots`/`force_close_delay_slots` outward after the market was already stale-resolvable, potentially blocking the permissionless resolver.

The fix freezes both paths once the current authenticated clock and current policy say the market is already permissionless-resolve-matured.

## Coverage

Adds `v16_attack_marketauth_lifecycle_actions_reject_when_resolve_matured`, which proves fresh marketauth `DrainOnly`/`Retire` are reachable, stale attempts reject byte-identically, and `ResolveStalePermissionless` remains live.

Adds `v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured`, which proves fresh reconfiguration remains reachable, stale reconfiguration rejects byte-identically, and the resolver remains live.

## Validation

Passed after `cargo build-sbf --no-default-features`:

- `cargo test -p percolator-prog --test v16_cu v16_attack_marketauth_lifecycle_actions_reject_when_resolve_matured -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_configure_permissionless_resolve_gated_and_bounded -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_permissionless_resolve_uses_authenticated_clock_slot -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_drain_only_blocks_new_risk_but_allows_reduce -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_permissionless_asset_shutdown_rejects_when_resolve_matured -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_bpf_privileged_retire_uses_authenticated_slot -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_bpf_privileged_reactivate_uses_authenticated_slot -- --nocapture`
- `git diff --check`

Full `cargo test -p percolator-prog --test v16_cu` was attempted and currently fails on rebuilt `main` too, independent of this branch:

- `v16_attack_underfunded_sync_with_cranker_reward_still_closes_payer`
- `v16_bpf_underfunded_flat_sync_sweeps_remaining_capital_once`
- `v16_bpf_batch_trade_cpi_14_legs_under_tx_limit`

`cargo fmt --check` also reports broad pre-existing formatting differences in `tests/v16_cu.rs`; this PR intentionally does not reformat unrelated code.