### PR TITLE
[codex] Fix CPI limit checks after price normalization

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6608,12 +6608,15 @@ pub mod processor {
             req_id,
         )?;
         if limit_price != 0 {
-            let limit_ok = if size_q > 0 {
-                ret.exec_price_e6 <= limit_price
-            } else {
-                ret.exec_price_e6 >= limit_price
-            };
-            if !limit_ok {
+            if !cpi_limit_allows_price(size_q, limit_price, ret.exec_price_e6) {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
+            let engine_price = accepted_reported_trade_price_from_market_account(
+                market_ai,
+                asset_index as usize,
+                ret.exec_price_e6,
+            )?;
+            if !cpi_limit_allows_price(size_q, limit_price, engine_price) {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
         }
@@ -6976,12 +6979,15 @@ pub mod processor {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             if leg.limit_price != 0 {
-                let limit_ok = if leg.size_q > 0 {
-                    ret.exec_price_e6 <= leg.limit_price
-                } else {
-                    ret.exec_price_e6 >= leg.limit_price
-                };
-                if !limit_ok {
+                if !cpi_limit_allows_price(leg.size_q, leg.limit_price, ret.exec_price_e6) {
+                    return Err(PercolatorError::InvalidInstruction.into());
+                }
+                let engine_price = accepted_reported_trade_price_from_market_account(
+                    market_ai,
+                    leg.asset_index as usize,
+                    ret.exec_price_e6,
+                )?;
+                if !cpi_limit_allows_price(leg.size_q, leg.limit_price, engine_price) {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
             }
@@ -11510,6 +11516,31 @@ pub mod processor {
             group.header.config.max_price_move_bps_per_slot.get(),
             dt_slots,
         ))
+    }
+
+    fn accepted_reported_trade_price_from_market_account(
+        market_ai: &AccountInfo<'_>,
+        asset_index: usize,
+        reported_exec_price: u64,
+    ) -> Result<u64, ProgramError> {
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (cfg, group) = state::market_view_mut(&mut market_data)?;
+        let oracle_profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
+        accepted_reported_trade_price_view(
+            &oracle_profile,
+            &group,
+            asset_index,
+            reported_exec_price,
+        )
+    }
+
+    fn cpi_limit_allows_price(size_q: i128, limit_price: u64, price: u64) -> bool {
+        limit_price == 0
+            || if size_q > 0 {
+                price <= limit_price
+            } else {
+                price >= limit_price
+            }
     }
 
     fn hybrid_trade_fee_quote_view(

--- a/tests/fixtures/hostile_matcher/src/lib.rs
+++ b/tests/fixtures/hostile_matcher/src/lib.rs
@@ -1,7 +1,8 @@
-//! Adversarial matcher for end-to-end testing of the wrapper's validate_matcher_return on BOTH the
-//! batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via the ctx-account return
-//! region). It returns CRAFTED returns; the attack "mode" is read from ctx_account.data[0] (set by the
-//! test). The wrapper MUST reject every hostile mode and accept only the honest one.
+//! Adversarial matcher for end-to-end testing of wrapper matcher-return validation and CPI slippage
+//! handling on BOTH the batch CPI (tag 3, via set_return_data) and the single TradeCpi (tag 0, via
+//! the ctx-account return region). It returns CRAFTED returns; the attack "mode" is read from
+//! ctx_account.data[0] (set by the test). Most hostile modes are malformed and must reject; mode 15
+//! is a valid low-price fill used to test limit-price enforcement after wrapper price normalization.
 #![allow(unexpected_cfgs)]
 use solana_program::{
     account_info::AccountInfo,
@@ -39,6 +40,7 @@ fn craft(mode: u8, req_id: u64, lp: u64, asset: u64, oracle: u64, req: i128) -> 
             flags = FLAG_VALID;
             size = req / 2
         } // unflagged partial (no PARTIAL_OK)
+        15 => price = 1, // valid but adversarial low price
         _ => {}                            // honest full fill -> wrapper accepts
     }
     let mut b = [0u8; 64];

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -21477,6 +21477,49 @@ fn v16_attack_tradecpi_limit_price_enforced() {
     assert_eq!(g1.vault, g1.c_tot + g1.insurance, "conservation after fill");
 }
 
+#[test]
+fn v16_attack_tradecpi_limit_rejects_normalized_engine_price_violation() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 500);
+    env.configure_ewma_mark_with_cu(0, 100, 10, 0);
+    let taker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&taker_owner, taker, 1_000_000);
+    env.deposit(&lp_owner, lp, 1_000_000);
+    let (hostile, ctx, delegate) = install_hostile_low_price_matcher(&mut env, &lp_owner, lp);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker).unwrap();
+    let lp_before = env.svm.get_account(&lp).unwrap();
+    env.svm.expire_blockhash();
+    let result = env.send(
+        ProgInstruction::TradeCpi {
+            asset_index: 0,
+            size_q: (5 * POS_SCALE) as i128,
+            fee_bps: 100,
+            limit_price: 1,
+        },
+        vec![
+            AccountMeta::new(taker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker, false),
+            AccountMeta::new(lp, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker_owner],
+    );
+    assert!(
+        result.is_err(),
+        "TradeCpi limit must apply to the normalized engine price, not only the raw matcher price"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&taker).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before);
+}
+
 // security.md sweep — TradeCpi zero-fill (#39): a zero-capacity matcher (max_fill_abs=0) returns
 // exec_size=0. The wrapper must handle it cleanly — reject or no-op — never create phantom OI/basis,
 // charge a fee on nothing, or corrupt conservation.
