### PR TITLE
[BLOCKER DoS] Commit recovery-required auto-crank progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=bd77e34739087a2f442792374e228af0ddd5aeba#bd77e34739087a2f442792374e228af0ddd5aeba"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "bd77e34739087a2f442792374e228af0ddd5aeba" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "bd77e34739087a2f442792374e228af0ddd5aeba" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10368,6 +10368,7 @@ pub mod processor {
         now_slot: u64,
         observation_hints: &[ix::CrankObservationHint],
         max_market_slots: usize,
+        market_mode: MarketModeV16,
     ) -> ProgramResult {
         if observation_hints.len() > percolator::V16_MAX_PORTFOLIO_ASSETS_N {
             return Err(PercolatorError::InvalidInstruction.into());
@@ -10385,6 +10386,34 @@ pub mod processor {
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut market_data)?;
+            if market_mode == MarketModeV16::Recovery {
+                let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;
+                let mut portfolio = state::portfolio_view_mut_for_market_slots(
+                    &mut portfolio_data,
+                    max_market_slots,
+                )?;
+                expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
+                let result = group
+                    .permissionless_auto_crank_not_atomic(
+                        &mut portfolio,
+                        AutoCrankWorkV16 {
+                            now_slot: authenticated_now_slot,
+                            observations: &[],
+                            resolved_close_fee_rate_per_slot: 0,
+                        },
+                    )
+                    .map_err(map_v16_error)?;
+                if result.selected != AutoCrankPlanV16::FinalizeRecovery
+                    || result.outcome != AutoCrankOutcomeV16::RecoveryResolved
+                {
+                    return Err(PercolatorError::InvalidInstruction.into());
+                }
+                group.validate_shape().map_err(map_v16_error)?;
+                portfolio
+                    .validate_with_market(&group.as_view())
+                    .map_err(map_v16_error)?;
+                return Ok(());
+            }
             let summary = {
                 let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;
                 let mut portfolio = state::portfolio_view_mut_for_market_slots(
@@ -10693,6 +10722,7 @@ pub mod processor {
             now_slot,
             observation_hints.as_slice(),
             max_market_slots,
+            mode,
         )
     }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -17205,7 +17205,8 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
         0,
     );
 
-    for (slot, mark) in [(1u64, 300u64), (2, 800)] {
+    let mut reached_recovery = false;
+    'mark_updates: for (slot, mark) in [(1u64, 300u64), (2, 800)] {
         env.svm.warp_to_slot(slot);
         env.push_auth_mark_with_cu(slot, mark);
         cfg_asset1(
@@ -17231,11 +17232,18 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
                     ],
                     &[],
                 );
+                if env.market_state().1.mode == MarketModeV16::Recovery {
+                    reached_recovery = true;
+                    break 'mark_updates;
+                }
             }
         }
     }
 
-    for _ in 0..8 {
+    'catchup: for _ in 0..8 {
+        if reached_recovery {
+            break;
+        }
         for ai in [0u16, 1] {
             for p in [victim, cp] {
                 env.svm.expire_blockhash();
@@ -17251,9 +17259,17 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
                     ],
                     &[],
                 );
+                if env.market_state().1.mode == MarketModeV16::Recovery {
+                    reached_recovery = true;
+                    break 'catchup;
+                }
             }
         }
     }
+    assert!(
+        reached_recovery,
+        "deep cross-margin insolvency must reach Recovery in bounded public cranks"
+    );
 
     let before = env.portfolio_state(victim);
     assert_eq!(before.capital.get(), 0, "setup makes victim insolvent");
@@ -17265,17 +17281,49 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
         has_active_leg_for_asset(&before, 0) && has_active_leg_for_asset(&before, 1),
         "setup leaves unattributed multi-asset exposure"
     );
