### PR TITLE
[codex] Remove public resolved bound refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=c8aab33814dd30878cf9b054eca89bcd6cf9f5e7#c8aab33814dd30878cf9b054eca89bcd6cf9f5e7"
+source = "git+https://github.com/aeyakovenko/percolator?rev=2cbca3eb832896e890ea79896ca3200b9e4bb5fd#2cbca3eb832896e890ea79896ca3200b9e4bb5fd"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8aab33814dd30878cf9b054eca89bcd6cf9f5e7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2cbca3eb832896e890ea79896ca3200b9e4bb5fd" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8aab33814dd30878cf9b054eca89bcd6cf9f5e7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2cbca3eb832896e890ea79896ca3200b9e4bb5fd" }
 
 [dev-dependencies]
 bincode = "1"

--- a/README.md
+++ b/README.md
@@ -475,8 +475,6 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
 - **ClaimResolvedPayoutTopup** (tag 46)
   - permissionless resolved-payout top-up claim; pays only the stored owner receipt token account
-- **RefineResolvedUnreceiptedBound** (tag 47)
-  - admin-gated monotonic decrease of the resolved unreceipted bound; cannot increase obligations
 
 ### Post-resolution / terminal close
 - **CloseResolved** (tag 30)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2627,9 +2627,6 @@ pub mod ix {
             side: u8,
         },
         ClaimResolvedPayoutTopup,
-        RefineResolvedUnreceiptedBound {
-            decrease_num: u128,
-        },
         SyncMaintenanceFee {
             now_slot: u64,
         },
@@ -2905,9 +2902,6 @@ pub mod ix {
                     side: read_u8(&mut rest)?,
                 },
                 46 => Self::ClaimResolvedPayoutTopup,
-                47 => Self::RefineResolvedUnreceiptedBound {
-                    decrease_num: read_u128(&mut rest)?,
-                },
                 48 => Self::SyncMaintenanceFee {
                     now_slot: read_u64(&mut rest)?,
                 },
@@ -3308,10 +3302,6 @@ pub mod ix {
                     out.push(side);
                 }
                 Self::ClaimResolvedPayoutTopup => out.push(46),
-                Self::RefineResolvedUnreceiptedBound { decrease_num } => {
-                    out.push(47);
-                    push_u128(&mut out, decrease_num);
-                }
                 Self::SyncMaintenanceFee { now_slot } => {
                     out.push(48);
                     push_u64(&mut out, now_slot);
@@ -5410,9 +5400,6 @@ pub mod processor {
             }
             Instruction::ClaimResolvedPayoutTopup => {
                 handle_claim_resolved_payout_topup(program_id, accounts)
-            }
-            Instruction::RefineResolvedUnreceiptedBound { decrease_num } => {
-                handle_refine_resolved_unreceipted_bound(program_id, accounts, decrease_num)
             }
             Instruction::SyncMaintenanceFee { now_slot } => {
                 handle_sync_maintenance_fee(program_id, accounts, now_slot)
@@ -9415,28 +9402,6 @@ pub mod processor {
         let (_cfg, mut group) = state::market_view_mut(&mut data)?;
         group
             .finalize_side_reset_not_atomic(asset_index as usize, side)
-            .map_err(map_v16_error)
-    }
-
-    #[inline(never)]
-    fn handle_refine_resolved_unreceipted_bound<'a>(
-        program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
-        decrease_num: u128,
-    ) -> ProgramResult {
-        let admin = account(accounts, 0)?;
-        let market_ai = account(accounts, 1)?;
-        expect_signer(admin)?;
-        expect_writable(market_ai)?;
-        expect_owner(market_ai, program_id)?;
-        if decrease_num == 0 {
-            return Err(PercolatorError::InvalidInstruction.into());
-        }
-        let mut data = market_ai.try_borrow_mut_data()?;
-        let (cfg, mut group) = state::market_view_mut(&mut data)?;
-        expect_live_authority(&cfg.marketauth, admin.key)?;
-        group
-            .refine_resolved_unreceipted_bound_not_atomic(decrease_num)
             .map_err(map_v16_error)
     }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3468,21 +3468,6 @@ impl V16CuEnv {
         .expect("claim resolved payout topup")
     }
 
-    fn refine_resolved_unreceipted_bound_with_cu(&mut self, decrease_num: u128) -> u64 {
-        send_tx(
-            &mut self.svm,
-            self.program_id,
-            &self.payer,
-            ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num },
-            vec![
-                AccountMeta::new(self.admin.pubkey(), true),
-                AccountMeta::new(self.market, false),
-            ],
-            &[&self.admin],
-        )
-        .expect("refine resolved unreceipted bound")
-    }
-
     fn crank(&mut self, portfolio: Pubkey, ix: ProgInstruction) -> u64 {
         let attempts = match ix {
             ProgInstruction::PermissionlessCrank { close_q, .. } if close_q != 0 => 2,
@@ -14087,46 +14072,6 @@ fn v16_bpf_resolved_payout_tags_are_bounded_and_update_state() {
     assert_eq!(group.vault, 0);
     assert_eq!(resolved_receipt(&account).paid_effective, 100);
     assert!(resolved_receipt(&account).finalized);
-
-    let mut refine_env = V16CuEnv::new();
-    refine_env.mutate_market(|_, group| {
-        group.mode = MarketModeV16::Resolved;
-        group.resolved_slot = 1;
-        group.current_slot = 1;
-        group.payout_snapshot_captured = true;
-        group.payout_snapshot = 100;
-        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
-            snapshot_residual: 100,
-            terminal_claim_exact_receipts_num: 0,
-            terminal_claim_bound_unreceipted_num: 100 * BOUND_SCALE,
-            current_payout_rate_num: 100 * BOUND_SCALE,
-            current_payout_rate_den: 100 * BOUND_SCALE,
-            snapshot_slot: 1,
-            payout_halted: false,
-            finalized: false,
-        };
-    });
-    let refine_cu = refine_env.refine_resolved_unreceipted_bound_with_cu(10 * BOUND_SCALE);
-    assert_cu_within(
-        "RefineResolvedUnreceiptedBound",
-        refine_cu,
-        CUSTODY_CU_LIMIT,
-    );
-    let (_, group) = refine_env.market_state();
-    assert_eq!(
-        group
-            .resolved_payout_ledger
-            .terminal_claim_bound_unreceipted_num,
-        90 * BOUND_SCALE
-    );
-    assert_eq!(
-        group.resolved_payout_ledger.current_payout_rate_num,
-        90 * BOUND_SCALE
-    );
-    assert_eq!(
-        group.resolved_payout_ledger.current_payout_rate_den,
-        90 * BOUND_SCALE
-    );
 }
 
 // Coverage probe (audit): an INSOLVENT resolved market (residual < positive-PnL
@@ -28676,177 +28621,53 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
     );
 }
 
