### PR TITLE
[audit] Prove stale defensive rebalance remains live

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8409,11 +8409,23 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
+            let asset_index_usize = asset_index as usize;
+            let profile = read_oracle_profile_from_view(group, cfg, asset_index_usize)
+                .map_err(|_| V16Error::InvalidConfig)?;
+            if group.header.mode == 0
+                && global_or_profile_resolve_matured_at_slot(
+                    cfg,
+                    &profile,
+                    authenticated_market_slot_or_fallback_view(group),
+                )
+            {
+                return Err(V16Error::Stale);
+            }
             group
                 .rebalance_reduce_position_not_atomic(
                     portfolio,
                     RebalanceRequestV16 {
-                        asset_index: asset_index as usize,
+                        asset_index: asset_index_usize,
                         reduce_q,
                     },
                 )

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8409,23 +8409,11 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
-            let asset_index_usize = asset_index as usize;
-            let profile = read_oracle_profile_from_view(group, cfg, asset_index_usize)
-                .map_err(|_| V16Error::InvalidConfig)?;
-            if group.header.mode == 0
-                && global_or_profile_resolve_matured_at_slot(
-                    cfg,
-                    &profile,
-                    authenticated_market_slot_or_fallback_view(group),
-                )
-            {
-                return Err(V16Error::Stale);
-            }
             group
                 .rebalance_reduce_position_not_atomic(
                     portfolio,
                     RebalanceRequestV16 {
-                        asset_index: asset_index_usize,
+                        asset_index: asset_index as usize,
                         reduce_q,
                     },
                 )

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26871,6 +26871,89 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
     );
 }
 
+#[test]
+fn v16_attack_non_base_local_stale_rebalance_reduce_rejects() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(5, 5);
+
+    env.activate_asset(1, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.try_trade_asset_with_cu(
+        1,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        100,
+        0,
+    )
+    .expect("asset-1 trade succeeds before local stale boundary");
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(long), 1),
+        "setup must leave the owner exposed to asset 1"
+    );
+
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_with_cu(4, 100);
+    let base_resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        base_resolve.is_err(),
+        "base market is fresh; this probe must isolate asset-1 local stale"
+    );
+
+    env.svm.warp_to_slot(6);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let long_before = env.svm.get_account(&long).unwrap();
+    let short_before = env.svm.get_account(&short).unwrap();
+    env.svm.expire_blockhash();
+    let reduce = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: 1,
+            reduce_q: POS_SCALE,
+        },
+        vec![
+            AccountMeta::new(long_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long, false),
+        ],
+        &[&long_owner],
+    );
+    assert!(
+        reduce.is_err(),
+        "RebalanceReduce must not bypass a locally stale non-base oracle"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected local-stale reduce leaves market unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&long).unwrap(),
+        long_before,
+        "rejected local-stale reduce leaves owner unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&short).unwrap(),
+        short_before,
+        "rejected local-stale reduce leaves counterparty unchanged"
+    );
+}
+
 // security.md sweep - permissionless asset oracle liveness DoS (#2/#30/#37): the reverse
 // isolation must also hold. A fresh permissionless asset oracle must not be able to bump the
 // market-wide stale clock and block ResolveStalePermissionless after the base market oracle is stale.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26872,7 +26872,7 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
 }
 
 #[test]
