### PR TITLE
[codex] Reject delegated terminal payout destinations

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10306,6 +10306,7 @@ pub mod processor {
                 &vault_authority,
                 &cfg_after,
             )?;
+            verify_permissionless_payout_dest_token_account(dest_token)?;
             let payout_u64 = amount_to_u64(payout)?;
             require_token_balance(vault_token, payout_u64)?;
             let bump_arr = [bump];
@@ -10368,6 +10369,7 @@ pub mod processor {
                 &vault_authority,
                 &cfg,
             )?;
+            verify_permissionless_payout_dest_token_account(dest_token)?;
             let payout_u64 = amount_to_u64(payout)?;
             require_token_balance(vault_token, payout_u64)?;
             let bump_arr = [bump];
@@ -11906,6 +11908,16 @@ pub mod processor {
             || *vault_token_ai.key != canonical_vault_address(expected_vault_owner, &vault.mint)
         {
             return Err(PercolatorError::InvalidVaultAccount.into());
+        }
+        Ok(())
+    }
+
+    fn verify_permissionless_payout_dest_token_account(
+        dest_token_ai: &AccountInfo,
+    ) -> Result<(), ProgramError> {
+        let dest = unpack_token_account(dest_token_ai)?;
+        if dest.delegate.is_some() || dest.close_authority.is_some() {
+            return Err(PercolatorError::InvalidTokenAccount.into());
         }
         Ok(())
     }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -371,6 +371,31 @@ fn make_token_data(mint: Pubkey, owner: Pubkey, amount: u64) -> Vec<u8> {
     data
 }
 
+fn make_delegated_token_data(
+    mint: Pubkey,
+    owner: Pubkey,
+    amount: u64,
+    delegate: Pubkey,
+    delegated_amount: u64,
+) -> Vec<u8> {
+    let mut data = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint,
+            owner,
+            amount,
+            delegate: COption::Some(delegate),
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount,
+            close_authority: COption::None,
+        },
+        &mut data,
+    )
+    .unwrap();
+    data
+}
+
 fn make_pyth_data(
     feed_id: &[u8; 32],
     price: i64,
@@ -10895,6 +10920,104 @@ fn v16_attack_close_resolved_ignores_spoofed_fee_rate_param() {
 }
 
 #[test]
+fn v16_attack_permissionless_close_resolved_rejects_delegated_dest() {
+    let mut env = V16CuEnv::new();
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&victim_owner, victim, 1_000);
+    env.resolve();
+
+    let attacker = Keypair::new();
+    let delegated_dest = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            delegated_dest,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_delegated_token_data(
+                    env.mint,
+                    victim_owner.pubkey(),
+                    0,
+                    attacker.pubkey(),
+                    u64::MAX,
+                ),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&delegated_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(victim_owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new(delegated_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "permissionless CloseResolved must reject a victim-owned destination with an active delegate"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected delegated-dest close leaves market accounting unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&victim).unwrap(),
+        portfolio_before,
+        "rejected delegated-dest close rolls back payout state"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected delegated-dest close moves no vault custody"
+    );
+    assert_eq!(
+        env.svm.get_account(&delegated_dest).unwrap(),
+        dest_before,
+        "delegated destination receives no payout"
+    );
+
+    let clean_dest = env.token_account(victim_owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(victim_owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new(clean_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    )
+    .expect("same permissionless close succeeds with a clean victim destination");
+    assert_eq!(env.token_amount(clean_dest), 1_000);
+    assert_eq!(env.market_state().1.vault, 0);
+    assert_eq!(env.portfolio_state(victim).capital.get(), 0);
+}
+
+#[test]
 fn v16_attack_claim_resolved_topup_rejects_live_market_without_mutation() {
     let mut env = V16CuEnv::new();
     let owner = Keypair::new();
@@ -14317,6 +14440,138 @@ fn v16_attack_resolved_payout_topup_bad_dest_does_not_burn_receipt() {
         env.token_amount(good_dest),
         60,
         "correct destination receives the pending top-up"
+    );
+    let account = env.portfolio_state(portfolio);
+    assert_eq!(resolved_receipt(&account).paid_effective, 100);
+    assert!(resolved_receipt(&account).finalized);
+    assert_eq!(env.market_state().1.vault, 0);
+}
+
+#[test]
+fn v16_attack_resolved_payout_topup_rejects_delegated_dest_without_burning_receipt() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    {
+        let mut market_account = env.svm.get_account(&env.market).expect("market account");
+        let mut portfolio_account = env.svm.get_account(&portfolio).expect("portfolio account");
+        let (cfg, mut group) = state::read_market(&market_account.data).unwrap();
+        let mut account = state::read_portfolio(&portfolio_account.data).unwrap();
+        group.mode = MarketModeV16::Resolved;
+        group.resolved_slot = 1;
+        group.current_slot = 1;
+        group.vault = 60;
+        group.payout_snapshot_captured = true;
+        group.payout_snapshot = 100;
+        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
+            snapshot_residual: 100,
+            terminal_claim_exact_receipts_num: 100 * BOUND_SCALE,
+            terminal_claim_bound_unreceipted_num: 0,
+            current_payout_rate_num: 100 * BOUND_SCALE,
+            current_payout_rate_den: 100 * BOUND_SCALE,
+            snapshot_slot: 1,
+            payout_halted: false,
+            finalized: false,
+        };
+        account.resolved_payout_receipt =
+            percolator::ResolvedPayoutReceiptV16Account::from_runtime(&ResolvedPayoutReceiptV16 {
+                present: true,
+                prior_bound_contribution_num: 100 * BOUND_SCALE,
+                live_released_face_at_receipt: 0,
+                terminal_positive_claim_face: 100,
+                paid_effective: 40,
+                finalized: false,
+            });
+        state::write_market(&mut market_account.data, &cfg, &group).unwrap();
+        state::write_portfolio(&mut portfolio_account.data, &account).unwrap();
+        env.svm.set_account(env.market, market_account).unwrap();
+        env.svm.set_account(portfolio, portfolio_account).unwrap();
+    }
+    env.set_token_account_amount(env.vault, env.mint, env.vault_authority, 60);
+
+    let attacker = Keypair::new();
+    let delegated_dest = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            delegated_dest,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_delegated_token_data(
+                    env.mint,
+                    owner.pubkey(),
+                    0,
+                    attacker.pubkey(),
+                    u64::MAX,
+                ),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&delegated_dest).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::ClaimResolvedPayoutTopup,
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(delegated_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "ClaimResolvedPayoutTopup must reject an owner destination with an active delegate"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected delegated-dest top-up leaves payout accounting unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before,
+        "rejected delegated-dest top-up must not burn the pending receipt"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected delegated-dest top-up moves no vault custody"
+    );
+    assert_eq!(
+        env.svm.get_account(&delegated_dest).unwrap(),
+        dest_before,
+        "delegated destination receives no payout"
+    );
+
+    let account = env.portfolio_state(portfolio);
+    assert_eq!(resolved_receipt(&account).paid_effective, 40);
+    assert!(
+        !resolved_receipt(&account).finalized,
+        "receipt remains claimable after delegated-destination rejection"
+    );
+
+    let clean_dest = env.token_account_for_mint(env.mint, owner.pubkey(), 0);
+    let cu = env.claim_resolved_payout_topup_with_cu(owner.pubkey(), portfolio, clean_dest);
+    assert_cu_within(
+        "ClaimResolvedPayoutTopup delegated-dest regression",
+        cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.token_amount(clean_dest),
+        60,
+        "same top-up succeeds after retrying with a clean owner destination"
     );
     let account = env.portfolio_state(portfolio);
     assert_eq!(resolved_receipt(&account).paid_effective, 100);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -396,6 +396,30 @@ fn make_delegated_token_data(
     data
 }
 
