### PR TITLE
[codex] Reject partial BatchTradeCpi fills and cap aggregate slippage

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6971,8 +6971,8 @@ pub mod processor {
                 leg.size_q,
                 req_id,
             )?;
-            // Atomic strategy semantics: every leg must fill (no zero/skip fills in a batch).
-            if ret.exec_size == 0 {
+            // Atomic strategy semantics: every leg must fill exactly as requested.
+            if ret.exec_size != leg.size_q {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             if leg.limit_price != 0 {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2470,6 +2470,9 @@ pub mod ix {
         /// every leg against a single LP, then all fills apply with one end-state margin check.
         BatchTradeCpi {
             legs: Vec<BatchTradeCpiLeg>,
+            /// Aggregate adverse slippage cap in base units across all legs.
+            /// `u64::MAX` disables the aggregate cap; per-leg `limit_price` still applies.
+            max_slippage_base: u64,
         },
         SetMatcherConfig {
             enabled: u8,
@@ -2741,7 +2744,15 @@ pub mod ix {
                             limit_price: read_u64(&mut rest)?,
                         });
                     }
-                    Self::BatchTradeCpi { legs }
+                    let max_slippage_base = if rest.is_empty() {
+                        u64::MAX
+                    } else {
+                        read_u64(&mut rest)?
+                    };
+                    Self::BatchTradeCpi {
+                        legs,
+                        max_slippage_base,
+                    }
                 }
                 68 => Self::SetMatcherConfig {
                     enabled: read_u8(&mut rest)?,
@@ -3027,7 +3038,10 @@ pub mod ix {
                         push_u64(&mut out, leg.fee_bps);
                     }
                 }
-                Self::BatchTradeCpi { ref legs } => {
+                Self::BatchTradeCpi {
+                    ref legs,
+                    max_slippage_base,
+                } => {
                     out.push(67);
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
@@ -3036,6 +3050,7 @@ pub mod ix {
                         push_u64(&mut out, leg.fee_bps);
                         push_u64(&mut out, leg.limit_price);
                     }
+                    push_u64(&mut out, max_slippage_base);
                 }
                 Self::SetMatcherConfig { enabled } => {
                     out.push(68);
@@ -5195,9 +5210,10 @@ pub mod processor {
             Instruction::BatchTradeNoCpi { legs } => {
                 handle_batch_trade_nocpi(program_id, accounts, &legs)
             }
-            Instruction::BatchTradeCpi { legs } => {
-                handle_batch_trade_cpi(program_id, accounts, &legs)
-            }
+            Instruction::BatchTradeCpi {
+                legs,
+                max_slippage_base,
+            } => handle_batch_trade_cpi(program_id, accounts, &legs, max_slippage_base),
             Instruction::SetMatcherConfig { enabled } => {
                 handle_set_matcher_config(program_id, accounts, enabled)
             }
@@ -5903,6 +5919,20 @@ pub mod processor {
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
         let den = percolator::MAX_MARGIN_BPS as u128;
         Ok((product / den) + u128::from(product % den != 0))
+    }
+
+    fn batch_adverse_slippage_base(
+        abs_size_q: u128,
+        is_buy: bool,
+        reference_price: u64,
+        exec_price: u64,
+    ) -> Result<u128, ProgramError> {
+        let adverse_delta = if is_buy {
+            exec_price.saturating_sub(reference_price)
+        } else {
+            reference_price.saturating_sub(exec_price)
+        };
+        trade_fee_notional_ceil(abs_size_q, adverse_delta)
     }
 
     /// Atomic multi-leg batch trade. `account_a` (taker) is the long side, `account_b` (LP) the
@@ -6759,6 +6789,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         legs: &[ix::BatchTradeCpiLeg],
+        max_slippage_base: u64,
     ) -> ProgramResult {
         if legs.is_empty() || legs.len() > MATCHER_BATCH_MAX_LEGS {
             return Err(PercolatorError::InvalidInstruction.into());
@@ -6959,6 +6990,7 @@ pub mod processor {
         }
 
         let mut exec_legs: Vec<ix::BatchTradeLeg> = Vec::with_capacity(legs.len());
+        let mut aggregate_adverse_slippage_base = 0u128;
         for (i, leg) in legs.iter().enumerate() {
             let chunk = &ret_data[i * matcher_abi::MATCHER_RETURN_BYTES
                 ..(i + 1) * matcher_abi::MATCHER_RETURN_BYTES];
@@ -6974,6 +7006,20 @@ pub mod processor {
             // Atomic strategy semantics: every leg must fill exactly as requested.
             if ret.exec_size != leg.size_q {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            if max_slippage_base != u64::MAX {
+                let adverse_slippage = batch_adverse_slippage_base(
+                    leg.size_q.unsigned_abs(),
+                    leg.size_q > 0,
+                    oracle_prices[i],
+                    ret.exec_price_e6,
+                )?;
+                aggregate_adverse_slippage_base = aggregate_adverse_slippage_base
+                    .checked_add(adverse_slippage)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                if aggregate_adverse_slippage_base > max_slippage_base as u128 {
+                    return Err(PercolatorError::InvalidInstruction.into());
+                }
             }
             if leg.limit_price != 0 {
                 let limit_ok = if leg.size_q > 0 {

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -17,6 +17,7 @@ entrypoint!(process);
 
 const ABI: u32 = 3;
 const FLAG_VALID: u32 = 1;
+const FLAG_PARTIAL_OK: u32 = 2;
 
 // Build one crafted 64-byte MatcherReturn; `mode` perturbs exactly one field (default = honest fill).
 fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> [u8; 64] {
@@ -39,6 +40,10 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
             flags = FLAG_VALID;
             size = req / 2
         } // unflagged partial (no PARTIAL_OK)
+        10 => {
+            flags = FLAG_VALID | FLAG_PARTIAL_OK;
+            size = req / 2
+        } // flagged partial fill
         _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -52132,6 +52132,107 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
     );
 }
 
+// LoF/DoS sweep: BatchTradeCpi has no caller opt-in for partial fills. A matcher that returns
+// FLAG_PARTIAL_OK for a batch leg must not be allowed to turn an atomic strategy into a partial
+// spread; otherwise a malicious LP matcher can leave the taker with unexpected exposure.
+#[test]
+fn v16_attack_batch_tradecpi_flagged_partial_rejects_atomically() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 1_000_000);
+    env.deposit(&lp, la, 1_000_000);
+
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &la,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 10; // valid FLAG_PARTIAL_OK partial fill from the hostile fixture.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, la, ctx, delegate, 1);
+
+    let sz = (6 * POS_SCALE) as i128;
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: vec![
+                BatchTradeCpiLeg {
+                    asset_index: 0,
+                    size_q: sz,
+                    fee_bps: 100,
+                    limit_price: 0,
+                },
+                BatchTradeCpiLeg {
+                    asset_index: 1,
+                    size_q: -sz,
+                    fee_bps: 100,
+                    limit_price: 0,
+                },
+            ],
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker],
+    );
+    assert!(
+        rejected.is_err(),
+        "BatchTradeCpi must reject flagged partial matcher returns; got {rejected:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+}
+
 // full-interface sweep / issue: removing the LP signer from TradeCpi is only safe if Percolator
 // verifies that the LP owner explicitly authorized this matcher program/context. A hostile matcher can
 // otherwise return a perfectly well-formed oracle-priced fill and force a victim LP portfolio into a

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -13276,6 +13276,7 @@ fn execute_account_residual_counter_trade_path(
                         fee_bps: 0,
                         limit_price: 0,
                     }],
+                    max_slippage_base: u64::MAX,
                 },
                 vec![
                     AccountMeta::new(taker_owner.pubkey(), true),
@@ -13429,6 +13430,7 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
                             limit_price: 0,
                         },
                     ],
+                    max_slippage_base: u64::MAX,
                 },
                 vec![
                     AccountMeta::new(taker_owner.pubkey(), true),
@@ -13617,6 +13619,7 @@ fn execute_backing_residual_counter_trade_path(
                         fee_bps: 0,
                         limit_price: 0,
                     }],
+                    max_slippage_base: u64::MAX,
                 },
                 vec![
                     AccountMeta::new(taker_owner.pubkey(), true),
@@ -20318,6 +20321,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
                 fee_bps: 100,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker_owner.pubkey(), true),
@@ -20682,6 +20686,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker_owner.pubkey(), true),
@@ -20714,6 +20719,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
                 fee_bps: 100,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker_owner.pubkey(), true),
