### PR TITLE
Reject stale TradeCpi matcher context replay

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -21,6 +21,7 @@ use solana_program::{
     clock::Clock,
     declare_id,
     entrypoint::ProgramResult,
+    hash::hashv,
     instruction::{AccountMeta, Instruction as SolInstruction},
     program::{invoke, invoke_signed},
     program_error::ProgramError,
@@ -6534,13 +6535,17 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
-        let ctx_return_before = {
-            let data = matcher_ctx.try_borrow_data()?;
-            let mut before = [0u8; matcher_abi::MATCHER_RETURN_BYTES];
-            before.copy_from_slice(&data[..matcher_abi::MATCHER_RETURN_BYTES]);
-            before
-        };
+        let req_id = matcher_context_bound_req_id(
+            current_slot_pre,
+            market_ai.key,
+            account_a_ai.key,
+            account_b_ai.key,
+            matcher_prog.key,
+            matcher_ctx,
+            asset_index,
+            oracle_price,
+            size_q,
+        )?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -6564,10 +6569,9 @@ pub mod processor {
             ],
         )?;
 
-        let (ret, ctx_return_unchanged) = {
+        let ret = {
             let data = matcher_ctx.try_borrow_data()?;
-            let unchanged = data[..matcher_abi::MATCHER_RETURN_BYTES] == ctx_return_before[..];
-            (matcher_abi::read_matcher_return(&data)?, unchanged)
+            matcher_abi::read_matcher_return(&data)?
         };
         matcher_abi::validate_matcher_return(
             &ret,
@@ -6577,9 +6581,6 @@ pub mod processor {
             size_q,
             req_id,
         )?;
-        if ret.exec_size != 0 && ctx_return_unchanged {
-            return Err(ProgramError::InvalidAccountData);
-        }
         if limit_price != 0 {
             let limit_ok = if size_q > 0 {
                 ret.exec_price_e6 <= limit_price
@@ -11570,6 +11571,42 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn matcher_context_bound_req_id(
+        current_slot: u64,
+        market: &Pubkey,
+        account_a: &Pubkey,
+        account_b: &Pubkey,
+        matcher_program: &Pubkey,
+        matcher_ctx: &AccountInfo<'_>,
+        asset_index: u16,
+        oracle_price_e6: u64,
+        req_size: i128,
+    ) -> Result<u64, ProgramError> {
+        let current_slot_bytes = current_slot.to_le_bytes();
+        let asset_index_bytes = asset_index.to_le_bytes();
+        let oracle_price_bytes = oracle_price_e6.to_le_bytes();
+        let req_size_bytes = req_size.to_le_bytes();
+        let ctx_data = matcher_ctx.try_borrow_data()?;
+        let ctx_len = core::cmp::min(ctx_data.len(), matcher_abi::MATCHER_RETURN_BYTES);
+        let digest = hashv(&[
+            b"percolator-v16-single-matcher-req",
+            &current_slot_bytes,
+            market.as_ref(),
+            account_a.as_ref(),
+            account_b.as_ref(),
+            matcher_program.as_ref(),
+            matcher_ctx.key.as_ref(),
+            &asset_index_bytes,
+            &oracle_price_bytes,
+            &req_size_bytes,
+            &ctx_data[..ctx_len],
+        ]);
+        Ok(u64::from_le_bytes(
+            digest.as_ref()[0..8].try_into().unwrap(),
+        ))
     }
 
     fn invoke_matcher<'a>(

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6535,6 +6535,12 @@ pub mod processor {
             &[asset_index],
         )?;
         let req_id = current_slot_pre.wrapping_add(1);
+        let ctx_return_before = {
+            let data = matcher_ctx.try_borrow_data()?;
+            let mut before = [0u8; matcher_abi::MATCHER_RETURN_BYTES];
+            before.copy_from_slice(&data[..matcher_abi::MATCHER_RETURN_BYTES]);
+            before
+        };
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -6558,9 +6564,10 @@ pub mod processor {
             ],
         )?;
 
-        let ret = {
+        let (ret, ctx_return_unchanged) = {
             let data = matcher_ctx.try_borrow_data()?;
-            matcher_abi::read_matcher_return(&data)?
+            let unchanged = data[..matcher_abi::MATCHER_RETURN_BYTES] == ctx_return_before[..];
+            (matcher_abi::read_matcher_return(&data)?, unchanged)
         };
         matcher_abi::validate_matcher_return(
             &ret,
@@ -6570,6 +6577,9 @@ pub mod processor {
             size_q,
             req_id,
         )?;
+        if ret.exec_size != 0 && ctx_return_unchanged {
+            return Err(ProgramError::InvalidAccountData);
+        }
         if limit_price != 0 {
             let limit_ok = if size_q > 0 {
                 ret.exec_price_e6 <= limit_price

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,8 @@
 //! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
 //! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (or
+//! data[64] when nonzero, for stale-return probes). The wrapper MUST reject every hostile mode and
+//! accept only the honest one.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program::set_return_data,
@@ -45,6 +46,26 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     b
 }
 
+fn mode_for_call(accounts: &[AccountInfo]) -> Result<(u8, bool), ProgramError> {
+    let mut d = accounts[1].try_borrow_mut_data()?;
+    let mode = if d.len() > 64 && d[64] != 0 {
+        d[64]
+    } else {
+        d[0]
+    };
+    if mode == 13 {
+        if d.len() <= 65 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if d[65] == 0 {
+            d[65] = 1;
+            return Ok((9, false));
+        }
+        return Ok((13, true));
+    }
+    Ok((mode, false))
+}
+
 fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     match data.first() {
         // Tag 0: single matcher call (67 bytes); write the crafted return into ctx[0..64].
@@ -57,7 +78,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +95,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51204,6 +51204,111 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     );
 }
 
+// security.md sweep - stale matcher context replay (#39/#49): TradeCpi reads matcher output from the
+// writable matcher context account. A matcher that writes a valid return for one CPI and then returns
+// Ok without writing for a second same-transaction CPI must not let the wrapper replay the stale first
+// response from ctx[0..64].
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 13; // first call writes a valid return; second same-tx call writes nothing.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let trade_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), trade_ix(), trade_ix()],
+        &[&taker],
+    );
+    assert!(
+        replay.is_err(),
+        "a matcher that omits second-call context output must not replay stale TradeCpi bytes: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "failed replay transaction must roll back the first matcher context write"
+    );
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51309,6 +51309,113 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
     );
 }
 
+// Liveness side of the stale-context fix: freshness must not mean "reject two identical honest
+// same-transaction fills." The single-fill request id is bound to the pre-call context state, so a
+// matcher that actually writes for each call can refresh the return even when the economic fill is
+// identical.
+#[test]
+fn v16_attack_honest_matcher_can_repeat_identical_single_fills_in_one_tx() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 9; // persistent faithful mode; ctx[0..64] is overwritten by each call.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let trade_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+
+    env.svm.expire_blockhash();
+    let filled_twice = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), trade_ix(), trade_ix()],
+        &[&taker],
+    );
+    assert!(
+        filled_twice.is_ok(),
+        "freshly-written identical TradeCpi fills must not be DoSed: {filled_twice:?}"
+    );
+    let taker_after = env.portfolio_state(ta);
+    let lp_after = env.portfolio_state(la);
+    assert_eq!(
+        active_leg_for_asset(&taker_after, 0).basis_pos_q,
+        2 * size_q,
+        "both honest fills landed on the taker"
+    );
+    assert_eq!(
+        active_leg_for_asset(&lp_after, 0).basis_pos_q,
+        -2 * size_q,
+        "both honest fills landed on the LP"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(group.vault, group.c_tot + group.insurance);
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA


### PR DESCRIPTION
## Summary
- Bind single `TradeCpi` matcher request ids to the pre-call matcher context bytes, market/accounts, matcher program/context, asset, oracle price, and requested size.
- Prevent a hostile matcher from returning `Ok(())` without writing fresh context bytes and replaying a stale valid return in a later same-transaction `TradeCpi`.
- Add fixture source support for a no-write replay mode and a liveness positive test showing two identical honest same-transaction fills still execute when the matcher writes fresh returns.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `(cd tests/fixtures/hostile_matcher && cargo build-sbf)`
- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context -- --nocapture`
- `cargo test --test v16_cu v16_attack_honest_matcher_can_repeat_identical_single_fills_in_one_tx -- --nocapture`
- `cargo test --test v16_cu -- --nocapture` (541/541)
