### PR TITLE
[codex] Reduce batch CPI preflight CU

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2645,6 +2645,7 @@ pub mod state {
             MarketModeV16,
             u64,
             u64,
+            usize,
             alloc::vec::Vec<u64>,
         ),
         ProgramError,
@@ -2700,6 +2701,7 @@ pub mod state {
             decode_market_mode(wire.mode)?,
             wire.current_slot.get(),
             engine_config.max_trading_fee_bps,
+            engine_config.max_market_slots as usize,
             prices,
         ))
     }
@@ -7225,14 +7227,21 @@ pub mod processor {
         let (
             mode_pre,
             current_slot_pre,
+            max_market_slots,
             oracle_prices,
             stale_matured,
             backing_fee_policy_active,
             fee_bounds_ok,
         ) = {
             let market_data = market_ai.try_borrow_data()?;
-            let (cfg_pre, mode_pre, current_slot_pre, max_trading_fee_bps, oracle_prices) =
-                state::read_asset_effective_prices(&market_data, &asset_indices)?;
+            let (
+                cfg_pre,
+                mode_pre,
+                current_slot_pre,
+                max_trading_fee_bps,
+                max_market_slots,
+                oracle_prices,
+            ) = state::read_asset_effective_prices(&market_data, &asset_indices)?;
             let authenticated_slot = authenticated_slot_or_fallback(current_slot_pre);
             let mut stale_matured = false;
             for &asset_index in &asset_indices {
@@ -7254,6 +7263,7 @@ pub mod processor {
             (
                 mode_pre,
                 current_slot_pre,
+                max_market_slots,
                 oracle_prices,
                 stale_matured,
                 cfg_pre.backing_trade_fee_policy_count != 0,
@@ -7380,8 +7390,6 @@ pub mod processor {
             });
         }
 
-        let (_, _, max_market_slots, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         handle_batch_execute_zero_copy(
             program_id,
             signer_a.key,


### PR DESCRIPTION
## Summary

`BatchTradeCpi` was doing a second market config/capacity parse after matcher return validation even though the preflight helper had already decoded the engine config. This carries `max_market_slots` out of that existing parse and reuses it for `handle_batch_execute_zero_copy`.

## Root Cause

The real matcher-backed 14-leg `BatchTradeCpi` route was just over the BPF CU meter on current `main`:

- before: `ProgramFailedToComplete`, program consumed `1,399,676 of 1,399,700` CU and then exceeded the BPF instruction meter
- after: `v16 batch 14-leg BatchTradeCpi (one matcher CPI) CU: 1,318,886` in the focused run, and `1,317,386` during the full-suite run

The existing mainline test `v16_bpf_batch_trade_cpi_14_legs_under_tx_limit` is the proof: it failed before this code change and passes after rebuilding SBF.

## Validation

- `cargo check -p percolator-prog --tests`
- `cargo build-sbf --no-default-features`
- `cargo test -p percolator-prog --test v16_cu v16_bpf_batch_trade_cpi_14_legs_under_tx_limit -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu v16_attack_batch_over_portfolio_leg_cap_rejects_atomically -- --nocapture`

Full `cargo test -p percolator-prog --test v16_cu -- --nocapture` currently has two unrelated failures that also reproduce on a fresh unmodified `main` worktree:

- `v16_bpf_underfunded_flat_sync_sweeps_remaining_capital_once`
- `v16_attack_underfunded_sync_with_cranker_reward_still_closes_payer`

Both fail on `materialized_portfolio_count` staying `2` instead of the tests' expected `1`; this PR does not touch that route.