### PR TITLE
[codex] Guard TradeCpi zero-fill shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=c8aab33814dd30878cf9b054eca89bcd6cf9f5e7#c8aab33814dd30878cf9b054eca89bcd6cf9f5e7"
+source = "git+https://github.com/aeyakovenko/percolator?rev=c8b86a4b795d296bd27a2edbed793691f12f3544#c8b86a4b795d296bd27a2edbed793691f12f3544"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8aab33814dd30878cf9b054eca89bcd6cf9f5e7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8b86a4b795d296bd27a2edbed793691f12f3544" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8aab33814dd30878cf9b054eca89bcd6cf9f5e7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8b86a4b795d296bd27a2edbed793691f12f3544" }
 
 [dev-dependencies]
 bincode = "1"

--- a/README.md
+++ b/README.md
@@ -475,8 +475,6 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
 - **ClaimResolvedPayoutTopup** (tag 46)
   - permissionless resolved-payout top-up claim; pays only the stored owner receipt token account
-- **RefineResolvedUnreceiptedBound** (tag 47)
-  - admin-gated monotonic decrease of the resolved unreceipted bound; cannot increase obligations
 
 ### Post-resolution / terminal close
 - **CloseResolved** (tag 30)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10602,17 +10602,14 @@ pub mod processor {
             let summary = group
                 .build_actionable_summary(&portfolio.as_view())
                 .map_err(map_v16_error)?;
-            if let Some(asset_index) =
-                auto_crank_selected_asset_that_accrues_view(&portfolio, &summary)?
-            {
-                reject_missing_pending_selected_observation_view(
-                    &cfg,
-                    &group,
-                    asset_index,
-                    authenticated_now_slot,
-                    observations.as_slice(),
-                )?;
-            }
+            reject_missing_pending_account_observations_view(
+                &cfg,
+                &group,
+                &portfolio,
+                &summary,
+                authenticated_now_slot,
+                observations.as_slice(),
+            )?;
             let result = match group.permissionless_auto_crank_not_atomic(
                 &mut portfolio,
                 AutoCrankWorkV16 {
@@ -10793,13 +10790,23 @@ pub mod processor {
         Ok(())
     }
 
-    fn first_active_asset_from_portfolio_view(
+    fn reject_missing_pending_account_observations_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
-    ) -> Result<Option<usize>, ProgramError> {
+        summary: &percolator::ActionableSummaryV16,
+        now_slot: u64,
+        observations: &[AutoCrankObservationV16],
+    ) -> ProgramResult {
+        if summary.b_stale || !(summary.stale || summary.liquidatable) {
+            return Ok(());
+        }
         let active_bitmap = portfolio
             .header
             .active_bitmap
             .map(percolator::V16PodU64::get);
+        let mut seen_assets = [u32::MAX; percolator::V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut seen_asset_count = 0usize;
         let mut slot = 0usize;
         while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = portfolio.header.legs[slot]
@@ -10810,24 +10817,26 @@ pub mod processor {
                 return Err(PercolatorError::EngineHiddenLeg.into());
             }
             if bit {
-                return Ok(Some(leg.asset_index as usize));
+                let mut seen = 0usize;
+                while seen < seen_asset_count {
+                    if seen_assets[seen] == leg.asset_index {
+                        return Err(PercolatorError::EngineHiddenLeg.into());
+                    }
+                    seen += 1;
+                }
+                seen_assets[seen_asset_count] = leg.asset_index;
+                seen_asset_count += 1;
+                reject_missing_pending_selected_observation_view(
+                    cfg,
+                    group,
+                    leg.asset_index as usize,
+                    now_slot,
+                    observations,
+                )?;
             }
             slot += 1;
         }
-        Ok(None)
-    }
-
-    fn auto_crank_selected_asset_that_accrues_view(
-        portfolio: &percolator::PortfolioV16ViewMut<'_>,
-        summary: &percolator::ActionableSummaryV16,
-    ) -> Result<Option<usize>, ProgramError> {
-        if summary.b_stale {
-            return Ok(None);
-        }
-        if summary.stale || summary.liquidatable {
-            return first_active_asset_from_portfolio_view(portfolio);
-        }
-        Ok(None)
+        Ok(())
     }
 
     fn reject_missing_pending_selected_observation_view(

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6605,6 +6605,9 @@ pub mod processor {
             }
         }
         if ret.exec_size == 0 {
+            let mut market_data = market_ai.try_borrow_mut_data()?;
+            let (_, group) = state::market_view_mut(&mut market_data)?;
+            group.validate_shape().map_err(map_v16_error)?;
             return Ok(());
         }
         let (_, _, max_market_slots, _) =

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2627,9 +2627,6 @@ pub mod ix {
             side: u8,
         },
         ClaimResolvedPayoutTopup,
-        RefineResolvedUnreceiptedBound {
-            decrease_num: u128,
-        },
         SyncMaintenanceFee {
             now_slot: u64,
         },
@@ -2905,9 +2902,6 @@ pub mod ix {
                     side: read_u8(&mut rest)?,
                 },
                 46 => Self::ClaimResolvedPayoutTopup,
-                47 => Self::RefineResolvedUnreceiptedBound {
-                    decrease_num: read_u128(&mut rest)?,
-                },
                 48 => Self::SyncMaintenanceFee {
                     now_slot: read_u64(&mut rest)?,
                 },
@@ -3308,10 +3302,6 @@ pub mod ix {
                     out.push(side);
                 }
                 Self::ClaimResolvedPayoutTopup => out.push(46),
-                Self::RefineResolvedUnreceiptedBound { decrease_num } => {
-                    out.push(47);
-                    push_u128(&mut out, decrease_num);
-                }
                 Self::SyncMaintenanceFee { now_slot } => {
                     out.push(48);
                     push_u64(&mut out, now_slot);
@@ -5410,9 +5400,6 @@ pub mod processor {
             }
             Instruction::ClaimResolvedPayoutTopup => {
                 handle_claim_resolved_payout_topup(program_id, accounts)
-            }
-            Instruction::RefineResolvedUnreceiptedBound { decrease_num } => {
-                handle_refine_resolved_unreceipted_bound(program_id, accounts, decrease_num)
             }
             Instruction::SyncMaintenanceFee { now_slot } => {
                 handle_sync_maintenance_fee(program_id, accounts, now_slot)
@@ -9415,28 +9402,6 @@ pub mod processor {
         let (_cfg, mut group) = state::market_view_mut(&mut data)?;
         group
             .finalize_side_reset_not_atomic(asset_index as usize, side)
-            .map_err(map_v16_error)
-    }
-
-    #[inline(never)]
-    fn handle_refine_resolved_unreceipted_bound<'a>(
-        program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
-        decrease_num: u128,
-    ) -> ProgramResult {
-        let admin = account(accounts, 0)?;
-        let market_ai = account(accounts, 1)?;
-        expect_signer(admin)?;
-        expect_writable(market_ai)?;
-        expect_owner(market_ai, program_id)?;
-        if decrease_num == 0 {
-            return Err(PercolatorError::InvalidInstruction.into());
-        }
-        let mut data = market_ai.try_borrow_mut_data()?;
-        let (cfg, mut group) = state::market_view_mut(&mut data)?;
-        expect_live_authority(&cfg.marketauth, admin.key)?;
-        group
-            .refine_resolved_unreceipted_bound_not_atomic(decrease_num)
             .map_err(map_v16_error)
     }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10326,6 +10326,180 @@ fn v16_attack_pending_selected_mark_requires_observation() {
 }
 
 #[test]
+fn v16_attack_no_observation_refresh_cannot_certify_over_later_active_mark_move() {
+    const MARK: u64 = 1_000_000;
+    const NEXT_MARK0: u64 = 1_100_000;
+    const NEXT_MARK2: u64 = 1_010_000;
+    const OPEN_SLOT: u64 = 1;
+    const CRANK_SLOT: u64 = 2;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(3, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_for_asset_as_admin(0, OPEN_SLOT, MARK);
+    env.configure_auth_mark_for_asset_as_admin(1, OPEN_SLOT, MARK);
+    env.configure_auth_mark_for_asset_as_admin(2, OPEN_SLOT, MARK);
+
+    let owner_a = Keypair::new();
+    let owner_b = Keypair::new();
+    let asset2_owner = Keypair::new();
+    let asset2_counter_owner = Keypair::new();
+    let account_a = env.create_portfolio(&owner_a);
+    let account_b = env.create_portfolio(&owner_b);
+    let asset2_account = env.create_portfolio(&asset2_owner);
+    let asset2_counter = env.create_portfolio(&asset2_counter_owner);
+    env.deposit(&owner_a, account_a, 100_000_000);
+    env.deposit(&owner_b, account_b, 100_000_000);
+    env.deposit(&asset2_owner, asset2_account, 100_000_000);
+    env.deposit(&asset2_counter_owner, asset2_counter, 100_000_000);
+
+    env.trade_asset_with_cu(
+        1,
+        &owner_a,
+        account_a,
+        &owner_b,
+        account_b,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &owner_a,
+        account_a,
+        &owner_b,
+        account_b,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        2,
+        &asset2_owner,
+        asset2_account,
+        &asset2_counter_owner,
+        asset2_counter,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    let account_before_mark = env.portfolio_state(account_a);
+    assert_eq!(
+        leg(&account_before_mark, 0).asset_index,
+        1,
+        "asset 1 must occupy the first active slot for this later-active probe"
+    );
+    assert_eq!(
+        leg(&account_before_mark, 1).asset_index,
+        0,
+        "asset 0 is active but not engine-selected first"
+    );
+
+    env.svm.warp_to_slot(CRANK_SLOT);
+    env.push_auth_mark_for_asset_as_admin(0, CRANK_SLOT, NEXT_MARK0);
+    let (_, pending_group) = env.market_state();
+    assert_eq!(
+        pending_group.assets[0].effective_price, MARK,
+        "PushAuthMark only stages the later active asset mark"
+    );
+    assert!(
+        pending_group.assets[0].slot_last < CRANK_SLOT,
+        "later active asset has a pending slot to consume"
+    );
+
+    env.push_auth_mark_for_asset_as_admin(2, CRANK_SLOT, NEXT_MARK2);
+    env.crank(
+        asset2_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: crank_observations(2),
+        },
+    );
+    let (_, stale_group) = env.market_state();
+    assert_eq!(stale_group.assets[2].effective_price, NEXT_MARK2);
+    assert_eq!(
+        stale_group.assets[0].effective_price, MARK,
+        "later active asset mark is still pending after unrelated asset progress"
+    );
+    assert!(
+        health_cert(&env.portfolio_state(account_a)).cert_oracle_epoch < stale_group.oracle_epoch,
+        "unrelated asset progress makes the target account stale"
+    );
+    let next_asset0_price = oracle_v16::effective_price_from_target(
+        stale_group.assets[0].effective_price,
+        NEXT_MARK0,
+        stale_group.config.max_price_move_bps_per_slot,
+        CRANK_SLOT - stale_group.assets[0].slot_last,
+        true,
+    );
+    assert_ne!(
+        next_asset0_price, stale_group.assets[0].effective_price,
+        "setup leaves a real pending mark move on the later active asset"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let account_before = env.svm.get_account(&account_a).unwrap();
+    env.svm.expire_blockhash();
+    let missing_later_observation = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+        ],
+        &[],
+    );
+    assert!(
+        missing_later_observation.is_err(),
+        "no-observation refresh must not certify over a later active leg's pending mark move"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected missing-observation refresh must not consume the later active mark at the old price"
+    );
+    assert_eq!(
+        env.svm.get_account(&account_a).unwrap(),
+        account_before,
+        "rejected missing-observation refresh must not certify the target over pending mark work"
+    );
+
+    env.svm.expire_blockhash();
+    let observed = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+        ],
+        &[],
+    );
+    assert!(
+        observed.is_ok(),
+        "supplying the later active asset observation must remain live: {observed:?}"
+    );
+    let (_, observed_group) = env.market_state();
+    assert_eq!(
+        observed_group.assets[0].effective_price, next_asset0_price,
+        "later active asset observation applies the pending mark"
+    );
+    assert_eq!(
+        health_cert(&env.portfolio_state(account_a)).cert_oracle_epoch,
+        observed_group.oracle_epoch,
+        "account certifies only after the later active asset work is applied"
+    );
+}
+
+#[test]
 fn v16_bpf_no_cranker_liquidation_rejects_invalid_final_market_shape() {
     let mut env = V16CuEnv::new();
     let long_owner = Keypair::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21662,6 +21662,113 @@ fn v16_attack_tradecpi_zero_fill_is_clean() {
     let _ = r;
 }
 
+// Full-interface rollback sweep: the single TradeCpi zero-fill path returns before the shared
+// no-CPI engine fill path. It still bumps matcher_req_seq and lets the matcher write its context, so
+// it must run the same final market-shape guard and propagate that error instead of committing a
+// successful no-op against malformed accounting.
+#[test]
+fn v16_attack_tradecpi_zero_fill_rejects_invalid_final_market_shape() {
+    let mut env = V16CuEnv::new();
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let taker_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let maker_owner = Keypair::new();
+    let maker = env.create_portfolio(&maker_owner);
+    env.deposit(&taker_owner, taker, 1_000_000);
+    env.deposit(&maker_owner, maker, 1_000_000);
+    let (ctx, delegate, _) = env.init_matcher_context_with_data_authorized(
+        matcher_program,
+        &maker_owner,
+        maker,
+        encode_matcher_init_passive(0),
+    );
+
+    env.mutate_market(|_, group| {
+        group.insurance_domain_budget[0] = group.insurance.saturating_add(1);
+    });
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker).unwrap();
+    let maker_before = env.svm.get_account(&maker).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q: (10 * POS_SCALE) as i128,
+            fee_bps: 100,
+            limit_price: 0,
+        },
+        vec![
+            AccountMeta::new(taker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker, false),
+            AccountMeta::new(maker, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker_owner],
+    );
+    assert!(
+        rejected.is_err(),
+        "TradeCpi zero-fill must reject an invalid final market shape"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "failed zero-fill must roll back the matcher req_id bump and market bytes"
+    );
+    assert_eq!(
+        env.svm.get_account(&taker).unwrap(),
+        taker_before,
+        "failed zero-fill must not mutate the taker portfolio"
+    );
+    assert_eq!(
+        env.svm.get_account(&maker).unwrap(),
+        maker_before,
+        "failed zero-fill must not mutate the LP portfolio"
+    );
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "failed zero-fill must roll back matcher context writes"
+    );
+
+    env.mutate_market(|_, group| {
+        group.insurance_domain_budget[0] = 0;
+    });
+    env.svm.expire_blockhash();
+    let accepted = env.send(
+        ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q: (10 * POS_SCALE) as i128,
+            fee_bps: 100,
+            limit_price: 0,
+        },
+        vec![
+            AccountMeta::new(taker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker, false),
+            AccountMeta::new(maker, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker_owner],
+    );
+    assert!(
+        accepted.is_ok(),
+        "valid zero-fill remains a clean no-op after shape repair: {accepted:?}"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(group.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group.assets[0].oi_eff_short_q, 0);
+    assert_eq!(group.vault as u64, env.token_amount(env.vault));
+}
+
 // security.md sweep — TradeCpi self-trade (#49 wash): taker == maker (same portfolio) on the matcher
 // CPI path must reject like TradeNoCpi self-trade — no wash position / OI fabrication.
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3468,21 +3468,6 @@ impl V16CuEnv {
         .expect("claim resolved payout topup")
     }
 
-    fn refine_resolved_unreceipted_bound_with_cu(&mut self, decrease_num: u128) -> u64 {
-        send_tx(
-            &mut self.svm,
-            self.program_id,
-            &self.payer,
-            ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num },
-            vec![
-                AccountMeta::new(self.admin.pubkey(), true),
-                AccountMeta::new(self.market, false),
-            ],
-            &[&self.admin],
-        )
-        .expect("refine resolved unreceipted bound")
-    }
-
     fn crank(&mut self, portfolio: Pubkey, ix: ProgInstruction) -> u64 {
         let attempts = match ix {
             ProgInstruction::PermissionlessCrank { close_q, .. } if close_q != 0 => 2,
@@ -14261,46 +14246,6 @@ fn v16_bpf_resolved_payout_tags_are_bounded_and_update_state() {
     assert_eq!(group.vault, 0);
     assert_eq!(resolved_receipt(&account).paid_effective, 100);
     assert!(resolved_receipt(&account).finalized);
-
-    let mut refine_env = V16CuEnv::new();
-    refine_env.mutate_market(|_, group| {
-        group.mode = MarketModeV16::Resolved;
-        group.resolved_slot = 1;
-        group.current_slot = 1;
-        group.payout_snapshot_captured = true;
-        group.payout_snapshot = 100;
-        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
-            snapshot_residual: 100,
-            terminal_claim_exact_receipts_num: 0,
-            terminal_claim_bound_unreceipted_num: 100 * BOUND_SCALE,
-            current_payout_rate_num: 100 * BOUND_SCALE,
-            current_payout_rate_den: 100 * BOUND_SCALE,
-            snapshot_slot: 1,
-            payout_halted: false,
-            finalized: false,
-        };
-    });
-    let refine_cu = refine_env.refine_resolved_unreceipted_bound_with_cu(10 * BOUND_SCALE);
-    assert_cu_within(
-        "RefineResolvedUnreceiptedBound",
-        refine_cu,
-        CUSTODY_CU_LIMIT,
-    );
-    let (_, group) = refine_env.market_state();
-    assert_eq!(
-        group
-            .resolved_payout_ledger
-            .terminal_claim_bound_unreceipted_num,
-        90 * BOUND_SCALE
-    );
-    assert_eq!(
-        group.resolved_payout_ledger.current_payout_rate_num,
-        90 * BOUND_SCALE
-    );
-    assert_eq!(
-        group.resolved_payout_ledger.current_payout_rate_den,
-        90 * BOUND_SCALE
-    );
 }
 
 // Coverage probe (audit): an INSOLVENT resolved market (residual < positive-PnL
@@ -28850,176 +28795,60 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
     );
 }
 
