### PR TITLE
Bind CPI limits to actual engine execution price

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4080,6 +4080,27 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
+    #[inline(always)]
+    pub fn limit_price_allows(size_q: i128, exec_price: u64, limit_price: u64) -> bool {
+        limit_price == 0
+            || if size_q > 0 {
+                exec_price <= limit_price
+            } else {
+                exec_price >= limit_price
+            }
+    }
+
+    #[inline(always)]
+    pub fn cpi_limit_prices_allow(
+        size_q: i128,
+        reported_exec_price: u64,
+        accepted_exec_price: u64,
+        limit_price: u64,
+    ) -> bool {
+        limit_price_allows(size_q, reported_exec_price, limit_price)
+            && limit_price_allows(size_q, accepted_exec_price, limit_price)
+    }
+
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
             return Some(0);
@@ -11473,15 +11494,6 @@ pub mod processor {
         ))
     }
 
-    fn limit_price_allows(size_q: i128, exec_price: u64, limit_price: u64) -> bool {
-        limit_price == 0
-            || if size_q > 0 {
-                exec_price <= limit_price
-            } else {
-                exec_price >= limit_price
-            }
-    }
-
     fn accepted_cpi_execution_price_view(
         market_ai: &AccountInfo<'_>,
         asset_index: usize,
@@ -11508,12 +11520,17 @@ pub mod processor {
         if limit_price == 0 {
             return Ok(());
         }
-        if !limit_price_allows(size_q, reported_exec_price, limit_price) {
+        if !policy_v16::limit_price_allows(size_q, reported_exec_price, limit_price) {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let accepted_exec_price =
             accepted_cpi_execution_price_view(market_ai, asset_index, reported_exec_price)?;
-        if !limit_price_allows(size_q, accepted_exec_price, limit_price) {
+        if !policy_v16::cpi_limit_prices_allow(
+            size_q,
+            reported_exec_price,
+            accepted_exec_price,
+            limit_price,
+        ) {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         Ok(())

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6588,16 +6588,13 @@ pub mod processor {
             size_q,
             req_id,
         )?;
-        if limit_price != 0 {
-            let limit_ok = if size_q > 0 {
-                ret.exec_price_e6 <= limit_price
-            } else {
-                ret.exec_price_e6 >= limit_price
-            };
-            if !limit_ok {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
-        }
+        ensure_cpi_limit_price_view(
+            market_ai,
+            asset_index as usize,
+            size_q,
+            ret.exec_price_e6,
+            limit_price,
+        )?;
         if ret.exec_size == 0 {
             return Ok(());
         }
@@ -6956,16 +6953,13 @@ pub mod processor {
             if ret.exec_size == 0 {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
-            if leg.limit_price != 0 {
-                let limit_ok = if leg.size_q > 0 {
-                    ret.exec_price_e6 <= leg.limit_price
-                } else {
-                    ret.exec_price_e6 >= leg.limit_price
-                };
-                if !limit_ok {
-                    return Err(PercolatorError::InvalidInstruction.into());
-                }
-            }
+            ensure_cpi_limit_price_view(
+                market_ai,
+                leg.asset_index as usize,
+                ret.exec_size,
+                ret.exec_price_e6,
+                leg.limit_price,
+            )?;
             exec_legs.push(ix::BatchTradeLeg {
                 asset_index: leg.asset_index,
                 size_q: ret.exec_size,
@@ -11477,6 +11471,52 @@ pub mod processor {
             group.header.config.max_price_move_bps_per_slot.get(),
             dt_slots,
         ))
+    }
+
+    fn limit_price_allows(size_q: i128, exec_price: u64, limit_price: u64) -> bool {
+        limit_price == 0
+            || if size_q > 0 {
+                exec_price <= limit_price
+            } else {
+                exec_price >= limit_price
+            }
+    }
+
+    fn accepted_cpi_execution_price_view(
+        market_ai: &AccountInfo<'_>,
+        asset_index: usize,
+        reported_exec_price: u64,
+    ) -> Result<u64, ProgramError> {
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (cfg, group) = state::market_view_mut(&mut market_data)?;
+        let oracle_profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
+        accepted_reported_trade_price_view(
+            &oracle_profile,
+            &group,
+            asset_index,
+            reported_exec_price,
+        )
+    }
+
+    fn ensure_cpi_limit_price_view(
+        market_ai: &AccountInfo<'_>,
+        asset_index: usize,
+        size_q: i128,
+        reported_exec_price: u64,
+        limit_price: u64,
+    ) -> ProgramResult {
+        if limit_price == 0 {
+            return Ok(());
+        }
+        if !limit_price_allows(size_q, reported_exec_price, limit_price) {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let accepted_exec_price =
+            accepted_cpi_execution_price_view(market_ai, asset_index, reported_exec_price)?;
+        if !limit_price_allows(size_q, accepted_exec_price, limit_price) {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        Ok(())
     }
 
     fn hybrid_trade_fee_quote_view(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -17,6 +17,7 @@ entrypoint!(process);
 
 const ABI: u32 = 3;
 const FLAG_VALID: u32 = 1;
+const FLAG_PARTIAL_OK: u32 = 2;
 
 // Build one crafted 64-byte MatcherReturn; `mode` perturbs exactly one field (default = honest fill).
 fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> [u8; 64] {
@@ -39,6 +40,11 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
             flags = FLAG_VALID;
             size = req / 2
         } // unflagged partial (no PARTIAL_OK)
+        11 => {
+            flags = FLAG_VALID | FLAG_PARTIAL_OK;
+            price = 1;
+            size = req / 2
+        } // valid partial at epsilon price
         _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21665,6 +21665,77 @@ fn v16_attack_cpi_limit_price_binds_internal_execution_price() {
         POS_SCALE as i128,
         "hostile matcher still only fills the flagged partial size"
     );
+
+    let mut batch_mode = env.svm.get_account(&ctx).unwrap();
+    batch_mode.data[64] = 11;
+    env.svm.set_account(ctx, batch_mode).unwrap();
+    let market_before_batch = env.svm.get_account(&env.market).unwrap();
+    let taker_before_batch = env.svm.get_account(&taker_account).unwrap();
+    let lp_before_batch = env.svm.get_account(&lp_account).unwrap();
+    let ctx_before_batch = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let tight_batch = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: vec![BatchTradeCpiLeg {
+                asset_index: 0,
+                size_q: (2 * POS_SCALE) as i128,
+                fee_bps: 0,
+                limit_price: 1,
+            }],
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_account, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker],
+    );
+    assert!(
+        tight_batch.is_err(),
+        "batch buy limit=1 must bind the internal execution price: {tight_batch:?}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_batch
+    );
+    assert_eq!(
+        env.svm.get_account(&taker_account).unwrap(),
+        taker_before_batch
+    );
+    assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before_batch);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before_batch);
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: vec![BatchTradeCpiLeg {
+                asset_index: 0,
+                size_q: (2 * POS_SCALE) as i128,
+                fee_bps: 0,
+                limit_price: 100,
+            }],
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_account, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker],
+    )
+    .expect("batch CPI remains live when the limit permits the internal price");
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(taker_account), 0).basis_pos_q,
+        (2 * POS_SCALE) as i128,
+        "single and batch hostile partial fills each add exactly one position unit"
+    );
 }
 
 // security.md sweep — TradeCpi zero-fill (#39): a zero-capacity matcher (max_fill_abs=0) returns

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21536,6 +21536,137 @@ fn v16_attack_tradecpi_limit_price_enforced() {
     assert_eq!(g1.vault, g1.c_tot + g1.insurance, "conservation after fill");
 }
 
+// LoF/slippage sweep: validate_matcher_return intentionally accepts any nonzero FLAG_PARTIAL_OK
+// exec_price, including epsilon prices, so the user's CPI limit must bind the wrapper-accepted
+// engine execution price, not only the raw matcher echo. Otherwise a hostile matcher can return
+// exec_price=1 to satisfy a buy limit while the wrapper settles the trade at the mark.
+#[test]
+fn v16_attack_cpi_limit_price_binds_internal_execution_price() {
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let taker_account = env.create_portfolio(&taker);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&taker, taker_account, 1_000_000);
+    env.deposit(&lp, lp_account, 1_000_000);
+
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp_account,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 11; // valid flagged partial at exec_price=1.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker_account).unwrap();
+    let lp_before = env.svm.get_account(&lp_account).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let tight = env.send(
+        ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q: (2 * POS_SCALE) as i128,
+            fee_bps: 0,
+            limit_price: 1,
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_account, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker],
+    );
+    assert!(
+        tight.is_err(),
+        "buy limit=1 must reject because the internal execution price is the auth mark"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&taker_account).unwrap(),
+        taker_before,
+        "tight-limit rejection rolls back the taker"
+    );
+    assert_eq!(
+        env.svm.get_account(&lp_account).unwrap(),
+        lp_before,
+        "tight-limit rejection rolls back the LP"
+    );
+    assert_eq!(
+        env.svm.get_account(&ctx).unwrap(),
+        ctx_before,
+        "tight-limit rejection rolls back matcher context writes"
+    );
+
+    env.svm.expire_blockhash();
+    let ok = env.send(
+        ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q: (2 * POS_SCALE) as i128,
+            fee_bps: 0,
+            limit_price: 100,
+        },
+        vec![
+            AccountMeta::new(taker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker_account, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker],
+    );
+    assert!(
+        ok.is_ok(),
+        "same epsilon matcher partial should execute once the limit permits the internal price: {ok:?}"
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(taker_account), 0).basis_pos_q,
+        POS_SCALE as i128,
+        "hostile matcher still only fills the flagged partial size"
+    );
+}
+
 // security.md sweep — TradeCpi zero-fill (#39): a zero-capacity matcher (max_fill_abs=0) returns
 // exec_size=0. The wrapper must handle it cleanly — reject or no-op — never create phantom OI/basis,
 // charge a fee on nothing, or corrupt conservation.

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -9,6 +9,77 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::policy_v16;
 
 #[kani::proof]