@@ -20972,6 +20978,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
                 fee_bps: 100,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker_owner.pubkey(), true),
@@ -21284,6 +21291,7 @@ fn v16_attack_permissionless_lp_cpi_rejects_wrong_delegate_owner_or_account_bind
             fee_bps: 100,
             limit_price: 0,
         }],
+        max_slippage_base: u64::MAX,
     };
     let taker_owner_key = taker_owner.pubkey();
     let market = env.market;
@@ -30255,6 +30263,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
                     fee_bps: 100,
                     limit_price: 0,
                 }],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(attacker.pubkey(), true),
@@ -30396,6 +30405,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
                 fee_bps: 100,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(cpi_taker.pubkey(), true),
@@ -40992,6 +41002,7 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_carry_protocol_state() {
                 limit_price: 0,
             },
         ],
+        max_slippage_base: u64::MAX,
     };
     let market = env.market;
     let taker_key = taker.pubkey();
@@ -41152,7 +41163,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            legs: legs.clone(),
+            max_slippage_base: u64::MAX,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -41194,7 +41208,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     env.svm.set_account(ctx, honest_ctx).unwrap();
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            legs,
+            max_slippage_base: u64::MAX,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -42799,6 +42816,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
                 fee_bps: 100,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(owner.pubkey(), true),
