### PR TITLE
[codex] Fix single TradeCpi stale matcher replay

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -21,6 +21,7 @@ use solana_program::{
     clock::Clock,
     declare_id,
     entrypoint::ProgramResult,
+    hash::hashv,
     instruction::{AccountMeta, Instruction as SolInstruction},
     program::{invoke, invoke_signed},
     program_error::ProgramError,
@@ -6534,7 +6535,17 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = matcher_context_bound_req_id(
+            current_slot_pre,
+            market_ai.key,
+            account_a_ai.key,
+            account_b_ai.key,
+            matcher_prog.key,
+            matcher_ctx,
+            asset_index,
+            oracle_price,
+            size_q,
+        )?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -11560,6 +11571,40 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn matcher_context_bound_req_id(
+        current_slot: u64,
+        market: &Pubkey,
+        account_a: &Pubkey,
+        account_b: &Pubkey,
+        matcher_program: &Pubkey,
+        matcher_ctx: &AccountInfo<'_>,
+        asset_index: u16,
+        oracle_price_e6: u64,
+        req_size: i128,
+    ) -> Result<u64, ProgramError> {
+        let current_slot_bytes = current_slot.to_le_bytes();
+        let asset_index_bytes = asset_index.to_le_bytes();
+        let oracle_price_bytes = oracle_price_e6.to_le_bytes();
+        let req_size_bytes = req_size.to_le_bytes();
+        let ctx_data = matcher_ctx.try_borrow_data()?;
+        let ctx_len = core::cmp::min(ctx_data.len(), matcher_abi::MATCHER_RETURN_BYTES);
+        let h = hashv(&[
+            b"percolator-v16-single-matcher-req",
+            &current_slot_bytes,
+            market.as_ref(),
+            account_a.as_ref(),
+            account_b.as_ref(),
+            matcher_program.as_ref(),
+            matcher_ctx.key.as_ref(),
+            &asset_index_bytes,
+            &oracle_price_bytes,
+            &req_size_bytes,
+            &ctx_data[..ctx_len],
+        ]);
+        Ok(u64::from_le_bytes(h.as_ref()[0..8].try_into().unwrap()))
     }
 
     fn invoke_matcher<'a>(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,8 @@
 //! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
 //! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (or
+//! data[64] when nonzero, for stale-return probes). The wrapper MUST reject every hostile mode and
+//! accept only the honest one.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program::set_return_data,
@@ -23,15 +24,18 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     let mut rid = req_id;
     let mut l = lp;
     match mode {
-        0 => size = req.saturating_mul(2),           // over-fill: open 2x the requested position
-        1 => size = req.checked_neg().unwrap_or(0),  // reversed direction
-        2 => a = asset.wrapping_add(1),              // forged asset echo
-        3 => o = oracle.wrapping_add(1),             // forged oracle echo
-        4 => rid = req_id.wrapping_add(1),           // forged req_id
-        5 => l = lp.wrapping_add(1),                 // forged lp_account_id
-        6 => price = 0,                              // zero exec price
-        7 => { flags = FLAG_VALID; size = req / 2 }  // unflagged partial (no PARTIAL_OK)
-        _ => {}                                      // honest full fill -> wrapper accepts
+        0 => size = req.saturating_mul(2), // over-fill: open 2x the requested position
+        1 => size = req.checked_neg().unwrap_or(0), // reversed direction
+        2 => a = asset.wrapping_add(1),    // forged asset echo
+        3 => o = oracle.wrapping_add(1),   // forged oracle echo
+        4 => rid = req_id.wrapping_add(1), // forged req_id
+        5 => l = lp.wrapping_add(1),       // forged lp_account_id
+        6 => price = 0,                    // zero exec price
+        7 => {
+            flags = FLAG_VALID;
+            size = req / 2
+        } // unflagged partial (no PARTIAL_OK)
+        _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];
     b[0..4].copy_from_slice(&ABI.to_le_bytes());
@@ -43,6 +47,26 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     b[48..56].copy_from_slice(&o.to_le_bytes());
     b[56..64].copy_from_slice(&a.to_le_bytes());
     b
+}
+
+fn mode_for_call(accounts: &[AccountInfo]) -> Result<(u8, bool), ProgramError> {
+    let mut d = accounts[1].try_borrow_mut_data()?;
+    let mode = if d.len() > 64 && d[64] != 0 {
+        d[64]
+    } else {
+        d[0]
+    };
+    if mode == 13 {
+        if d.len() <= 65 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if d[65] == 0 {
+            d[65] = 1;
+            return Ok((9, false));
+        }
+        return Ok((13, true));
+    }
+    Ok((mode, mode == 12))
 }
 
 fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
@@ -57,7 +81,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +98,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {
@@ -79,7 +109,8 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
                 let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
                 let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
                 let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
-                out[i * 64..i * 64 + 64].copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
+                out[i * 64..i * 64 + 64]
+                    .copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
             }
             set_return_data(&out[..emit * 64]);
             Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51204,6 +51204,107 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     );
 }
 
+// security.md sweep - stale matcher context replay (#39/#49): the single TradeCpi path reads the
+// matcher result from the matcher-owned ctx account. A matcher that writes a valid ctx return for
+// one CPI and then returns Ok without rewriting on a second same-transaction CPI must not let the
+// wrapper replay the stale first response.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 13; // first call writes a valid fill; second call returns Ok without rewriting.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let trade_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), trade_ix(), trade_ix()],
+        &[&taker],
+    );
+    assert!(
+        replay.is_err(),
+        "a matcher that omits second-call ctx output must not replay stale single TradeCpi output: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA


### PR DESCRIPTION
## Summary

Fixes a single `TradeCpi` stale matcher-context replay issue. The single-fill path read matcher output from the matcher-owned context account, but its request id was only `current_slot + 1`, so two same-transaction calls in the same slot could collide. A matcher could write a valid context return for the first call, then return `Ok(())` without rewriting on the second call, and the wrapper would accept the stale first response.

The fix derives the single matcher request id from the current slot, trade identity fields, and the pre-invoke matcher context bytes. If the matcher does not rewrite the context, the stale echoed request id no longer validates. Honest matcher writes still echo the fresh request id and continue to work.

## Changes

- Bind single `TradeCpi` matcher request ids to the pre-invoke matcher context.
- Add a hostile matcher no-write mode for stale replay probes.
- Add a LiteSVM regression that sends two same-transaction single `TradeCpi` calls and asserts the second no-write call cannot replay the first context output.

## Validation

Built BPF artifacts and ran:

- `cargo build-sbf --no-default-features`
- `cd tests/fixtures/hostile_matcher && cargo build-sbf`
- `cargo test v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context -- --nocapture`
- `cargo test v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected -- --nocapture`
- `cargo test v16_attack_matcher_return_antispoof_rejections -- --nocapture`
- `cargo test v16_attack_hostile_matcher_batch_returns_all_rejected -- --nocapture`
- `cargo test v16_attack_tradecpi_zero_fill_is_clean -- --nocapture`
- `cargo test v16_attack_tradecpi_atomic_fill_vs_capacity -- --nocapture`
- `cargo test v16_attack_tradecpi_limit_price_enforced -- --nocapture`
- `cargo test v16_attack_tradecpi_rejects_unapproved_unsigned_lp_matcher -- --nocapture`
- `git diff --check`

`cargo fmt --check` still reports pre-existing broad formatting churn in `tests/v16_cu.rs`; I only ran targeted formatting on the hostile matcher fixture.