-// security.md sweep — RefineResolvedUnreceiptedBound gating (#6/#30): this wind-down tool (decreases
-// the unreceipted resolved claim bound) is admin-only and resolved-mode-only. A non-admin must
-// reject, and it must reject in Live mode — no tampering with the resolved payout accounting.
+// issue88: resolved unreceipted-bound refinement is an internal engine step only.
+// No public wrapper tag, including an admin-signed raw tag 47, may mutate payout accounting.
 #[test]
-fn v16_attack_refine_resolved_bound_admin_and_mode_gated() {
+fn v16_attack_refine_resolved_bound_tag_is_not_public() {
     let mut env = V16CuEnv::new();
-    let owner = Keypair::new();
-    let p = env.create_portfolio(&owner);
-    env.deposit(&owner, p, 1_000_000);
-    let mallory = Keypair::new();
-    env.ensure_signer_account(mallory.pubkey());
-    // 1) Live mode: even the admin can't refine (mode != Resolved).
-    env.svm.expire_blockhash();
-    let r_live = send_tx(
-        &mut env.svm,
-        env.program_id,
-        &env.payer,
-        ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        vec![
-            AccountMeta::new(env.admin.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&env.admin],
-    );
-    assert!(r_live.is_err(), "refine must reject in Live mode");
-    // 2) Resolved mode: a NON-admin can't refine.
-    env.resolve();
-    env.svm.expire_blockhash();
-    let r_nonadmin = send_tx(
-        &mut env.svm,
-        env.program_id,
-        &env.payer,
-        ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        vec![
-            AccountMeta::new(mallory.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&mallory],
-    );
-    assert!(
-        r_nonadmin.is_err(),
-        "non-admin refine must reject in resolved mode"
-    );
-    // user funds still fully recoverable (the rejected refines didn't corrupt the resolved accounting).
-    let cr = env.close_resolved(&owner, p);
-    assert_eq!(
-        env.token_amount(cr),
-        1_000_000,
-        "user recovers full resolved payout after rejected refines"
-    );
-}
-
-// security.md sweep - terminal payout bound refinement (#14/#21): even an authorized market admin
-// must not be able to over-decrease the unreceipted claim bound. A bad refine would either underflow
-// terminal accounting or lower the payout denominator incorrectly, locking or haircutting users.
-#[test]
-fn v16_attack_refine_resolved_bound_over_decrease_is_atomic() {
-    let mut env = V16CuEnv::new();
-    let owner_a = Keypair::new();
-    let portfolio_a = env.create_portfolio(&owner_a);
-    let owner_b = Keypair::new();
-    let portfolio_b = env.create_portfolio(&owner_b);
-    let owner_c = Keypair::new();
-    let portfolio_c = env.create_portfolio(&owner_c);
-    env.deposit(&owner_a, portfolio_a, 1_000_000);
-    env.deposit(&owner_b, portfolio_b, 1_000_000);
-    env.deposit(&owner_c, portfolio_c, 500_000);
-    // Two PLAIN-JUNIOR positive-pnl winners (no source backing -> they flow through the junior
-    // receipt pool / unreceipted bound, which is what the refine targets), funded by a third
-    // account that donated its 500k capital into the junior residual. (Source-backed claims now
-    // realize straight to capital and never populate the unreceipted bound.) Conservation holds:
-    // vault 2.5M >= c_tot 2.0M + net positive pnl 0.5M.
-    {
-        let mut m = env.svm.get_account(&env.market).unwrap();
-        let mut pa = env.svm.get_account(&portfolio_a).unwrap();
-        let mut pb = env.svm.get_account(&portfolio_b).unwrap();
-        let mut pc = env.svm.get_account(&portfolio_c).unwrap();
-        let (cfg, mut g) = state::read_market(&m.data).unwrap();
-        let mut a = state::read_portfolio(&pa.data).unwrap();
-        let mut b = state::read_portfolio(&pb.data).unwrap();
-        let mut c = state::read_portfolio(&pc.data).unwrap();
-        // C donates its capital to the junior residual.
-        g.c_tot -= 500_000;
-        c.capital = percolator::V16PodU128::new(0);
-        c.last_fee_slot = percolator::V16PodU64::new(1);
-        // A and B hold matured junior positive pnl.
-        a.pnl = percolator::V16PodI128::new(250_000);
-        a.last_fee_slot = percolator::V16PodU64::new(1);
-        b.pnl = percolator::V16PodI128::new(250_000);
-        b.last_fee_slot = percolator::V16PodU64::new(1);
-        g.pnl_pos_tot = 500_000;
-        g.pnl_matured_pos_tot = 500_000;
-        g.pnl_pos_bound_tot = 500_000;
-        g.pnl_pos_bound_tot_num = 500_000 * BOUND_SCALE;
-        g.mode = MarketModeV16::Resolved;
-        g.resolved_slot = 1;
-        g.current_slot = 1;
-        state::write_market(&mut m.data, &cfg, &g).unwrap();
-        state::write_portfolio(&mut pa.data, &a).unwrap();
-        state::write_portfolio(&mut pb.data, &b).unwrap();
-        state::write_portfolio(&mut pc.data, &c).unwrap();
-        env.svm.set_account(env.market, m).unwrap();
-        env.svm.set_account(portfolio_a, pa).unwrap();
-        env.svm.set_account(portfolio_b, pb).unwrap();
-        env.svm.set_account(portfolio_c, pc).unwrap();
-    }
-
-    let dest_a = env.close_resolved(&owner_a, portfolio_a);
-    assert_eq!(
-        env.token_amount(dest_a),
-        1_250_000,
-        "first winner receives capital + full junior claim and becomes an exact receipt"
-    );
-
-    let (_, group_before) = env.market_state();
-    let bound = group_before
-        .resolved_payout_ledger
-        .terminal_claim_bound_unreceipted_num;
-    assert!(
-        bound > 0,
-        "remaining junior user claim contributes to the unreceipted bound"
-    );
-    assert!(
-        group_before
-            .resolved_payout_ledger
-            .terminal_claim_exact_receipts_num
-            > 0,
-        "first close converted one winner into an exact receipt"
-    );
+    env.mutate_market(|_, group| {
+        group.mode = MarketModeV16::Resolved;
+        group.resolved_slot = 1;
+        group.current_slot = 1;
+        group.payout_snapshot_captured = true;
+        group.payout_snapshot = 100;
+        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
+            snapshot_residual: 100,
+            terminal_claim_exact_receipts_num: 0,
+            terminal_claim_bound_unreceipted_num: 100 * BOUND_SCALE,
+            current_payout_rate_num: 100 * BOUND_SCALE,
+            current_payout_rate_den: 100 * BOUND_SCALE,
+            snapshot_slot: 1,
+            payout_halted: false,
+            finalized: false,
+        };
+    });
 
     let market_before = env.svm.get_account(&env.market).unwrap();
-    let portfolio_before = env.svm.get_account(&portfolio_b).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let mut data = Vec::with_capacity(17);
+    data.push(47);
+    data.extend_from_slice(&(10 * BOUND_SCALE).to_le_bytes());
     let admin = env.admin.insecure_clone();
     env.svm.expire_blockhash();
-    let rejected = env.send(
-        ProgInstruction::RefineResolvedUnreceiptedBound {
-            decrease_num: bound + 1,
+    let rejected = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data,
         },
-        vec![
-            AccountMeta::new(env.admin.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
         &[&admin],
     );
-    assert!(
-        rejected.is_err(),
-        "authorized over-decrease of resolved payout bound must reject"
-    );
+
+    assert!(rejected.is_err(), "raw refine tag must be unavailable");
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
         market_before,
-        "rejected over-refine leaves resolved market accounting byte-identical"
-    );
-    assert_eq!(
-        env.svm.get_account(&portfolio_b).unwrap(),
-        portfolio_before,
-        "rejected over-refine leaves user payout state byte-identical"
+        "rejected raw refine leaves resolved market accounting byte-identical"
     );
     assert_eq!(
         env.svm.get_account(&env.vault).unwrap(),
         vault_before,
-        "rejected over-refine moves no custody"
-    );
-
-    let dest = env.close_resolved(&owner_b, portfolio_b);
-    assert_eq!(
-        env.token_amount(dest),
-        1_250_000,
-        "remaining user still recovers the full terminal payout after rejected over-refine"
+        "rejected raw refine moves no custody"
     );
 }
 

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -142,14 +142,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
     kani::assume(
-        tag == 3
-            || tag == 4
-            || tag == 9
-            || tag == 28
-            || tag == 30
-            || tag == 41
-            || tag == 42
-            || tag == 47,
+        tag == 3 || tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42,
     );
     let amount: u128 = kani::any();
 
@@ -172,9 +165,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
                 optional_deposit: got,
             },
         ) => assert_eq!(got, amount),
-        (47, Instruction::RefineResolvedUnreceiptedBound { decrease_num }) => {
-            assert_eq!(decrease_num, amount)
-        }
         _ => unreachable!(),
     }
 }
