### PR TITLE
[codex] Bind matcher CPI outputs to fresh calls

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6534,7 +6534,16 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        let req_id = current_slot_pre.wrapping_add(1);
+        // Single TradeCpi reads the matcher result from matcher_ctx bytes. Bind the
+        // request id to pre-CPI portfolio state so stale bytes from an earlier fill
+        // cannot validate as a fresh response after a nonzero fill mutates state.
+        let req_id = matcher_request_id(
+            current_slot_pre,
+            account_a_ai,
+            account_b_ai,
+            max_market_slots,
+            &[asset_index],
+        )?;
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -6872,6 +6881,8 @@ pub mod processor {
             &asset_indices,
         )?;
 
+        // Force the batch matcher to emit fresh return data for this CPI.
+        solana_program::program::set_return_data(&[]);
         invoke_matcher_batch(
             matcher_prog,
             matcher_ctx,
@@ -11560,6 +11571,112 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    fn mix_request_u64(mut acc: u64, value: u64) -> u64 {
+        acc ^= value
+            .wrapping_add(0x9e37_79b9_7f4a_7c15)
+            .wrapping_add(acc << 6)
+            .wrapping_add(acc >> 2);
+        acc.rotate_left(27).wrapping_mul(0x94d0_49bb_1331_11eb)
+    }
+
+    fn mix_request_u128(acc: u64, value: u128) -> u64 {
+        let acc = mix_request_u64(acc, value as u64);
+        mix_request_u64(acc, (value >> 64) as u64)
+    }
+
+    fn mix_request_i128(acc: u64, value: i128) -> u64 {
+        mix_request_u128(acc, value as u128)
+    }
+
+    fn mix_matcher_portfolio_request_state(
+        mut acc: u64,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        asset_indices: &[u16],
+    ) -> Result<u64, ProgramError> {
+        acc = mix_request_u128(acc, portfolio.header.capital.get());
+        acc = mix_request_i128(acc, portfolio.header.pnl.get());
+        acc = mix_request_u128(acc, portfolio.header.reserved_pnl.get());
+        acc = mix_request_i128(acc, portfolio.header.fee_credits.get());
+        acc = mix_request_u64(acc, portfolio.header.last_fee_slot.get());
+        for word in portfolio.header.active_bitmap {
+            acc = mix_request_u64(acc, word.get());
+        }
+        acc = mix_request_u64(acc, portfolio.header.stale_state as u64);
+        acc = mix_request_u64(acc, portfolio.header.b_stale_state as u64);
+        acc = mix_request_u64(acc, portfolio.header.rebalance_lock as u64);
+        acc = mix_request_u64(acc, portfolio.header.liquidation_lock as u64);
+
+        for &asset_index in asset_indices {
+            let mut found = false;
+            let mut slot = 0usize;
+            while slot < portfolio.header.legs.len() {
+                let leg = portfolio.header.legs[slot]
+                    .try_to_runtime()
+                    .map_err(map_v16_error)?;
+                if leg.active && leg.asset_index == asset_index as u32 {
+                    if found {
+                        return Err(PercolatorError::EngineHiddenLeg.into());
+                    }
+                    found = true;
+                    acc = mix_request_u64(acc, slot as u64);
+                    acc = mix_request_u64(acc, leg.asset_index as u64);
+                    acc = mix_request_u64(acc, leg.market_id);
+                    acc = mix_request_u64(
+                        acc,
+                        match leg.side {
+                            SideV16::Long => 1,
+                            SideV16::Short => 2,
+                        },
+                    );
+                    acc = mix_request_i128(acc, leg.basis_pos_q);
+                    acc = mix_request_u128(acc, leg.a_basis);
+                    acc = mix_request_i128(acc, leg.k_snap);
+                    acc = mix_request_i128(acc, leg.f_snap);
+                    acc = mix_request_u64(acc, leg.epoch_snap);
+                    acc = mix_request_u128(acc, leg.loss_weight);
+                    acc = mix_request_u128(acc, leg.b_snap);
+                    acc = mix_request_u128(acc, leg.b_rem);
+                    acc = mix_request_u64(acc, leg.b_epoch_snap);
+                    acc = mix_request_u64(acc, leg.b_stale as u64);
+                    acc = mix_request_u64(acc, leg.stale as u64);
+                }
+                slot += 1;
+            }
+            if !found {
+                acc = mix_request_u64(acc, asset_index as u64);
+                acc = mix_request_u64(acc, 0);
+            }
+        }
+        Ok(acc)
+    }
+
+    fn matcher_request_id(
+        current_slot: u64,
+        account_a_ai: &AccountInfo<'_>,
+        account_b_ai: &AccountInfo<'_>,
+        max_market_slots: usize,
+        asset_indices: &[u16],
+    ) -> Result<u64, ProgramError> {
+        let mut acc = mix_request_u64(0x7065_7263_6d61_7463, current_slot);
+        acc = mix_request_u64(acc, asset_indices.len() as u64);
+        for &asset_index in asset_indices {
+            acc = mix_request_u64(acc, asset_index as u64);
+        }
+        {
+            let mut account_a_data = account_a_ai.try_borrow_mut_data()?;
+            let account_a =
+                state::portfolio_view_mut_for_market_slots(&mut account_a_data, max_market_slots)?;
+            acc = mix_matcher_portfolio_request_state(acc, &account_a, asset_indices)?;
+        }
+        {
+            let mut account_b_data = account_b_ai.try_borrow_mut_data()?;
+            let account_b =
+                state::portfolio_view_mut_for_market_slots(&mut account_b_data, max_market_slots)?;
+            acc = mix_matcher_portfolio_request_state(acc, &account_b, asset_indices)?;
+        }
+        Ok(acc)
     }
 
     fn invoke_matcher<'a>(

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -46,7 +46,7 @@ pub mod constants {
     pub const KIND_INSURANCE_LEDGER: u8 = 4;
 
     pub const HEADER_LEN: usize = 16;
-    pub const WRAPPER_CONFIG_LEN: usize = 432;
+    pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
@@ -547,6 +547,8 @@ pub mod state {
         pub backing_trade_fee_insurance_share_bps_long: u16,
         pub backing_trade_fee_insurance_share_bps_short: u16,
         pub fee_redirect_to_market_0_bps: u16,
+        pub matcher_req_seq: u64,
+        pub _padding1: [u8; 8],
     }
 
     #[repr(C)]
@@ -963,6 +965,7 @@ pub mod state {
             || config.conf_filter_bps > 10_000
             || config.invert > 1
             || config._padding0 != 0
+            || config._padding1 != [0u8; 8]
             || config.fee_redirect_to_market_0_bps > 10_000
             || config.oracle_leg_count as usize > ORACLE_LEG_CAP
             || (config.oracle_leg_flags & !ORACLE_LEG_FLAGS_MASK) != 0
@@ -1368,6 +1371,18 @@ pub mod state {
     ) -> Result<(), ProgramError> {
         check_header(data, KIND_MARKET)?;
         write_wrapper_config_to_bytes(data, config)
+    }
+
+    pub fn bump_matcher_req_seq(data: &mut [u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        let mut config = read_wrapper_config_from_bytes(data)?;
+        config.matcher_req_seq = config
+            .matcher_req_seq
+            .checked_add(1)
+            .ok_or(PercolatorError::InvalidInstruction)?;
+        let req_id = config.matcher_req_seq;
+        write_wrapper_config_to_bytes(data, &config)?;
+        Ok(req_id)
     }
 
     pub fn market_view_mut(
@@ -5517,6 +5532,8 @@ pub mod processor {
             backing_trade_fee_insurance_share_bps_long: 0,
             backing_trade_fee_insurance_share_bps_short: 0,
             fee_redirect_to_market_0_bps: 0,
+            matcher_req_seq: 0,
+            _padding1: [0u8; 8],
         };
         state::init_market_account_zero_copy(
             &mut market_ai.try_borrow_mut_data()?,
@@ -6534,16 +6551,10 @@ pub mod processor {
             max_market_slots,
             &[asset_index],
         )?;
-        // Single TradeCpi reads the matcher result from matcher_ctx bytes. Bind the
-        // request id to pre-CPI portfolio state so stale bytes from an earlier fill
-        // cannot validate as a fresh response after a nonzero fill mutates state.
-        let req_id = matcher_request_id(
-            current_slot_pre,
-            account_a_ai,
-            account_b_ai,
-            max_market_slots,
-            &[asset_index],
-        )?;
+        let req_id = {
+            let mut market_data = market_ai.try_borrow_mut_data()?;
+            state::bump_matcher_req_seq(&mut market_data)?
+        };
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         invoke_matcher(
@@ -6773,7 +6784,7 @@ pub mod processor {
         // re-parsing the market once per leg).
         let (
             mode_pre,
-            current_slot_pre,
+            _current_slot_pre,
             max_market_slots,
             oracle_prices,
             stale_matured,
@@ -6862,7 +6873,10 @@ pub mod processor {
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
         validate_matcher_tail(tail, market_ai, account_a_ai, account_b_ai, program_id)?;
 
-        let req_id = current_slot_pre.wrapping_add(1);
+        let req_id = {
+            let mut market_data = market_ai.try_borrow_mut_data()?;
+            state::bump_matcher_req_seq(&mut market_data)?
+        };
         let lp_account_id = matcher_lp_account_id(&delegate);
 
         // Build the matcher batch request: per leg, (asset, that asset's oracle price, signed size).
@@ -11571,112 +11585,6 @@ pub mod processor {
     fn matcher_lp_account_id(delegate: &Pubkey) -> u64 {
         let bytes = delegate.to_bytes();
         u64::from_le_bytes(bytes[0..8].try_into().unwrap())
-    }
-
-    fn mix_request_u64(mut acc: u64, value: u64) -> u64 {
-        acc ^= value
-            .wrapping_add(0x9e37_79b9_7f4a_7c15)
-            .wrapping_add(acc << 6)
-            .wrapping_add(acc >> 2);
-        acc.rotate_left(27).wrapping_mul(0x94d0_49bb_1331_11eb)
-    }
-
-    fn mix_request_u128(acc: u64, value: u128) -> u64 {
-        let acc = mix_request_u64(acc, value as u64);
-        mix_request_u64(acc, (value >> 64) as u64)
-    }
-
-    fn mix_request_i128(acc: u64, value: i128) -> u64 {
-        mix_request_u128(acc, value as u128)
-    }
-
-    fn mix_matcher_portfolio_request_state(
-        mut acc: u64,
-        portfolio: &percolator::PortfolioV16ViewMut<'_>,
-        asset_indices: &[u16],
-    ) -> Result<u64, ProgramError> {
-        acc = mix_request_u128(acc, portfolio.header.capital.get());
-        acc = mix_request_i128(acc, portfolio.header.pnl.get());
-        acc = mix_request_u128(acc, portfolio.header.reserved_pnl.get());
-        acc = mix_request_i128(acc, portfolio.header.fee_credits.get());
-        acc = mix_request_u64(acc, portfolio.header.last_fee_slot.get());
-        for word in portfolio.header.active_bitmap {
-            acc = mix_request_u64(acc, word.get());
-        }
-        acc = mix_request_u64(acc, portfolio.header.stale_state as u64);
-        acc = mix_request_u64(acc, portfolio.header.b_stale_state as u64);
-        acc = mix_request_u64(acc, portfolio.header.rebalance_lock as u64);
-        acc = mix_request_u64(acc, portfolio.header.liquidation_lock as u64);
-
-        for &asset_index in asset_indices {
-            let mut found = false;
-            let mut slot = 0usize;
-            while slot < portfolio.header.legs.len() {
-                let leg = portfolio.header.legs[slot]
-                    .try_to_runtime()
-                    .map_err(map_v16_error)?;
-                if leg.active && leg.asset_index == asset_index as u32 {
-                    if found {
-                        return Err(PercolatorError::EngineHiddenLeg.into());
-                    }
-                    found = true;
-                    acc = mix_request_u64(acc, slot as u64);
-                    acc = mix_request_u64(acc, leg.asset_index as u64);
-                    acc = mix_request_u64(acc, leg.market_id);
-                    acc = mix_request_u64(
-                        acc,
-                        match leg.side {
-                            SideV16::Long => 1,
-                            SideV16::Short => 2,
-                        },
-                    );
-                    acc = mix_request_i128(acc, leg.basis_pos_q);
-                    acc = mix_request_u128(acc, leg.a_basis);
-                    acc = mix_request_i128(acc, leg.k_snap);
-                    acc = mix_request_i128(acc, leg.f_snap);
-                    acc = mix_request_u64(acc, leg.epoch_snap);
-                    acc = mix_request_u128(acc, leg.loss_weight);
-                    acc = mix_request_u128(acc, leg.b_snap);
-                    acc = mix_request_u128(acc, leg.b_rem);
-                    acc = mix_request_u64(acc, leg.b_epoch_snap);
-                    acc = mix_request_u64(acc, leg.b_stale as u64);
-                    acc = mix_request_u64(acc, leg.stale as u64);
-                }
-                slot += 1;
-            }
-            if !found {
-                acc = mix_request_u64(acc, asset_index as u64);
-                acc = mix_request_u64(acc, 0);
-            }
-        }
-        Ok(acc)
-    }
-
-    fn matcher_request_id(
-        current_slot: u64,
-        account_a_ai: &AccountInfo<'_>,
-        account_b_ai: &AccountInfo<'_>,
-        max_market_slots: usize,
-        asset_indices: &[u16],
-    ) -> Result<u64, ProgramError> {
-        let mut acc = mix_request_u64(0x7065_7263_6d61_7463, current_slot);
-        acc = mix_request_u64(acc, asset_indices.len() as u64);
-        for &asset_index in asset_indices {
-            acc = mix_request_u64(acc, asset_index as u64);
-        }
-        {
-            let mut account_a_data = account_a_ai.try_borrow_mut_data()?;
-            let account_a =
-                state::portfolio_view_mut_for_market_slots(&mut account_a_data, max_market_slots)?;
-            acc = mix_matcher_portfolio_request_state(acc, &account_a, asset_indices)?;
-        }
-        {
-            let mut account_b_data = account_b_ai.try_borrow_mut_data()?;
-            let account_b =
-                state::portfolio_view_mut_for_market_slots(&mut account_b_data, max_market_slots)?;
-            acc = mix_matcher_portfolio_request_state(acc, &account_b, asset_indices)?;
-        }
-        Ok(acc)
     }
 
     fn invoke_matcher<'a>(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -23,15 +23,18 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     let mut rid = req_id;
     let mut l = lp;
     match mode {
-        0 => size = req.saturating_mul(2),           // over-fill: open 2x the requested position
-        1 => size = req.checked_neg().unwrap_or(0),  // reversed direction
-        2 => a = asset.wrapping_add(1),              // forged asset echo
-        3 => o = oracle.wrapping_add(1),             // forged oracle echo
-        4 => rid = req_id.wrapping_add(1),           // forged req_id
-        5 => l = lp.wrapping_add(1),                 // forged lp_account_id
-        6 => price = 0,                              // zero exec price
-        7 => { flags = FLAG_VALID; size = req / 2 }  // unflagged partial (no PARTIAL_OK)
-        _ => {}                                      // honest full fill -> wrapper accepts
+        0 => size = req.saturating_mul(2), // over-fill: open 2x the requested position
+        1 => size = req.checked_neg().unwrap_or(0), // reversed direction
+        2 => a = asset.wrapping_add(1),    // forged asset echo
+        3 => o = oracle.wrapping_add(1),   // forged oracle echo
+        4 => rid = req_id.wrapping_add(1), // forged req_id
+        5 => l = lp.wrapping_add(1),       // forged lp_account_id
+        6 => price = 0,                    // zero exec price
+        7 => {
+            flags = FLAG_VALID;
+            size = req / 2
+        } // unflagged partial (no PARTIAL_OK)
+        _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];
     b[0..4].copy_from_slice(&ABI.to_le_bytes());
@@ -43,6 +46,26 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
     b[48..56].copy_from_slice(&o.to_le_bytes());
     b[56..64].copy_from_slice(&a.to_le_bytes());
     b
+}
+
+fn mode_for_call(accounts: &[AccountInfo]) -> Result<(u8, bool), ProgramError> {
+    let mut d = accounts[1].try_borrow_mut_data()?;
+    let mode = if d.len() > 64 && d[64] != 0 {
+        d[64]
+    } else {
+        d[0]
+    };
+    if mode == 13 {
+        if d.len() <= 65 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if d[65] == 0 {
+            d[65] = 1;
+            return Ok((9, false));
+        }
+        return Ok((13, true));
+    }
+    Ok((mode, false))
 }
 
 fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
@@ -57,7 +80,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
             let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
             let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let rec = craft(mode, req_id, lp, asset, oracle, req);
             let mut d = accounts[1].try_borrow_mut_data()?;
             d[0..64].copy_from_slice(&rec);
@@ -71,7 +97,10 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
             }
             let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
             let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
-            let mode = accounts[1].try_borrow_data()?[0];
+            let (mode, no_write) = mode_for_call(accounts)?;
+            if no_write {
+                return Ok(());
+            }
             let mut out = [0u8; 16 * 64];
             let emit = if mode == 8 { n.saturating_sub(1) } else { n }; // mode 8 = short return length
             for i in 0..n {
@@ -79,7 +108,8 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
                 let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
                 let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
                 let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
-                out[i * 64..i * 64 + 64].copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
+                out[i * 64..i * 64 + 64]
+                    .copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
             }
             set_return_data(&out[..emit * 64]);
             Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51204,6 +51204,228 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
     );
 }
 
+// security.md sweep - stale matcher return-data replay (#39/#49): BatchTradeCpi reads matcher output
+// from Solana return data. A matcher that sets valid return data for one batch CPI and then returns
+// Ok without setting return data for a second same-transaction batch must not let the wrapper replay
+// the stale first response.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[64] = 13; // first batch writes return data; second same-tx batch writes nothing.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let batch_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::BatchTradeCpi {
+            legs: vec![
+                BatchTradeCpiLeg {
+                    asset_index: 0,
+                    size_q,
+                    fee_bps: 100,
+                    limit_price: 0,
+                },
+                BatchTradeCpiLeg {
+                    asset_index: 1,
+                    size_q: -size_q,
+                    fee_bps: 100,
+                    limit_price: 0,
+                },
+            ],
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), batch_ix(), batch_ix()],
+        &[&taker],
+    );
+    assert!(
+        replay.is_err(),
+        "a matcher that omits second-call return data must not replay stale batch return data: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "failed replay transaction must roll back the first matcher context write"
+    );
+}
+
+// security.md sweep - stale matcher context replay (#39/#49): single TradeCpi reads the matcher
+// result from the writable matcher context account. A matcher that writes a valid response once and
+// then returns Ok without overwriting the context on a second same-transaction call must not let the
+// wrapper replay the stale first response as a fresh fill.
+#[test]
+fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 10_000_000);
+    env.deposit(&lp, la, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 9; // faithful first fill
+    ctx_data[64] = 13; // after the first fill, hostile fixture returns Ok without writing output
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let size_q = POS_SCALE as i128;
+    let program_id = env.program_id;
+    let market = env.market;
+    let taker_key = taker.pubkey();
+    let single_ix = || Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(taker_key, true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        data: ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q,
+            fee_bps: 100,
+            limit_price: 0,
+        }
+        .encode(),
+    };
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let replay = send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![heap_ix(), cu_ix(), single_ix(), single_ix()],
+        &[&taker],
+    );
+    assert!(
+        replay.is_err(),
+        "a matcher that omits second-call context output must not replay stale TradeCpi bytes: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "failed replay transaction must roll back the first matcher context write"
+    );
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -51426,6 +51426,67 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
     );
 }
 
