### PR TITLE
[PDD] Allow safe hybrid soft-stale crank without oracle tail

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -3593,11 +3593,11 @@ pub mod oracle_v16 {
         profile: &AssetOracleProfileV16,
         now_unix_ts: i64,
     ) -> bool {
-        if profile.max_staleness_secs == 0 || profile.oracle_target_publish_time == 0 {
-            return false;
-        }
-        let age = now_unix_ts.saturating_sub(profile.oracle_target_publish_time);
-        age >= 0 && age as u64 > profile.max_staleness_secs
+        super::policy_v16::stored_oracle_sample_stale(
+            profile.max_staleness_secs,
+            profile.oracle_target_publish_time,
+            now_unix_ts,
+        )
     }
 
     pub fn hard_stale_matured(config: &WrapperConfigV16, now_slot: u64) -> bool {
@@ -4089,7 +4089,44 @@ pub mod oracle_v16 {
 }
 
 pub mod policy_v16 {
-    use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
+    use crate::constants::{MAX_DYNAMIC_TRADE_FEE_BPS, ORACLE_MODE_HYBRID_AFTER_HOURS};
+
+    #[inline(always)]
+    pub fn stored_oracle_sample_stale(
+        max_staleness_secs: u64,
+        publish_time: i64,
+        now_unix_ts: i64,
+    ) -> bool {
+        if max_staleness_secs == 0 || publish_time == 0 {
+            return false;
+        }
+        let age = now_unix_ts.saturating_sub(publish_time);
+        age >= 0 && age as u64 > max_staleness_secs
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    pub fn hybrid_crank_oracle_count_allowed(
+        supplied_accounts: usize,
+        expected_accounts: usize,
+        oracle_mode: u8,
+        hybrid_soft_stale_slots: u64,
+        last_good_oracle_slot: u64,
+        now_slot: u64,
+        max_staleness_secs: u64,
+        publish_time: i64,
+        now_unix_ts: i64,
+    ) -> bool {
+        if supplied_accounts == expected_accounts {
+            return true;
+        }
+        supplied_accounts == 0
+            && expected_accounts != 0
+            && oracle_mode == ORACLE_MODE_HYBRID_AFTER_HOURS
+            && hybrid_soft_stale_slots != 0
+            && now_slot.saturating_sub(last_good_oracle_slot) > hybrid_soft_stale_slots
+            && stored_oracle_sample_stale(max_staleness_secs, publish_time, now_unix_ts)
+    }
 
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
@@ -10492,22 +10529,18 @@ pub mod processor {
                         .oracle_target_publish_time
                         .saturating_add(i64::try_from(elapsed_slots).unwrap_or(i64::MAX))
                 });
-                let expected_oracle_account_count = oracle_profile.oracle_leg_count as usize;
-                if oracle_account_count != expected_oracle_account_count {
-                    let soft_stale_missing_tail =
-                        oracle_account_count == 0
-                            && oracle_v16::profile_is_hybrid(&oracle_profile)
-                            && oracle_v16::profile_hybrid_soft_stale_matured(
-                                &oracle_profile,
-                                authenticated_now_slot,
-                            )
-                            && oracle_v16::profile_stored_oracle_sample_stale(
-                                &oracle_profile,
-                                now_unix_ts,
-                            );
-                    if !soft_stale_missing_tail {
-                        return Err(PercolatorError::InvalidInstruction.into());
-                    }
+                if !policy_v16::hybrid_crank_oracle_count_allowed(
+                    oracle_account_count,
+                    oracle_profile.oracle_leg_count as usize,
+                    oracle_profile.oracle_mode,
+                    oracle_profile.hybrid_soft_stale_slots,
+                    oracle_profile.last_good_oracle_slot,
+                    authenticated_now_slot,
+                    oracle_profile.max_staleness_secs,
+                    oracle_profile.oracle_target_publish_time,
+                    now_unix_ts,
+                ) {
+                    return Err(PercolatorError::InvalidInstruction.into());
                 }
                 if oracle_tail.len() < oracle_account_count {
                     return Err(ProgramError::NotEnoughAccountKeys);
@@ -11691,7 +11724,17 @@ pub mod processor {
                     return Err(e);
                 }
                 if e == ProgramError::NotEnoughAccountKeys
-                    && !oracle_v16::profile_stored_oracle_sample_stale(profile, now_unix_ts)
+                    && !policy_v16::hybrid_crank_oracle_count_allowed(
+                        oracle_accounts.len(),
+                        profile.oracle_leg_count as usize,
+                        profile.oracle_mode,
+                        profile.hybrid_soft_stale_slots,
+                        profile.last_good_oracle_slot,
+                        now_slot,
+                        profile.max_staleness_secs,
+                        profile.oracle_target_publish_time,
+                        now_unix_ts,
+                    )
                 {
                     return Err(e);
                 }

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -3589,6 +3589,17 @@ pub mod oracle_v16 {
                 > profile.hybrid_soft_stale_slots
     }
 
+    pub fn profile_stored_oracle_sample_stale(
+        profile: &AssetOracleProfileV16,
+        now_unix_ts: i64,
+    ) -> bool {
+        if profile.max_staleness_secs == 0 || profile.oracle_target_publish_time == 0 {
+            return false;
+        }
+        let age = now_unix_ts.saturating_sub(profile.oracle_target_publish_time);
+        age >= 0 && age as u64 > profile.max_staleness_secs
+    }
+
     pub fn hard_stale_matured(config: &WrapperConfigV16, now_slot: u64) -> bool {
         is_hybrid(config) && permissionless_stale_matured(config, now_slot)
     }
@@ -10474,14 +10485,6 @@ pub mod processor {
                 }
                 let oracle_account_count = hint.oracle_accounts as usize;
                 let mut oracle_profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
-                if oracle_account_count != oracle_profile.oracle_leg_count as usize {
-                    return Err(PercolatorError::InvalidInstruction.into());
-                }
-                if oracle_tail.len() < oracle_account_count {
-                    return Err(ProgramError::NotEnoughAccountKeys);
-                }
-                let (observation_tail, rest) = oracle_tail.split_at(oracle_account_count);
-                oracle_tail = rest;
                 let now_unix_ts = clock_unix_ts.unwrap_or_else(|| {
                     let elapsed_slots =
                         authenticated_now_slot.saturating_sub(oracle_profile.last_good_oracle_slot);
@@ -10489,6 +10492,28 @@ pub mod processor {
                         .oracle_target_publish_time
                         .saturating_add(i64::try_from(elapsed_slots).unwrap_or(i64::MAX))
                 });
+                let expected_oracle_account_count = oracle_profile.oracle_leg_count as usize;
+                if oracle_account_count != expected_oracle_account_count {
+                    let soft_stale_missing_tail =
+                        oracle_account_count == 0
+                            && oracle_v16::profile_is_hybrid(&oracle_profile)
+                            && oracle_v16::profile_hybrid_soft_stale_matured(
+                                &oracle_profile,
+                                authenticated_now_slot,
+                            )
+                            && oracle_v16::profile_stored_oracle_sample_stale(
+                                &oracle_profile,
+                                now_unix_ts,
+                            );
+                    if !soft_stale_missing_tail {
+                        return Err(PercolatorError::InvalidInstruction.into());
+                    }
+                }
+                if oracle_tail.len() < oracle_account_count {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
+                let (observation_tail, rest) = oracle_tail.split_at(oracle_account_count);
+                oracle_tail = rest;
                 reject_non_base_oracle_update_after_global_resolve_matured(
                     &cfg,
                     asset_index,
@@ -11663,6 +11688,11 @@ pub mod processor {
                     || e == ProgramError::NotEnoughAccountKeys =>
             {
                 if !oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot) {
+                    return Err(e);
+                }
+                if e == ProgramError::NotEnoughAccountKeys
+                    && !oracle_v16::profile_stored_oracle_sample_stale(profile, now_unix_ts)
+                {
                     return Err(e);
                 }
                 profile.mark_ewma_e6

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12888,6 +12888,193 @@ fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
 }
 
 #[test]
+fn v16_attack_hybrid_soft_stale_crank_progresses_without_oracle_tail() {
+    let mut env = V16CuEnv::new();
+    set_test_clock(&mut env, 1, 100);
+
+    let feed = [0xc7u8; 32];
+    let initial = env.set_pyth_price(&feed, 100, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[initial],
+        1,
+        100,
+        0,
+        0,
+        3,
+        500,
+    )
+    .expect("configure one-leg hybrid oracle");
+    assert_eq!(env.market_state().1.assets[0].effective_price, 100_000_000);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 1_000_000_000);
+    env.deposit(&short_owner, short_account, 1_000_000_000);
+
+    set_test_clock(&mut env, 2, 101);
+    env.svm.expire_blockhash();
+    let pre_soft_stale_no_tail = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_account, false),
+        ],
+        &[],
+    );
+    assert!(
+        pre_soft_stale_no_tail.is_err(),
+        "fresh hybrid crank must still require the configured oracle tail"
+    );
+
+    set_test_clock(&mut env, 5, 104);
+    env.try_trade_asset_with_cu(
+        0,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        POS_SCALE as i128,
+        150_000_000,
+        0,
+    )
+    .expect("after-hours hybrid trade updates fallback EWMA");
+    let (after_trade_cfg, after_trade_group) = env.market_state();
+    assert!(
+        after_trade_cfg.mark_ewma_e6 > after_trade_group.assets[0].effective_price,
+        "setup must leave a pending fallback EWMA move"
+    );
+
+    set_test_clock(&mut env, 65, 165);
+    env.svm.expire_blockhash();
+    let no_tail = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 65,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_account, false),
+        ],
+        &[],
+    );
+    assert!(
+        no_tail.is_ok(),
+        "soft-stale hybrid crank should use the fallback EWMA when no external oracle tail is available: {no_tail:?}"
+    );
+    let (_, group) = env.market_state();
+    assert!(
+        group.assets[0].effective_price > 100_000_000,
+        "missing-tail soft-stale crank must make price progress from the fallback EWMA"
+    );
+}
+
+#[test]
+fn v16_attack_hybrid_soft_stale_no_tail_cannot_bypass_fresh_stored_oracle() {
+    let mut env = V16CuEnv::new();
+    set_test_clock(&mut env, 1, 100);
+
+    let feed = [0xc8u8; 32];
+    let initial = env.set_pyth_price(&feed, 100, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [feed, [0u8; 32], [0u8; 32]],
+        &[initial],
+        1,
+        100,
+        0,
+        0,
+        3,
+        500,
+    )
+    .expect("configure one-leg hybrid oracle");
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 1_000_000_000);
+    env.deposit(&short_owner, short_account, 1_000_000_000);
+
+    set_test_clock(&mut env, 5, 104);
+    env.try_trade_asset_with_cu(
+        0,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        POS_SCALE as i128,
+        150_000_000,
+        0,
+    )
+    .expect("after-hours hybrid trade updates fallback EWMA");
+    let (after_trade_cfg, after_trade_group) = env.market_state();
+    assert!(
+        after_trade_cfg.mark_ewma_e6 > after_trade_group.assets[0].effective_price,
+        "setup must leave a pending fallback mark above the still-fresh oracle"
+    );
+
+    set_test_clock(&mut env, 6, 105);
+    env.svm.expire_blockhash();
+    let no_tail = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            close_q: 0,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_account, false),
+        ],
+        &[],
+    );
+    assert!(
+        no_tail.is_err(),
+        "no-tail fallback must not bypass a stored oracle sample that is still fresh by max_staleness_secs: {no_tail:?}"
+    );
+
+    env.svm.expire_blockhash();
+    let with_tail = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            close_q: 0,
+            observations: crank_observations_with_accounts(0, 1),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_account, false),
+            AccountMeta::new_readonly(initial, false),
+        ],
+        &[],
+    );
+    assert!(
+        with_tail.is_ok(),
+        "the valid fresh-oracle-tail crank must remain available: {with_tail:?}"
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(
+        group.assets[0].effective_price, 100_000_000,
+        "fresh oracle tail must keep the market on the external oracle instead of the fallback mark"
+    );
+}
+
+#[test]
 fn v16_bpf_configure_and_push_ewma_mark_are_bounded_and_clock_authenticated() {
     let mut env = V16CuEnv::new();
     let configure_real_slot = 8;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12918,11 +12918,12 @@ fn v16_attack_hybrid_soft_stale_crank_progresses_without_oracle_tail() {
     env.deposit(&short_owner, short_account, 1_000_000_000);
 
     set_test_clock(&mut env, 2, 101);
+    let fresh_market_before = env.svm.get_account(&env.market).unwrap();
+    let fresh_long_before = env.svm.get_account(&long_account).unwrap();
     env.svm.expire_blockhash();
     let pre_soft_stale_no_tail = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 2,
-            close_q: 0,
             observations: crank_observations(0),
         },
         vec![
@@ -12935,6 +12936,14 @@ fn v16_attack_hybrid_soft_stale_crank_progresses_without_oracle_tail() {
     assert!(
         pre_soft_stale_no_tail.is_err(),
         "fresh hybrid crank must still require the configured oracle tail"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        fresh_market_before
+    );
+    assert_eq!(
+        env.svm.get_account(&long_account).unwrap(),
+        fresh_long_before
     );
 
     set_test_clock(&mut env, 5, 104);
@@ -12954,30 +12963,49 @@ fn v16_attack_hybrid_soft_stale_crank_progresses_without_oracle_tail() {
         after_trade_cfg.mark_ewma_e6 > after_trade_group.assets[0].effective_price,
         "setup must leave a pending fallback EWMA move"
     );
+    let long_after_trade = env.portfolio_state(long_account);
 
     set_test_clock(&mut env, 65, 165);
     env.svm.expire_blockhash();
-    let no_tail = env.send(
-        ProgInstruction::PermissionlessCrank {
-            now_slot: 65,
-            close_q: 0,
-            observations: crank_observations(0),
-        },
-        vec![
-            AccountMeta::new(env.payer.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(long_account, false),
-        ],
-        &[],
-    );
-    assert!(
-        no_tail.is_ok(),
-        "soft-stale hybrid crank should use the fallback EWMA when no external oracle tail is available: {no_tail:?}"
+    let no_tail_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 65,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long_account, false),
+            ],
+            &[],
+        )
+        .expect("soft-stale hybrid crank uses fallback EWMA without an external oracle tail");
+    assert_cu_within(
+        "hybrid missing-tail fallback crank",
+        no_tail_cu,
+        CRANK_CU_LIMIT,
     );
     let (_, group) = env.market_state();
     assert!(
         group.assets[0].effective_price > 100_000_000,
         "missing-tail soft-stale crank must make price progress from the fallback EWMA"
+    );
+    assert!(
+        group.assets[0].slot_last > after_trade_group.assets[0].slot_last
+            && group.assets[0].slot_last <= 65,
+        "one fallback crank makes bounded accrual progress without pretending to catch up instantly"
+    );
+    assert_eq!(group.vault, after_trade_group.vault);
+    assert_eq!(group.c_tot, after_trade_group.c_tot);
+    assert_eq!(group.insurance, after_trade_group.insurance);
+    let long_after_crank = env.portfolio_state(long_account);
+    assert_eq!(long_after_crank.capital, long_after_trade.capital);
+    assert!(long_after_crank.pnl.get() > long_after_trade.pnl.get());
+    assert_eq!(
+        active_leg_for_asset(&long_after_crank, 0).basis_pos_q,
+        active_leg_for_asset(&long_after_trade, 0).basis_pos_q,
+        "fallback refresh updates valuation without changing position size"
     );
 }
 
@@ -13029,11 +13057,12 @@ fn v16_attack_hybrid_soft_stale_no_tail_cannot_bypass_fresh_stored_oracle() {
     );
 
     set_test_clock(&mut env, 6, 105);
+    let fresh_market_before = env.svm.get_account(&env.market).unwrap();
+    let fresh_long_before = env.svm.get_account(&long_account).unwrap();
     env.svm.expire_blockhash();
     let no_tail = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 6,
-            close_q: 0,
             observations: crank_observations(0),
         },
         vec![
@@ -13047,12 +13076,19 @@ fn v16_attack_hybrid_soft_stale_no_tail_cannot_bypass_fresh_stored_oracle() {
         no_tail.is_err(),
         "no-tail fallback must not bypass a stored oracle sample that is still fresh by max_staleness_secs: {no_tail:?}"
     );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        fresh_market_before
+    );
+    assert_eq!(
+        env.svm.get_account(&long_account).unwrap(),
+        fresh_long_before
+    );
 
     env.svm.expire_blockhash();
     let with_tail = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 6,