@@ -50783,6 +50826,51 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     );
 }
 
+#[test]
+fn v16_attack_batch_cpi_limit_rejects_normalized_engine_price_violation() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 500);
+    env.configure_ewma_mark_with_cu(0, 100, 10, 0);
+    let taker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&taker_owner, taker, 1_000_000);
+    env.deposit(&lp_owner, lp, 1_000_000);
+    let (hostile, ctx, delegate) = install_hostile_low_price_matcher(&mut env, &lp_owner, lp);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker).unwrap();
+    let lp_before = env.svm.get_account(&lp).unwrap();
+    env.svm.expire_blockhash();
+    let result = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: vec![BatchTradeCpiLeg {
+                asset_index: 0,
+                size_q: (5 * POS_SCALE) as i128,
+                fee_bps: 100,
+                limit_price: 1,
+            }],
+        },
+        vec![
+            AccountMeta::new(taker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(taker, false),
+            AccountMeta::new(lp, false),
+            AccountMeta::new_readonly(hostile, false),
+            AccountMeta::new(ctx, false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&taker_owner],
+    );
+    assert!(
+        result.is_err(),
+        "BatchTradeCpi limit must apply to the normalized engine price, not only the raw matcher price"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&taker).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before);
+}
+
 // security.md sweep - BatchTradeCpi zero-fill atomicity (#22/#39): batch strategies require every
 // leg to fill. A zero-capacity matcher returning exec_size=0 must reject the whole batch, not create
 // phantom no-op success or partially advance matcher/protocol state.
@@ -51964,6 +52052,55 @@ fn hostile_matcher_program_path() -> PathBuf {
         "build the hostile matcher: cargo build-sbf in {path:?}"
     );
     path
+}
+
+fn install_hostile_low_price_matcher(
+    env: &mut V16CuEnv,
+    lp_owner: &Keypair,
+    lp: Pubkey,
+) -> (Pubkey, Pubkey, Pubkey) {
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp,
+        &lp_owner.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 15; // valid hostile fill with exec_price_e6 = 1.
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, lp_owner, lp, ctx, delegate, 1);
+    (hostile, ctx, delegate)
 }
 
 // End-to-end adversarial: a HOSTILE matcher .so returns crafted tag-3 replies (over-fill, reversed


### PR DESCRIPTION
## Summary

Fixes a public-interface CPI slippage/value bug in `TradeCpi` and `BatchTradeCpi`.

A matcher could return a raw `exec_price_e6` that satisfied the user limit while the wrapper later normalized that reported price through the market/oracle profile before sending it into the engine. For EWMA/hybrid/mark-priced paths, the normalized engine price can differ from the raw matcher price, so the user limit was not actually enforced on the price used by the engine.

This PR enforces CPI limits on both values:

- the raw matcher-returned `exec_price_e6`
- the normalized accepted engine price from `accepted_reported_trade_price_view`

That keeps existing raw-price rejection behavior while closing the normalized-price bypass.

## Tests

- Added a hostile matcher mode that returns a valid low nonzero price (`exec_price_e6 = 1`).
- Added LiteSVM public-interface regressions for both `TradeCpi` and `BatchTradeCpi` proving a buy limit of `1` rejects when the normalized engine price violates the limit, with market/taker/LP rollback checks.
- Verified existing raw limit tests still pass.

Validation run locally:

- `cargo fmt`
- `cd tests/fixtures/hostile_matcher && cargo build-sbf`
- `cd tests/fixtures/auth_matcher && cargo build-sbf`
- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu normalized_engine_price_violation --features test-sbf -- --nocapture`
- `cargo test --test v16_cu limit_price --features test-sbf -- --nocapture`
- `cargo test --test v16_cu per_leg_limit --features test-sbf -- --nocapture`
- `cargo test --test v16_cu --features test-sbf` (`561 passed`)
- `cargo test --features test-sbf` (`561 passed`)
