### PR TITLE
[codex] Fix stale matcher return replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,10 @@ Authority fields are split by scope:
 - **`AssetOracleProfileV16.asset_admin`**: per-asset cold key that rotates that asset's scoped authorities
 - **`AssetOracleProfileV16.insurance_authority` / `insurance_operator` / `backing_bucket_authority` / `oracle_authority`**: per-asset operational authorities
 
-Matcher requests do not use a persisted market nonce. The wrapper invokes the matcher and requires the response to echo the request id, LP identity, asset index, oracle price, and requested size/sign constraints.
+Matcher requests use a wrapper-owned sequence stored in the LP portfolio matcher config. The low
+bit is the enabled flag and the high bits are the request sequence. The wrapper increments it before
+matcher CPI and requires the return data to echo the request id, LP identity, asset index, oracle
+price, and requested size/sign constraints.
 
 ### Vault token account (market collateral)
 - SPL Token account holding collateral for this market
@@ -357,8 +360,8 @@ wrong matcher program/context/delegate, wrong LP owner, or wrong LP portfolio al
 - account owned by matcher program
 - matcher programs should initialize/configure the context under their own LP-owner signature
   policy and store/check the expected delegate PDA
-- matcher writes its return prefix into the first bytes
-- Percolator reads and validates the prefix after CPI
+- matcher-owned state passed to the matcher CPI
+- Percolator reads matcher results from Solana return data and validates the ABI fields after CPI
 
 ---
 
@@ -423,8 +426,9 @@ This section describes intent and operational ordering, not argument-by-argument
 - **TradeNoCpi**
   - trade without external matcher (used for testing / deterministic scenarios)
 - **TradeCpi**
-  - trade via LP-chosen matcher CPI with strict binding + validation. The LP portfolio must already
-    store an enabled matcher config for the passed matcher program/context/delegate tuple.
+  - trade via LP-chosen matcher CPI with strict binding + validation. The wrapper submits a one-leg
+    matcher tag-3 request and validates the returned data. The LP portfolio must already store an
+    enabled matcher config for the passed matcher program/context/delegate tuple.
 - **BatchTradeNoCpi** (tag 66)
   - atomic multi-leg batch (up to the portfolio asset cap) against one taker/LP pair; each leg's
     **signed** `size_q` sets its direction, so a single batch can carry a mixed long/short spread.
@@ -505,9 +509,9 @@ Percolator treats a matcher like a price/size oracle **with rules** chosen by th
   - matcher program must be executable
   - context must not be executable
   - context owner must be matcher program
-  - context length must be sufficient for the return prefix
+  - context length must satisfy the wrapper's matcher context minimum
 - **Request echo binding**: response must echo the request id and echoed request fields
-- **ABI validation**: strict validation of return prefix fields
+- **ABI validation**: strict validation of return-data fields
 - **Execution size discipline**: engine trade uses matcher's `exec_size` (never the user's requested size)
 
 ### What the matcher controls (LP-scoped)
@@ -895,7 +899,7 @@ These are intended hard boundaries enforced in code and test suites:
 - missing, disabled, or argument-mismatched LP matcher config
 - bad matcher shape (non-executable program, executable ctx, wrong ctx owner, short ctx)
 - matcher delegate PDA mismatch / wrong PDA shape
-- ABI prefix invalid (flags, echoed fields, size constraints)
+- matcher return data invalid (flags, echoed fields, size constraints)
 
 These are expected and should be treated as **hard safety rejections**, not transient errors.
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -757,7 +757,7 @@ pub mod state {
                 .get(..config_len)
                 .ok_or(PercolatorError::InvalidAccountLen)?,
         );
