### PR TITLE
[codex] Reject stale matcher return replay

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -21,6 +21,7 @@ use solana_program::{
     clock::Clock,
     declare_id,
     entrypoint::ProgramResult,
+    hash::hashv,
     instruction::{AccountMeta, Instruction as SolInstruction},
     program::{invoke, invoke_signed},
     program_error::ProgramError,
@@ -6534,7 +6535,7 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = matcher_request_id(current_slot_pre, matcher_ctx)?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -6853,7 +6854,7 @@ pub mod processor {
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
         validate_matcher_tail(tail, market_ai, account_a_ai, account_b_ai, program_id)?;
 
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = matcher_request_id(current_slot_pre, matcher_ctx)?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         // Build the matcher batch request: per leg, (asset, that asset's oracle price, signed size).
@@ -11560,6 +11561,26 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    fn matcher_request_id(
+        current_slot: u64,
+        matcher_ctx: &AccountInfo,
+    ) -> Result<u64, ProgramError> {
+        let slot_bytes = current_slot.to_le_bytes();
+        let data = matcher_ctx.try_borrow_data()?;
+        let prefix = data
+            .get(..matcher_abi::MATCHER_RETURN_BYTES)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        let digest = hashv(&[
+            b"percolator-v16-matcher-req",
+            &slot_bytes,
+            matcher_ctx.key.as_ref(),
+            prefix,
+        ]);
+        Ok(u64::from_le_bytes(
+            digest.to_bytes()[0..8].try_into().unwrap(),
+        ))
     }
 
     fn invoke_matcher<'a>(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,8 @@
 //! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
 //! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (or
+//! data[64] when nonzero, for stale-return probes). The wrapper MUST reject every hostile mode and
+//! accept only the honest one.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program::set_return_data,
@@ -57,7 +58,13 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let mode = {
+                let d = accounts[1].try_borrow_data()?;
+                if d.len() > 64 && d[64] != 0 { d[64] } else { d[0] }
+            };
+            if mode == 12 {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +78,13 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let mode = {
+                let d = accounts[1].try_borrow_data()?;
+                if d.len() > 64 && d[64] != 0 { d[64] } else { d[0] }
+            };
+            if mode == 12 {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51204,6 +51204,112 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     );
 }
 
+// security.md sweep - stale matcher context replay (#39/#49): the single TradeCpi path reads the
+// matcher return from a persistent matcher-owned context account. A matcher that returns Ok without
+// writing a fresh prefix must not let a taker replay the previous same-slot return.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_tradecpi_return() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 9; // faithful fill writes a valid return prefix.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let send_trade = |env: &mut V16CuEnv| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::TradeCpi {
+                asset_index: 0,
+                size_q,
+                fee_bps: 100,
+                limit_price: 0,
+            },
+            vec![
+                AccountMeta::new(taker.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(ta, false),
+                AccountMeta::new(la, false),
+                AccountMeta::new_readonly(hostile, false),
+                AccountMeta::new(ctx, false),
+                AccountMeta::new_readonly(delegate, false),
+            ],
+            &[&taker],
+        )
+    };
+
+    let first = send_trade(&mut env);
+    assert!(first.is_ok(), "faithful control fill writes return: {first:?}");
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(ta), 0).basis_pos_q,
+        size_q
+    );
+
+    let mut stale_ctx = env.svm.get_account(&ctx).unwrap();
+    assert_eq!(
+        u32::from_le_bytes(stale_ctx.data[0..4].try_into().unwrap()),
+        MATCHER_ABI_VERSION,
+        "control fill left a valid return prefix in matcher context"
+    );
+    stale_ctx.data[64] = 12; // no-write mode outside the return prefix.
+    env.svm.set_account(ctx, stale_ctx).unwrap();
+
+    let replay = send_trade(&mut env);
+    assert!(
+        replay.is_err(),
+        "a matcher that returns Ok without writing must not replay the stale context return: {replay:?}"
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(ta), 0).basis_pos_q,
+        size_q,
+        "no stale replay fill"
+    );
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA


### PR DESCRIPTION
## Summary

Fixes a stale matcher-context replay in the single `TradeCpi` path.

`TradeCpi` reads the matcher return from the persistent matcher context account. The old request id was `current_slot + 1`, so two same-slot requests with the same tuple could share the same id. If a matcher returned `Ok` without writing a fresh return prefix, the wrapper could accept the previous context return and apply a second fill.

This PR derives the matcher request id from the authenticated slot plus the pre-CPI matcher context return prefix and context key. A consumed return prefix therefore cannot validate as the next request unless the matcher writes a fresh response echoing the new request id.

## Tests

- `cargo build-sbf --no-default-features`
- `cd tests/fixtures/hostile_matcher && cargo build-sbf`
- `cargo test v16_attack_hostile_matcher_no_write_cannot_replay_stale_tradecpi_return -- --nocapture`
- `cargo test v16_attack_hostile_matcher -- --nocapture`
- `cargo test v16_bpf_tradecpi -- --nocapture`
- `cargo test v16_bpf_batch_trade_cpi_14_legs_under_tx_limit -- --nocapture`

Note: `cargo fmt --check` reports broad pre-existing formatting drift in `tests/v16_cu.rs`; I did not apply unrelated rustfmt churn.