@@ -1330,10 +1320,6 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
         extra,
     );
     assert_rejects_trailing_byte(Instruction::ClaimResolvedPayoutTopup, extra);
-    assert_rejects_trailing_byte(
-        Instruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        extra,
-    );
     assert_rejects_trailing_byte(Instruction::ClosePortfolio, extra);
 }
 
@@ -1370,7 +1356,6 @@ fn kani_v16_unknown_or_truncated_tags_reject() {
     kani::assume(tag != 44);
     kani::assume(tag != 45);
     kani::assume(tag != 46);
-    kani::assume(tag != 47);
     kani::assume(tag != 48);
     kani::assume(tag != 49);
     kani::assume(tag != 50);
@@ -1383,6 +1368,16 @@ fn kani_v16_unknown_or_truncated_tags_reject() {
 
     let deposit_tag_only = [3u8];
     assert!(Instruction::decode(&deposit_tag_only).is_err());
+}
+
+#[kani::proof]
+fn kani_v16_refine_resolved_bound_tag_is_not_public() {
+    let decrease_num: u128 = kani::any();
+    let mut data = [0u8; 17];
+    data[0] = 47;
+    data[1..17].copy_from_slice(&decrease_num.to_le_bytes());
+
+    assert!(Instruction::decode(&data).is_err());
 }
 
 #[kani::proof]


### PR DESCRIPTION
## What changed

- Add a final market-shape validation before the single `TradeCpi` zero-fill early return.
- Add a LiteSVM regression proving a zero-fill matcher cannot commit the `matcher_req_seq` bump or matcher context write when the market shape is invalid.

## Root cause

The single `TradeCpi` path bumps `matcher_req_seq` and invokes the matcher before reading the matcher return. If the matcher returned `exec_size == 0`, the wrapper returned `Ok(())` immediately, bypassing the shared no-CPI trade path and its final shape guard. That made the zero-fill branch a distinct successful public exit that could commit wrapper/matcher-side state even when the market accounting shape was malformed.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test v16_cu v16_attack_tradecpi_zero_fill -- --nocapture`
- `cargo test --test v16_kani`

Note: before the fix, `v16_attack_tradecpi_zero_fill_rejects_invalid_final_market_shape` failed because the zero-fill branch returned success.