-fn v16_attack_non_base_local_stale_rebalance_reduce_rejects() {
+fn v16_attack_stale_asset_operator_cannot_block_defensive_rebalance_exit() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
     env.configure_permissionless_resolve_with_cu(5, 5);
 
@@ -26917,41 +26917,68 @@ fn v16_attack_non_base_local_stale_rebalance_reduce_rejects() {
     );
 
     env.svm.warp_to_slot(6);
-    let market_before = env.svm.get_account(&env.market).unwrap();
-    let long_before = env.svm.get_account(&long).unwrap();
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+            .unwrap();
+    assert_eq!(profile.last_good_oracle_slot, 0);
+    assert!(6 - profile.last_good_oracle_slot >= 5);
+
+    let (_, group_before) = env.market_state();
+    let long_before = env.portfolio_state(long);
+    let short_state_before = env.portfolio_state(short);
     let short_before = env.svm.get_account(&short).unwrap();
     env.svm.expire_blockhash();
-    let reduce = env.send(
-        ProgInstruction::RebalanceReduce {
-            asset_index: 1,
-            reduce_q: POS_SCALE,
-        },
-        vec![
-            AccountMeta::new(long_owner.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(long, false),
-        ],
-        &[&long_owner],
+    let reduce_cu = env
+        .send(
+            ProgInstruction::RebalanceReduce {
+                asset_index: 1,
+                reduce_q: POS_SCALE,
+            },
+            vec![
+                AccountMeta::new(long_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[&long_owner],
+        )
+        .expect("owner defensive rebalance remains live after its asset oracle stalls");
+    assert_cu_within(
+        "stale defensive RebalanceReduce",
+        reduce_cu,
+        CUSTODY_CU_LIMIT,
     );
-    assert!(
-        reduce.is_err(),
-        "RebalanceReduce must not bypass a locally stale non-base oracle"
-    );
-    assert_eq!(
-        env.svm.get_account(&env.market).unwrap(),
-        market_before,
-        "rejected local-stale reduce leaves market unchanged"
-    );
-    assert_eq!(
-        env.svm.get_account(&long).unwrap(),
-        long_before,
-        "rejected local-stale reduce leaves owner unchanged"
-    );
+
+    let (_, group_after) = env.market_state();
+    let long_after = env.portfolio_state(long);
+    let short_state_after = env.portfolio_state(short);
+    assert_eq!(group_after.vault, group_before.vault);
+    assert_eq!(group_after.c_tot, group_before.c_tot);
+    assert_eq!(group_after.insurance, group_before.insurance);
+    assert_eq!(long_after.capital, long_before.capital);
+    assert_eq!(long_after.pnl, long_before.pnl);
+    assert_eq!(short_state_after.capital, short_state_before.capital);
+    assert_eq!(short_state_after.pnl, short_state_before.pnl);
+    assert!(!has_active_leg_for_asset(&long_after, 1));
+    assert!(has_active_leg_for_asset(&short_state_after, 1));
+    assert_eq!(group_after.assets[1].oi_eff_long_q, 0);
+    assert_eq!(group_after.assets[1].oi_eff_short_q, 0);
     assert_eq!(
         env.svm.get_account(&short).unwrap(),
         short_before,
-        "rejected local-stale reduce leaves counterparty unchanged"
+        "defensive rebalance does not mutate the counterparty account"
     );
+
+    let long_dest = env.withdraw(&long_owner, long, 1_000_000);
+    assert_eq!(env.token_amount(long_dest), 1_000_000);
+    let forfeit_cu = env.forfeit_recovery_leg_with_cu(&short_owner, short, 1, 1);
+    assert_cu_within("orphaned-side forfeit", forfeit_cu, CUSTODY_CU_LIMIT);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(short), 1));
+    let short_dest = env.withdraw(&short_owner, short, 1_000_000);
+    assert_eq!(env.token_amount(short_dest), 1_000_000);
+    let (_, final_group) = env.market_state();
+    assert_eq!(final_group.vault, 0);
+    assert_eq!(final_group.c_tot, 0);
+    assert_eq!(final_group.insurance, 0);
 }
 
 // security.md sweep - permissionless asset oracle liveness DoS (#2/#30/#37): the reverse


### PR DESCRIPTION
## Audit result

The original production change was rejected by proof-driven analysis. A local-stale guard on `RebalanceReduce` contradicts the frozen specification, which explicitly permits defensive rebalancing while stale, and gives a stale oracle operator a way to block an owner from reducing risk.

This revision removes that guard. The final diff is a production-path LiteSVM regression proving the required liveness and conservation properties.

## PDD red/green

**Red:** reintroducing the proposed profile-aware stale guard makes the regression fail with `Custom(19)` before the owner can reduce risk. The rejected path consumed 95,292 CU and left the stale operator able to block exit.

**Green:** the public `RebalanceReduce` path:

- opens real non-base long/short exposure before staleness;
- isolates asset-local staleness while the base market remains fresh;
- lets the owner reduce exactly toward zero within the custody CU limit;
- preserves `vault`, `c_tot`, insurance, both users' capital, and both users' PnL;
- clears effective long/short OI without mutating the counterparty account;
- permits the counterparty to forfeit the orphaned recovery leg; and
- lets both users withdraw exactly their original 1,000,000 atoms, ending with zero vault, capital total, and insurance.

The engine dependency at `143e68c` separately proves the production `kernel_reduce_position_delta` contract over symbolic inputs: exact toward-zero reduction, no over-close, and strict progress. A wrapper-only boolean policy harness would be weaker than this engine contract plus the full SBF lifecycle regression.

## Verification

- `cargo test --all-targets`: 569 passed, 0 failed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with the repository's existing warnings)
- `git diff --check origin/main...HEAD`

This PR remains draft and unmerged for review.
