### PR TITLE
[codex] Reject local-stale domain withdrawals

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4422,6 +4422,8 @@ pub mod processor {
         if shutdown_asset_empty_and_matured_now_view(cfg, group, asset_index).is_ok() {
             return Ok(true);
         }
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+        reject_permissionless_resolve_matured_live_for_profile_view(cfg, &profile, group)?;
         reject_permissionless_resolve_matured_live_view(cfg, group)?;
         if group.header.bankruptcy_hlock_active != 0
             || group.header.threshold_stress_active != 0

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4080,6 +4080,17 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
+    pub fn price_managed_profile_resolve_matured(
+        price_managed: bool,
+        resolve_stale_slots: u64,
+        last_good_oracle_slot: u64,
+        now_slot: u64,
+    ) -> bool {
+        price_managed
+            && resolve_stale_slots != 0
+            && now_slot.saturating_sub(last_good_oracle_slot) >= resolve_stale_slots
+    }
+
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
             return Some(0);
@@ -4307,24 +4318,18 @@ pub mod processor {
         )
     }
 
-    fn permissionless_resolve_matured_for_profile_at_slot(
-        cfg: &WrapperConfigV16,
-        profile: &state::AssetOracleProfileV16,
-        now_slot: u64,
-    ) -> bool {
-        cfg.permissionless_resolve_stale_slots != 0
-            && now_slot.saturating_sub(profile.last_good_oracle_slot)
-                >= cfg.permissionless_resolve_stale_slots
-    }
-
     fn global_or_profile_resolve_matured_at_slot(
         cfg: &WrapperConfigV16,
         profile: &state::AssetOracleProfileV16,
         now_slot: u64,
     ) -> bool {
         oracle_v16::permissionless_stale_matured(cfg, now_slot)
-            || (oracle_v16::profile_is_price_managed(profile)
-                && permissionless_resolve_matured_for_profile_at_slot(cfg, profile, now_slot))
+            || policy_v16::price_managed_profile_resolve_matured(
+                oracle_v16::profile_is_price_managed(profile),
+                cfg.permissionless_resolve_stale_slots,
+                profile.last_good_oracle_slot,
+                now_slot,
+            )
     }
 
     fn reject_permissionless_resolve_matured_live_view(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26845,7 +26845,8 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
         100 * BOUND_SCALE
     );
     assert_eq!(
-        fresh_group.source_backing_buckets[2].utilization_fee_earnings, 30
+        fresh_group.source_backing_buckets[2].utilization_fee_earnings,
+        30
     );
     assert!(
         has_active_leg_for_asset(&env.portfolio_state(long), 1),
@@ -26979,7 +26980,9 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
     env.push_auth_mark_for_asset_with_authority(1, &creator, 7, 100);
     let (fresh_dest, _) = env
         .try_withdraw_insurance_asset_with_authority(&creator, 1, 50)
-        .expect("after a public asset-1 oracle refresh, live insurance withdrawal remains reachable");
+        .expect(
+            "after a public asset-1 oracle refresh, live insurance withdrawal remains reachable",
+        );
     assert_eq!(env.token_amount(fresh_dest), 50);
 
     env.svm.expire_blockhash();
@@ -27003,6 +27006,33 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
         "after a public asset-1 oracle refresh, backing withdrawal remains reachable: {fresh_backing:?}"
     );
     assert_eq!(env.token_amount(backing_dest), 50);
+
+    env.svm.expire_blockhash();
+    let fresh_earnings = env.send(
+        ProgInstruction::WithdrawBackingBucketEarnings {
+            domain: 2,
+            amount: 10,
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(earnings_ledger, false),
+            AccountMeta::new(earnings_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    );
+    assert!(
+        fresh_earnings.is_ok(),
+        "after a public asset-1 oracle refresh, earnings withdrawal remains reachable: {fresh_earnings:?}"
+    );
+    assert_eq!(env.token_amount(earnings_dest), 10);
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[2].utilization_fee_earnings,
+        20
+    );
 }
 
 // security.md sweep - slot-zero local stale bypass (#24/#30/#37): a non-base price-managed asset can

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26868,6 +26868,13 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
 
     env.svm.expire_blockhash();
     let stale_insurance = env.try_withdraw_insurance_asset_with_authority(&creator, 1, 50);
