### PR TITLE
[codex] Bound terminal asset insurance withdrawal

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8440,42 +8440,67 @@ pub mod processor {
         let long_domain = asset_index
             .checked_mul(2)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        let (bump, amount_u64) = verify_domain_withdrawal_preflight(
-            program_id,
-            market_ai,
-            operator,
-            dest_token,
-            vault_token,
-            vault_authority_ai,
-            long_domain,
-            amount,
-            true,
-            DOMAIN_WITHDRAW_AUTH_INSURANCE,
-        )?;
+        let amount_u64 = amount_to_u64(amount)?;
+        {
+            let market_data = market_ai.try_borrow_data()?;
+            let (cfg, mode, configured_slots, _) =
+                state::read_market_config_mode_and_capacity(&market_data)?;
+            if (mode != MarketModeV16::Live && mode != MarketModeV16::Resolved)
+                || asset_index >= configured_slots
+                || long_domain >= configured_slots.saturating_mul(2)
+            {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
+            let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
+            expect_key(vault_authority_ai, &vault_authority)?;
+            verify_withdrawable_token_accounts(
+                dest_token,
+                operator.key,
+                vault_token,
+                &vault_authority,
+                &cfg,
+            )?;
+            require_token_balance(vault_token, amount_u64)?;
+        }
+        let (_, bump) = derive_vault_authority(program_id, market_ai.key);
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
-            if group.header.mode != 0 {
+            let live_mode = group.header.mode == 0;
+            let resolved_mode = group.header.mode == 1;
+            if !live_mode && !resolved_mode {
                 return Err(PercolatorError::EngineLockActive.into());
             }
             let configured_slots = group.header.config.max_market_slots.get() as usize;
             if asset_index >= configured_slots || asset_index >= group.markets.len() {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
-            let shutdown_drain =
-                live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
             let authorities = domain_authorities_from_view(&group, &cfg, long_domain)?;
-            let local_authorized =
-                live_authority_matches(&authorities.insurance_operator, operator.key);
-            let admin_shutdown_authorized = asset_index != 0
-                && shutdown_drain
-                && live_authority_matches(&cfg.marketauth, operator.key);
-            if !local_authorized && !admin_shutdown_authorized {
-                return Err(PercolatorError::Unauthorized.into());
-            }
-            let ledger_authority = if admin_shutdown_authorized && !local_authorized {
-                cfg.marketauth
+            let ledger_authority = if live_mode {
+                let shutdown_drain =
+                    live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
+                let local_authorized =
+                    live_authority_matches(&authorities.insurance_operator, operator.key);
+                let admin_shutdown_authorized = asset_index != 0
+                    && shutdown_drain
+                    && live_authority_matches(&cfg.marketauth, operator.key);
+                if !local_authorized && !admin_shutdown_authorized {
+                    return Err(PercolatorError::Unauthorized.into());
+                }
+                if admin_shutdown_authorized && !local_authorized {
+                    cfg.marketauth
+                } else {
+                    authorities.insurance_authority
+                }
             } else {
+                if group.header.materialized_portfolio_count.get() != 0
+                    || group.header.c_tot.get() != 0
+                {
+                    return Err(PercolatorError::EngineLockActive.into());
+                }
+                if !live_authority_matches(&authorities.insurance_authority, operator.key) {
+                    return Err(PercolatorError::Unauthorized.into());
+                }
                 authorities.insurance_authority
             };
             let available = market_insurance_withdraw_capacity_view(&group, asset_index)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -46772,6 +46772,104 @@ fn v16_bpf_terminal_insurance_partial_ledger_ignores_other_authority_budget_on_1
     assert_eq!(group.vault as u64, env.token_amount(env.vault));
 }
 
+#[test]
+fn v16_bpf_terminal_asset_insurance_partial_ledger_middle_domain_stays_bounded_on_10m_market() {
+    const N: usize = 5_834;
+    const MIDDLE_ASSET: usize = N / 2;
+    const HIGH_ASSET: usize = N - 1;
+    const PRICE: u64 = 100;
+    const FUNDED: u128 = 123;
+    const PARTIAL: u128 = 1;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    let account_len = grow_market_to_10m_with_high_active_asset(&mut env, N, HIGH_ASSET, PRICE);
+    let middle_authority = Keypair::new();
+    let profile0 = {
+        let data = env.svm.get_account(&env.market).unwrap().data;
+        state::read_asset_oracle_profile(&data, 0).unwrap()
+    };
+    let template = env.market_state().1.assets[0];
+    env.mutate_market(|_cfg, group| {
+        let middle_market_id = (MIDDLE_ASSET as u64) + 1;
+        let mut middle = template;
+        middle.market_id = middle_market_id;
+        group.assets[MIDDLE_ASSET] = middle;
+        let (long_domain, short_domain) = (2 * MIDDLE_ASSET, 2 * MIDDLE_ASSET + 1);
+        group.source_backing_buckets[long_domain] =
+            percolator::BackingBucketV16::empty_for_market(middle_market_id);
+        group.source_backing_buckets[short_domain] =
+            percolator::BackingBucketV16::empty_for_market(middle_market_id);
+    });
+    {
+        let mut acct = env.svm.get_account(&env.market).unwrap();
+        state::write_asset_oracle_profile(&mut acct.data, MIDDLE_ASSET, &profile0).unwrap();
+        env.svm.set_account(env.market, acct).unwrap();
+    }
+    let admin = env.admin.insecure_clone();
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&middle_authority),
+        MIDDLE_ASSET as u16,
+        processor::ASSET_AUTH_INSURANCE,
+        middle_authority.pubkey().to_bytes(),
+    )
+    .expect("rotate middle insurance authority");
+
+    let middle_domain = (2 * MIDDLE_ASSET + 1) as u16;
+    env.top_up_insurance_domain_with_authority_and_cu(&middle_authority, middle_domain, FUNDED);
+    let before_resolve = env.market_state().1;
+    assert_eq!(
+        before_resolve.insurance_domain_budget[middle_domain as usize],
+        FUNDED,
+        "setup funds only a middle-domain authority budget"
+    );
+
+    let ledger = env.insurance_ledger_account();
+    env.resolve();
+    let dest = env.token_account_for_mint(env.mint, middle_authority.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let withdraw_cu = env
+        .send(
+            ProgInstruction::WithdrawInsuranceAsset {
+                asset_index: MIDDLE_ASSET as u16,
+                amount: PARTIAL,
+            },
+            vec![
+                AccountMeta::new(middle_authority.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger, false),
+            ],
+            &[&middle_authority],
+        )
+        .expect("terminal asset-indexed insurance withdrawal");
+    println!(
+        "v16 10MiB terminal middle-domain partial WithdrawInsuranceAsset + ledger: \
+         assets={N}, account_len={account_len}, middle_domain={middle_domain}, CU={withdraw_cu}"
+    );
+    assert_cu_within(
+        "10MiB middle-domain terminal partial WithdrawInsuranceAsset with ledger",
+        withdraw_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.token_amount(dest), PARTIAL as u64);
+
+    let ledger_state =
+        state::read_insurance_ledger(&env.svm.get_account(&ledger).unwrap().data).unwrap();
+    assert_eq!(ledger_state.authority, middle_authority.pubkey().to_bytes());
+    assert_eq!(ledger_state.total_withdrawn_atoms, PARTIAL);
+    assert_eq!(ledger_state.last_observed_insurance_atoms, FUNDED - PARTIAL);
+    let (_, group) = env.market_state();
+    assert_eq!(
+        group.insurance_domain_budget[middle_domain as usize],
+        FUNDED - PARTIAL
+    );
+    assert_eq!(group.vault as u64, env.token_amount(env.vault));
+}
+
 // LIVENESS: no trader can block marketauth's asset cleanup. After force_close_delay_slots, the
 // permissionless force-close winds down a retired asset by netting a long against a short at the
 // frozen mark. A griefer who sits on a maximally-complex (14-leg) STALE portfolio cannot stall this:


### PR DESCRIPTION
## Summary

Fixes a terminal insurance liveness/CU issue found during the LoF/DoS sweep. A 10MiB market with terminal insurance only in a middle domain can make the global terminal `WithdrawInsurance` scanner spend ~699k CU before reaching the funded authority budget. That is below the tx cap but well above the custody CU guard, and existing sparse front/tail coverage did not hit the middle-domain worst case.

The fix makes the existing asset-indexed `WithdrawInsuranceAsset { asset_index }` path usable in `Resolved` mode by the asset domain's cold `insurance_authority`, after confirming no portfolios or capital remain live. Live-mode behavior is preserved: the hot insurance operator remains required except for the existing marketauth shutdown-drain path.

## Coverage

Adds `v16_bpf_terminal_asset_insurance_partial_ledger_middle_domain_stays_bounded_on_10m_market`, which builds a 5,834-asset / 10MiB market, funds only the middle asset's terminal insurance budget, resolves the market, then withdraws through `WithdrawInsuranceAsset` with a ledger and asserts it stays within `CUSTODY_CU_LIMIT`.

## Validation

Passed:

- `git diff --check`
- `cargo test -p percolator-prog --test v16_cu v16_bpf_terminal_asset_insurance_partial_ledger_middle_domain_stays_bounded_on_10m_market -- --nocapture`

Earlier full `v16_cu` on this branch reached 535/537 passing; the two failures were the known rebuilt-main underfunded sync tests, independent of this patch:

- `v16_attack_underfunded_sync_with_cranker_reward_still_closes_payer`
- `v16_bpf_underfunded_flat_sync_sweeps_remaining_capital_once`