-            close_q: 0,
             observations: crank_observations_with_accounts(0, 1),
         },
         vec![

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -9,6 +9,126 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::policy_v16;
 
 #[kani::proof]
+fn kani_v16_hybrid_missing_tail_admission_is_exact_and_non_bypassable() {
+    let supplied: u8 = kani::any();
+    let expected: u8 = kani::any();
+    let oracle_mode: u8 = kani::any();
+    let soft_stale_slots: u64 = kani::any();
+    let last_good_slot: u64 = kani::any();
+    let now_slot: u64 = kani::any();
+    let max_staleness_secs: u64 = kani::any();
+    let publish_time: i64 = kani::any();
+    let now_unix_ts: i64 = kani::any();
+
+    let stored_age = now_unix_ts as i128 - publish_time as i128;
+    let stored_sample_stale =
+        policy_v16::stored_oracle_sample_stale(max_staleness_secs, publish_time, now_unix_ts);
+    if publish_time > 0 {
+        assert_eq!(
+            stored_sample_stale,
+            max_staleness_secs != 0 && stored_age > max_staleness_secs as i128
+        );
+    }
+    if stored_sample_stale {
+        assert_ne!(max_staleness_secs, 0);
+        assert_ne!(publish_time, 0);
+        assert!(stored_age > max_staleness_secs as i128);
+    }
+    let missing_tail_fallback = supplied == 0
+        && expected != 0
+        && oracle_mode == percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS
+        && soft_stale_slots != 0
+        && now_slot.saturating_sub(last_good_slot) > soft_stale_slots
+        && stored_sample_stale;
+    let allowed = policy_v16::hybrid_crank_oracle_count_allowed(
+        supplied as usize,
+        expected as usize,
+        oracle_mode,
+        soft_stale_slots,
+        last_good_slot,
+        now_slot,
+        max_staleness_secs,
+        publish_time,
+        now_unix_ts,
+    );
+
+    assert_eq!(allowed, supplied == expected || missing_tail_fallback);
+    if allowed && supplied != expected {
+        assert_eq!(supplied, 0);
+        assert_ne!(expected, 0);
+        assert!(stored_sample_stale);
+    }
+
+    kani::cover!(
+        supplied == expected && allowed,
+        "exact account count accepted"
+    );
+    kani::cover!(
+        supplied != 0 && supplied != expected && !allowed,
+        "partial or oversized tail rejected"
+    );
+    kani::cover!(
+        missing_tail_fallback && allowed,
+        "mature missing-tail fallback accepted"
+    );
+    kani::cover!(
+        supplied == 0
+            && expected != 0
+            && now_slot.saturating_sub(last_good_slot) == soft_stale_slots
+            && !allowed,
+        "soft-stale slot boundary rejected"
+    );
+    kani::cover!(
+        supplied == 0 && expected != 0 && stored_age == max_staleness_secs as i128 && !allowed,
+        "stored-sample age boundary rejected"
+    );
+}
+
+#[kani::proof]
+fn kani_v16_hybrid_missing_tail_liveness_is_monotone_after_maturity() {
+    let expected: u8 = kani::any();
+    let soft_stale_slots: u64 = kani::any();
+    let last_good_slot: u64 = kani::any();
+    let now_slot: u64 = kani::any();
+    let future_slot: u64 = kani::any();
+    let max_staleness_secs: u64 = kani::any();
+    let publish_time: i64 = kani::any();
+    let now_unix_ts: i64 = kani::any();
+    let future_unix_ts: i64 = kani::any();
+
+    kani::assume(expected != 0);
+    kani::assume(future_slot >= now_slot);
+    kani::assume(future_unix_ts >= now_unix_ts);
+    kani::assume(policy_v16::hybrid_crank_oracle_count_allowed(
+        0,
+        expected as usize,
+        percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS,
+        soft_stale_slots,
+        last_good_slot,
+        now_slot,
+        max_staleness_secs,
+        publish_time,
+        now_unix_ts,
+    ));
+
+    assert!(policy_v16::hybrid_crank_oracle_count_allowed(
+        0,
+        expected as usize,
+        percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS,
+        soft_stale_slots,
+        last_good_slot,
+        future_slot,
+        max_staleness_secs,
+        publish_time,
+        future_unix_ts,
+    ));
+    kani::cover!(
+        future_slot > now_slot && future_unix_ts > now_unix_ts,
+        "fallback remains live after both clocks advance"
+    );
+}
+
+#[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
     let mark_raw: u16 = kani::any();
     let index_raw: u16 = kani::any();


### PR DESCRIPTION
## Summary

Fixes a permissionless crank liveness mismatch for hybrid assets. Once both the configured soft-stale slot window and the persisted oracle sample's time-staleness window have elapsed, the engine can make bounded progress from the internally maintained, fee-supported EWMA. The wrapper previously rejected a zero-account observation before that fallback path was reachable.

The account-count policy is now one inlined production predicate shared by preflight and price execution. It accepts either the exact configured account count or an exact zero-account hybrid fallback; every nonzero mismatch remains rejected. Missing-tail fallback additionally requires a nonzero configured feed count, hybrid mode, strict soft-stale maturity, and a strictly stale persisted sample.

## Proof-driven development

Two full-width Kani harnesses exercise the production predicate:

- `kani_v16_hybrid_missing_tail_admission_is_exact_and_non_bypassable` proves the admission rule is exact, malformed nonzero counts cannot enter fallback, slot/time boundaries remain closed, and accepted fallback implies a genuinely stale persisted sample. All five covers are satisfied.
- `kani_v16_hybrid_missing_tail_liveness_is_monotone_after_maturity` proves that once fallback is admitted, nondecreasing authenticated slot and Unix clocks cannot make it unavailable. Its non-vacuity cover is satisfied.

Both harnesses finish with about one second of solver time.

**Red mutation:** restoring the old exact-count-only rule makes the admission theorem fail and makes its mature-fallback cover unsatisfiable. The public LiteSVM crank also fails with `Custom(9)` after 12,753 CU, before any engine progress.

**Green public path:** the LiteSVM regressions prove that:

- fresh or time-fresh samples cannot omit the configured oracle tail and reject atomically;
- the normal authenticated oracle-tail path remains live;
- a genuinely soft/time-stale hybrid can crank without an external account;
- one crank makes bounded accrual and valuation progress within the CU guardrail; and
- fallback leaves vault, capital-total, insurance, account capital, and position size unchanged.

## Verification

- `cargo build-sbf --no-default-features`
- both affected Kani harnesses: passed, all 6 covers satisfied
- `cargo test --all-targets`: 570 passed, 0 failed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with the repository's existing warnings)
- `git diff --check origin/main...HEAD`

This PR remains draft and unmerged for review.
