### PR TITLE
[PARTIAL LoF] Clamp EWMA movement to collected trade fees

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5874,11 +5874,17 @@ pub mod processor {
                 outcome.fee_a,
                 outcome.fee_b,
             )?;
+            let collected_post_trade_mark = collected_fee_supported_mark_view(
+                &oracle_profile,
+                fee_quote,
+                outcome.fee_a,
+                outcome.fee_b,
+            )?;
             update_hybrid_mark_after_trade_view(
                 &mut oracle_profile,
                 &group,
                 asset_index as usize,
-                fee_quote.post_trade_mark_e6,
+                collected_post_trade_mark,
             )?;
             write_oracle_profile_to_view(&mut group, asset_index as usize, &oracle_profile)?;
             if asset_index == 0 && oracle_v16::profile_is_price_managed(&oracle_profile) {
@@ -6087,33 +6093,40 @@ pub mod processor {
                 )
                 .map_err(map_v16_error)?;
 
-            // Post-pass: split fees back to each asset's domains and drive its hybrid mark. Fees are
-            // reconstructed deterministically per leg; the running total must equal the engine's
-            // aggregate or we refuse the batch (no silent mis-accounting).
-            let mut reconstructed_total: u128 = 0;
+            // The engine reports one collected-fee aggregate per account. Allocate each aggregate
+            // against requested fees in request order. This deterministic wrapper policy conserves
+            // the engine total while keeping risk-reducing exits live; no asset is credited, or has
+            // its mark moved, using a fee that the engine did not collect.
+            let mut remaining_fee_a = outcome.fee_a;
+            let mut remaining_fee_b = outcome.fee_b;
             let mut cfg_dirty = false;
             for (asset_index, oracle_profile, fee_basis_price, fee_quote, abs_size) in
                 leg_ctx.iter_mut()
             {
-                let fee_leg = batch_leg_fee(*abs_size, *fee_basis_price, fee_quote.fee_bps)?;
+                let requested_fee_leg =
+                    batch_leg_fee(*abs_size, *fee_basis_price, fee_quote.fee_bps)?;
+                let fee_a = requested_fee_leg.min(remaining_fee_a);
+                let fee_b = requested_fee_leg.min(remaining_fee_b);
+                remaining_fee_a = remaining_fee_a
+                    .checked_sub(fee_a)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                remaining_fee_b = remaining_fee_b
+                    .checked_sub(fee_b)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
                 credit_trade_fees_to_market_budgets_view(
                     &cfg,
                     &mut group,
                     *asset_index,
-                    fee_leg,
-                    fee_leg,
+                    fee_a,
+                    fee_b,
                 )?;
-                let total_fee_leg = fee_leg
-                    .checked_add(fee_leg)
-                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-                reconstructed_total = reconstructed_total
-                    .checked_add(total_fee_leg)
-                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                let collected_post_trade_mark =
+                    collected_fee_supported_mark_view(oracle_profile, *fee_quote, fee_a, fee_b)?;
                 update_hybrid_mark_after_trade_view(
                     oracle_profile,
                     &group,
                     *asset_index,
-                    fee_quote.post_trade_mark_e6,
+                    collected_post_trade_mark,
                 )?;
                 write_oracle_profile_to_view(&mut group, *asset_index, oracle_profile)?;
                 if *asset_index == 0 && oracle_v16::profile_is_price_managed(oracle_profile) {
@@ -6122,11 +6135,7 @@ pub mod processor {
                     cfg_dirty = true;
                 }
             }
-            let engine_total = outcome
-                .fee_a
-                .checked_add(outcome.fee_b)
-                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-            if reconstructed_total != engine_total {
+            if remaining_fee_a != 0 || remaining_fee_b != 0 {
                 return Err(PercolatorError::EngineArithmeticOverflow.into());
             }
             if cfg_dirty {
@@ -11425,6 +11434,8 @@ pub mod processor {
     struct HybridTradeFeeQuote {
         fee_bps: u64,
         post_trade_mark_e6: u64,
+        base_fee_paid: u128,
+        mark_externality_notional: u128,
     }
 
     fn two_sided_trade_fee_paid_view(notional: u128, fee_bps: u64) -> Result<u128, ProgramError> {
@@ -11540,12 +11551,16 @@ pub mod processor {
             return Ok(HybridTradeFeeQuote {
                 fee_bps: base,
                 post_trade_mark_e6: 0,
+                base_fee_paid: 0,
+                mark_externality_notional: 0,
             });
         }
         if oracle_v16::profile_is_auth_mark(profile) {
             return Ok(HybridTradeFeeQuote {
                 fee_bps: base,
                 post_trade_mark_e6: 0,
+                base_fee_paid: 0,
+                mark_externality_notional: 0,
             });
         }
         let now_slot = authenticated_market_slot_or_fallback_view(group);
@@ -11555,6 +11570,8 @@ pub mod processor {
             return Ok(HybridTradeFeeQuote {
                 fee_bps: base,
                 post_trade_mark_e6: 0,
+                base_fee_paid: 0,
+                mark_externality_notional: 0,
             });
         }
         if asset_index >= group.header.config.max_market_slots.get() as usize
@@ -11563,6 +11580,8 @@ pub mod processor {
             return Ok(HybridTradeFeeQuote {
                 fee_bps: base,
                 post_trade_mark_e6: 0,
+                base_fee_paid: 0,
+                mark_externality_notional: 0,
             });
         }
         let asset = group.markets[asset_index].engine.asset;
@@ -11636,7 +11655,35 @@ pub mod processor {
         Ok(HybridTradeFeeQuote {
             fee_bps,
             post_trade_mark_e6,
+            base_fee_paid,
+            mark_externality_notional,
         })
+    }
+
+    fn collected_fee_supported_mark_view(
+        profile: &state::AssetOracleProfileV16,
+        quote: HybridTradeFeeQuote,
+        fee_a: u128,
+        fee_b: u128,
+    ) -> Result<u64, ProgramError> {
+        if quote.post_trade_mark_e6 == 0 || quote.mark_externality_notional == 0 {
+            return Ok(quote.post_trade_mark_e6);
+        }
+        let collected = fee_a
+            .checked_add(fee_b)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        let externality_fee = collected.saturating_sub(quote.base_fee_paid);
+        let supported_move_bps = externality_fee
+            .checked_mul(10_000)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?
+            .checked_div(quote.mark_externality_notional)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        Ok(oracle_v16::clamp_toward_engine_dt(
+            profile.mark_ewma_e6,
+            quote.post_trade_mark_e6,
+            u64::try_from(supported_move_bps).unwrap_or(u64::MAX),
+            1,
+        ))
     }
 
     fn hybrid_effective_price_for_crank_view(

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4127,6 +4127,42 @@ pub mod policy_v16 {
         u64::try_from(bps).ok()
     }
 
+    pub fn collected_fee_supported_mark(
+        old_mark_e6: u64,
+        quoted_mark_e6: u64,
+        base_fee_paid: u128,
+        mark_externality_notional: u128,
+        fee_a: u128,
+        fee_b: u128,
+    ) -> Option<u64> {
+        if quoted_mark_e6 == 0 || mark_externality_notional == 0 {
+            return Some(quoted_mark_e6);
+        }
+        let collected = fee_a.checked_add(fee_b)?;
+        let externality_fee = collected.saturating_sub(base_fee_paid);
+        let supported_move_bps = externality_fee
+            .checked_mul(10_000)?
+            .checked_div(mark_externality_notional)?;
+        Some(clamp_mark_to_supported_move_bps(
+            old_mark_e6,
+            quoted_mark_e6,
+            u64::try_from(supported_move_bps).unwrap_or(u64::MAX),
+        ))
+    }
+
+    pub fn clamp_mark_to_supported_move_bps(
+        old_mark_e6: u64,
+        quoted_mark_e6: u64,
+        supported_move_bps: u64,
+    ) -> u64 {
+        super::oracle_v16::clamp_toward_engine_dt(
+            old_mark_e6,
+            quoted_mark_e6,
+            supported_move_bps,
+            1,
+        )
+    }
+
     pub fn premium_funding_rate_e9(
         mark_e6: u64,
         index_e6: u64,
@@ -11666,24 +11702,15 @@ pub mod processor {
         fee_a: u128,
         fee_b: u128,
     ) -> Result<u64, ProgramError> {
-        if quote.post_trade_mark_e6 == 0 || quote.mark_externality_notional == 0 {
-            return Ok(quote.post_trade_mark_e6);
-        }
-        let collected = fee_a
-            .checked_add(fee_b)
-            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        let externality_fee = collected.saturating_sub(quote.base_fee_paid);
-        let supported_move_bps = externality_fee
-            .checked_mul(10_000)
-            .ok_or(PercolatorError::EngineArithmeticOverflow)?
-            .checked_div(quote.mark_externality_notional)
-            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        Ok(oracle_v16::clamp_toward_engine_dt(
+        policy_v16::collected_fee_supported_mark(
             profile.mark_ewma_e6,
             quote.post_trade_mark_e6,
-            u64::try_from(supported_move_bps).unwrap_or(u64::MAX),
-            1,
-        ))
+            quote.base_fee_paid,
+            quote.mark_externality_notional,
+            fee_a,
+            fee_b,
+        )
+        .ok_or(PercolatorError::EngineArithmeticOverflow.into())
     }
 
     fn hybrid_effective_price_for_crank_view(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59602,3 +59602,119 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+fn assert_underfunded_ewma_exit_uses_collected_fee(path: NoCpiReportedPricePath) {
+    const MARK: u64 = 1_000_000;
+    const SIZE_Q: i128 = POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: MARK,
+        max_trading_fee_bps: 10_000,
+        max_price_move_bps_per_slot: 10_000,
+        max_accrual_dt_slots: 1,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_ewma_mark_with_cu(0, MARK, 1, 0);
+    let (long_owner, long, short_owner, short) =
+        funded_no_cpi_reported_price_pair(&mut env, MARK as u128);
+
+    try_no_cpi_reported_price_trade_with_cu(
+        &mut env,
+        path,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        SIZE_Q,
+        MARK,
+        0,
+    )
+    .unwrap_or_else(|err| panic!("{path:?}: setup open failed: {err}"));
+
+    // A legitimate oracle-authority update and public cranks leave the long healthy at the exact
+    // maintenance boundary, but with less capital than the maximum fee on a full exit.
+    env.svm.warp_to_slot(10);
+    env.push_ewma_mark_with_cu(10, 1);
+    for account in [long, short] {
+        env.svm.expire_blockhash();
+        env.crank(
+            account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 10,
+                close_q: 0,
+                observations: crank_observations(0),
+            },
+        );
+    }
+
+    env.svm.warp_to_slot(20);
+    let (cfg_before, group_before) = env.market_state();
+    let reported_exit_price = group_before.assets[0]
+        .effective_price
+        .checked_mul(2)
+        .expect("one-slot upper price envelope");
+    let requested_fee_per_side = reported_exit_price as u128;
+    let long_capital = env.portfolio_state(long).capital.get();
+    assert!(
+        0 < long_capital && long_capital < requested_fee_per_side,
+        "{path:?}: setup must make one side's quoted fee partly uncollectible"
+    );
+
+    env.svm.expire_blockhash();
+    let exit = try_no_cpi_reported_price_trade_with_cu(
+        &mut env,
+        path,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        -SIZE_Q,
+        reported_exit_price,
+        0,
+    );
+    assert!(
+        exit.is_ok(),
+        "{path:?}: an underfunded risk-reducing full exit must remain live: {exit:?}"
+    );
+
+    let (cfg_after, group_after) = env.market_state();
+    assert_eq!(group_after.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group_after.assets[0].oi_eff_short_q, 0);
+    let collected_fee = group_after.insurance - group_before.insurance;
+    let quoted_two_sided_fee = requested_fee_per_side * 2;
+    assert!(
+        collected_fee < quoted_two_sided_fee,
+        "{path:?}: setup must exercise a real engine partial fee charge"
+    );
+
+    // The mark externality is priced against max(pre-trade OI notional, trade notional) on both
+    // sides. A successful trade may collect less than quoted, but its EWMA move cannot consume the
+    // uncollectible part as though it were paid.
+    let mark_externality_notional = quoted_two_sided_fee;
+    let paid_move_bps = collected_fee * 10_000 / mark_externality_notional;
+    let mark_move_bps = percolator_prog::policy_v16::price_move_bps_ceil(
+        cfg_before.mark_ewma_e6,
+        cfg_after.mark_ewma_e6,
+    )
+    .expect("mark move bps");
+    assert!(mark_move_bps > 0, "{path:?}: control must move the EWMA");
+    assert!(
+        mark_move_bps <= paid_move_bps as u64,
+        "{path:?}: EWMA move {mark_move_bps} bps exceeds collected-fee support {paid_move_bps} bps"
+    );
+}
+
+// Public-only regression for a fee-backed mark invariant. The engine intentionally allows a full
+// risk-reducing exit to charge only available capital. Single TradeNoCpi used to move EWMA from the
+// nominal quote anyway; BatchTradeNoCpi instead detected the short aggregate and reverted the exit.
+// Both routes must execute, and both may move the mark only as far as their collected fees support.
+#[test]
+fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
+    for path in [
+        NoCpiReportedPricePath::Single,
+        NoCpiReportedPricePath::Batch,
+    ] {
+        assert_underfunded_ewma_exit_uses_collected_fee(path);
+    }
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59642,7 +59642,6 @@ fn assert_underfunded_ewma_exit_uses_collected_fee(path: NoCpiReportedPricePath)
             account,
             ProgInstruction::PermissionlessCrank {
                 now_slot: 10,
-                close_q: 0,
                 observations: crank_observations(0),
             },
         );

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -35,6 +35,66 @@ fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
 }
 
 #[kani::proof]
+fn kani_v16_fee_supported_mark_clamp_is_directional_and_zero_support_is_noop() {
+    let old_mark = kani::any::<u64>();
+    let quoted_mark = kani::any::<u64>();
+    let supported_move_bps = kani::any::<u64>();
+    kani::assume(old_mark > 0 && quoted_mark > 0);
+    let mark =
+        policy_v16::clamp_mark_to_supported_move_bps(old_mark, quoted_mark, supported_move_bps);
+
+    kani::cover!(
+        supported_move_bps == 0,
+        "zero paid support cannot move mark"
+    );
+    kani::cover!(
+        quoted_mark > old_mark && mark > old_mark,
+        "upward paid movement"
+    );
+    kani::cover!(
+        quoted_mark < old_mark && mark < old_mark,
+        "downward paid movement"
+    );
+
+    assert!(mark >= old_mark.min(quoted_mark));
+    assert!(mark <= old_mark.max(quoted_mark));
+    if supported_move_bps == 0 {
+        assert_eq!(mark, old_mark);
+    }
+}
+
+#[kani::proof]
+fn kani_v16_collected_base_fee_cannot_fund_mark_movement() {
+    let old_mark = kani::any::<u64>();
+    let quoted_mark = kani::any::<u64>();
+    let fee_a = kani::any::<u32>() as u128;
+    let fee_b = kani::any::<u32>() as u128;
+    let base_fee_paid = fee_a + fee_b + kani::any::<u32>() as u128;
+    let mark_externality_notional = kani::any::<u32>() as u128 + 1;
+    kani::assume(old_mark > 0 && quoted_mark > 0);
+
+    let mark = policy_v16::collected_fee_supported_mark(
+        old_mark,
+        quoted_mark,
+        base_fee_paid,
+        mark_externality_notional,
+        fee_a,
+        fee_b,
+    )
+    .unwrap();
+
+    kani::cover!(
+        quoted_mark != old_mark && fee_a > 0 && fee_b > 0,
+        "both counterparties pay only base fee against a moving quote"
+    );
+    kani::cover!(
+        base_fee_paid > fee_a + fee_b,
+        "collected fee does not fully cover base fee"
+    );
+    assert_eq!(mark, old_mark);
+}
+
+#[kani::proof]
 fn kani_v16_init_market_decode_preserves_wire_fields() {
     // Full-width symbolic inputs (audit: avoid the u16->u64/u128 widening collapse so
     // narrow-read / high-byte decode bugs are observable).


### PR DESCRIPTION
## Finding

The engine intentionally permits a risk-reducing full exit to collect only the capital that remains. The wrapper's single-trade path nevertheless advanced EWMA using the nominal quoted fee.

A public LiteSVM lifecycle reproduced this without state injection:

- open a normal EWMA position at the mark
- apply a legitimate adverse EWMA update and permissionless cranks
- fully close at a valid dt-clamped reported price
- observe a real partial fee charge
- compare the resulting mark movement with support from collected fees

On the manually reverted implementation, the exact regression fails: EWMA moves 9,090 bps while collected fees support only 7,045 bps. The batch route also compared reconstructed nominal fees with the engine's collected aggregate and reverted an otherwise valid risk-reducing exit.

## Fix

- carry base-fee and mark-externality context in the hybrid quote
- after execution, clamp mark movement to fees the engine actually collected, with base fee paid first
- allocate batch aggregate fees deterministically against per-leg requested fees in engine execution order
- preserve underfunded risk-reducing trade liveness instead of rejecting

## PDD coverage

`v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee` exercises both `TradeNoCpi` and `BatchTradeNoCpi` through public instructions. It proves a real partial charge, successful full exit, zero remaining OI, and mark movement bounded by collected fee support.

Two production-kernel Kani harnesses prove, over full-width marks, that the clamp is directional and zero support cannot move the mark, and that fees insufficient to clear the base fee cannot fund any mark movement. All five non-vacuity covers are reached; both harnesses finish in under 7 seconds.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 569 passed (5 unit + 564 LiteSVM)
- both new Kani harnesses: successful, all covers reached
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with existing baseline warnings)

Head: `7eea209b23e4ebbebcf834130918253c54599402`.