+fn kani_v16_cpi_limit_binds_reported_and_engine_accepted_prices() {
+    let size_q: i128 = kani::any();
+    let reported: u64 = kani::any();
+    let accepted: u64 = kani::any();
+    let limit: u64 = kani::any();
+
+    let allowed = policy_v16::cpi_limit_prices_allow(size_q, reported, accepted, limit);
+    let expected = limit == 0
+        || if size_q > 0 {
+            reported <= limit && accepted <= limit
+        } else {
+            reported >= limit && accepted >= limit
+        };
+    assert_eq!(allowed, expected);
+
+    if allowed && limit != 0 && size_q > 0 {
+        assert!(reported <= limit);
+        assert!(accepted <= limit);
+    }
+    if allowed && limit != 0 && size_q < 0 {
+        assert!(reported >= limit);
+        assert!(accepted >= limit);
+    }
+
+    kani::cover!(limit == 0 && allowed, "disabled limit accepts both prices");
+    kani::cover!(
+        size_q > 0 && limit != 0 && reported <= limit && accepted <= limit && allowed,
+        "buy with both prices in range is live"
+    );
+    kani::cover!(
+        size_q > 0 && reported <= limit && accepted > limit && !allowed,
+        "buy cannot hide an out-of-limit internal price"
+    );
+    kani::cover!(
+        size_q < 0 && limit != 0 && reported >= limit && accepted >= limit && allowed,
+        "sell with both prices in range is live"
+    );
+    kani::cover!(
+        size_q < 0 && reported >= limit && accepted < limit && !allowed,
+        "sell cannot hide an out-of-limit internal price"
+    );
+}
+
+#[kani::proof]
+fn kani_v16_cpi_partial_fill_preserves_limit_direction() {
+    let requested: i128 = kani::any();
+    let filled: i128 = kani::any();
+    let reported: u64 = kani::any();
+    let accepted: u64 = kani::any();
+    let limit: u64 = kani::any();
+
+    kani::assume(requested != 0 && requested != i128::MIN);
+    kani::assume(filled != 0 && filled != i128::MIN);
+    kani::assume(requested.signum() == filled.signum());
+    kani::assume(filled.unsigned_abs() <= requested.unsigned_abs());
+
+    assert_eq!(
+        policy_v16::cpi_limit_prices_allow(requested, reported, accepted, limit),
+        policy_v16::cpi_limit_prices_allow(filled, reported, accepted, limit)
+    );
+    kani::cover!(
+        requested > 0 && filled.unsigned_abs() < requested.unsigned_abs(),
+        "positive partial fill is reachable"
+    );
+    kani::cover!(
+        requested < 0 && filled.unsigned_abs() < requested.unsigned_abs(),
+        "negative partial fill is reachable"
+    );
+}
+
+#[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
     let mark_raw: u16 = kani::any();
     let index_raw: u16 = kani::any();