+    if let Ok((dest, _)) = &stale_insurance {
+        assert_eq!(
+            env.token_amount(*dest),
+            50,
+            "an accepted stale insurance withdrawal moves real custody"
+        );
+    }
     assert!(
         stale_insurance.is_err(),
         "WithdrawInsuranceAsset must not drain protection from a locally stale non-base asset"
@@ -26911,6 +26918,13 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
         ],
         &[&creator],
     );
+    if stale_backing.is_ok() {
+        assert_eq!(
+            env.token_amount(backing_dest),
+            50,
+            "an accepted stale backing withdrawal moves real custody"
+        );
+    }
     assert!(
         stale_backing.is_err(),
         "WithdrawBackingBucket must not drain backing from a locally stale non-base asset"
@@ -26951,6 +26965,13 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
         ],
         &[&creator],
     );
+    if stale_earnings.is_ok() {
+        assert_eq!(
+            env.token_amount(earnings_dest),
+            10,
+            "an accepted stale earnings withdrawal moves real custody"
+        );
+    }
     assert!(
         stale_earnings.is_err(),
         "WithdrawBackingBucketEarnings must not drain provider earnings from a locally stale non-base asset"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26772,6 +26772,180 @@ fn v16_attack_stale_permissionless_asset_cannot_global_resolve_market() {
     assert!(group_after_trade.assets[1].oi_eff_long_q > 0);
 }
 
+#[test]
+fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.update_market_init_fee_policy_with_cu(1);
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.configure_auth_mark_with_cu(1, 100);
+
+    let creator = Keypair::new();
+    let creator_key = creator.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        1,
+        1,
+        100,
+        creator_key,
+        creator_key,
+        creator_key,
+        creator_key,
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &creator, 1, 100);
+    env.top_up_insurance_domain_with_authority(&creator, 2, 100);
+    env.top_up_insurance_domain_with_authority(&creator, 3, 100);
+    env.top_up_backing_bucket_with_authority(&creator, 2, 100, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_with_cu(3, 100);
+    let base_resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        base_resolve.is_err(),
+        "base market is fresh; this probe must isolate asset-1 local stale"
+    );
+    let (_, fresh_group) = env.market_state();
+    assert_eq!(fresh_group.insurance_domain_budget[2], 100);
+    assert_eq!(fresh_group.insurance_domain_budget[3], 100);
+    assert_eq!(
+        fresh_group.source_backing_buckets[2].fresh_unliened_backing_num,
+        100 * BOUND_SCALE
+    );
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(long), 1),
+        "setup must leave asset-1 OI protected by the funded domains"
+    );
+
+    env.svm.warp_to_slot(7);
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+            .unwrap();
+    assert_eq!(
+        profile.last_good_oracle_slot, 1,
+        "asset-1 profile must be locally stale by slot 7"
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let long_before = env.svm.get_account(&long).unwrap();
+    let short_before = env.svm.get_account(&short).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+
+    env.svm.expire_blockhash();
+    let stale_insurance = env.try_withdraw_insurance_asset_with_authority(&creator, 1, 50);
+    assert!(
+        stale_insurance.is_err(),
+        "WithdrawInsuranceAsset must not drain protection from a locally stale non-base asset"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected local-stale insurance withdrawal leaves market accounting unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&long).unwrap(),
+        long_before,
+        "rejected local-stale insurance withdrawal leaves the long unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&short).unwrap(),
+        short_before,
+        "rejected local-stale insurance withdrawal leaves the short unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected local-stale insurance withdrawal moves no custody"
+    );
+
+    let backing_dest = env.token_account_for_mint(env.mint, creator.pubkey(), 0);
+    let backing_dest_before = env.svm.get_account(&backing_dest).unwrap();
+    env.svm.expire_blockhash();
+    let stale_backing = env.send(
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 2,
+            amount: 50,
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    );
+    assert!(
+        stale_backing.is_err(),
+        "WithdrawBackingBucket must not drain backing from a locally stale non-base asset"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected local-stale backing withdrawal leaves market accounting unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&backing_dest).unwrap(),
+        backing_dest_before,
+        "rejected local-stale backing withdrawal pays no tokens"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected local-stale backing withdrawal moves no custody"
+    );
+
+    env.svm.expire_blockhash();
+    env.push_auth_mark_for_asset_with_authority(1, &creator, 7, 100);
+    let (fresh_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&creator, 1, 50)
+        .expect("after a public asset-1 oracle refresh, live insurance withdrawal remains reachable");
+    assert_eq!(env.token_amount(fresh_dest), 50);
+
+    env.svm.expire_blockhash();
+    let fresh_backing = env.send(
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 2,
+            amount: 50,
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    );
+    assert!(
+        fresh_backing.is_ok(),
+        "after a public asset-1 oracle refresh, backing withdrawal remains reachable: {fresh_backing:?}"
+    );
+    assert_eq!(env.token_amount(backing_dest), 50);
+}
+
 // security.md sweep - slot-zero local stale bypass (#24/#30/#37): a non-base price-managed asset can
 // be configured at the authenticated genesis slot. Its local stale clock must still mature; otherwise
 // stale AuthMark/EWMA assets born at slot 0 can keep trading forever while the base oracle stays fresh.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -26797,6 +26797,17 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
     env.top_up_insurance_domain_with_authority(&creator, 2, 100);
     env.top_up_insurance_domain_with_authority(&creator, 3, 100);
     env.top_up_backing_bucket_with_authority(&creator, 2, 100, 100);