-// security.md sweep — RefineResolvedUnreceiptedBound gating (#6/#30): this wind-down tool (decreases
-// the unreceipted resolved claim bound) is admin-only and resolved-mode-only. A non-admin must
-// reject, and it must reject in Live mode — no tampering with the resolved payout accounting.
+// Issue #88: resolved bound refinement is internal engine accounting. Raw tag
+// 47 must reject before any resolved payout or custody state can move.
 #[test]
-fn v16_attack_refine_resolved_bound_admin_and_mode_gated() {
+fn v16_attack_refine_resolved_bound_tag_is_not_public() {
     let mut env = V16CuEnv::new();
-    let owner = Keypair::new();
-    let p = env.create_portfolio(&owner);
-    env.deposit(&owner, p, 1_000_000);
-    let mallory = Keypair::new();
-    env.ensure_signer_account(mallory.pubkey());
-    // 1) Live mode: even the admin can't refine (mode != Resolved).
-    env.svm.expire_blockhash();
-    let r_live = send_tx(
-        &mut env.svm,
-        env.program_id,
-        &env.payer,
-        ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        vec![
-            AccountMeta::new(env.admin.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&env.admin],
-    );
-    assert!(r_live.is_err(), "refine must reject in Live mode");
-    // 2) Resolved mode: a NON-admin can't refine.
-    env.resolve();
-    env.svm.expire_blockhash();
-    let r_nonadmin = send_tx(
-        &mut env.svm,
-        env.program_id,
-        &env.payer,
-        ProgInstruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        vec![
-            AccountMeta::new(mallory.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&mallory],
-    );
-    assert!(
-        r_nonadmin.is_err(),
-        "non-admin refine must reject in resolved mode"
-    );
-    // user funds still fully recoverable (the rejected refines didn't corrupt the resolved accounting).
-    let cr = env.close_resolved(&owner, p);
-    assert_eq!(
-        env.token_amount(cr),
-        1_000_000,
-        "user recovers full resolved payout after rejected refines"
-    );
-}
-
-// security.md sweep - terminal payout bound refinement (#14/#21): even an authorized market admin
-// must not be able to over-decrease the unreceipted claim bound. A bad refine would either underflow
-// terminal accounting or lower the payout denominator incorrectly, locking or haircutting users.
-#[test]
-fn v16_attack_refine_resolved_bound_over_decrease_is_atomic() {
-    let mut env = V16CuEnv::new();
-    let owner_a = Keypair::new();
-    let portfolio_a = env.create_portfolio(&owner_a);
-    let owner_b = Keypair::new();
-    let portfolio_b = env.create_portfolio(&owner_b);
-    let owner_c = Keypair::new();
-    let portfolio_c = env.create_portfolio(&owner_c);
-    env.deposit(&owner_a, portfolio_a, 1_000_000);
-    env.deposit(&owner_b, portfolio_b, 1_000_000);
-    env.deposit(&owner_c, portfolio_c, 500_000);
-    // Two PLAIN-JUNIOR positive-pnl winners (no source backing -> they flow through the junior
-    // receipt pool / unreceipted bound, which is what the refine targets), funded by a third
-    // account that donated its 500k capital into the junior residual. (Source-backed claims now
-    // realize straight to capital and never populate the unreceipted bound.) Conservation holds:
-    // vault 2.5M >= c_tot 2.0M + net positive pnl 0.5M.
-    {
-        let mut m = env.svm.get_account(&env.market).unwrap();
-        let mut pa = env.svm.get_account(&portfolio_a).unwrap();
-        let mut pb = env.svm.get_account(&portfolio_b).unwrap();
-        let mut pc = env.svm.get_account(&portfolio_c).unwrap();
-        let (cfg, mut g) = state::read_market(&m.data).unwrap();
-        let mut a = state::read_portfolio(&pa.data).unwrap();
-        let mut b = state::read_portfolio(&pb.data).unwrap();
-        let mut c = state::read_portfolio(&pc.data).unwrap();
-        // C donates its capital to the junior residual.
-        g.c_tot -= 500_000;
-        c.capital = percolator::V16PodU128::new(0);
-        c.last_fee_slot = percolator::V16PodU64::new(1);
-        // A and B hold matured junior positive pnl.
-        a.pnl = percolator::V16PodI128::new(250_000);
-        a.last_fee_slot = percolator::V16PodU64::new(1);
-        b.pnl = percolator::V16PodI128::new(250_000);
-        b.last_fee_slot = percolator::V16PodU64::new(1);
-        g.pnl_pos_tot = 500_000;
-        g.pnl_matured_pos_tot = 500_000;
-        g.pnl_pos_bound_tot = 500_000;
-        g.pnl_pos_bound_tot_num = 500_000 * BOUND_SCALE;
-        g.mode = MarketModeV16::Resolved;
-        g.resolved_slot = 1;
-        g.current_slot = 1;
-        state::write_market(&mut m.data, &cfg, &g).unwrap();
-        state::write_portfolio(&mut pa.data, &a).unwrap();
-        state::write_portfolio(&mut pb.data, &b).unwrap();
-        state::write_portfolio(&mut pc.data, &c).unwrap();
-        env.svm.set_account(env.market, m).unwrap();
-        env.svm.set_account(portfolio_a, pa).unwrap();
-        env.svm.set_account(portfolio_b, pb).unwrap();
-        env.svm.set_account(portfolio_c, pc).unwrap();
-    }
-
-    let dest_a = env.close_resolved(&owner_a, portfolio_a);
-    assert_eq!(
-        env.token_amount(dest_a),
-        1_250_000,
-        "first winner receives capital + full junior claim and becomes an exact receipt"
-    );
-
-    let (_, group_before) = env.market_state();
-    let bound = group_before
-        .resolved_payout_ledger
-        .terminal_claim_bound_unreceipted_num;
-    assert!(
-        bound > 0,
-        "remaining junior user claim contributes to the unreceipted bound"
-    );
-    assert!(
-        group_before
-            .resolved_payout_ledger
-            .terminal_claim_exact_receipts_num
-            > 0,
-        "first close converted one winner into an exact receipt"
-    );
+    env.mutate_market(|_, group| {
+        group.mode = MarketModeV16::Resolved;
+        group.resolved_slot = 1;
+        group.current_slot = 1;
+        group.payout_snapshot_captured = true;
+        group.payout_snapshot = 100;
+        group.resolved_payout_ledger = ResolvedPayoutLedgerV16 {
+            snapshot_residual: 100,
+            terminal_claim_exact_receipts_num: 0,
+            terminal_claim_bound_unreceipted_num: 100 * BOUND_SCALE,
+            current_payout_rate_num: 100 * BOUND_SCALE,
+            current_payout_rate_den: 100 * BOUND_SCALE,
+            snapshot_slot: 1,
+            payout_halted: false,
+            finalized: false,
+        };
+    });
 
     let market_before = env.svm.get_account(&env.market).unwrap();
-    let portfolio_before = env.svm.get_account(&portfolio_b).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let mut data = Vec::with_capacity(17);
+    data.push(47);
+    data.extend_from_slice(&(10 * BOUND_SCALE).to_le_bytes());
     let admin = env.admin.insecure_clone();
     env.svm.expire_blockhash();
-    let rejected = env.send(
-        ProgInstruction::RefineResolvedUnreceiptedBound {
-            decrease_num: bound + 1,
+    let rejected = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data,
         },
-        vec![
-            AccountMeta::new(env.admin.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
         &[&admin],
     );
-    assert!(
-        rejected.is_err(),
-        "authorized over-decrease of resolved payout bound must reject"
-    );
-    assert_eq!(
-        env.svm.get_account(&env.market).unwrap(),
-        market_before,
-        "rejected over-refine leaves resolved market accounting byte-identical"
-    );
-    assert_eq!(
-        env.svm.get_account(&portfolio_b).unwrap(),
-        portfolio_before,
-        "rejected over-refine leaves user payout state byte-identical"
-    );
-    assert_eq!(
-        env.svm.get_account(&env.vault).unwrap(),
-        vault_before,
-        "rejected over-refine moves no custody"
-    );
 
-    let dest = env.close_resolved(&owner_b, portfolio_b);
-    assert_eq!(
-        env.token_amount(dest),
-        1_250_000,
-        "remaining user still recovers the full terminal payout after rejected over-refine"
-    );
+    assert!(rejected.is_err(), "raw refine tag must be unavailable");
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 }
 
 // security.md sweep — TopUpInsuranceDomain authorization (#6): a per-domain insurance top-up is gated

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -142,14 +142,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
     kani::assume(
-        tag == 3
-            || tag == 4
-            || tag == 9
-            || tag == 28
-            || tag == 30
-            || tag == 41
-            || tag == 42
-            || tag == 47,
+        tag == 3 || tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42,
     );
     let amount: u128 = kani::any();
 
@@ -172,9 +165,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
                 optional_deposit: got,
             },
         ) => assert_eq!(got, amount),
-        (47, Instruction::RefineResolvedUnreceiptedBound { decrease_num }) => {
-            assert_eq!(decrease_num, amount)
-        }
         _ => unreachable!(),
     }
 }
@@ -1330,10 +1320,6 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
         extra,
     );
     assert_rejects_trailing_byte(Instruction::ClaimResolvedPayoutTopup, extra);