### PR DESCRIPTION
## Security premise

`TradeCpi` and `BatchTradeCpi` previously checked the user's limit against only the matcher-reported price. The wrapper could then normalize that quote and settle through the engine at a different accepted price. A hostile matcher could therefore report a limit-compatible price while causing execution beyond the user's bound, producing a direct slippage/loss-of-funds surface.

## PDD fix

- Keep the cheap early check against the matcher-reported price.
- Apply the same directional limit predicate to the accepted price actually passed to the engine.
- Share one inlined production predicate between single and batch paths.
- Preserve signed partial-fill semantics and disabled-limit behavior.

The public LiteSVM regression proves that hostile tight-limit single and batch requests reject atomically with market, taker, LP, and matcher context unchanged. Permissive limits execute both paths at exactly the requested partial sizes.

## Proofs

- `kani_v16_cpi_limit_binds_reported_and_engine_accepted_prices` proves exact full-width buy, sell, and disabled-limit semantics. Acceptance implies both reported and accepted engine prices satisfy the bound. All 5 covers are reachable, including hidden internal-price rejection in both directions.
- `kani_v16_cpi_partial_fill_preserves_limit_direction` proves every valid nonzero signed partial fill retains the request's limit direction. Both long and short partial-fill covers are reachable.
- Both harnesses finish in under one second locally.

For the red step, the production predicate was mutated to ignore the accepted engine price. The first theorem failed, both hidden-price rejection covers became unreachable, and the public tight-limit attack was accepted. Restoring the two-price predicate makes all proofs and regressions pass.

## Verification

- `cargo test --lib`: 5 passed
- `cargo test --all-targets`: 569 passed
- Both affected Kani harnesses: 7/7 covers, all checks passed
- `cargo build-sbf --no-default-features`
- Hostile matcher fixture `cargo build-sbf`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (existing test warnings only)
- `git diff --check origin/main...HEAD`

This PR remains draft and unmerged pending review.