@@ -48476,6 +48494,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -48535,6 +48554,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -48634,7 +48654,10 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
             .unwrap();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                legs,
+                max_slippage_base: u64::MAX,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -48817,6 +48840,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
                     fee_bps: 0,
                     limit_price: 0,
                 }],
+                max_slippage_base: u64::MAX,
             },
         ),
     ] {
@@ -49090,6 +49114,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         let rejected = env.send(
             ProgInstruction::BatchTradeCpi {
                 legs: cpi_legs(OVER),
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -49115,6 +49140,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         let ok = env.send(
             ProgInstruction::BatchTradeCpi {
                 legs: cpi_legs(CAP),
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -49237,7 +49263,10 @@ fn v16_attack_batch_tradecpi_configured_leg_cap_rejects_before_hostile_matcher_c
             .collect();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                legs,
+                max_slippage_base: u64::MAX,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -49356,7 +49385,10 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
         .collect();
     env.svm.expire_blockhash();
     let cpi = env.send(
-        ProgInstruction::BatchTradeCpi { legs: cpi_legs },
+        ProgInstruction::BatchTradeCpi {
+            legs: cpi_legs,
+            max_slippage_base: u64::MAX,
+        },
         vec![],
         &[],
     );
@@ -49412,6 +49444,7 @@ fn v16_bpf_batch_trade_cpi_executes_mixed_spread_through_matcher() {
                         limit_price: 0,
                     },
                 ],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -49511,6 +49544,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
                 fee_bps: 0,
                 limit_price: 0,
             }],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -50096,6 +50130,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
                             fee_bps: 0,
                             limit_price: 0,
                         }],
+                        max_slippage_base: u64::MAX,
                     },
                     accounts(&env),
                     &[&taker],
