### PR TITLE
[codex] Gate live insurance on local loss stale

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4912,8 +4912,28 @@ pub mod processor {
         {
             return Err(PercolatorError::EngineLockActive.into());
         }
+        if asset_local_loss_stale_view(group, asset_index) {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         reject_exposed_target_effective_lag_view(group, asset_index)?;
         Ok(false)
+    }
+
+    fn asset_local_loss_stale_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> bool {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return true;
+        }
+        let asset = &group.markets[asset_index].engine.asset;
+        matches!(
+            asset.lifecycle,
+            ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY
+        ) && asset.slot_last.get() < group.header.current_slot.get()
+            && asset_local_has_position_or_loss_state_view(group, asset_index)
     }
 
     fn asset_has_exposed_target_effective_lag_view(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34121,6 +34121,108 @@ fn v16_attack_live_insurance_withdraw_rejects_while_stressed_or_hlocked() {
 }
 
 #[test]
+fn v16_attack_unrelated_refresh_cannot_mask_loss_stale_insurance_gate() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(4, 1_000, 1_000, 500);
+    env.enable_live_insurance_withdrawal();
+    let admin = env.admin.insecure_clone();
+    env.top_up_insurance_domain_with_authority(&admin, 2, 100);
+
+    let stale_long_owner = Keypair::new();
+    let stale_short_owner = Keypair::new();
+    let stale_long = env.create_portfolio(&stale_long_owner);
+    let stale_short = env.create_portfolio(&stale_short_owner);
+    env.deposit(&stale_long_owner, stale_long, 1_000_000_000);
+    env.deposit(&stale_short_owner, stale_short, 1_000_000_000);
+    env.trade_asset_with_cu(
+        1,
+        &stale_long_owner,
+        stale_long,
+        &stale_short_owner,
+        stale_short,
+        (10 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    let cranker_owner = Keypair::new();
+    let cranker = env.create_portfolio(&cranker_owner);
+    env.svm.warp_to_slot(3);
+    for _ in 0..3 {
+        env.svm.expire_blockhash();
+        env.crank(
+            cranker,
+            ProgInstruction::PermissionlessCrank {
+                action: 0,
+                asset_index: 0,
+                now_slot: 3,
+                funding_rate_e9: 0,
+                close_q: 0,
+                fee_bps: 0,
+                recovery_reason: 0,
+            },
+        );
+    }
+    env.svm.expire_blockhash();
+    env.crank(
+        cranker,
+        ProgInstruction::PermissionlessCrank {
+            action: 0,
+            asset_index: 1,
+            now_slot: 3,
+            funding_rate_e9: 0,
+            close_q: 0,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+    );
+
+    let before_mask = env.market_state().1;
+    assert!(before_mask.loss_stale_active);
+    assert!(before_mask.assets[1].slot_last < before_mask.current_slot);
+    assert!(
+        env.try_withdraw_insurance_domain_with_authority(&admin, 2, 10)
+            .is_err(),
+        "asset-1 live insurance is initially locked by its loss-stale exposure"
+    );
+
+    env.svm.expire_blockhash();
+    env.crank(
+        cranker,
+        ProgInstruction::PermissionlessCrank {
+            action: 0,
+            asset_index: 0,
+            now_slot: 3,
+            funding_rate_e9: 0,
+            close_q: 0,
+            fee_bps: 0,
+            recovery_reason: 0,
+        },
+    );
+    let after_unrelated_refresh = env.market_state().1;
+    assert!(
+        after_unrelated_refresh.assets[1].slot_last < after_unrelated_refresh.current_slot,
+        "asset 1 remains locally loss-stale after the unrelated asset-0 refresh"
+    );
+
+    let withdraw = env.try_withdraw_insurance_domain_with_authority(&admin, 2, 10);
+    assert!(
+        withdraw.is_err(),
+        "an unrelated refresh must not make asset-1 insurance withdrawable while asset 1 is loss-stale"
+    );
+    let after_withdraw_attempt = env.market_state().1;
+    assert_eq!(
+        after_withdraw_attempt.insurance_domain_budget[2],
+        after_unrelated_refresh.insurance_domain_budget[2],
+        "rejected stale-asset withdrawal must leave the domain budget untouched"
+    );
+    assert_eq!(
+        after_withdraw_attempt.insurance,
+        after_unrelated_refresh.insurance,
+        "rejected stale-asset withdrawal must leave insurance untouched"
+    );
+}
+
+#[test]
 fn v16_attack_unexposed_target_move_cannot_grief_live_insurance_withdrawals() {
     let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
         V16CuMarketParams {


### PR DESCRIPTION
## Summary
- Add an asset-local loss-stale check to live `WithdrawInsuranceAsset` gating.
- Add a LiteSVM regression where asset 1 remains loss-stale, an unrelated asset-0 refresh masks the global summary bit, and asset-1 insurance withdrawal must still reject atomically.

## Root Cause
`live_domain_withdraw_health_or_shutdown_view` only checked the global `loss_stale_active` summary. A permissionless refresh of an unrelated current asset can rewrite that summary while another asset remains locally loss-stale, making the stale asset's live insurance domain withdrawable.

## Validation
- `cargo build-sbf --no-default-features`
- `cargo test v16_attack_unrelated_refresh_cannot_mask_loss_stale_insurance_gate -- --nocapture`
- `cargo test live_insurance_withdraw -- --nocapture`
- `cargo test loss_stale -- --nocapture`
- `cargo test withdraw_insurance_asset -- --nocapture`