+#[test]
+fn v16_attack_tradecpi_matcher_req_id_advances_monotonically_on_market() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let taker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&taker_owner, taker, 10_000_000);
+    env.deposit(&lp_owner, lp, 10_000_000);
+    let (ctx, delegate, _) = env.init_auth_matcher_context(matcher_program, &lp_owner, lp);
+    let read_ctx_req_id = |env: &V16CuEnv| {
+        let ctx_data = env.svm.get_account(&ctx).unwrap().data;
+        u64::from_le_bytes(ctx_data[32..40].try_into().unwrap())
+    };
+
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker_owner,
+        taker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        ctx,
+        delegate,
+        0,
+        POS_SCALE as i128,
+        100,
+    )
+    .expect("first matcher fill succeeds");
+    assert_eq!(
+        read_ctx_req_id(&env),
+        1,
+        "first matcher fill should use market request sequence 1"
+    );
+    assert_eq!(env.market_state().0.matcher_req_seq, 1);
+
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker_owner,
+        taker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        ctx,
+        delegate,
+        0,
+        POS_SCALE as i128,
+        100,
+    )
+    .expect("second matcher fill succeeds");
+    assert_eq!(
+        read_ctx_req_id(&env),
+        2,
+        "second matcher fill should use the next market request sequence"
+    );
+    assert_eq!(env.market_state().0.matcher_req_seq, 2);
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA


