### PR TITLE
[codex] Reject drain-only CPI risk increases before matcher

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6563,12 +6563,13 @@ pub mod processor {
         }
         let (_, _, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        let cpi_requests = [(asset_index, size_q)];
         ensure_cpi_trade_portfolios_current_before_matcher(
             market_ai,
             account_a_ai,
             account_b_ai,
             max_market_slots,
-            &[asset_index],
+            &cpi_requests,
         )?;
         let req_id = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
@@ -6914,18 +6915,20 @@ pub mod processor {
 
         // Build the matcher batch request: per leg, (asset, that asset's oracle price, signed size).
         let mut matcher_legs: Vec<(u16, u64, i128)> = Vec::with_capacity(legs.len());
+        let mut cpi_requests: Vec<(u16, i128)> = Vec::with_capacity(legs.len());
         for (i, leg) in legs.iter().enumerate() {
             if oracle_prices[i] == 0 {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             matcher_legs.push((leg.asset_index, oracle_prices[i], leg.size_q));
+            cpi_requests.push((leg.asset_index, leg.size_q));
         }
         ensure_cpi_trade_portfolios_current_before_matcher(
             market_ai,
             account_a_ai,
             account_b_ai,
             max_market_slots,
-            &asset_indices,
+            &cpi_requests,
         )?;
 
         // Force the batch matcher to emit fresh return data for this CPI.
@@ -10792,6 +10795,31 @@ pub mod processor {
         Ok(false)
     }
 
+    fn signed_position_for_asset_view(
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+    ) -> Result<i128, ProgramError> {
+        if asset_index >= group.markets.len() {
+            return Err(PercolatorError::EngineInvalidConfig.into());
+        }
+        let market_id = group.markets[asset_index].engine.asset.market_id.get();
+        let mut slot = 0usize;
+        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            if leg.active && leg.asset_index as usize == asset_index && leg.market_id == market_id {
+                return Ok(match leg.side {
+                    SideV16::Long => leg.basis_pos_q.unsigned_abs() as i128,
+                    SideV16::Short => -(leg.basis_pos_q.unsigned_abs() as i128),
+                });
+            }
+            slot += 1;
+        }
+        Ok(0)
+    }
+
     fn ensure_trade_portfolio_current_for_requests_view(
         group: &state::MarketViewMutV16<'_>,
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
@@ -10860,32 +10888,43 @@ pub mod processor {
         ensure_trade_portfolio_current_for_requests_view(group, account_b, requests)
     }
 
+    fn requested_delta_must_increase_risk(current_q: i128, delta_q: i128) -> bool {
+        current_q == 0 || (current_q > 0 && delta_q > 0) || (current_q < 0 && delta_q < 0)
+    }
+
     fn ensure_cpi_trade_asset_lifecycle_before_matcher(
         group: &state::MarketViewMutV16<'_>,
         account_a: &percolator::PortfolioV16ViewMut<'_>,
         account_b: &percolator::PortfolioV16ViewMut<'_>,
-        asset_indices: &[u16],
+        cpi_requests: &[(u16, i128)],
     ) -> ProgramResult {
-        for &asset_index in asset_indices {
-            let asset_index_usize = asset_index as usize;
-            if asset_index_usize >= group.header.config.max_market_slots.get() as usize
-                || asset_index_usize >= group.markets.len()
+        for &(asset_index_u16, size_q) in cpi_requests {
+            let asset_index = asset_index_u16 as usize;
+            if asset_index >= group.header.config.max_market_slots.get() as usize
+                || asset_index >= group.markets.len()
             {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
-            let lifecycle = group.markets[asset_index_usize].engine.asset.lifecycle;
-            if lifecycle == ASSET_LIFECYCLE_ACTIVE {
-                continue;
-            }
-            let account_a_has_asset =
-                portfolio_has_active_asset_view(group, account_a, asset_index_usize)?;
-            let account_b_has_asset =
-                portfolio_has_active_asset_view(group, account_b, asset_index_usize)?;
-            if !account_a_has_asset && !account_b_has_asset {
-                return Err(PercolatorError::EngineLockActive.into());
-            }
-            match lifecycle {
-                ASSET_LIFECYCLE_DRAIN_ONLY | ASSET_LIFECYCLE_RECOVERY => {}
+            match group.markets[asset_index].engine.asset.lifecycle {
+                ASSET_LIFECYCLE_ACTIVE => {}
+                ASSET_LIFECYCLE_DRAIN_ONLY | ASSET_LIFECYCLE_RECOVERY => {
+                    let account_a_has_asset =
+                        portfolio_has_active_asset_view(group, account_a, asset_index)?;
+                    let account_b_has_asset =
+                        portfolio_has_active_asset_view(group, account_b, asset_index)?;
+                    if !account_a_has_asset && !account_b_has_asset {
+                        return Err(PercolatorError::EngineLockActive.into());
+                    }
+                    let account_a_pos =
+                        signed_position_for_asset_view(group, account_a, asset_index)?;
+                    let account_b_pos =
+                        signed_position_for_asset_view(group, account_b, asset_index)?;
+                    if requested_delta_must_increase_risk(account_a_pos, size_q)
+                        || requested_delta_must_increase_risk(account_b_pos, -size_q)
+                    {
+                        return Err(PercolatorError::EngineLockActive.into());
+                    }
+                }
                 _ => return Err(PercolatorError::EngineLockActive.into()),
             }
         }
@@ -10897,12 +10936,12 @@ pub mod processor {
         account_a_ai: &AccountInfo<'_>,
         account_b_ai: &AccountInfo<'_>,
         max_market_slots: usize,
-        asset_indices: &[u16],
+        cpi_requests: &[(u16, i128)],
     ) -> ProgramResult {
         ensure_portfolio_storage_for_market_slots(account_a_ai, max_market_slots)?;
         ensure_portfolio_storage_for_market_slots(account_b_ai, max_market_slots)?;
-        let mut requests: Vec<TradeRequestV16> = Vec::with_capacity(asset_indices.len());
-        for &asset_index in asset_indices {
+        let mut requests: Vec<TradeRequestV16> = Vec::with_capacity(cpi_requests.len());
+        for &(asset_index, _) in cpi_requests {
             requests.push(TradeRequestV16 {
                 asset_index: asset_index as usize,
                 size_q: 1,
@@ -10922,7 +10961,7 @@ pub mod processor {
             &group,
             &account_a,
             &account_b,
-            asset_indices,
+            cpi_requests,
         )?;
         ensure_trade_portfolios_current_for_requests_view(&group, &account_a, &account_b, &requests)
     }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -47520,6 +47520,143 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
     assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
 }
 
+// LoF/DoS sweep: DrainOnly is allowed to reduce existing risk, but a CPI request whose signed size
+// can only increase an existing long/short pair is guaranteed to be rejected by the engine. That
+// rejection should happen before invoking an external matcher; otherwise a hostile LP matcher can
+// burn CU on work the wrapper already knows cannot commit.
+#[test]
+fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_cpi() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 5_000, 10_000, 1_000);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let taker_account = env.create_portfolio(&taker);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&taker, taker_account, 1_000_000);
+    env.deposit(&lp, lp_account, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_DRAIN_ONLY,
+        0,
+        0,
+        0,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::DrainOnly
+    );
+
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp_account,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 0;
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+
+    let accounts = |env: &V16CuEnv| {
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_account, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ]
+    };
+
+    for (route, instruction) in [
+        (
+            "TradeCpi",
+            ProgInstruction::TradeCpi {
+                asset_index: 0,
+                size_q: POS_SCALE as i128,
+                fee_bps: 0,
+                limit_price: 0,
+            },
+        ),
+        (
+            "BatchTradeCpi",
+            ProgInstruction::BatchTradeCpi {
+                legs: vec![BatchTradeCpiLeg {
+                    asset_index: 0,
+                    size_q: POS_SCALE as i128,
+                    fee_bps: 0,
+                    limit_price: 0,
+                }],
+            },
+        ),
+    ] {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let taker_before = env.svm.get_account(&taker_account).unwrap();
+        let lp_before = env.svm.get_account(&lp_account).unwrap();
+        let ctx_before = env.svm.get_account(&ctx).unwrap();
+        env.svm.expire_blockhash();
+        let rejected = env
+            .send(instruction, accounts(&env), &[&taker])
+            .expect_err("DrainOnly CPI risk increase must reject before matcher CPI");
+        assert!(
+            rejected.contains("Custom(21)") || rejected.contains("custom program error: 0x15"),
+            "{route} DrainOnly risk-increase should be EngineLockActive, got {rejected}"
+        );
+        assert!(
+            !rejected.contains("InvalidAccountData"),
+            "{route} must not reach hostile matcher validation: {rejected}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&taker_account).unwrap(), taker_before);
+        assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before);
+        assert_eq!(
+            env.svm.get_account(&ctx).unwrap(),
+            ctx_before,
+            "{route} must not give the hostile matcher a writable context"
+        );
+    }
+}
+
 // BatchTradeNoCpi end-state margin: a leg that is individually margin-INFEASIBLE (it would leave the
 // taker holding two full positions at once) is rejected as a standalone trade, but the SAME leg in a
 // batch that also closes the offsetting position SUCCEEDS, because the batch checks initial margin


### PR DESCRIPTION
## Summary

Reject guaranteed risk-increasing CPI trade requests on DrainOnly/Recovery assets before invoking the external matcher.

## Root Cause

The CPI pre-matcher guard only checked account currentness and asset ids. If both portfolios already had the asset, a taker could submit a signed size that could only increase an existing long/short pair on a DrainOnly asset. The engine would reject the final trade, but only after the wrapper had already invoked the matcher, letting a hostile matcher consume CU and mutate its writable context before rollback.

## Fix

Carry signed CPI request sizes into the wrapper preflight and reject non-active asset requests that are guaranteed to open or increase risk. Opposite-side requests still pass through because a matcher partial fill can be a valid risk reduction.

## Validation

- `cargo fmt --check`
- `cargo build-sbf --no-default-features`
- `cargo test v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_cpi --test v16_cu -- --nocapture`
- `cargo test --all-targets`