+    let earnings_ledger = env.backing_domain_ledger_account();
+    env.mutate_market(|_, group| {
+        group.source_backing_buckets[2].utilization_fee_earnings = 30;
+        group.vault += 30;
+    });
+    env.set_token_account_amount(
+        env.vault,
+        env.mint,
+        env.vault_authority,
+        env.market_state().1.vault as u64,
+    );
 
     let long_owner = Keypair::new();
     let short_owner = Keypair::new();
@@ -26832,6 +26843,9 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
     assert_eq!(
         fresh_group.source_backing_buckets[2].fresh_unliened_backing_num,
         100 * BOUND_SCALE
+    );
+    assert_eq!(
+        fresh_group.source_backing_buckets[2].utilization_fee_earnings, 30
     );
     assert!(
         has_active_leg_for_asset(&env.portfolio_state(long), 1),
@@ -26914,6 +26928,51 @@ fn v16_attack_non_base_local_stale_domain_withdrawals_reject() {
         env.svm.get_account(&env.vault).unwrap(),
         vault_before,
         "rejected local-stale backing withdrawal moves no custody"
+    );
+
+    let earnings_dest = env.token_account_for_mint(env.mint, creator.pubkey(), 0);
+    let earnings_dest_before = env.svm.get_account(&earnings_dest).unwrap();
+    let earnings_ledger_before = env.svm.get_account(&earnings_ledger).unwrap();
+    env.svm.expire_blockhash();
+    let stale_earnings = env.send(
+        ProgInstruction::WithdrawBackingBucketEarnings {
+            domain: 2,
+            amount: 10,
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(earnings_ledger, false),
+            AccountMeta::new(earnings_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&creator],
+    );
+    assert!(
+        stale_earnings.is_err(),
+        "WithdrawBackingBucketEarnings must not drain provider earnings from a locally stale non-base asset"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected local-stale earnings withdrawal leaves market accounting unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&earnings_ledger).unwrap(),
+        earnings_ledger_before,
+        "rejected local-stale earnings withdrawal leaves the provider ledger unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&earnings_dest).unwrap(),
+        earnings_dest_before,
+        "rejected local-stale earnings withdrawal pays no tokens"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected local-stale earnings withdrawal moves no custody"
     );
 
     env.svm.expire_blockhash();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -35,6 +35,62 @@ fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
 }
 
 #[kani::proof]
