### PR TITLE
[codex] Reject stale selected-mark auto cranks

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10601,6 +10601,20 @@ pub mod processor {
             let mut portfolio =
                 state::portfolio_view_mut_for_market_slots(&mut portfolio_data, max_market_slots)?;
             expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
+            let summary = group
+                .build_actionable_summary(&portfolio.as_view())
+                .map_err(map_v16_error)?;
+            if let Some(asset_index) =
+                auto_crank_selected_asset_that_accrues_view(&portfolio, &summary)?
+            {
+                reject_missing_pending_selected_observation_view(
+                    &cfg,
+                    &group,
+                    asset_index,
+                    authenticated_now_slot,
+                    observations.as_slice(),
+                )?;
+            }
             let result = match group.permissionless_auto_crank_not_atomic(
                 &mut portfolio,
                 AutoCrankWorkV16 {
@@ -10777,6 +10791,86 @@ pub mod processor {
             .map_err(map_v16_error)?;
         if header.portfolio_account_id != key.to_bytes() {
             return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        Ok(())
+    }
+
+    fn first_active_asset_from_portfolio_view(
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+    ) -> Result<Option<usize>, ProgramError> {
+        let active_bitmap = portfolio
+            .header
+            .active_bitmap
+            .map(percolator::V16PodU64::get);
+        let mut slot = 0usize;
+        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            let bit = percolator::active_bitmap_get(active_bitmap, slot);
+            if bit != leg.active {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            if bit {
+                return Ok(Some(leg.asset_index as usize));
+            }
+            slot += 1;
+        }
+        Ok(None)
+    }
+
+    fn auto_crank_selected_asset_that_accrues_view(
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        summary: &percolator::ActionableSummaryV16,
+    ) -> Result<Option<usize>, ProgramError> {
+        if summary.b_stale {
+            return Ok(None);
+        }
+        if summary.stale || summary.liquidatable {
+            return first_active_asset_from_portfolio_view(portfolio);
+        }
+        Ok(None)
+    }
+
+    fn reject_missing_pending_selected_observation_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        now_slot: u64,
+        observations: &[AutoCrankObservationV16],
+    ) -> ProgramResult {
+        if observations.iter().any(|o| o.asset_index == asset_index) {
+            return Ok(());
+        }
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+        if !oracle_v16::profile_is_price_managed(&profile) {
+            return Ok(());
+        }
+        let asset = group.markets[asset_index].engine.asset;
+        let dt = asset_segment_dt_view(group, asset_index, now_slot)?;
+        if dt == 0 {
+            return Ok(());
+        }
+        let target = profile.mark_ewma_e6;
+        if target == 0 {
+            return Err(PercolatorError::OracleInvalid.into());
+        }
+        let current = asset.effective_price.get();
+        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+        let next = oracle_v16::effective_price_from_target(
+            current,
+            target,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt,
+            exposed,
+        );
+        if next != current {
+            return Err(PercolatorError::EngineNonProgress.into());
         }
         Ok(())
     }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10157,6 +10157,174 @@ fn v16_attack_auto_crank_refresh_not_blocked_by_unneeded_first_asset_oracle() {
     );
 }
 
+// LoF/DoS sweep: committed-state refresh is valid only when the selected
+// engine asset has no pending wrapper-side mark. If a public keeper can omit
+// the selected asset observation while another asset made the account stale,
+// the engine fallback would accrue the selected asset at its old committed
+// price and consume the slot, making the pending mark impossible to apply in
+// that slot. That lets out-of-order keepers starve mark/funding progress by
+// repeatedly landing no-observation refreshes first.
+#[test]
+fn v16_attack_pending_selected_mark_requires_observation() {
+    const MARK: u64 = 1_000_000;
+    const NEXT_MARK0: u64 = 1_100_000;
+    const NEXT_MARK1: u64 = 1_010_000;
+    const OPEN_SLOT: u64 = 1;
+    const CRANK_SLOT: u64 = 2;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_for_asset_as_admin(0, OPEN_SLOT, MARK);
+    env.configure_auth_mark_for_asset_as_admin(1, OPEN_SLOT, MARK);
+
+    let owner_a = Keypair::new();
+    let owner_b = Keypair::new();
+    let asset1_owner = Keypair::new();
+    let asset1_counter_owner = Keypair::new();
+    let account_a = env.create_portfolio(&owner_a);
+    let account_b = env.create_portfolio(&owner_b);
+    let asset1_account = env.create_portfolio(&asset1_owner);
+    let asset1_counter = env.create_portfolio(&asset1_counter_owner);
+    env.deposit(&owner_a, account_a, 100_000_000);
+    env.deposit(&owner_b, account_b, 100_000_000);
+    env.deposit(&asset1_owner, asset1_account, 100_000_000);
+    env.deposit(&asset1_counter_owner, asset1_counter, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &owner_a,
+        account_a,
+        &owner_b,
+        account_b,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        1,
+        &owner_a,
+        account_a,
+        &owner_b,
+        account_b,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        1,
+        &asset1_owner,
+        asset1_account,
+        &asset1_counter_owner,
+        asset1_counter,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+    let account_before_mark = env.portfolio_state(account_a);
+    assert_eq!(
+        leg(&account_before_mark, 0).asset_index,
+        0,
+        "asset 0 must occupy the first active slot for this selected-asset probe"
+    );
+    assert_eq!(
+        active_leg_for_asset(&account_before_mark, 0).asset_index,
+        0,
+        "asset 0 is the engine-selected first active leg"
+    );
+    assert_eq!(active_leg_for_asset(&account_before_mark, 1).asset_index, 1);
+
+    env.svm.warp_to_slot(CRANK_SLOT);
+    env.push_auth_mark_for_asset_as_admin(0, CRANK_SLOT, NEXT_MARK0);
+    let profile0 =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+            .unwrap();
+    let (_, pending_group) = env.market_state();
+    assert_eq!(profile0.mark_ewma_e6, NEXT_MARK0);
+    assert_eq!(profile0.mark_ewma_last_slot, CRANK_SLOT);
+    assert_eq!(
+        pending_group.assets[0].effective_price, MARK,
+        "PushAuthMark only stages the selected asset mark"
+    );
+    assert!(
+        pending_group.assets[0].slot_last < CRANK_SLOT,
+        "selected asset has a pending slot to consume"
+    );
+
+    env.push_auth_mark_for_asset_as_admin(1, CRANK_SLOT, NEXT_MARK1);
+    env.crank(
+        asset1_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: crank_observations(1),
+        },
+    );
+    let (_, stale_group) = env.market_state();
+    assert_eq!(stale_group.assets[1].effective_price, NEXT_MARK1);
+    assert_eq!(
+        stale_group.assets[0].effective_price, MARK,
+        "selected asset mark is still pending after unrelated asset progress"
+    );
+    assert!(
+        health_cert(&env.portfolio_state(account_a)).cert_oracle_epoch < stale_group.oracle_epoch,
+        "unrelated asset progress makes the target account stale"
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let account_before = env.svm.get_account(&account_a).unwrap();
+    env.svm.expire_blockhash();
+    let missing_selected_observation = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+        ],
+        &[],
+    );
+    assert!(
+        missing_selected_observation.is_err(),
+        "selected asset has a pending mark, so no-observation refresh must not consume its slot"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected missing-observation refresh must not advance the selected asset at the old price"
+    );
+    assert_eq!(
+        env.svm.get_account(&account_a).unwrap(),
+        account_before,
+        "rejected missing-observation refresh must not certify the target against a pending mark"
+    );
+
+    env.svm.expire_blockhash();
+    let observed = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: CRANK_SLOT,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+        ],
+        &[],
+    );
+    assert!(
+        observed.is_ok(),
+        "supplying the selected asset observation must remain live: {observed:?}"
+    );
+    let (_, observed_group) = env.market_state();
+    assert_eq!(
+        observed_group.assets[0].effective_price, NEXT_MARK0,
+        "selected asset observation applies the pending mark"
+    );
+}
+
 #[test]
 fn v16_bpf_no_cranker_liquidation_rejects_invalid_final_market_shape() {
     let mut env = V16CuEnv::new();


### PR DESCRIPTION
## What changed

- Adds a wrapper-side pre-dispatch guard for `PermissionlessCrank`/`permissionless_auto_crank_not_atomic`.
- If the engine-selected active asset has a pending wrapper-managed mark movement, the public crank must include that selected asset observation instead of falling back to the old committed price.
- Adds a public LiteSVM TDD regression covering the stale selected-mark no-observation path.

## Root cause

Engine auto-crank can validly fall back to committed market state when an observation is omitted. That fallback is safe only when the selected asset has no pending wrapper-side price-managed mark. Before this PR, a keeper could make an account stale through an unrelated asset, then land a no-observation crank on the target. The wrapper would let the engine accrue/certify the selected first active asset at the old price, consuming that slot and starving the pending mark update for that slot.

## Impact

This is a public-interface LoF/DoS fix: it prevents out-of-order permissionless cranks from suppressing pending selected-asset mark progress while preserving the committed-state fallback for assets with no pending movement.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test v16_attack_pending_selected_mark_requires_observation -- --nocapture`
- `cargo test v16_attack_auto_crank_refresh_not_blocked_by_unneeded_first_asset_oracle -- --nocapture`
- `cargo test v16_cu_permissionless_crank_refresh_is_bounded -- --nocapture` (`43798` CU)
- `cargo test v16_bpf_10m_market_liquidation_high_asset_stays_bounded -- --nocapture` (`172799` CU for liquidation crank)

Engine pin: `83387267a09c95cfbf5dfd7b66f55bb8e4d3489e`.