-    env.resolve();
+    let (_, recovery) = env.market_state();
+    assert_eq!(
+        recovery.mode,
+        MarketModeV16::Recovery,
+        "live liquidation must first commit its terminal recovery rank"
+    );
+    let recovery_market = env.svm.get_account(&env.market).unwrap();
+    let recovery_victim = env.svm.get_account(&victim).unwrap();
+    env.svm.expire_blockhash();
+    let finalize_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: u64::MAX,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim, false),
+            ],
+            &[],
+        )
+        .expect("Recovery must have a bounded permissionless transition to Resolved");
+    assert_cu_within(
+        "PermissionlessCrank cross-margin Recovery-to-Resolved",
+        finalize_cu,
+        CRANK_CU_LIMIT,
+    );
+    let (_, resolved) = env.market_state();
+    assert_eq!(resolved.mode, MarketModeV16::Resolved);
+    assert_ne!(env.svm.get_account(&env.market).unwrap(), recovery_market);
+    assert_eq!(env.svm.get_account(&victim).unwrap(), recovery_victim);
+    assert_eq!(resolved.vault, recovery.vault);
+    assert_eq!(resolved.c_tot, recovery.c_tot);
+    assert_eq!(resolved.insurance, recovery.insurance);
+    assert_eq!(resolved.vault as u64, env.token_amount(env.vault));
 
     env.svm.expire_blockhash();
     let loser_crank_cu = env
         .send(
             ProgInstruction::PermissionlessCrank {
                 now_slot: u64::MAX,
-                observations: vec![CrankObservationHint {
-                    asset_index: u16::MAX,
-                    oracle_accounts: u8::MAX,
-                }],
+                observations: vec![],
             },
             vec![
                 AccountMeta::new_readonly(victim_owner.pubkey(), false),
@@ -39929,48 +39977,46 @@ fn v16_attack_public_liquidation_recovery_required_commits_recovery() {
         0,
     );
 
+    let mut recovery_transition = None;
     for slot in 1..=40u64 {
         env.svm.warp_to_slot(slot);
         let _ = env.push_auth_mark_with_cu(slot, 1_070_000);
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let (_, group_before) = env.market_state();
+        let short_before = env.svm.get_account(&short).unwrap();
+        let cert_before = health_cert(&env.portfolio_state(short));
         env.svm.expire_blockhash();
-        let _ = env.send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: slot,
-                close_q: 0,
-                observations: crank_observations(0),
-            },
-            vec![
-                AccountMeta::new(env.payer.pubkey(), true),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(short, false),
-            ],
-            &[],
-        );
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(short, false),
+                ],
+                &[],
+            )
+            .unwrap_or_else(|err| {
+                panic!(
+                    "setup crank slot={slot} mode={:?} cert={cert_before:?} failed: {err}",
+                    group_before.mode
+                )
+            });
+        if env.market_state().1.mode == MarketModeV16::Recovery {
+            recovery_transition =
+                Some((cu, market_before, group_before, short_before, cert_before));
+            break;
+        }
     }
+    let (cu, market_before, group_before, short_before, cert_before) = recovery_transition
+        .expect("a recovery-required liquidation must have a finite public continuation");
     assert!(
-        health_cert(&env.portfolio_state(short)).certified_liq_deficit != 0,
-        "setup must make the short liquidatable before probing recovery-required liquidation"
+        cert_before.valid && cert_before.certified_liq_deficit != 0,
+        "the successful recovery transition must start from a current liquidatable account"
     );
-
-    let market_before = env.svm.get_account(&env.market).unwrap();
-    let (_, group_before) = env.market_state();
-    let short_before = env.svm.get_account(&short).unwrap();
-    env.svm.expire_blockhash();
-    let cu = env
-        .send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 40,
-                close_q: POS_SCALE,
-                observations: crank_observations(0),
-            },
-            vec![
-                AccountMeta::new(env.payer.pubkey(), true),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(short, false),
-            ],
-            &[],
-        )
-        .expect("recovery-required liquidation must commit recovery instead of rolling back");
     assert_cu_within(
         "PermissionlessCrank recovery-required liquidation",
         cu,
@@ -40002,6 +40048,45 @@ fn v16_attack_public_liquidation_recovery_required_commits_recovery() {
     assert_eq!(recovered.c_tot, group_before.c_tot);
     assert_eq!(recovered.insurance, group_before.insurance);
     assert!(recovered.vault >= recovered.c_tot + recovered.insurance);
+
+    let recovery_market = env.svm.get_account(&env.market).unwrap();
+    let recovery_short = env.svm.get_account(&short).unwrap();
+    env.svm.expire_blockhash();
+    let finalize_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: u64::MAX,
+                observations: vec![CrankObservationHint {
+                    asset_index: u16::MAX,
+                    oracle_accounts: u8::MAX,
+                }],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        )
+        .expect("Recovery must finalize through the public crank without oracle input");
+    assert_cu_within(
+        "PermissionlessCrank Recovery-to-Resolved",
+        finalize_cu,
+        CRANK_CU_LIMIT,
+    );
+    let (_, resolved) = env.market_state();
+    assert_eq!(resolved.mode, MarketModeV16::Resolved);
+    assert_eq!(resolved.recovery_reason, recovered.recovery_reason);
+    assert_ne!(
+        env.svm.get_account(&env.market).unwrap(),
+        recovery_market,
+        "the terminal mode transition must commit"
+    );
+    assert_eq!(env.svm.get_account(&short).unwrap(), recovery_short);
+    assert_eq!(resolved.vault, recovered.vault);
+    assert_eq!(resolved.c_tot, recovered.c_tot);
+    assert_eq!(resolved.insurance, recovered.insurance);
+    assert_eq!(resolved.vault as u64, env.token_amount(env.vault));
 }
 
 // security.md sweep — repeated partial-liquidation fee stop (#3/#33): the liquidation fee is charged

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -16990,7 +16990,8 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
         }
     }
     // A live liquidation cannot safely close this deeply insolvent cross-margin victim. It must
