### PR TITLE
[codex] Bind single matcher replies to state nonce

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6534,7 +6534,12 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = matcher_state_bound_req_id(
+            current_slot_pre.wrapping_add(1),
+            account_a_ai,
+            account_b_ai,
+            max_market_slots,
+        )?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -11560,6 +11565,83 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    fn matcher_req_id_mix_u64(acc: u64, value: u64) -> u64 {
+        acc ^ value
+            .wrapping_add(0x9e37_79b9_7f4a_7c15)
+            .wrapping_add(acc << 6)
+            .wrapping_add(acc >> 2)
+    }
+
+    fn matcher_req_id_mix_u128(acc: u64, value: u128) -> u64 {
+        let lo = value as u64;
+        let hi = (value >> 64) as u64;
+        matcher_req_id_mix_u64(matcher_req_id_mix_u64(acc, lo), hi)
+    }
+
+    fn matcher_req_id_mix_i128(acc: u64, value: i128) -> u64 {
+        matcher_req_id_mix_u128(acc, value as u128)
+    }
+
+    fn matcher_req_id_mix_portfolio(
+        mut acc: u64,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+    ) -> Result<u64, ProgramError> {
+        acc = matcher_req_id_mix_u128(acc, portfolio.header.capital.get());
+        acc = matcher_req_id_mix_i128(acc, portfolio.header.pnl.get());
+        acc = matcher_req_id_mix_u128(acc, portfolio.header.reserved_pnl.get());
+        acc = matcher_req_id_mix_i128(acc, portfolio.header.fee_credits.get());
+        acc = matcher_req_id_mix_u64(acc, portfolio.header.last_fee_slot.get());
+        for word in portfolio.header.active_bitmap {
+            acc = matcher_req_id_mix_u64(acc, word.get());
+        }
+        for leg in portfolio.header.legs.iter() {
+            let leg = leg.try_to_runtime().map_err(map_v16_error)?;
+            acc = matcher_req_id_mix_u64(acc, u64::from(leg.active));
+            if leg.active {
+                acc = matcher_req_id_mix_u64(acc, leg.asset_index as u64);
+                acc = matcher_req_id_mix_u64(acc, leg.market_id);
+                acc = matcher_req_id_mix_u64(
+                    acc,
+                    match leg.side {
+                        SideV16::Long => 1,
+                        SideV16::Short => 2,
+                    },
+                );
+                acc = matcher_req_id_mix_i128(acc, leg.basis_pos_q);
+                acc = matcher_req_id_mix_u128(acc, leg.a_basis);
+                acc = matcher_req_id_mix_i128(acc, leg.k_snap);
+                acc = matcher_req_id_mix_i128(acc, leg.f_snap);
+                acc = matcher_req_id_mix_u64(acc, leg.epoch_snap);
+                acc = matcher_req_id_mix_u128(acc, leg.loss_weight);
+                acc = matcher_req_id_mix_u128(acc, leg.b_snap);
+                acc = matcher_req_id_mix_u128(acc, leg.b_rem);
+                acc = matcher_req_id_mix_u64(acc, leg.b_epoch_snap);
+                acc = matcher_req_id_mix_u64(acc, u64::from(leg.b_stale));
+                acc = matcher_req_id_mix_u64(acc, u64::from(leg.stale));
+            }
+        }
+        Ok(acc)
+    }
+
+    fn matcher_state_bound_req_id(
+        base_req_id: u64,
+        account_a_ai: &AccountInfo<'_>,
+        account_b_ai: &AccountInfo<'_>,
+        max_market_slots: usize,
+    ) -> Result<u64, ProgramError> {
+        let mut account_a_data = account_a_ai.try_borrow_mut_data()?;
+        let account_a =
+            state::portfolio_view_mut_for_market_slots(&mut account_a_data, max_market_slots)?;
+        let mut acc = matcher_req_id_mix_portfolio(base_req_id, &account_a)?;
+        drop(account_a_data);
+
+        let mut account_b_data = account_b_ai.try_borrow_mut_data()?;
+        let account_b =
+            state::portfolio_view_mut_for_market_slots(&mut account_b_data, max_market_slots)?;
+        acc = matcher_req_id_mix_portfolio(acc, &account_b)?;
+        Ok(acc)
     }
 
     fn invoke_matcher<'a>(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,8 @@
 //! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
 //! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (or
