### PR TITLE
[codex] Bound stale asset shutdown authority

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9214,11 +9214,11 @@ pub mod processor {
                 if !marketauth_authorized && !asset_admin_authorized {
                     return Err(PercolatorError::Unauthorized.into());
                 }
-                reject_permissionless_resolve_matured_live_for_profile_view(
-                    &cfg,
-                    &profile,
-                    &group,
-                )?;
+                if !marketauth_authorized {
+                    reject_permissionless_resolve_matured_live_for_profile_view(
+                        &cfg, &profile, &group,
+                    )?;
+                }
                 if authenticated_slot < group.header.current_slot.get() {
                     return Err(PercolatorError::EngineStale.into());
                 }

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9214,6 +9214,11 @@ pub mod processor {
                 if !marketauth_authorized && !asset_admin_authorized {
                     return Err(PercolatorError::Unauthorized.into());
                 }
+                reject_permissionless_resolve_matured_live_for_profile_view(
+                    &cfg,
+                    &profile,
+                    &group,
+                )?;
                 if authenticated_slot < group.header.current_slot.get() {
                     return Err(PercolatorError::EngineStale.into());
                 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26722,7 +26722,7 @@ fn v16_attack_stale_permissionless_asset_cannot_global_resolve_market() {
 }
 
 #[test]
-fn v16_attack_non_base_local_stale_shutdown_rejects_before_freeze() {
+fn v16_attack_non_base_local_stale_admin_cannot_block_delayed_shutdown() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
     env.update_market_init_fee_policy_with_cu(1);
     env.configure_permissionless_resolve_with_cu(5, 5);
@@ -26811,18 +26811,50 @@ fn v16_attack_non_base_local_stale_shutdown_rejects_before_freeze() {
         "rejected local-stale shutdown leaves the short unchanged"
     );
 
+    let marketauth = env.admin.insecure_clone();
     env.svm.expire_blockhash();
-    env.push_auth_mark_for_asset_with_authority(1, &creator, 7, 101);
-    env.svm.expire_blockhash();
-    let fresh_shutdown = env.try_shutdown_asset_with_authority(&creator, 1, 7);
+    let forced_shutdown = env.try_shutdown_asset_with_authority(&marketauth, 1, 7);
     assert!(
-        fresh_shutdown.is_ok(),
-        "after a public asset-1 oracle refresh, shutdown remains reachable: {fresh_shutdown:?}"
+        forced_shutdown.is_ok(),
+        "asset-0 market authority must be able to shut down an abandoned stale asset: \
+         {forced_shutdown:?}"
     );
+    let shutdown_data = env.svm.get_account(&env.market).unwrap().data;
+    let (_, shutdown_group) = state::read_market(&shutdown_data).unwrap();
+    let shutdown_profile = state::read_asset_oracle_profile(&shutdown_data, 1).unwrap();
     assert_eq!(
-        env.market_state().1.assets[1].lifecycle,
+        shutdown_group.assets[1].lifecycle,
         AssetLifecycleV16::Recovery
     );
+    assert_eq!(shutdown_group.assets[1].effective_price, 100);
+    assert_eq!(shutdown_profile.last_good_oracle_slot, 7);
+    assert!(has_active_leg_for_asset(&env.portfolio_state(long), 1));
+    assert!(has_active_leg_for_asset(&env.portfolio_state(short), 1));
+
+    let cranker = Keypair::new();
+    env.svm.warp_to_slot(11);
+    env.push_auth_mark_with_cu(11, 100);
+    let early =
+        env.try_force_close_abandoned_asset_with_cu(&cranker, long, short, 1, 11, POS_SCALE);
+    assert!(
+        early.is_err(),
+        "the market-authority escape hatch must preserve the configured trader exit window"
+    );
+    assert!(has_active_leg_for_asset(&env.portfolio_state(long), 1));
+    assert!(has_active_leg_for_asset(&env.portfolio_state(short), 1));
+
+    env.svm.warp_to_slot(12);
+    env.svm.expire_blockhash();
+    let late = env.try_force_close_abandoned_asset_with_cu(&cranker, long, short, 1, 12, POS_SCALE);
+    assert!(
+        late.is_ok(),
+        "permissionless wind-down must progress after the exact timeout: {late:?}"
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 1));
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(short), 1));
+    let final_group = env.market_state().1;
+    assert!(final_group.vault >= final_group.c_tot + final_group.insurance);
+    assert_eq!(final_group.vault as u64, env.token_amount(env.vault));
 }
 
 // security.md sweep - slot-zero local stale bypass (#24/#30/#37): a non-base price-managed asset can

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26721,6 +26721,110 @@ fn v16_attack_stale_permissionless_asset_cannot_global_resolve_market() {
     assert!(group_after_trade.assets[1].oi_eff_long_q > 0);
 }
 