-    // return recovery-required and roll back, not partially apply a value-creating close.
+    // commit the recovery declaration as public progress, not partially apply a value-creating close
+    // or return an instruction error that rolls the declaration back.
     let close_ix = ProgInstruction::PermissionlessCrank {
         now_slot: 2,
         observations: crank_observations(0),
@@ -17001,31 +17002,50 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
         AccountMeta::new(victim, false),
     ];
     env.svm.expire_blockhash();
+    let market_before_first_close = env.svm.get_account(&env.market).unwrap();
     let first = env.send(close_ix.clone(), close_accounts.clone(), &[]);
-    let (market_before_reject, reject) = if first.is_ok() {
+    let (_, first_group) = env.market_state();
+    let recovery_cu = if first_group.mode == MarketModeV16::Recovery {
+        first.expect("recovery declaration must commit")
+    } else {
+        first.expect("first auto-crank close attempt may refresh before recovery declaration");
         assert!(
             has_active_leg_for_asset(&env.portfolio_state(victim), 0),
-            "first auto-crank close attempt may only refresh before the rejecting liquidation"
+            "refresh-only attempt must not live-liquidate the insolvent leg"
         );
-        let before = env.svm.get_account(&env.market).unwrap();
+        let market_before_recovery = env.svm.get_account(&env.market).unwrap();
+        let victim_before_recovery = env.svm.get_account(&victim).unwrap();
         env.svm.expire_blockhash();
-        (before, env.send(close_ix, close_accounts, &[]))
-    } else {
-        (env.svm.get_account(&env.market).unwrap(), first)
+        let cu = env
+            .send(close_ix, close_accounts, &[])
+            .expect("deep cross-margin insolvency must commit recovery");
+        assert_ne!(
+            env.svm.get_account(&env.market).unwrap().data,
+            market_before_recovery.data,
+            "recovery declaration must update market bytes"
+        );
+        assert_eq!(
+            env.svm.get_account(&victim).unwrap().data,
+            victim_before_recovery.data,
+            "recovery-required liquidation must not partially mutate the target portfolio"
+        );
+        cu
     };
-    assert!(
-        reject.is_err(),
-        "deep cross-margin insolvency must not live-liquidate"
+    assert_cu_within(
+        "PermissionlessCrank cross-margin recovery declaration",
+        recovery_cu,
+        CRANK_CU_LIMIT,
     );
-    let err = format!("{:?}", reject);
-    assert!(
-        err.contains("Custom(23)"),
-        "expected EngineRecoveryRequired, got {err}"
-    );
+    let (_, recovery_group) = env.market_state();
+    assert_eq!(recovery_group.mode, MarketModeV16::Recovery);
     assert_eq!(
+        recovery_group.recovery_reason,
+        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)
+    );
+    assert_ne!(
         env.svm.get_account(&env.market).unwrap().data,
-        market_before_reject.data,
-        "rejected cross-margin liquidation rolls back market bytes"
+        market_before_first_close.data,
+        "at least the recovery declaration must be committed"
     );
 
     let v = state::read_portfolio(&env.svm.get_account(&victim).unwrap().data).unwrap();
@@ -39875,6 +39895,113 @@ fn v16_attack_insurance_covered_liquidation_does_not_strand_empty_portfolio() {
         1,
         "only the long counterparty remains materialized"
     );
+}
+
+// Public liveness sweep: when liquidation discovers that the market must enter Recovery, the wrapper
+// must commit that engine recovery declaration as successful crank progress. Returning an instruction
+// error rolls the declaration back under SVM semantics, leaving keepers with no bounded public progress
+// path for the account.
+#[test]
+fn v16_attack_public_liquidation_recovery_required_commits_recovery() {
+    const SHORT_CAP: u128 = 55_000;
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        public_b_chunk_atoms: 1,
+        max_bankrupt_close_lifetime_slots: 1,
+        ..production_risk_params()
+    });
+    env.update_liquidation_fee_policy_with_cu(0);
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 100_000_000);
+    env.deposit(&short_owner, short, SHORT_CAP);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+
+    for slot in 1..=40u64 {
+        env.svm.warp_to_slot(slot);
+        let _ = env.push_auth_mark_with_cu(slot, 1_070_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                close_q: 0,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        );
+    }
+    assert!(
+        health_cert(&env.portfolio_state(short)).certified_liq_deficit != 0,
+        "setup must make the short liquidatable before probing recovery-required liquidation"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let (_, group_before) = env.market_state();
+    let short_before = env.svm.get_account(&short).unwrap();
+    env.svm.expire_blockhash();
+    let cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                close_q: POS_SCALE,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        )
+        .expect("recovery-required liquidation must commit recovery instead of rolling back");
+    assert_cu_within(
+        "PermissionlessCrank recovery-required liquidation",
+        cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let (_, recovered) = env.market_state();
+    assert_eq!(recovered.mode, MarketModeV16::Recovery);
+    assert_eq!(
+        recovered.recovery_reason,
+        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)
+    );
+    assert_ne!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "the recovery declaration must be committed, not rolled back"
+    );
+    assert_eq!(
+        env.svm.get_account(&short).unwrap(),
+        short_before,
+        "the failed liquidation itself must not partially mutate the target account"
+    );
+    assert_eq!(
+        recovered.vault as u64,
+        env.token_amount(env.vault),
+        "recovery declaration moves no custody"
+    );
+    assert_eq!(recovered.vault, group_before.vault);
+    assert_eq!(recovered.c_tot, group_before.c_tot);
+    assert_eq!(recovered.insurance, group_before.insurance);
+    assert!(recovered.vault >= recovered.c_tot + recovered.insurance);
 }
 
 // security.md sweep — repeated partial-liquidation fee stop (#3/#33): the liquidation fee is charged


