### PR TITLE
[codex] Reject CloseSlab market destination alias

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8551,6 +8551,9 @@ pub mod processor {
         expect_writable(admin_dest)?;
         expect_writable(market_ai)?;
         expect_writable(vault_token)?;
+        if admin_dest.key == market_ai.key {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
         expect_owner(market_ai, program_id)?;
         verify_token_program(token_program)?;
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26221,6 +26221,187 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
     );
 }
 
+// full-interface sweep: a real market account can be a signing system-created keypair. If marketauth is
+// rotated to that key, CloseSlab must still reject using the market slab itself as the lamport destination;
+// otherwise the final reclaim can zero the data while leaving rent on a program-owned, closed slab.
+#[test]
+fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
+    let mut svm = LiteSVM::new();
+    let program_id = percolator_prog::id();
+    svm.add_program(
+        program_id,
+        &std::fs::read(program_path()).expect("read BPF"),
+    );
+    svm.add_program(
+        spl_token::ID,
+        &std::fs::read(spl_token_program_path()).expect("read token BPF"),
+    );
+
+    let payer = Keypair::new();
+    let admin = Keypair::new();
+    let market = Keypair::new();
+    let mint = Pubkey::new_unique();
+    let params = V16CuMarketParams::default();
+    let vault_authority =
+        Pubkey::find_program_address(&[b"vault", market.pubkey().as_ref()], &program_id).0;
+    let vault = canonical_vault_ata(vault_authority, mint);
+    svm.airdrop(&payer.pubkey(), 100_000_000_000).unwrap();
+    svm.airdrop(&admin.pubkey(), 1_000_000_000).unwrap();
+    svm.set_account(
+        mint,
+        Account {
+            lamports: 1_000_000_000,
+            data: make_mint_data(),
+            owner: spl_token::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    svm.set_account(
+        market.pubkey(),
+        Account {
+            lamports: 1_000_000_000,
+            data: vec![0u8; state::market_account_len_for_capacity(1).unwrap()],
+            owner: program_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    svm.set_account(
+        vault,
+        Account {
+            lamports: 1_000_000_000,
+            data: make_token_data(mint, vault_authority, 0),
+            owner: spl_token::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    send_tx(
+        &mut svm,
+        program_id,
+        &payer,
+        ProgInstruction::InitMarket {
+            max_portfolio_assets: params.max_portfolio_assets,
+            h_min: params.h_min,
+            h_max: params.h_max,
+            initial_price: params.initial_price,
+            min_nonzero_mm_req: params.min_nonzero_mm_req,
+            min_nonzero_im_req: params.min_nonzero_im_req,
+            maintenance_margin_bps: params.maintenance_margin_bps,
+            initial_margin_bps: params.initial_margin_bps,
+            max_trading_fee_bps: params.max_trading_fee_bps,
+            trade_fee_base_bps: params.trade_fee_base_bps,
+            liquidation_fee_bps: params.liquidation_fee_bps,
+            liquidation_fee_cap: params.liquidation_fee_cap,
+            min_liquidation_abs: params.min_liquidation_abs,
+            max_price_move_bps_per_slot: params.max_price_move_bps_per_slot,
+            max_accrual_dt_slots: params.max_accrual_dt_slots,
+            max_abs_funding_e9_per_slot: params.max_abs_funding_e9_per_slot,
+            min_funding_lifetime_slots: params.min_funding_lifetime_slots,
+            max_account_b_settlement_chunks: params.max_account_b_settlement_chunks,
+            max_bankrupt_close_chunks: params.max_bankrupt_close_chunks,
+            max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots,
+            public_b_chunk_atoms: params.public_b_chunk_atoms,
+            maintenance_fee_per_slot: params.maintenance_fee_per_slot,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(market.pubkey(), false),
+            AccountMeta::new_readonly(mint, false),
+        ],
+        &[&admin],
+    )
+    .expect("init market");
+
+    svm.expire_blockhash();
+    send_tx(
+        &mut svm,
+        program_id,
+        &payer,
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: market.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(market.pubkey(), true),
+            AccountMeta::new(market.pubkey(), false),
+        ],
+        &[&admin, &market],
+    )
+    .expect("rotate marketauth to signing market key");
+
+    svm.expire_blockhash();
+    send_tx(
+        &mut svm,
+        program_id,
+        &payer,
+        ProgInstruction::ResolveMarket,
+        vec![
+            AccountMeta::new(market.pubkey(), true),
+            AccountMeta::new(market.pubkey(), false),
+        ],
+        &[&market],
+    )
+    .expect("market key can resolve after handoff");
+
+    let dest = Pubkey::new_unique();
+    svm.set_account(
+        dest,
+        Account {
+            lamports: 1_000_000_000,
+            data: make_token_data(mint, market.pubkey(), 0),
+            owner: spl_token::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    let market_before = svm.get_account(&market.pubkey()).unwrap();
+    let vault_before = svm.get_account(&vault).unwrap();
+    let dest_before = svm.get_account(&dest).unwrap();
+
+    svm.expire_blockhash();
+    let rejected = send_tx(
+        &mut svm,
+        program_id,
+        &payer,
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(market.pubkey(), true),
+            AccountMeta::new(market.pubkey(), false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&market],
+    );
+    assert!(
+        rejected.is_err(),
+        "CloseSlab must reject market-as-destination alias"
+    );
+    assert_eq!(
+        svm.get_account(&market.pubkey()).unwrap(),
+        market_before,
+        "market-as-destination rejection leaves the slab initialized"
+    );
+    assert_eq!(
+        svm.get_account(&vault).unwrap(),
+        vault_before,
+        "market-as-destination rejection leaves the vault open"
+    );
+    assert_eq!(
+        svm.get_account(&dest).unwrap(),
+        dest_before,
+        "market-as-destination rejection pays no dust"
+    );
+}
+
 // security.md sweep - CloseSlab vault delegate/close-authority guard (#44/#48):
 // CloseSlab is the terminal path that transfers any raw vault dust, closes the SPL vault account, and
 // zeroes the market slab. Even with the canonical vault address, a delegated or separately closable


### PR DESCRIPTION
## Summary

Fixes a terminal `CloseSlab` account-alias bug found during the LoF/DoS sweep.

A signing, system-created market key can become `marketauth` through the normal co-signed authority handoff. Before this patch, that key could call `CloseSlab` with the market slab itself as `admin_dest` and `market_ai`. The handler would close the vault, zero the market data, then move the market lamports from the slab back onto the same program-owned slab account. That leaves rent on a closed program-owned account instead of reclaiming it to an external authority destination.

## Fix

- Reject `admin_dest == market_ai` at the top of `handle_close_slab`, before token CPIs or slab zeroing.
- Add a LiteSVM reproducer using a real signing market keypair, rotating marketauth to that key, resolving, then attempting the market-as-destination close.

## Validation

Passed after `cargo build-sbf --no-default-features`:

- `cargo test -p percolator-prog --test v16_cu v16_attack_close_slab_rejects_market_as_lamport_destination -- --nocapture`
- `cargo test -p percolator-prog --test v16_cu close_slab -- --nocapture`
- `git diff --check`

Also attempted full `cargo test -p percolator-prog --test v16_cu -- --nocapture` on this `origin/main`-based branch. It hit the same unrelated rebuilt-main maintenance-sync failures already documented in open PR #141:

- `v16_attack_underfunded_sync_with_cranker_reward_still_closes_payer`
- `v16_bpf_underfunded_flat_sync_sweeps_remaining_capital_once`