### PR DESCRIPTION
## Summary

Fixes stale matcher-output replay across matcher CPI routes.

- `TradeCpi` and `BatchTradeCpi` now allocate matcher `req_id` values from a market-scoped monotonic `matcher_req_seq` stored in `WrapperConfigV16`.
- This uses the market account because trades already write-lock the market, so freshness does not add another contended account or require LP-local coordination.
- `BatchTradeCpi` still clears wrapper return data immediately before the matcher CPI, forcing the matcher to emit fresh return data for that call.
- Adds LiteSVM regressions for stale single-context replay, stale batch return-data replay, and the market nonce advancing monotonically across matcher fills.

## Root Cause

The single-fill path read matcher output from the writable matcher context account. A hostile matcher could write a valid response during one CPI, then return `Ok` without overwriting the context on a later CPI in the same transaction. Because the old `req_id` was only `current_slot + 1`, stale bytes from the earlier fill could still satisfy the echo checks.

The batch path used Solana return data, but clearing return data before the CPI makes the freshness requirement explicit and prevents stale transaction return data from being reused if a matcher omits output.

## Layout Impact

`WRAPPER_CONFIG_LEN` increases from 432 to 448 bytes to store `matcher_req_seq` plus padding. New markets initialize the counter to zero and every matcher CPI consumes the next nonzero sequence value.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test --lib wrapper_config_len_matches_struct_size -- --nocapture`
- `cargo test --test v16_cu v16_attack_tradecpi_matcher_req_id_advances_monotonically_on_market -- --nocapture`
- `cargo test --test v16_cu v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data -- --nocapture`
- `cargo test --test v16_cu v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context -- --nocapture`
- `cargo test --test v16_cu v16_bpf_batch_trade_cpi_14_legs_under_tx_limit -- --nocapture`
- `cargo test --test v16_cu v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded -- --nocapture`
- `cargo test --all-targets`