+fn make_closable_token_data(
+    mint: Pubkey,
+    owner: Pubkey,
+    amount: u64,
+    close_authority: Pubkey,
+) -> Vec<u8> {
+    let mut data = vec![0u8; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint,
+            owner,
+            amount,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::Some(close_authority),
+        },
+        &mut data,
+    )
+    .unwrap();
+    data
+}
+
 fn make_pyth_data(
     feed_id: &[u8; 32],
     price: i64,
@@ -10994,6 +11018,54 @@ fn v16_attack_permissionless_close_resolved_rejects_delegated_dest() {
         "delegated destination receives no payout"
     );
 
+    let closable_dest = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            closable_dest,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_closable_token_data(
+                    env.mint,
+                    victim_owner.pubkey(),
+                    0,
+                    attacker.pubkey(),
+                ),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let closable_before = env.svm.get_account(&closable_dest).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(victim_owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new(closable_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "permissionless CloseResolved must reject a victim-owned destination with close authority"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&victim).unwrap(), portfolio_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(
+        env.svm.get_account(&closable_dest).unwrap(),
+        closable_before,
+        "close-authority destination receives no payout"
+    );
+
     let clean_dest = env.token_account(victim_owner.pubkey(), 0);
     env.svm.expire_blockhash();
     env.send(
@@ -14552,6 +14624,47 @@ fn v16_attack_resolved_payout_topup_rejects_delegated_dest_without_burning_recei
         env.svm.get_account(&delegated_dest).unwrap(),
         dest_before,
         "delegated destination receives no payout"
+    );
+
+    let closable_dest = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            closable_dest,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_closable_token_data(env.mint, owner.pubkey(), 0, attacker.pubkey()),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let closable_before = env.svm.get_account(&closable_dest).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::ClaimResolvedPayoutTopup,
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(closable_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert!(
+        rejected.is_err(),
+        "ClaimResolvedPayoutTopup must reject an owner destination with close authority"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&portfolio).unwrap(), portfolio_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(
+        env.svm.get_account(&closable_dest).unwrap(),
+        closable_before,
+        "close-authority destination receives no payout"
     );
 
     let account = env.portfolio_state(portfolio);


### PR DESCRIPTION
## Summary

Fixes a terminal payout routing bug in the permissionless resolved payout paths.

`CloseResolved` and `ClaimResolvedPayoutTopup` already required the destination token account to be owned by the portfolio owner, but they still accepted owner token accounts carrying an active SPL delegate or close authority. Because these paths are permissionless, a third party could choose a victim-owned destination with a pre-existing delegate allowance and route the payout into an account that the delegate can drain later.

This PR adds a narrow destination hardening check for the permissionless terminal payout routes only. Owner-signed normal withdrawals keep using the existing destination validation.

## Tests

- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_permissionless_close_resolved_rejects_delegated_dest -- --nocapture`
- `cargo test --test v16_cu v16_attack_resolved_payout_topup_rejects_delegated_dest_without_burning_receipt -- --nocapture`
- `cargo test --test v16_cu v16_attack_permissionless_close_resolved_bad_dest_rolls_back_legacy_realloc -- --nocapture`
- `cargo test --test v16_cu v16_attack_resolved_payout_topup_bad_dest_does_not_burn_receipt -- --nocapture`
- `cargo test --test v16_cu v16_bpf_close_resolved_pays_positive_pnl_through_engine_ledger -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test v16_cu -- --nocapture` (541/541 passed)