### PR TITLE
Preserve proportional BatchTradeCpi partial fills

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4080,6 +4080,29 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
+    #[inline(always)]
+    pub fn batch_trade_size_allowed(size_q: i128) -> bool {
+        size_q != 0 && size_q != i128::MIN && size_q.unsigned_abs() <= percolator::MAX_TRADE_SIZE_Q
+    }
+
+    #[inline(always)]
+    pub fn batch_fill_ratios_equal(
+        exec_abs: u128,
+        req_abs: u128,
+        first_exec_abs: u128,
+        first_req_abs: u128,
+    ) -> bool {
+        if exec_abs == first_exec_abs && req_abs == first_req_abs {
+            return true;
+        }
+        let full = exec_abs == req_abs;
+        let first_full = first_exec_abs == first_req_abs;
+        if full || first_full {
+            return full && first_full;
+        }
+        exec_abs * first_req_abs == first_exec_abs * req_abs
+    }
+
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
             return Some(0);
@@ -6774,7 +6797,7 @@ pub mod processor {
         // is read for matcher request/return binding.
         let mut asset_indices: Vec<u16> = Vec::with_capacity(legs.len());
         for leg in legs {
-            if leg.size_q == 0 || leg.size_q == i128::MIN {
+            if !policy_v16::batch_trade_size_allowed(leg.size_q) {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             asset_indices.push(leg.asset_index);
@@ -6960,13 +6983,12 @@ pub mod processor {
             let exec_abs = ret.exec_size.unsigned_abs();
             let req_abs = leg.size_q.unsigned_abs();
             if let Some((first_exec_abs, first_req_abs)) = batch_fill_ratio {
-                let lhs = exec_abs
-                    .checked_mul(first_req_abs)
-                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-                let rhs = first_exec_abs
-                    .checked_mul(req_abs)
-                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-                if lhs != rhs {
+                if !policy_v16::batch_fill_ratios_equal(
+                    exec_abs,
+                    req_abs,
+                    first_exec_abs,
+                    first_req_abs,
+                ) {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
             } else {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6940,6 +6940,7 @@ pub mod processor {
         }
 
         let mut exec_legs: Vec<ix::BatchTradeLeg> = Vec::with_capacity(legs.len());
+        let mut batch_fill_ratio: Option<(u128, u128)> = None;
         for (i, leg) in legs.iter().enumerate() {
             let chunk = &ret_data[i * matcher_abi::MATCHER_RETURN_BYTES
                 ..(i + 1) * matcher_abi::MATCHER_RETURN_BYTES];
@@ -6955,6 +6956,21 @@ pub mod processor {
             // Atomic strategy semantics: every leg must fill (no zero/skip fills in a batch).
             if ret.exec_size == 0 {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            let exec_abs = ret.exec_size.unsigned_abs();
+            let req_abs = leg.size_q.unsigned_abs();
+            if let Some((first_exec_abs, first_req_abs)) = batch_fill_ratio {
+                let lhs = exec_abs
+                    .checked_mul(first_req_abs)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                let rhs = first_exec_abs
+                    .checked_mul(req_abs)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                if lhs != rhs {
+                    return Err(PercolatorError::InvalidInstruction.into());
+                }
+            } else {
+                batch_fill_ratio = Some((exec_abs, req_abs));
             }
             if leg.limit_price != 0 {
                 let limit_ok = if leg.size_q > 0 {

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -17,6 +17,7 @@ entrypoint!(process);
 
 const ABI: u32 = 3;
 const FLAG_VALID: u32 = 1;
+const FLAG_PARTIAL_OK: u32 = 2;
 
 // Build one crafted 64-byte MatcherReturn; `mode` perturbs exactly one field (default = honest fill).
 fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> [u8; 64] {
@@ -39,6 +40,14 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
             flags = FLAG_VALID;
             size = req / 2
         } // unflagged partial (no PARTIAL_OK)
+        10 => {
+            flags = FLAG_VALID | FLAG_PARTIAL_OK;
+            size = req / 2
+        } // valid proportional partial
+        15 => {
+            flags = FLAG_VALID | FLAG_PARTIAL_OK;
+            size = req / 2
+        } // batch-only non-proportional partial; first leg is rewritten to full below
         _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];
@@ -84,7 +93,11 @@ fn maybe_drain_tail_signer(mode: u8, accounts: &[AccountInfo]) -> ProgramResult 
     if accounts.len() >= 5 {
         invoke(
             &ix,
-            &[accounts[2].clone(), accounts[3].clone(), accounts[4].clone()],
+            &[
+                accounts[2].clone(),
+                accounts[3].clone(),
+                accounts[4].clone(),
+            ],
         )
     } else {
         invoke(&ix, &[accounts[2].clone(), accounts[3].clone()])
@@ -133,8 +146,9 @@ fn process(_pid: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResul
                 let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
                 let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
                 let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
+                let batch_mode = if mode == 15 && i == 0 { 9 } else { mode };
                 out[i * 64..i * 64 + 64]
-                    .copy_from_slice(&craft(mode, req_id, lp, asset, oracle, req));
+                    .copy_from_slice(&craft(batch_mode, req_id, lp, asset, oracle, req));
             }
             set_return_data(&out[..emit * 64]);
             Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -50900,6 +50900,158 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
     );
 }
 
+// LoF sweep: BatchTradeCpi is an atomic spread route. A hostile configured LP matcher can return
+// FLAG_PARTIAL_OK for every leg but fill the hedge legs at different ratios. Per-leg price limits
+// and the nonzero-fill gate both pass, but the taker receives unintended one-sided residual
+// exposure. The wrapper must reject non-proportional partial batches atomically while still allowing
+// proportional partial batches.
+#[test]
+fn v16_attack_batch_tradecpi_rejects_nonproportional_partial_fills() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, 100);
+
+    let matcher_program = Pubkey::new_unique();
+    env.svm.add_program(
+        matcher_program,
+        &std::fs::read(hostile_matcher_program_path()).expect("read hostile matcher BPF"),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let taker_portfolio = env.create_portfolio(&taker);
+    let lp_portfolio = env.create_portfolio(&lp);
+    env.deposit(&taker, taker_portfolio, 1_000_000);
+    env.deposit(&lp, lp_portfolio, 1_000_000);
+
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp_portfolio,
+        &lp.pubkey(),
+        &matcher_program,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![15u8; MATCHER_CONTEXT_LEN],
+                owner: matcher_program,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(matcher_program, &lp, lp_portfolio, ctx, delegate, 1);
+
+    let sz = (8 * POS_SCALE) as i128;
+    let legs = vec![
+        BatchTradeCpiLeg {
+            asset_index: 0,
+            size_q: sz,
+            fee_bps: 100,
+            limit_price: 0,
+        },
+        BatchTradeCpiLeg {
+            asset_index: 1,
+            size_q: -sz,
+            fee_bps: 100,
+            limit_price: 0,
+        },
+    ];
+    let accounts = |env: &V16CuEnv| {
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_portfolio, false),
+            AccountMeta::new(lp_portfolio, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ]
+    };
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker_portfolio).unwrap();
+    let lp_before = env.svm.get_account(&lp_portfolio).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let rejected = env.send(
+        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        accounts(&env),
+        &[&taker],
+    );
+    assert!(
+        rejected.is_err(),
+        "BatchTradeCpi must reject non-proportional partial leg fills"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "non-proportional partial rejection rolls back market writes"
+    );
+    assert_eq!(
+        env.svm.get_account(&taker_portfolio).unwrap(),
+        taker_before,
+        "non-proportional partial rejection rolls back taker writes"
+    );
+    assert_eq!(
+        env.svm.get_account(&lp_portfolio).unwrap(),
+        lp_before,
+        "non-proportional partial rejection rolls back LP writes"
+    );
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "non-proportional partial rejection rolls back matcher context writes"
+    );
+
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 10;
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: matcher_program,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let accepted = env
+        .send(
+            ProgInstruction::BatchTradeCpi { legs },
+            accounts(&env),
+            &[&taker],
+        )
+        .expect("proportional partial BatchTradeCpi control remains live");
+    assert_cu_within(
+        "BatchTradeCpi proportional partial after bad partial reject",
+        accepted,
+        TRADE_CU_LIMIT,
+    );
+    let taker_after = env.portfolio_state(taker_portfolio);
+    assert_eq!(active_leg_for_asset(&taker_after, 0).basis_pos_q, sz / 2);
+    assert_eq!(active_leg_for_asset(&taker_after, 1).basis_pos_q, -sz / 2);
+}
+
 // security.md sweep - stale-resolve BatchTradeCpi rollback (#30/#35/#48): the batch CPI path invokes
 // the matcher before it reaches the shared batch engine pre-pass that freezes stale-matured markets.
 // Once the oracle is past permissionless_resolve_stale_slots, a batched matcher fill must reject and

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -50958,17 +50958,18 @@ fn v16_attack_batch_tradecpi_rejects_nonproportional_partial_fills() {
         .unwrap();
     env.set_matcher_config(matcher_program, &lp, lp_portfolio, ctx, delegate, 1);
 
-    let sz = (8 * POS_SCALE) as i128;
+    let long_sz = (8 * POS_SCALE) as i128;
+    let short_sz = (4 * POS_SCALE) as i128;
     let legs = vec![
         BatchTradeCpiLeg {
             asset_index: 0,
-            size_q: sz,
+            size_q: long_sz,
             fee_bps: 100,
             limit_price: 0,
         },
         BatchTradeCpiLeg {
             asset_index: 1,
-            size_q: -sz,
+            size_q: -short_sz,
             fee_bps: 100,
             limit_price: 0,
         },
@@ -51048,8 +51049,14 @@ fn v16_attack_batch_tradecpi_rejects_nonproportional_partial_fills() {
         TRADE_CU_LIMIT,
     );
     let taker_after = env.portfolio_state(taker_portfolio);
-    assert_eq!(active_leg_for_asset(&taker_after, 0).basis_pos_q, sz / 2);
-    assert_eq!(active_leg_for_asset(&taker_after, 1).basis_pos_q, -sz / 2);
+    assert_eq!(
+        active_leg_for_asset(&taker_after, 0).basis_pos_q,
+        long_sz / 2
+    );
+    assert_eq!(
+        active_leg_for_asset(&taker_after, 1).basis_pos_q,
+        -short_sz / 2
+    );
 }
 
 // security.md sweep - stale-resolve BatchTradeCpi rollback (#30/#35/#48): the batch CPI path invokes

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -9,6 +9,92 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::policy_v16;
 
 #[kani::proof]
+fn kani_v16_batch_fill_ratio_cannot_overflow_for_any_engine_valid_size() {
+    let first_req_signed: i128 = kani::any();
+    let req_signed: i128 = kani::any();
+    kani::assume(policy_v16::batch_trade_size_allowed(first_req_signed));
+    kani::assume(policy_v16::batch_trade_size_allowed(req_signed));
+    let first_req = first_req_signed.unsigned_abs();
+    let req = req_signed.unsigned_abs();
+    let first_exec = kani::any::<u64>() as u128;
+    let exec = kani::any::<u64>() as u128;
+    kani::assume(first_exec > 0 && first_exec <= first_req);
+    kani::assume(exec > 0 && exec <= req);
+
+    let actual = policy_v16::batch_fill_ratios_equal(exec, req, first_exec, first_req);
+
+    assert!(exec.checked_mul(first_req).is_some());
+    assert!(first_exec.checked_mul(req).is_some());
+    kani::cover!(actual, "a production-bounded common fill ratio is accepted");
+    kani::cover!(
+        !actual,
+        "a production-bounded mismatched fill ratio is rejected"
+    );
+    kani::cover!(
+        first_req_signed < 0
+            && req_signed > 0
+            && first_req > u32::MAX as u128
+            && req > u32::MAX as u128,
+        "the production cap admits mixed-sign valid sizes wider than 32 bits"
+    );
+}
+
+#[kani::proof]
+fn kani_v16_batch_fill_ratio_rejects_full_vs_partial_and_keeps_common_ratio_live() {
+    let req = kani::any::<u16>() as u128;
+    let exec = kani::any::<u16>() as u128;
+    kani::assume(req > 1);
+    kani::assume(exec > 0 && exec < req);
+
+    assert!(!policy_v16::batch_fill_ratios_equal(exec, req, 1, 1));
+    assert!(policy_v16::batch_fill_ratios_equal(exec, req, exec, req));
+    kani::cover!(
+        exec + 1 < req,
+        "a deeply partial leg is rejected against a fully filled leg"
+    );
+}
+
+#[kani::proof]
+fn kani_v16_batch_fill_ratio_preserves_signed_spread_shape() {
+    let req_abs = kani::any::<u16>() as u128 + 1;
+    let exec_abs = kani::any::<u16>() as u128 + 1;
+    kani::assume(exec_abs <= req_abs);
+    assert!(policy_v16::batch_fill_ratios_equal(
+        exec_abs, req_abs, exec_abs, req_abs
+    ));
+
+    let first_positive: bool = kani::any();
+    let positive: bool = kani::any();
+    let signed = |magnitude: u128, is_positive: bool| {
+        if is_positive {
+            magnitude as i128
+        } else {
+            -(magnitude as i128)
+        }
+    };
+    let first_req = signed(req_abs, first_positive);
+    let req = signed(req_abs, positive);
+    let first_exec = signed(exec_abs, first_positive);
+    let exec = signed(exec_abs, positive);
+
+    if first_positive == positive {
+        assert_eq!(first_req, req);
+        assert_eq!(first_exec, exec);
+    } else {
+        assert_eq!(first_req, -req);
+        assert_eq!(first_exec, -exec);
+    }
+    kani::cover!(
+        first_positive == positive && exec_abs < req_abs,
+        "same-direction partial legs preserve their requested ratio"
+    );
+    kani::cover!(
+        first_positive != positive && exec_abs < req_abs,
+        "mixed-direction partial legs preserve their requested spread shape"
+    );
+}
+
+#[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
     let mark_raw: u16 = kani::any();
     let index_raw: u16 = kani::any();


### PR DESCRIPTION
## Security premise

`BatchTradeCpi` validated each matcher return independently. A configured LP matcher could mark every leg partial-valid while filling hedge legs at different requested-size ratios. Every per-leg bound passed, but an atomic spread could become unintended directional exposure, creating a user loss surface.

## PDD fix

- Require every nonzero matcher fill to have the same exact `abs(exec_size) / abs(request_size)` ratio as the first leg.
- Compare ratios by cross multiplication, avoiding division and rounding ambiguity.
- Enforce the engine's `MAX_TRADE_SIZE_Q` bound before matcher CPI, making those products infallible for every executable request.
- Fast-path identical ratio pairs and all-full/full-versus-partial cases, avoiding `u128` multiplication on normal full batches.
- Keep proportional partial batches live and preserve mixed signed directions.

The public LiteSVM regression uses unequal requested magnitudes and opposite directions. A hostile full/half return rejects atomically with market, taker, LP, and matcher context unchanged; a common half-fill then executes both legs at the exact expected sizes.

## Proofs

- `kani_v16_batch_fill_ratio_cannot_overflow_for_any_engine_valid_size` invokes the exact production size preflight and proves both cross-products fit for all valid signed request magnitudes. It reaches accepted and rejected ratios plus mixed-sign values wider than 32 bits.
- `kani_v16_batch_fill_ratio_rejects_full_vs_partial_and_keeps_common_ratio_live` proves a symbolic full/partial mismatch always rejects while the same arbitrary partial ratio remains live.
- `kani_v16_batch_fill_ratio_preserves_signed_spread_shape` proves same- and opposite-direction partial legs preserve their requested relation.
- All 6 covers are reachable; every harness finishes in under one second locally.

For the red step, the production ratio predicate was replaced with unconditional acceptance. Kani failed its full-versus-partial invariant immediately, and the public hostile batch executed instead of rejecting. Restoring the exact predicate makes both layers pass.

## Verification

- `cargo test --all-targets`: 5 unit + 564 LiteSVM passed
- All 3 affected Kani harnesses: all checks and 6/6 covers passed
- `cargo build-sbf --no-default-features`
- Hostile and authenticated matcher fixture `cargo build-sbf`
- Existing 14-leg `BatchTradeCpi` and non-CPI transaction-CU guards passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (existing test warnings only)
- `git diff --check`

This PR remains draft and unmerged pending review.