+fn kani_v16_price_managed_profile_resolve_boundary_is_exact_and_live() {
+    let price_managed = kani::any::<bool>();
+    let resolve_stale_slots = kani::any::<u64>();
+    let last_good_oracle_slot = kani::any::<u64>();
+    let now_slot = kani::any::<u64>();
+    let matured = policy_v16::price_managed_profile_resolve_matured(
+        price_managed,
+        resolve_stale_slots,
+        last_good_oracle_slot,
+        now_slot,
+    );
+
+    kani::cover!(
+        matured && now_slot - last_good_oracle_slot == resolve_stale_slots,
+        "exact local-stale boundary matures"
+    );
+    kani::cover!(
+        matured && now_slot - last_good_oracle_slot > resolve_stale_slots,
+        "profile stays matured after the boundary"
+    );
+    kani::cover!(
+        price_managed
+            && resolve_stale_slots != 0
+            && now_slot >= last_good_oracle_slot
+            && now_slot - last_good_oracle_slot < resolve_stale_slots
+            && !matured,
+        "fresh price-managed profile remains live"
+    );
+    kani::cover!(
+        now_slot < last_good_oracle_slot && !matured,
+        "regressed slot cannot manufacture maturity"
+    );
+    kani::cover!(
+        (!price_managed || resolve_stale_slots == 0) && !matured,
+        "unmanaged or disabled profiles never mature locally"
+    );
+
+    if matured {
+        assert!(price_managed);
+        assert!(resolve_stale_slots != 0);
+        assert!(now_slot >= last_good_oracle_slot);
+        assert!(now_slot - last_good_oracle_slot >= resolve_stale_slots);
+    }
+    if price_managed
+        && resolve_stale_slots != 0
+        && now_slot >= last_good_oracle_slot
+        && now_slot - last_good_oracle_slot >= resolve_stale_slots
+    {
+        assert!(matured);
+    }
+    if !price_managed || resolve_stale_slots == 0 || now_slot < last_good_oracle_slot {
+        assert!(!matured);
+    }
+}
+
+#[kani::proof]
 fn kani_v16_init_market_decode_preserves_wire_fields() {
     // Full-width symbolic inputs (audit: avoid the u16->u64/u128 widening collapse so
     // narrow-read / high-byte decode bugs are observable).


### PR DESCRIPTION
## Root cause

The shared live-domain withdrawal gate checked global resolve maturity, market stress/lock state, local loss staleness, and target/effective lag, but not the selected non-base profile's local oracle-stale clock.

## Impact and red

A permissionless asset authority could keep asset 0 fresh, let its own price-managed asset mature locally with open OI, then remove protection before a fresh local mark or wind-down. With the profile-aware gate manually removed on current `main`, independent red runs confirm that the stale authority can move:

- 50 insurance atoms
- 50 backing-principal atoms
- 10 provider-earnings atoms

Each amount reaches the authority’s token account before the regression rejects the behavior.

## Fix

`live_domain_withdraw_health_or_shutdown_view` now loads the selected asset profile and applies the profile-aware resolve-maturity gate before allowing live insurance, backing-principal, or provider-earnings withdrawals. The terminal empty-and-matured shutdown escape remains first, preserving wind-down liveness.

## PDD coverage

`v16_attack_non_base_local_stale_domain_withdrawals_reject` creates a permissionless non-base AuthMark asset, publicly funds its insurance and backing, opens real OI, keeps asset 0 fresh, and matures only asset 1. It proves all three withdrawals reject atomically, then refreshes asset 1 and proves insurance, backing principal, and earnings are all withdrawable again.

Provider earnings are installed as valid vault-backed test state because this regression targets the withdrawal gate, not the separate source-lien accrual path. Insurance and backing principal are funded through public instructions.

`kani_v16_price_managed_profile_resolve_boundary_is_exact_and_live` invokes the production predicate over full-width symbolic slots. It proves exact/post-boundary maturity, pre-boundary liveness, regressed-slot safety, and unmanaged/disabled-profile liveness. All 5 covers are reached in 0.21 seconds.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 569 passed (5 unit + 564 LiteSVM)
- new Kani harness: successful, 5/5 covers reached
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with existing baseline warnings)

Head: `b24f063cc228ed8a1963497ec2b40431af2ab16d`.