-        if cfg.enabled > 1 {
+        if cfg.enabled != 0 && (cfg.enabled & 1) == 0 {
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(cfg)
@@ -769,7 +769,7 @@ pub mod state {
         cfg: &PortfolioMatcherConfigV16,
     ) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
-        if cfg.enabled > 1 {
+        if cfg.enabled != 0 && (cfg.enabled & 1) == 0 {
             return Err(ProgramError::InvalidAccountData);
         }
         let bytes = matcher_config_bytes_mut(data)?;
@@ -6394,7 +6394,7 @@ pub mod processor {
         matcher_delegate_key: &Pubkey,
     ) -> Result<usize, ProgramError> {
         let cfg = state::read_portfolio_matcher_config(&account_b_ai.try_borrow_data()?)?;
-        if cfg.enabled != 1
+        if (cfg.enabled & 1) != 1
             || cfg.matcher_program != matcher_prog_key.to_bytes()
             || cfg.matcher_context != matcher_ctx_key.to_bytes()
             || cfg.matcher_delegate != matcher_delegate_key.to_bytes()
@@ -6402,6 +6402,22 @@ pub mod processor {
             return Err(PercolatorError::Unauthorized.into());
         }
         Ok(7)
+    }
+
+    fn advance_matcher_req_id(account_b_ai: &AccountInfo) -> Result<u64, ProgramError> {
+        let mut data = account_b_ai.try_borrow_mut_data()?;
+        let mut cfg = state::read_portfolio_matcher_config(&data)?;
+        if (cfg.enabled & 1) != 1 {
+            return Err(PercolatorError::Unauthorized.into());
+        }
+        let sequence = cfg.enabled >> 1;
+        if sequence == (u64::MAX >> 1) {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let next = sequence + 1;
+        cfg.enabled = (next << 1) | 1;
+        state::write_portfolio_matcher_config(&mut data, &cfg)?;
+        Ok(next)
     }
 
     fn validate_matcher_tail<'a>(
@@ -6534,19 +6550,18 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = advance_matcher_req_id(account_b_ai)?;
         let lp_account_id = matcher_lp_account_id(&delegate);
+        let matcher_legs = [(asset_index, oracle_price, size_q)];
 
-        invoke_matcher(
+        invoke_matcher_batch(
             matcher_prog,
             matcher_ctx,
             matcher_delegate,
             tail,
             req_id,
-            asset_index,
             lp_account_id,
-            oracle_price,
-            size_q,
+            &matcher_legs,
             &[
                 b"matcher",
                 market_ai.key.as_ref(),
@@ -6558,10 +6573,12 @@ pub mod processor {
             ],
         )?;
 
-        let ret = {
-            let data = matcher_ctx.try_borrow_data()?;
-            matcher_abi::read_matcher_return(&data)?
-        };
+        let (ret_program, ret_data) = solana_program::program::get_return_data()
+            .ok_or(PercolatorError::InvalidInstruction)?;
+        if ret_program != *matcher_prog.key || ret_data.len() != matcher_abi::MATCHER_RETURN_BYTES {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let ret = matcher_abi::read_matcher_return(&ret_data)?;
         matcher_abi::validate_matcher_return(
             &ret,
             lp_account_id,
@@ -6764,7 +6781,6 @@ pub mod processor {
         // re-parsing the market once per leg).
         let (
             mode_pre,
-            current_slot_pre,
             max_market_slots,
             oracle_prices,
             stale_matured,
@@ -6800,7 +6816,6 @@ pub mod processor {
             });
             (
                 mode_pre,
-                current_slot_pre,
                 max_market_slots,
                 oracle_prices,
                 stale_matured,
@@ -6853,7 +6868,7 @@ pub mod processor {
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
         validate_matcher_tail(tail, market_ai, account_a_ai, account_b_ai, program_id)?;
 
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = advance_matcher_req_id(account_b_ai)?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         // Build the matcher batch request: per leg, (asset, that asset's oracle price, signed size).
@@ -11560,52 +11575,6 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
-    }
-
-    fn invoke_matcher<'a>(
-        matcher_prog: &AccountInfo<'a>,
-        matcher_ctx: &AccountInfo<'a>,
-        matcher_delegate: &AccountInfo<'a>,
-        tail: &[AccountInfo<'a>],
-        req_id: u64,
-        asset_index: u16,
-        lp_account_id: u64,
-        oracle_price_e6: u64,
-        req_size: i128,
-        seeds: &[&[u8]],
-    ) -> ProgramResult {
-        let mut data = [0u8; 67];
-        data[0] = 0;
-        data[1..9].copy_from_slice(&req_id.to_le_bytes());
-        data[9..11].copy_from_slice(&(asset_index as u16).to_le_bytes());
-        data[11..19].copy_from_slice(&lp_account_id.to_le_bytes());
-        data[19..27].copy_from_slice(&oracle_price_e6.to_le_bytes());
-        data[27..43].copy_from_slice(&req_size.to_le_bytes());
-
-        let mut metas = Vec::with_capacity(2 + tail.len());
-        metas.push(AccountMeta::new_readonly(*matcher_delegate.key, true));
-        metas.push(AccountMeta::new(*matcher_ctx.key, false));
-        for ai in tail {
-            if ai.is_writable {
-                metas.push(AccountMeta::new(*ai.key, ai.is_signer));
-            } else {
-                metas.push(AccountMeta::new_readonly(*ai.key, ai.is_signer));
-            }
-        }
-
-        let ix = SolInstruction {
-            program_id: *matcher_prog.key,
-            accounts: metas,
-            data: data.to_vec(),
-        };
-        let mut infos = Vec::with_capacity(3 + tail.len());
-        infos.push(matcher_delegate.clone());
-        infos.push(matcher_ctx.clone());
-        infos.push(matcher_prog.clone());
-        for ai in tail {
-            infos.push(ai.clone());
-        }
-        invoke_signed(&ix, &infos, &[seeds])
     }
 
     fn amount_to_u64(amount: u128) -> Result<u64, ProgramError> {

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,7 @@
-//! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
-//! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on matcher
+//! CPI return data. It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0]
+//! or ctx_account.data[64] for replay tests. The wrapper MUST reject every hostile mode and accept
+//! only the honest one.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program::set_return_data,
@@ -12,6 +12,7 @@ entrypoint!(process);
 
 const ABI: u32 = 3;
 const FLAG_VALID: u32 = 1;
+const FLAG_PARTIAL_OK: u32 = 2;
 
 // Build one crafted 64-byte MatcherReturn; `mode` perturbs exactly one field (default = honest fill).
 fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> [u8; 64] {
@@ -31,6 +32,8 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
         5 => l = lp.wrapping_add(1),                 // forged lp_account_id
         6 => price = 0,                              // zero exec price
         7 => { flags = FLAG_VALID; size = req / 2 }  // unflagged partial (no PARTIAL_OK)
+        10 => { flags = FLAG_VALID | FLAG_PARTIAL_OK; size = req / 2 } // valid partial
+        11 => size = 0,                              // explicit no-fill
         _ => {}                                      // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];
@@ -45,9 +48,29 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     b
 }
 
+fn mode_for_call(accounts: &[AccountInfo]) -> Result<(u8, bool), ProgramError> {
+    let mut d = accounts[1].try_borrow_mut_data()?;
+    let mode = if d.len() > 64 && d[64] != 0 {
+        d[64]
+    } else {
+        d[0]
+    };
+    if mode == 13 {
+        if d.len() <= 65 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if d[65] == 0 {
+            d[65] = 1;
+            return Ok((9, false));
+        }
+        return Ok((13, true));
+    }
+    Ok((mode, mode == 12))
+}
+
 fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     match data.first() {
-        // Tag 0: single matcher call (67 bytes); write the crafted return into ctx[0..64].
+        // Legacy tag 0: single matcher call (67 bytes); write the crafted return into ctx[0..64].
         Some(&0) => {
             if data.len() < 67 {
                 return Err(ProgramError::InvalidInstructionData);
@@ -57,7 +80,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +97,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {
@@ -79,7 +108,8 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
                 let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
                 let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
                 let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
-                out[i * 64..i * 64 + 64].copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
+                out[i * 64..i * 64 + 64]
+                    .copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
             }
             set_return_data(&out[..emit * 64]);
             Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -8905,7 +8905,6 @@ fn v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded() {
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let taker_data = env.svm.get_account(&taker_account).unwrap().data;
     let maker_data = env.svm.get_account(&maker_account).unwrap().data;
-    let matcher_data = env.svm.get_account(&matcher_ctx).unwrap().data;
     let (_, group) = state::read_market(&market_data).unwrap();
     let taker = state::read_portfolio(&taker_data).unwrap();
     let maker = state::read_portfolio(&maker_data).unwrap();
@@ -8922,15 +8921,12 @@ fn v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded() {
         group.insurance, 20,
         "passive matcher fills at oracle price; 100 bps charges 10 to each side"
     );
+    let matcher_cfg = env.portfolio_matcher_config(maker_account);
+    assert_eq!(matcher_cfg.enabled & 1, 1, "matcher config remains enabled");
     assert_eq!(
-        u32::from_le_bytes(matcher_data[0..4].try_into().unwrap()),
-        MATCHER_ABI_VERSION,
-        "LiteSVM matcher path must use the same ABI version as the wrapper"
-    );
-    assert_eq!(
-        u64::from_le_bytes(matcher_data[56..64].try_into().unwrap()),
-        0,
-        "matcher must echo the requested asset index in the v3 return slot"
+        matcher_cfg.enabled >> 1,
+        1,
+        "TradeCpi advances the LP-owned matcher request sequence exactly once"
     );
     assert_eq!(group.c_tot + group.insurance, group.vault);
 }
@@ -8976,7 +8972,6 @@ fn v16_bpf_tradecpi_external_matcher_executes_on_added_asset() {
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let taker_data = env.svm.get_account(&taker_account).unwrap().data;
     let maker_data = env.svm.get_account(&maker_account).unwrap().data;
-    let matcher_data = env.svm.get_account(&matcher_ctx).unwrap().data;
     let (_, group) = state::read_market(&market_data).unwrap();
     let taker = state::read_portfolio(&taker_data).unwrap();
     let maker = state::read_portfolio(&maker_data).unwrap();
@@ -9000,10 +8995,12 @@ fn v16_bpf_tradecpi_external_matcher_executes_on_added_asset() {
         group.insurance, 50,
         "passive matcher fills asset 2 at 250; notional=2500 and 100 bps charges 25 to each side"
     );
+    let matcher_cfg = env.portfolio_matcher_config(maker_account);
+    assert_eq!(matcher_cfg.enabled & 1, 1, "matcher config remains enabled");
     assert_eq!(
-        u64::from_le_bytes(matcher_data[56..64].try_into().unwrap()),
-        2,
-        "external matcher must echo the requested nonzero asset index"
+        matcher_cfg.enabled >> 1,
+        1,
+        "TradeCpi advances the LP-owned matcher request sequence exactly once"
     );
     assert_eq!(group.c_tot + group.insurance, group.vault);
 }
@@ -49958,6 +49955,110 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
     );
 }
 
+// Stale-return replay: the matcher writes a valid return for the first same-transaction TradeCpi,
+// then returns success without emitting data for the second. The wrapper must reject the second call,
+// not reuse the first call's matcher output from the context account.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_return_data() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 13; // first call emits return data; second same-tx call emits nothing.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let trade_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), trade_ix(), trade_ix()],
+        &[&taker],
+    );
+    assert!(
+        replay.is_err(),
+        "a matcher that omits second-call return data must not replay stale single TradeCpi data: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "failed replay transaction must roll back the first matcher context mutation"
+    );
+}
+
 // full-interface sweep / issue: removing the LP signer from TradeCpi is only safe if Percolator
 // verifies that the LP owner explicitly authorized this matcher program/context. A hostile matcher can
 // otherwise return a perfectly well-formed oracle-priced fill and force a victim LP portfolio into a
@@ -51046,11 +51147,11 @@ fn v16_attack_marketauth_terminal_close_cannot_burn_pending_payout_topup() {
     );
 }
 
-// End-to-end adversarial coverage of the PRODUCTION single-fill path: a hostile matcher writes a
-// crafted tag-0 return into the ctx account (over-fill / reversed / forged echo / zero-price /
-// unflagged-partial). handle_trade_cpi reads the ctx return + validate_matcher_return must REJECT
-// every hostile mode (no position opened); only the faithful reply executes. Complements the batch
-// (tag-3 / return_data) hostile test and the validation unit test.
+// End-to-end adversarial coverage of the PRODUCTION single-fill path: a hostile matcher emits a
+// crafted return-data reply (over-fill / reversed / forged echo / zero-price / unflagged-partial).
+// handle_trade_cpi reads return data + validate_matcher_return must REJECT every hostile mode (no
+// position opened); only the faithful reply executes. Complements the batch hostile test and the
+// validation unit test.
 #[test]
 fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);


### PR DESCRIPTION
## Summary

Fixes a stale matcher return replay in `TradeCpi`.

Root cause: the single-fill matcher CPI used `current_slot + 1` as `req_id` and read matcher output from the matcher context account. Two same-transaction calls could therefore share the same request id, and a matcher that wrote a valid response once then returned success without writing could leave stale bytes available for replay.

Changes:
- store a wrapper-owned matcher request sequence in the LP portfolio matcher config (`enabled` low bit remains the enabled flag; high bits are the sequence)
- increment that sequence before `TradeCpi` / `BatchTradeCpi` matcher CPI and bind returns to it
- route single `TradeCpi` through the same tag-3 return-data ABI as batch, instead of reading a ctx-account return prefix
- add a hostile matcher LiteSVM regression where the second same-transaction call emits no return data and must fail atomically
- update positive matcher tests and README docs for the return-data path

## Validation

- `cargo fmt`
- `cargo check --tests`
- `cargo build-sbf --no-default-features`
- `(cd tests/fixtures/hostile_matcher && cargo build-sbf)`
- `cargo test v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_return_data --test v16_cu -- --nocapture`
- `cargo test v16_attack_hostile_matcher --test v16_cu -- --nocapture`
- `cargo test v16_bpf_tradecpi --test v16_cu -- --nocapture`
- `cargo test` (540 `v16_cu` tests + unit/doc tests passed)
- `git diff --check`

Kani note: `cargo kani --tests` and `cargo kani --tests --no-default-features` both fail before wrapper harnesses run while compiling pinned engine `percolator@bbe745a`, at `PortfolioAccountV16Account` size assertion `== 9291`. I did not fold that unrelated engine/Kani blocker into this PR.