@@ -50162,6 +50197,7 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
                     fee_bps,
                     limit_price: 0,
                 }],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -50256,7 +50292,10 @@ fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {
     env.svm.expire_blockhash();
     let cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                legs,
+                max_slippage_base: u64::MAX,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -50442,7 +50481,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let rejected = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                legs: legs.clone(),
+                max_slippage_base: u64::MAX,
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50475,7 +50517,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let allowed_cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                legs,
+                max_slippage_base: u64::MAX,
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50737,6 +50782,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
                     limit_price: 100,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         metas(&env),
         &[&taker],
@@ -50768,6 +50814,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
                     limit_price: 1_000_000,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         metas(&env),
         &[&taker],
@@ -50780,6 +50827,103 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     assert!(
         has_active_leg_for_asset(&t2, 0) && has_active_leg_for_asset(&t2, 1),
         "both legs filled"
+    );
+}
+
+// SOL-028 aggregate slippage: per-leg limits can be intentionally loose for spread strategies, but
+// the taker can still cap total adverse execution in base units across the whole atomic batch.
+#[test]
+fn v16_attack_batch_cpi_aggregate_slippage_cap_aborts_whole_batch() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, 100);
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let ta = env.create_portfolio(&taker);
+    let la = env.create_portfolio(&lp);
+    env.deposit(&taker, ta, 1_000_000);
+    env.deposit(&lp, la, 1_000_000);
+
+    // spread matcher: oracle 100, base spread 500 bps -> buy ask = 105 on every leg.
+    let (ctx, delegate, _) = env.init_matcher_context_with_passive_spread_authorized(
+        matcher_program,
+        &lp,
+        la,
+        500,
+        1_000,
+    );
+    let sz = (5 * POS_SCALE) as i128;
+    let adverse_per_leg = (sz.unsigned_abs() * 5 + POS_SCALE - 1) / POS_SCALE;
+    let aggregate_cap = u64::try_from(adverse_per_leg * 2).unwrap();
+    assert_eq!(aggregate_cap, 50);
+    let legs = vec![
+        BatchTradeCpiLeg {
+            asset_index: 0,
+            size_q: sz,
+            fee_bps: 100,
+            limit_price: 1_000_000,
+        },
+        BatchTradeCpiLeg {
+            asset_index: 1,
+            size_q: sz,
+            fee_bps: 100,
+            limit_price: 1_000_000,
+        },
+    ];
+    let metas = |env: &V16CuEnv| {
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ta, false),
+            AccountMeta::new(la, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ]
+    };
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&ta).unwrap();
+    let lp_before = env.svm.get_account(&la).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: legs.clone(),
+            max_slippage_base: aggregate_cap - 1,
+        },
+        metas(&env),
+        &[&taker],
+    );
+    assert!(
+        rejected.is_err(),
+        "batch must reject when aggregate adverse slippage exceeds the base-unit cap"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&ta).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&la).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs,
+            max_slippage_base: aggregate_cap,
+        },
+        metas(&env),
+        &[&taker],
+    );
+    assert!(
+        ok.is_ok(),
+        "batch with aggregate adverse slippage inside the cap must execute: {ok:?}"
+    );
+    let taker_after = state::read_portfolio(&env.svm.get_account(&ta).unwrap().data).unwrap();
+    assert!(
+        has_active_leg_for_asset(&taker_after, 0) && has_active_leg_for_asset(&taker_after, 1),
+        "successful capped batch fills both legs"
     );
 }
 
@@ -50842,7 +50986,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            legs: legs.clone(),
+            max_slippage_base: u64::MAX,
+        },
         accounts(&env, ctx, delegate),
         &[&taker],
     );
@@ -50882,7 +51029,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
         env.init_matcher_context_authorized(matcher_program, &lp, lp_portfolio);
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            legs,
+            max_slippage_base: u64::MAX,
+        },
         accounts(&env, ok_ctx, ok_delegate),
         &[&taker],
     );
@@ -50950,7 +51100,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
     env.svm.warp_to_slot(4);
     env.svm.expire_blockhash();
     let fresh = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            legs: legs.clone(),
+            max_slippage_base: u64::MAX,
+        },
         accounts(&env),
         &[&taker],
     );
@@ -50972,7 +51125,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            legs,
+            max_slippage_base: u64::MAX,
+        },
         accounts(&env),
         &[&taker],
     );
@@ -51121,7 +51277,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let fresh_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                legs: legs.clone(),
+                max_slippage_base: u64::MAX,
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51144,7 +51303,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let stale_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                legs,
+                max_slippage_base: u64::MAX,
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51419,7 +51581,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let fresh_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+                ProgInstruction::BatchTradeCpi {
+                    legs: legs.clone(),
+                    max_slippage_base: u64::MAX,
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51446,7 +51611,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let stale_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs },
+                ProgInstruction::BatchTradeCpi {
+                    legs,
+                    max_slippage_base: u64::MAX,
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51548,6 +51716,7 @@ fn v16_attack_batch_tradecpi_fee_bps_rejects_before_hostile_matcher_cpi() {
                     fee_bps,
                     limit_price: 0,
                 }],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -51682,6 +51851,7 @@ fn v16_attack_batch_tradecpi_backing_fee_policy_rejects_before_hostile_matcher_c
                     fee_bps: 0,
                     limit_price: 0,
                 }],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -52060,6 +52230,7 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
                         limit_price: 0,
                     },
                 ],
+                max_slippage_base: u64::MAX,
             },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
@@ -52211,6 +52382,7 @@ fn v16_attack_batch_tradecpi_flagged_partial_rejects_atomically() {
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -52407,6 +52579,7 @@ fn v16_attack_batch_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -53566,6 +53739,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
                     limit_price: 0,
                 },
             ],
+            max_slippage_base: u64::MAX,
         }
         .encode(),
     };

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -692,6 +692,70 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
 }
 
 #[kani::proof]