+//! data[64] when nonzero, for stale-return probes). The wrapper MUST reject every hostile mode and
+//! accept only the honest one.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program::set_return_data,
@@ -23,15 +24,18 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     let mut rid = req_id;
     let mut l = lp;
     match mode {
-        0 => size = req.saturating_mul(2),           // over-fill: open 2x the requested position
-        1 => size = req.checked_neg().unwrap_or(0),  // reversed direction
-        2 => a = asset.wrapping_add(1),              // forged asset echo
-        3 => o = oracle.wrapping_add(1),             // forged oracle echo
-        4 => rid = req_id.wrapping_add(1),           // forged req_id
-        5 => l = lp.wrapping_add(1),                 // forged lp_account_id
-        6 => price = 0,                              // zero exec price
-        7 => { flags = FLAG_VALID; size = req / 2 }  // unflagged partial (no PARTIAL_OK)
-        _ => {}                                      // honest full fill -> wrapper accepts
+        0 => size = req.saturating_mul(2), // over-fill: open 2x the requested position
+        1 => size = req.checked_neg().unwrap_or(0), // reversed direction
+        2 => a = asset.wrapping_add(1),    // forged asset echo
+        3 => o = oracle.wrapping_add(1),   // forged oracle echo
+        4 => rid = req_id.wrapping_add(1), // forged req_id
+        5 => l = lp.wrapping_add(1),       // forged lp_account_id
+        6 => price = 0,                    // zero exec price
+        7 => {
+            flags = FLAG_VALID;
+            size = req / 2
+        } // unflagged partial (no PARTIAL_OK)
+        _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];
     b[0..4].copy_from_slice(&ABI.to_le_bytes());
@@ -43,6 +47,26 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     b[48..56].copy_from_slice(&o.to_le_bytes());
     b[56..64].copy_from_slice(&a.to_le_bytes());
     b
+}
+
+fn mode_for_call(accounts: &[AccountInfo]) -> Result<(u8, bool), ProgramError> {
+    let mut d = accounts[1].try_borrow_mut_data()?;
+    let mode = if d.len() > 64 && d[64] != 0 {
+        d[64]
+    } else {
+        d[0]
+    };
+    if mode == 13 {
+        if d.len() <= 65 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if d[65] == 0 {
+            d[65] = 1;
+            return Ok((9, false));
+        }
+        return Ok((13, true));
+    }
+    Ok((mode, mode == 12))
 }
 
 fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
@@ -57,7 +81,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +98,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {
@@ -79,7 +109,8 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
                 let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
                 let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
                 let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
-                out[i * 64..i * 64 + 64].copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
+                out[i * 64..i * 64 + 64]
+                    .copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
             }
             set_return_data(&out[..emit * 64]);
             Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51204,6 +51204,109 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     );
 }
 
+// security.md sweep - stale matcher ctx replay (#39/#49): the single TradeCpi path reads matcher
+// output from the matcher-owned context account. A matcher that returns Ok without writing the ctx
+// must not let stale bytes from a prior same-transaction fill replay as a fresh response.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_ctx() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 13; // first single call writes; second same-tx call returns Ok without writing.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let trade_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), trade_ix(), trade_ix()],
+        &[&taker],
+    );
+    let replay_err = replay.expect_err(
+        "a matcher that omits a second ctx write must not replay stale single-fill bytes",
+    );
+    assert!(
+        replay_err.contains("InvalidAccountData"),
+        "same-tx stale ctx replay must fail at matcher-return validation, got {replay_err}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA


### PR DESCRIPTION
## Summary
- Bind single TradeCpi matcher request ids to the current taker/maker portfolio state so stale matcher context bytes cannot be replayed as a fresh fill after a prior same-transaction fill.
- Extend the hostile matcher fixture with a mode that writes once, then returns Ok without updating the ctx account.
- Add a LiteSVM regression that sends two single TradeCpi calls in one transaction and asserts the second stale ctx replay is rejected with rollback.

## Validation
- cd tests/fixtures/hostile_matcher && cargo build-sbf
- cargo build-sbf --no-default-features
- cargo test --test v16_cu v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_ctx -- --nocapture
- cargo test --test v16_cu v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected -- --nocapture
- cargo test --test v16_cu v16_attack_hostile_matcher_batch_returns_all_rejected -- --nocapture
- cargo test --test v16_cu v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded -- --nocapture
- cargo fmt --check
- git diff --check
- cargo test --test v16_cu
