### PR TITLE
[PDD] Prove matcher replay safety across LP close/reinit

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -1376,9 +1376,7 @@ pub mod state {
     pub fn bump_matcher_req_seq(data: &mut [u8]) -> Result<u64, ProgramError> {
         check_header(data, KIND_MARKET)?;
         let mut config = read_wrapper_config_from_bytes(data)?;
-        config.matcher_req_seq = config
-            .matcher_req_seq
-            .checked_add(1)
+        config.matcher_req_seq = super::policy_v16::next_matcher_request_id(config.matcher_req_seq)
             .ok_or(PercolatorError::InvalidInstruction)?;
         let req_id = config.matcher_req_seq;
         write_wrapper_config_to_bytes(data, &config)?;
@@ -4079,6 +4077,11 @@ pub mod oracle_v16 {
 
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
+
+    #[inline(always)]
+    pub fn next_matcher_request_id(current: u64) -> Option<u64> {
+        current.checked_add(1)
+    }
 
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -53728,7 +53728,7 @@ fn v16_attack_matcher_context_replay_after_lp_close_reinit_rejects() {
         (2 * POS_SCALE) as i128,
         100,
     )
-    .expect("first hostile matcher call writes a valid partial response");
+    .expect("first hostile matcher call writes a valid response");
     assert_eq!(env.market_state().0.matcher_req_seq, 1);
     assert_eq!(
         u64::from_le_bytes(
@@ -53816,6 +53816,34 @@ fn v16_attack_matcher_context_replay_after_lp_close_reinit_rejects() {
     assert_eq!(env.svm.get_account(&taker_account).unwrap(), taker_before);
     assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before);
     assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+
+    let mut fresh_ctx = env.svm.get_account(&ctx).unwrap();
+    fresh_ctx.data[64] = 10;
+    env.svm.set_account(ctx, fresh_ctx).unwrap();
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        100,
+    )
+    .expect("a freshly written matcher response remains live after LP close/reinit");
+    assert_eq!(env.market_state().0.matcher_req_seq, 2);
+    assert_eq!(
+        u64::from_le_bytes(
+            env.svm.get_account(&ctx).unwrap().data[32..40]
+                .try_into()
+                .unwrap()
+        ),
+        2,
+        "post-reinit fill is bound to the next market-level request id"
+    );
 }
 
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -53664,6 +53664,160 @@ fn v16_attack_tradecpi_matcher_req_id_advances_monotonically_on_market() {
     assert_eq!(env.market_state().0.matcher_req_seq, 2);
 }
 
+#[test]
+fn v16_attack_matcher_context_replay_after_lp_close_reinit_rejects() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let taker_account = env.create_portfolio(&taker);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&taker, taker_account, 10_000_000);
+    env.deposit(&lp, lp_account, 10_000_000);
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp_account,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 10; // valid full fill; leaves a valid req_id=1 response in ctx[0..64].
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        100,
+    )
+    .expect("first hostile matcher call writes a valid partial response");
+    assert_eq!(env.market_state().0.matcher_req_seq, 1);
+    assert_eq!(
+        u64::from_le_bytes(
+            env.svm.get_account(&ctx).unwrap().data[32..40]
+                .try_into()
+                .unwrap()
+        ),
+        1,
+        "test setup leaves a stale valid matcher response in ctx[0..64]"
+    );
+
+    env.trade_asset_with_cu(
+        0,
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        -((2 * POS_SCALE) as i128),
+        100,
+        100,
+    );
+    env.push_auth_mark_for_asset_as_admin(0, env.svm.get_sysvar::<Clock>().slot, 100);
+    let lp_capital = env.portfolio_state(lp_account).capital.get();
+    assert!(lp_capital > 0, "LP should still have withdrawable capital");
+    env.withdraw(&lp, lp_account, lp_capital);
+    env.close_portfolio_with_cu(&lp, lp_account);
+
+    env.svm
+        .set_account(
+            lp_account,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![0u8; env.portfolio_account_len],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(lp.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(lp_account, false),
+        ],
+        &[&lp],
+    )
+    .expect("LP reinitializes the same portfolio account");
+    assert_eq!(
+        env.market_state().0.matcher_req_seq,
+        1,
+        "LP close/reinit must not reset the market-level matcher request sequence"
+    );
+    env.deposit(&lp, lp_account, 10_000_000);
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+
+    let mut stale_no_write_ctx = env.svm.get_account(&ctx).unwrap();
+    stale_no_write_ctx.data[64] = 13;
+    stale_no_write_ctx.data[65] = 1; // force no-write on the next hostile matcher call.
+    env.svm.set_account(ctx, stale_no_write_ctx).unwrap();
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker_account).unwrap();
+    let lp_before = env.svm.get_account(&lp_account).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let replay = env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        100,
+    );
+    assert!(
+        replay.is_err(),
+        "LP close/reinit must not reset matcher freshness enough to replay stale ctx[0..64]: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&taker_account).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+}
+
 // DoS/manipulation rate-limit: PushEwmaMark feeds a SMOOTHED mark (EWMA over dt slots). A mark
 // authority must not defeat the per-slot rate limit by pushing repeatedly within ONE slot (each push
 // compounding toward an extreme value -> instant mark manipulation -> mis-liquidation). The EWMA

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -9,6 +9,41 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::policy_v16;
 
 #[kani::proof]
+fn kani_v16_matcher_request_ids_are_strict_unique_and_fail_closed() {
+    let current: u64 = kani::any();
+    let first = policy_v16::next_matcher_request_id(current);
+
+    if current == u64::MAX {
+        assert!(first.is_none());
+    } else {
+        let first = first.unwrap();
+        assert_eq!(first, current + 1);
+        assert!(first > current);
+        assert_ne!(first, 0);
+
+        let second = policy_v16::next_matcher_request_id(first);
+        if first == u64::MAX {
+            assert!(second.is_none());
+        } else {
+            let second = second.unwrap();
+            assert_eq!(second, first + 1);
+            assert!(second > first);
+            assert_ne!(second, current);
+        }
+    }
+
+    kani::cover!(current < u64::MAX - 1, "two successive unique ids are live");
+    kani::cover!(
+        current == u64::MAX - 1 && first == Some(u64::MAX),
+        "last id is issued without wrapping"
+    );
+    kani::cover!(
+        current == u64::MAX && first.is_none(),
+        "exhaustion rejects instead of replaying id zero"
+    );
+}
+
+#[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
     let mark_raw: u16 = kani::any();
     let index_raw: u16 = kani::any();


### PR DESCRIPTION
## Summary

Adds proof-driven coverage for stale matcher-context replay across an LP portfolio close/reinitialize lifecycle. The behavioral fix is already on `main`: matcher freshness is a market-level sequence, so destroying and reusing an LP portfolio cannot make an old matcher response current again.

The production increment is factored through an inlined `next_matcher_request_id` kernel without changing behavior.

## Proof-driven development

`kani_v16_matcher_request_ids_are_strict_unique_and_fail_closed` proves over every `u64` state that:

- every issued request ID is exactly the predecessor plus one;
- successive issued IDs are strictly increasing and distinct;
- ID zero can never be reached by wraparound;
- `u64::MAX` is issued once from `MAX - 1`; and
- exhaustion at `MAX` rejects instead of wrapping or replaying.

All 52 checks pass, all three normal/terminal/exhaustion covers are satisfied, and solver time is about 0.1 seconds.

The public LiteSVM lifecycle regression then covers the storage-scope property that arithmetic alone cannot prove:

1. A real CPI fill leaves a valid response bound to market request ID 1.
2. The LP position is closed, capital withdrawn, and the same portfolio account closed and reinitialized.
3. A hostile matcher returns successfully without writing fresh context; the stale ID-1 response is rejected and market, taker, LP, and context accounts all roll back byte-for-byte.
4. A newly written response remains live and succeeds at market request ID 2.

**Red mutation:** resetting `matcher_req_seq` in the portfolio-close path makes the regression fail immediately after close/reinitialize (`0 != 1`). This recreates the reported storage-scope bug and demonstrates that the test is not merely confirming current output.

## Verification

- `cargo build-sbf --no-default-features`
- affected Kani harness: passed, 3/3 covers satisfied
- `cargo test --all-targets`: 569 passed, 0 failed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with the repository's existing warnings)
- `git diff --check origin/main...HEAD`

This PR remains draft and unmerged for review.