+#[test]
+fn v16_attack_non_base_local_stale_shutdown_rejects_before_freeze() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.update_market_init_fee_policy_with_cu(1);
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.configure_auth_mark_with_cu(1, 100);
+
+    let creator = Keypair::new();
+    let creator_key = creator.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        1,
+        1,
+        100,
+        creator_key,
+        creator_key,
+        creator_key,
+        creator_key,
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &creator, 1, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_with_cu(3, 100);
+    let base_resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        base_resolve.is_err(),
+        "base market is fresh; this probe must isolate asset-1 local stale"
+    );
+
+    env.svm.warp_to_slot(7);
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+            .unwrap();
+    assert_eq!(
+        profile.last_good_oracle_slot, 1,
+        "asset-1 profile must be locally stale by slot 7"
+    );
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(long), 1),
+        "setup must leave a live asset-1 position exposed to stale shutdown"
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let long_before = env.svm.get_account(&long).unwrap();
+    let short_before = env.svm.get_account(&short).unwrap();
+
+    env.svm.expire_blockhash();
+    let stale_shutdown = env.try_shutdown_asset_with_authority(&creator, 1, 7);
+    assert!(
+        stale_shutdown.is_err(),
+        "UpdateAssetLifecycle::Shutdown must not freeze a locally stale non-base oracle"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected local-stale shutdown leaves market/lifecycle/profile unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&long).unwrap(),
+        long_before,
+        "rejected local-stale shutdown leaves the long unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&short).unwrap(),
+        short_before,
+        "rejected local-stale shutdown leaves the short unchanged"
+    );
+
+    env.svm.expire_blockhash();
+    env.push_auth_mark_for_asset_with_authority(1, &creator, 7, 101);
+    env.svm.expire_blockhash();
+    let fresh_shutdown = env.try_shutdown_asset_with_authority(&creator, 1, 7);
+    assert!(
+        fresh_shutdown.is_ok(),
+        "after a public asset-1 oracle refresh, shutdown remains reachable: {fresh_shutdown:?}"
+    );
+    assert_eq!(
+        env.market_state().1.assets[1].lifecycle,
+        AssetLifecycleV16::Recovery
+    );
+}
+
 // security.md sweep - slot-zero local stale bypass (#24/#30/#37): a non-base price-managed asset can
 // be configured at the authenticated genesis slot. Its local stale clock must still mature; otherwise
 // stale AuthMark/EWMA assets born at slot 0 can keep trading forever while the base oracle stays fresh.


### PR DESCRIPTION
## Summary

Preserves the local-stale shutdown guard for a permissionless asset admin without allowing an abandoned oracle/admin to block asset-0 market-authority shutdown forever.

## PDD

The public LiteSVM regression creates asset 1, opens balanced positions, keeps the base market fresh, and lets only asset 1 become stale. It proves:

- the local asset admin cannot freeze a stale mark;
- the market authority can still move the abandoned asset into Recovery at the committed last-good mark;
- both positions remain open during the configured exit window;
- permissionless force-close rejects before the exact timeout and succeeds at maturity;
- vault accounting and token custody remain conserved.

The prior blanket guard failed the market-authority liveness case.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_non_base_local_stale_admin_cannot_block_delayed_shutdown -- --nocapture`
- `cargo test shutdown --test v16_cu -- --nocapture`

No merge requested.