-    assert_rejects_trailing_byte(
-        Instruction::RefineResolvedUnreceiptedBound { decrease_num: 1 },
-        extra,
-    );
     assert_rejects_trailing_byte(Instruction::ClosePortfolio, extra);
 }
 
@@ -1370,7 +1356,6 @@ fn kani_v16_unknown_or_truncated_tags_reject() {
     kani::assume(tag != 44);
     kani::assume(tag != 45);
     kani::assume(tag != 46);
-    kani::assume(tag != 47);
     kani::assume(tag != 48);
     kani::assume(tag != 49);
     kani::assume(tag != 50);
@@ -1383,6 +1368,16 @@ fn kani_v16_unknown_or_truncated_tags_reject() {
 
     let deposit_tag_only = [3u8];
     assert!(Instruction::decode(&deposit_tag_only).is_err());
+}
+
+#[kani::proof]
+fn kani_v16_refine_resolved_bound_tag_is_not_public() {
+    let decrease_num: u128 = kani::any();
+    let mut data = [0u8; 17];
+    data[0] = 47;
+    data[1..].copy_from_slice(&decrease_num.to_le_bytes());
+
+    assert!(Instruction::decode(&data).is_err());
 }
 
 #[kani::proof]


### PR DESCRIPTION
## Summary
- Removes public instruction tag 47, its encoder/decoder variant, dispatch handler, and README entry.
- Pins the merged engine fix from aeyakovenko/percolator#89.
- Adds a symbolic decoder theorem for every 128-bit tag-47 payload and a raw-wire LiteSVM rollback regression.

## Why
Resolved unreceipted-bound refinement is derived internal engine accounting. Exposing an admin-selected decrement could inflate early resolved payouts and strand later claimants.

Refs aeyakovenko/percolator#88.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib`
- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_refine_resolved_bound_tag_is_not_public -- --nocapture`
- `cargo test --test v16_cu v16_bpf_resolved_payout_tags_are_bounded_and_update_state -- --nocapture`
- `cargo test --test v16_cu v16_bpf_close_resolved_moves_payout_tokens_with_ledger -- --nocapture`
- `cargo kani --tests --harness kani_v16_refine_resolved_bound_tag_is_not_public`: 0 failures, 0.61 seconds