### PR TITLE
[codex] Reject local-stale no-observation liquidation

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4080,6 +4080,17 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
+    pub fn missing_selected_observation_is_resolve_matured(
+        price_managed: bool,
+        resolve_stale_slots: u64,
+        last_good_oracle_slot: u64,
+        now_slot: u64,
+    ) -> bool {
+        price_managed
+            && resolve_stale_slots != 0
+            && now_slot.saturating_sub(last_good_oracle_slot) >= resolve_stale_slots
+    }
+
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
             return Some(0);
@@ -10813,10 +10824,16 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
-        if !oracle_v16::profile_is_price_managed(&profile) {
+        let price_managed = oracle_v16::profile_is_price_managed(&profile);
+        if !price_managed {
             return Ok(());
         }
-        if permissionless_resolve_matured_for_profile_at_slot(cfg, &profile, now_slot) {
+        if policy_v16::missing_selected_observation_is_resolve_matured(
+            price_managed,
+            cfg.permissionless_resolve_stale_slots,
+            profile.last_good_oracle_slot,
+            now_slot,
+        ) {
             return Err(PercolatorError::OracleStale.into());
         }
         let asset = group.markets[asset_index].engine.asset;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10816,6 +10816,9 @@ pub mod processor {
         if !oracle_v16::profile_is_price_managed(&profile) {
             return Ok(());
         }
+        if permissionless_resolve_matured_for_profile_at_slot(cfg, &profile, now_slot) {
+            return Err(PercolatorError::OracleStale.into());
+        }
         let asset = group.markets[asset_index].engine.asset;
         let dt = asset_segment_dt_view(group, asset_index, now_slot)?;
         if dt == 0 {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10017,6 +10017,145 @@ fn v16_attack_stale_resolve_matured_no_observation_liquidation_rejects() {
 }
 
 #[test]
+fn v16_attack_non_base_local_stale_no_observation_liquidation_rejects() {
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.update_market_init_fee_policy_with_cu(1);
+    env.top_up_insurance(1_000_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+
+    let creator = Keypair::new();
+    let creator_key = creator.pubkey();
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        1,
+        1,
+        100,
+        creator_key,
+        creator_key,
+        creator_key,
+        creator_key,
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &creator, 1, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 10_000);
+    env.deposit(&short_owner, short_account, 3_000);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        (10 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_with_authority(1, &creator, 2, 300);
+    env.crank(
+        short_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            close_q: 0,
+            observations: crank_observations(1),
+        },
+    );
+    env.svm.warp_to_slot(3);
+    env.crank(
+        short_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            close_q: 0,
+            observations: crank_observations(1),
+        },
+    );
+    assert!(
+        health_cert(&env.portfolio_state(short_account)).certified_liq_deficit != 0,
+        "setup must be liquidatable before local-stale probe"
+    );
+
+    env.svm.warp_to_slot(7);
+    env.push_auth_mark_with_cu(7, 100);
+    let base_resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        base_resolve.is_err(),
+        "base market is fresh; this probe must isolate asset-1 local stale"
+    );
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+            .unwrap();
+    assert_eq!(profile.last_good_oracle_slot, 2);
+
+    let before_group = env.market_state().1;
+    let before_market = env.svm.get_account(&env.market).unwrap();
+    let before_short = env.svm.get_account(&short_account).unwrap();
+    env.svm.expire_blockhash();
+    let result = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 7,
+            close_q: POS_SCALE,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short_account, false),
+        ],
+        &[],
+    );
+    if result.is_ok() {
+        let after_group = env.market_state().1;
+        assert!(
+            after_group.assets[1].oi_eff_short_q < before_group.assets[1].oi_eff_short_q,
+            "accepted local-stale no-observation liquidation must be a real liquidation, not a no-op"
+        );
+    }
+    let err = result
+        .expect_err("local-stale no-observation liquidation must reject before live mutation");
+    assert!(
+        err.contains("Custom(27)") || err.contains("custom program error: 0x1b"),
+        "local-stale no-observation liquidation should fail as OracleStale, got: {err}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_market);
+    assert_eq!(env.svm.get_account(&short_account).unwrap(), before_short);
+
+    env.svm.expire_blockhash();
+    env.push_auth_mark_for_asset_with_authority(1, &creator, 7, 300);
+    let fresh_liquidation = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 7,
+            close_q: POS_SCALE,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short_account, false),
+        ],
+        &[],
+    );
+    assert!(
+        fresh_liquidation.is_ok(),
+        "after a public asset-1 refresh, the bounded liquidation remains reachable: {fresh_liquidation:?}"
+    );
+    assert!(
+        env.market_state().1.assets[1].oi_eff_short_q < before_group.assets[1].oi_eff_short_q,
+        "fresh liquidation reduces asset-1 OI"
+    );
+}
+
+#[test]
 fn v16_attack_stale_resolve_matured_b_stale_cleanup_still_progresses() {
     let mut env = V16CuEnv::new();
     env.configure_permissionless_resolve_with_cu(5, 5);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10063,7 +10063,6 @@ fn v16_attack_non_base_local_stale_no_observation_liquidation_rejects() {
         short_account,
         ProgInstruction::PermissionlessCrank {
             now_slot: 2,
-            close_q: 0,
             observations: crank_observations(1),
         },
     );
@@ -10072,7 +10071,6 @@ fn v16_attack_non_base_local_stale_no_observation_liquidation_rejects() {
         short_account,
         ProgInstruction::PermissionlessCrank {
             now_slot: 3,
-            close_q: 0,
             observations: crank_observations(1),
         },
     );
@@ -10104,7 +10102,6 @@ fn v16_attack_non_base_local_stale_no_observation_liquidation_rejects() {
     let result = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 7,
-            close_q: POS_SCALE,
             observations: vec![],
         },
         vec![
@@ -10135,7 +10132,6 @@ fn v16_attack_non_base_local_stale_no_observation_liquidation_rejects() {
     let fresh_liquidation = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 7,
-            close_q: POS_SCALE,
             observations: vec![],
         },
         vec![

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -35,6 +35,62 @@ fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
 }
 
 #[kani::proof]
+fn kani_v16_missing_selected_observation_resolve_boundary_is_exact_and_live() {
+    let price_managed = kani::any::<bool>();
+    let resolve_stale_slots = kani::any::<u64>();
+    let last_good_oracle_slot = kani::any::<u64>();
+    let now_slot = kani::any::<u64>();
+    let rejected = policy_v16::missing_selected_observation_is_resolve_matured(
+        price_managed,
+        resolve_stale_slots,
+        last_good_oracle_slot,
+        now_slot,
+    );
+
+    kani::cover!(
+        rejected && now_slot - last_good_oracle_slot == resolve_stale_slots,
+        "exact local-stale boundary rejects"
+    );
+    kani::cover!(
+        rejected && now_slot - last_good_oracle_slot > resolve_stale_slots,
+        "matured selected profile rejects after the boundary"
+    );
+    kani::cover!(
+        price_managed
+            && resolve_stale_slots != 0
+            && now_slot >= last_good_oracle_slot
+            && now_slot - last_good_oracle_slot < resolve_stale_slots
+            && !rejected,
+        "fresh selected profile remains live"
+    );
+    kani::cover!(
+        now_slot < last_good_oracle_slot && !rejected,
+        "regressed slot cannot manufacture staleness"
+    );
+    kani::cover!(
+        (!price_managed || resolve_stale_slots == 0) && !rejected,
+        "unmanaged or disabled profiles remain live"
+    );
+
+    if rejected {
+        assert!(price_managed);
+        assert!(resolve_stale_slots != 0);
+        assert!(now_slot >= last_good_oracle_slot);
+        assert!(now_slot - last_good_oracle_slot >= resolve_stale_slots);
+    }
+    if price_managed
+        && resolve_stale_slots != 0
+        && now_slot >= last_good_oracle_slot
+        && now_slot - last_good_oracle_slot >= resolve_stale_slots
+    {
+        assert!(rejected);
+    }
+    if !price_managed || resolve_stale_slots == 0 || now_slot < last_good_oracle_slot {
+        assert!(!rejected);
+    }
+}
+
+#[kani::proof]
 fn kani_v16_init_market_decode_preserves_wire_fields() {
     // Full-width symbolic inputs (audit: avoid the u16->u64/u128 widening collapse so
     // narrow-read / high-byte decode bugs are observable).


### PR DESCRIPTION
## Root cause

`PermissionlessCrank` required a selected-asset observation only while a price-managed asset still had pending effective-price movement. A non-base AuthMark/EWMA profile could therefore be locally resolve-matured but fully applied, allowing a public no-observation liquidation against stale selected-asset data while the base market remained fresh.

## Impact and red

The public LiteSVM lifecycle creates a permissionless non-base AuthMark asset, opens real OI, makes the short liquidatable, refreshes only the base profile, and matures only asset 1. With the guard manually removed on current `main`, the no-observation crank succeeds at `253,494` CU and reduces asset-1 short OI before the regression fails. This is a state-changing stale-price liquidation, not an injected state or no-op.

## Fix

For a price-managed selected asset, reject a missing observation once that profile reaches its configured permissionless-resolve boundary. Fresh profiles and non-price-managed profiles retain their prior liveness behavior. The wrapper still delegates liquidation sizing to the engine.

## PDD coverage

`v16_attack_non_base_local_stale_no_observation_liquidation_rejects` proves through public instructions that:

- asset 1 is locally stale while the base market is fresh
- no-observation liquidation rejects as `OracleStale` with market and portfolio bytes unchanged
- a public selected-asset refresh restores bounded liquidation progress

`kani_v16_missing_selected_observation_resolve_boundary_is_exact_and_live` calls the production policy kernel over full-width symbolic slots. It proves exact-boundary and post-boundary rejection, fresh-profile liveness, regressed-slot safety, and unmanaged/disabled-profile liveness. All five covers are reached in 0.22 seconds.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 569 passed (5 unit + 564 LiteSVM)
- new Kani harness: successful, 5/5 covers reached
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with existing baseline warnings)

Head: `3805e83291fce156b10662a4da01b81e1c248c91`.