+fn kani_v16_batch_trade_cpi_decode_preserves_aggregate_slippage_cap() {
+    let asset_index: u16 = kani::any();
+    let size_q: i128 = kani::any();
+    let fee_bps: u64 = kani::any();
+    let limit_price: u64 = kani::any();
+    let max_slippage_base: u64 = kani::any();
+
+    let mut data = [0u8; 44];
+    data[0] = 67;
+    data[1] = 1;
+    data[2..4].copy_from_slice(&asset_index.to_le_bytes());
+    data[4..20].copy_from_slice(&size_q.to_le_bytes());
+    data[20..28].copy_from_slice(&fee_bps.to_le_bytes());
+    data[28..36].copy_from_slice(&limit_price.to_le_bytes());
+    data[36..44].copy_from_slice(&max_slippage_base.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::BatchTradeCpi {
+            legs,
+            max_slippage_base: got_cap,
+        } => {
+            assert_eq!(legs.len(), 1);
+            assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].size_q, size_q);
+            assert_eq!(legs[0].fee_bps, fee_bps);
+            assert_eq!(legs[0].limit_price, limit_price);
+            assert_eq!(got_cap, max_slippage_base);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_batch_trade_cpi_legacy_decode_defaults_slippage_cap_disabled() {
+    let asset_index: u16 = kani::any();
+    let size_q: i128 = kani::any();
+    let fee_bps: u64 = kani::any();
+    let limit_price: u64 = kani::any();
+
+    let mut data = [0u8; 36];
+    data[0] = 67;
+    data[1] = 1;
+    data[2..4].copy_from_slice(&asset_index.to_le_bytes());
+    data[4..20].copy_from_slice(&size_q.to_le_bytes());
+    data[20..28].copy_from_slice(&fee_bps.to_le_bytes());
+    data[28..36].copy_from_slice(&limit_price.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::BatchTradeCpi {
+            legs,
+            max_slippage_base,
+        } => {
+            assert_eq!(legs.len(), 1);
+            assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].size_q, size_q);
+            assert_eq!(legs[0].fee_bps, fee_bps);
+            assert_eq!(legs[0].limit_price, limit_price);
+            assert_eq!(max_slippage_base, u64::MAX);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
 fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
 


### PR DESCRIPTION
## Summary
- require each `BatchTradeCpi` matcher return to fill exactly the requested leg size
- add `max_slippage_base` for aggregate adverse slippage caps in base units across the whole atomic batch
- keep legacy opcode 67 payloads compatible by defaulting omitted caps to `u64::MAX` (disabled)
- add hostile/public LiteSVM regressions for partial-fill rejection and aggregate slippage rollback
- add Kani decoder coverage for new and legacy `BatchTradeCpi` wire payloads

## Root Cause
`BatchTradeCpi` reused the matcher ABI validator, which correctly accepts `FLAG_PARTIAL_OK` for single `TradeCpi` semantics. The batch route has no caller opt-in for partial fills and only rejected zero fills, so a hostile authorized matcher could return a valid flagged half-fill and turn an atomic multi-leg strategy into partial exposure.

Per-leg limits also do not express an aggregate strategy budget: a user may intentionally set loose per-leg limits for route flexibility, but still need a base-unit cap on total adverse execution across all legs.

## Fix
`BatchTradeCpi` now rejects any matcher return whose `exec_size` differs from the requested leg size. It also accepts an optional aggregate adverse slippage cap, computed per leg against authenticated reference prices and summed in base units. Favorable execution contributes zero and does not offset adverse legs. `u64::MAX` disables the aggregate cap for existing behavior.

## Validation
- `cargo build-sbf --no-default-features`
- `cd tests/fixtures/hostile_matcher && cargo build-sbf`
- `cd tests/fixtures/auth_matcher && cargo build-sbf`
- `cargo test --test v16_cu v16_attack_batch_tradecpi_flagged_partial_rejects_atomically -- --nocapture`
- `cargo test --test v16_cu v16_attack_batch_cpi_aggregate_slippage_cap_aborts_whole_batch -- --nocapture`
- `cargo test --test v16_cu v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch -- --nocapture`
- `cargo test --test v16_cu v16_bpf_batch_trade_cpi_executes_mixed_spread_through_matcher -- --nocapture`
- `cargo kani --tests --harness kani_v16_batch_trade_cpi_decode_preserves_aggregate_slippage_cap`
- `cargo kani --tests --harness kani_v16_batch_trade_cpi_legacy_decode_defaults_slippage_cap_disabled`
- `cargo test --test v16_cu` (561 passed)
- `cargo fmt --check`
- `git diff --check`