### PR DESCRIPTION
## What changed

- Pin engine PR #114, where the auto-crank commits a complete reactive Recovery terminal as `Ok(RecoveryDeclared)` without duplicate hot-path scans.
- Route an already-Recovery market directly through the same public engine auto-crank API before Live-mode summary/oracle processing, allowing the bounded Recovery-to-Resolved step.
- Keep malformed Live inputs and all non-Recovery engine errors fail-closed; the wrapper does not swallow `RecoveryRequired`.
- Rebase onto current `main` and the engine-selected liquidation API.

## PDD evidence

- Red, engine parent `143e68c`: the public liquidation crank fails `Custom(23)` after 95,157 CU; SVM rollback erases Recovery.
- Green: the same public transaction commits Recovery without changing target portfolio bytes, vault, `c_tot`, or insurance.
- A second empty-observation public crank reaches Resolved, changes only terminal market state, and preserves the target portfolio and value aggregates.
- Cross-margin deep-insolvency wind-down and ordinary engine-selected liquidation conservation regressions pass.

## Validation

- `cargo build-sbf --no-default-features`: passed
- Exact recovery-required public regression: passed
- Cross-margin Recovery-to-Resolved regression: passed
- Issue-103 partial-liquidation 325k CU guard: passed
- `cargo test --all-targets --no-default-features`: 5 unit + 564 LiteSVM tests passed
- Engine Kani theorem in PR #114: 296 checks, 4/4 covers, 0.126s
- `cargo fmt --all -- --check`
- `git diff --check`
