### PR TITLE
[codex] Freeze stale-window auto-crank liquidation

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10416,7 +10416,7 @@ pub mod processor {
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut market_data)?;
-            {
+            let summary = {
                 let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;
                 let mut portfolio = state::portfolio_view_mut_for_market_slots(
                     &mut portfolio_data,
@@ -10458,6 +10458,13 @@ pub mod processor {
                     group.validate_shape().map_err(map_v16_error)?;
                     return Ok(());
                 }
+                summary
+            };
+            if summary.liquidatable
+                && !summary.b_stale
+                && permissionless_resolve_matured_now_view(&cfg, &group)
+            {
+                return Err(PercolatorError::OracleStale.into());
             }
             let reward_enabled = cfg.liquidation_cranker_fee_share_bps != 0;
             let mut oracle_tail = tail;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9749,6 +9749,165 @@ fn v16_attack_auto_crank_current_solvent_partial_liquidation_makes_progress() {
     assert!(after_group.vault >= after_group.c_tot + after_group.insurance);
 }
 
+#[test]
+fn v16_attack_stale_resolve_matured_no_observation_liquidation_rejects() {
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.top_up_insurance(1_000_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 10_000);
+    env.deposit(&short_owner, short_account, 3_000);
+    env.trade_with_cu(
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        (10 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 300);
+    env.crank(
+        short_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(3);
+    env.crank(
+        short_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+    );
+    assert!(
+        health_cert(&env.portfolio_state(short_account)).certified_liq_deficit != 0,
+        "setup must be liquidatable before stale-window probe"
+    );
+
+    env.svm.warp_to_slot(40);
+    let before_market = env.svm.get_account(&env.market).unwrap();
+    let before_short = env.svm.get_account(&short_account).unwrap();
+    env.svm.expire_blockhash();
+    let result = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            close_q: POS_SCALE,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short_account, false),
+        ],
+        &[],
+    );
+    let err = result
+        .expect_err("stale-window no-observation liquidation must reject before live mutation");
+    assert!(
+        err.contains("Custom(27)") || err.contains("custom program error: 0x1b"),
+        "stale-window no-observation liquidation should fail as OracleStale, got: {err}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        before_market,
+        "rejected stale-window liquidation leaves market state unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&short_account).unwrap(),
+        before_short,
+        "rejected stale-window liquidation leaves target portfolio unchanged"
+    );
+
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "permissionless stale resolve remains available after rejected liquidation: {resolve:?}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
+#[test]
+fn v16_attack_stale_resolve_matured_b_stale_cleanup_still_progresses() {
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 10_000);
+    env.deposit(&short_owner, short_account, 10_000);
+    env.trade_with_cu(
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.mark_b_stale_gap(long_account, 0, 1);
+    assert!(
+        env.portfolio_state(long_account).b_stale_state != 0,
+        "setup must leave a B-stale account that blocks final cleanup"
+    );
+
+    env.svm.warp_to_slot(40);
+    env.svm.expire_blockhash();
+    let settle = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            close_q: 0,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_account, false),
+        ],
+        &[],
+    );
+    assert!(
+        settle.is_ok(),
+        "stale boundary must still allow B-stale cleanup required for resolution: {settle:?}"
+    );
+    assert_eq!(
+        env.portfolio_state(long_account).b_stale_state,
+        0,
+        "B-stale cleanup clears the account blocker"
+    );
+
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "permissionless stale resolve remains available after B cleanup: {resolve:?}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
 // Public auto-crank ordering sweep: a stale budgeted liquidation tx may land after
 // the account's selected step has changed to a committed-state refresh. In that
 // case the tx may make refresh progress and apply a valid unrelated oracle update,


### PR DESCRIPTION
## What changed

PermissionlessCrank now rejects the specific global-stale case where the engine summary says the normal auto-crank selector would take the liquidation route.

The stale gate is deliberately after the expired-close recovery escape hatch and deliberately narrower than a blanket auto-crank freeze. Refresh/B-stale cleanup remains available when needed to clear blockers before ResolveStalePermissionless.

## Why

A public no-observation PermissionlessCrank against an already-current liquidatable account could still execute after the base market was permissionless-resolve matured. The existing stale freeze coverage exercised observation-bearing cranks, but not the no-observation liquidation path.

Pre-fix TDD result for the new LiteSVM probe was Ok(166121) with both market and target portfolio mutated after the stale boundary. That lets a cranker alter live liquidation state in the stale window before the terminal resolve snapshot.

While narrowing the fix, I added a companion regression proving the wrapper does not turn stale cleanup into a DoS: a B-stale account can still make the required cleanup progress after the stale boundary and then ResolveStalePermissionless succeeds.

## Validation

- cargo build-sbf --no-default-features
- cargo test --test v16_cu stale_resolve_matured -- --nocapture
- cargo test --test v16_cu expired_close -- --nocapture
- cargo test --test v16_cu live_value_paths_reject_when_resolve_matured -- --nocapture
- cargo fmt --check
- cargo test --test v16_cu