### PR TITLE
[HARDENING] Unblock zero-OI recovery leg cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed close recovery path; optional deposit is transferred first, then the engine cancels the pending close if the cure succeeds
 - **ForfeitRecoveryLeg** (tag 43)
   - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
+  - after the force-close delay, any signer may refresh and detach a zero-effective-OI, reset-pending Recovery leg only when the engine reports no forfeited PnL or loss flow
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
 - **ClaimResolvedPayoutTopup** (tag 46)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8385,14 +8385,94 @@ pub mod processor {
         if b_delta_budget == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
-            if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
-                return Err(V16Error::LockActive);
+        let actor = account(accounts, 0)?;
+        let market_ai = account(accounts, 1)?;
+        let portfolio_ai = account(accounts, 2)?;
+        expect_signer(actor)?;
+        expect_writable(market_ai)?;
+        expect_writable(portfolio_ai)?;
+        expect_owner(market_ai, program_id)?;
+        expect_owner(portfolio_ai, program_id)?;
+
+        let (_, _, max_market_slots, _) =
+            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        ensure_portfolio_storage_for_market_slots(portfolio_ai, max_market_slots)?;
+
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
+        let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;
+        let mut portfolio =
+            state::portfolio_view_mut_for_market_slots(&mut portfolio_data, max_market_slots)?;
+        expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
+
+        let owner_signed = portfolio.header.owner == actor.key.to_bytes();
+        if !owner_signed {
+            let asset_index = asset_index as usize;
+            if group.header.mode != 0
+                || cfg.force_close_delay_slots == 0
+                || asset_index >= group.header.config.max_market_slots.get() as usize
+                || asset_index >= group.markets.len()
+                || group.markets[asset_index].engine.asset.lifecycle != ASSET_LIFECYCLE_RECOVERY
+            {
+                return Err(PercolatorError::Unauthorized.into());
             }
+            let leg = active_leg_for_asset_view(&portfolio, asset_index)?;
+            let asset = group.markets[asset_index]
+                .engine
+                .asset
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            let side_is_zero_oi_reset = match leg.side {
+                SideV16::Long => {
+                    asset.oi_eff_long_q == 0
+                        && asset.mode_long == percolator::SideModeV16::ResetPending
+                }
+                SideV16::Short => {
+                    asset.oi_eff_short_q == 0
+                        && asset.mode_short == percolator::SideModeV16::ResetPending
+                }
+            };
+            if !side_is_zero_oi_reset {
+                return Err(PercolatorError::Unauthorized.into());
+            }
+            let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
+            let shutdown_slot = profile.last_good_oracle_slot;
+            let now_slot = authenticated_market_slot_or_fallback_view(&group);
+            if shutdown_slot == 0
+                || now_slot < shutdown_slot
+                || now_slot.saturating_sub(shutdown_slot) < cfg.force_close_delay_slots
+            {
+                return Err(PercolatorError::Unauthorized.into());
+            }
+        }
+        if group.header.mode == 0 && permissionless_resolve_matured_now_view(&cfg, &group) {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
+        if !owner_signed {
             group
-                .forfeit_recovery_leg_not_atomic(portfolio, asset_index as usize, b_delta_budget)
-                .map(|_| ())
-        })
+                .full_account_refresh_not_atomic(&mut portfolio)
+                .map_err(map_v16_error)?;
+        }
+        let outcome = group
+            .forfeit_recovery_leg_not_atomic(&mut portfolio, asset_index as usize, b_delta_budget)
+            .map_err(map_v16_error)?;
+        if !owner_signed
+            && (!outcome.detached
+                || outcome.positive_pnl_forfeited != 0
+                || outcome.loss_settled != 0
+                || outcome.support_consumed != 0
+                || outcome.junior_face_burned != 0
+                || outcome.principal_used != 0
+                || outcome.insurance_used != 0
+                || outcome.residual_booked != 0
+                || outcome.explicit_loss != 0)
+        {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
+        group.validate_shape().map_err(map_v16_error)?;
+        portfolio
+            .validate_with_market(&group.as_view())
+            .map_err(map_v16_error)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -40138,6 +40138,15 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
         b_progress_steps > 1,
         "the regression must exercise multi-transaction B progress",
     );
+    assert_eq!(final_asset.lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(final_asset.oi_eff_long_q, 0);
+    assert_eq!(final_asset.mode_long, SideModeV16::ResetPending);
+    let final_profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+            .unwrap();
+    assert_eq!(final_profile.last_good_oracle_slot, 31);
+    assert_eq!(env.market_state().0.force_close_delay_slots, 5);
+    assert_eq!(env.svm.get_sysvar::<Clock>().slot, 37);
 
     let long_before_forfeit = env.portfolio_state(long);
     let capital_before_forfeit = long_before_forfeit.capital.get();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -39957,7 +39957,7 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
     let long = env.create_portfolio(&long_owner);
     let short = env.create_portfolio(&short_owner);
     env.deposit(&long_owner, long, 100_000_000);
-    env.deposit(&short_owner, short, 250_000);
+    env.deposit(&short_owner, short, 110_000);
     env.trade_asset_with_cu(
         0,
         &long_owner,
@@ -39971,22 +39971,29 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
 
     for slot in 1..=30u64 {
         env.svm.warp_to_slot(slot);
-        env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.push_auth_mark_with_cu(slot, 1_070_000);
         env.svm.expire_blockhash();
         let _ = env.send(
             ProgInstruction::PermissionlessCrank {
                 now_slot: slot,
-                close_q: 0,
                 observations: crank_observations(0),
             },
             vec![
                 AccountMeta::new(env.payer.pubkey(), true),
                 AccountMeta::new(env.market, false),
-                AccountMeta::new(short, false),
+                AccountMeta::new(long, false),
             ],
             &[],
         );
     }
+
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+    );
 
     let (_, before_liquidation) = env.market_state();
     assert_eq!(before_liquidation.assets[0].oi_eff_long_q, 2 * POS_SCALE);
@@ -40000,7 +40007,6 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
         short,
         ProgInstruction::PermissionlessCrank {
             now_slot: 30,
-            close_q: POS_SCALE,
             observations: crank_observations(0),
         },
     );
@@ -40023,7 +40029,7 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
     );
 
     env.svm.warp_to_slot(31);
-    env.push_auth_mark_with_cu(31, 2_000_000);
+    env.push_auth_mark_with_cu(31, 1_070_000);
     let admin = env.admin.insecure_clone();
     env.svm.expire_blockhash();
     env.try_shutdown_asset_with_authority(&admin, 0, 31)
@@ -40070,12 +40076,11 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
             .is_err(),
         "paired force-close has no opposite stored leg",
     );
-    let orphan_before = env.svm.get_account(&long).unwrap();
+    let orphan_before = env.portfolio_state(long);
     env.svm.expire_blockhash();
     let recovery_crank = env.send(
         ProgInstruction::PermissionlessCrank {
             now_slot: 37,
-            close_q: 0,
             observations: vec![],
         },
         vec![
@@ -40085,8 +40090,54 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
         ],
         &[],
     );
-    assert!(recovery_crank.is_err());
-    assert_eq!(env.svm.get_account(&long).unwrap(), orphan_before);
+    assert!(
+        recovery_crank.is_ok(),
+        "the current auto-crank can refresh an asset-Recovery account",
+    );
+    let orphan_after_refresh = env.portfolio_state(long);
+    assert!(
+        has_active_leg_for_asset(&orphan_after_refresh, 0),
+        "refresh alone cannot detach the stored zero-OI leg",
+    );
+    assert_eq!(
+        orphan_after_refresh.capital.get(),
+        orphan_before.capital.get(),
+        "refresh cannot take orphan principal",
+    );
+
+    let mut b_progress_steps = 0usize;
+    for _ in 0..2_048 {
+        let leg = active_leg_for_asset(&env.portfolio_state(long), 0);
+        if !leg.b_stale {
+            break;
+        }
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 37,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("bounded public cranks must settle the orphan B backlog");
+        b_progress_steps += 1;
+    }
+    let final_leg = active_leg_for_asset(&env.portfolio_state(long), 0);
+    let final_asset = env.market_state().1.assets[0];
+    assert!(
+        !final_leg.b_stale,
+        "the public crank sequence must reach a B-clean orphan: snap={} target={}",
+        final_leg.b_snap, final_asset.b_epoch_start_long_num,
+    );
+    assert!(
+        b_progress_steps > 1,
+        "the regression must exercise multi-transaction B progress",
+    );
 
     let long_before_forfeit = env.portfolio_state(long);
     let capital_before_forfeit = long_before_forfeit.capital.get();
@@ -40106,9 +40157,10 @@ fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
         capital_before_forfeit,
         "dead-leg cleanup cannot take account principal",
     );
-    assert!(
-        env.portfolio_state(long).pnl.get() > pnl_before_forfeit,
-        "the profitable orphan's latent mark PnL must be booked, not forfeited",
+    assert_eq!(
+        env.portfolio_state(long).pnl.get(),
+        pnl_before_forfeit,
+        "permissionless detach cannot forfeit or create PnL",
     );
 
     for side in [0, 1] {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -28816,9 +28816,9 @@ fn v16_attack_topup_insurance_domain_authority_gated() {
     assert_eq!(g1.vault, g0.vault, "vault unchanged");
     assert!(g1.vault >= g1.c_tot + g1.insurance, "senior conservation");
 }
-// security.md sweep — recovery-tool gating (#6): ForfeitRecoveryLeg is owner-gated
-// (with_one_portfolio_view enforces owner signs + matches the portfolio). FinalizeResetSide is
-// market-only and permissionless, so a bogus victim-portfolio account list must not be accepted.
+// security.md sweep — before the abandoned-asset delay, ForfeitRecoveryLeg is owner-gated.
+// FinalizeResetSide is market-only and permissionless, so a bogus victim-portfolio account list must
+// not be accepted.
 #[test]
 fn v16_attack_recovery_tools_owner_gated() {
     let mut env = V16CuEnv::new();
@@ -39944,6 +39944,243 @@ fn v16_attack_repeated_partial_liquidation_stops_charging_after_health_restored(
         "accounting == real vault"
     );
     assert!(g.vault >= g.c_tot + g.insurance, "senior conservation");
+}
+
+#[test]
+fn v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.configure_permissionless_resolve_with_cu(1_000, 5);
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 100_000_000);
+    env.deposit(&short_owner, short, 250_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        1_000_000,
+        0,
+    );
+
+    for slot in 1..=30u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                close_q: 0,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        );
+    }
+
+    let (_, before_liquidation) = env.market_state();
+    assert_eq!(before_liquidation.assets[0].oi_eff_long_q, 2 * POS_SCALE);
+    assert_eq!(before_liquidation.assets[0].oi_eff_short_q, 2 * POS_SCALE);
+    assert!(
+        health_cert(&env.portfolio_state(short)).certified_liq_deficit > 0,
+        "setup must make the short publicly liquidatable",
+    );
+
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            close_q: POS_SCALE,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, after_liquidation) = env.market_state();
+    let long_after_liquidation = env.portfolio_state(long);
+    let short_after_liquidation = env.portfolio_state(short);
+    assert_eq!(after_liquidation.assets[0].oi_eff_long_q, 0);
+    assert_eq!(after_liquidation.assets[0].oi_eff_short_q, 0);
+    assert!(!has_active_leg_for_asset(&short_after_liquidation, 0));
+    assert_eq!(
+        active_leg_for_asset(&long_after_liquidation, 0)
+            .basis_pos_q
+            .unsigned_abs(),
+        2 * POS_SCALE,
+        "the opposite stored leg remains raw-scaled after unilateral liquidation",
+    );
+    assert!(
+        after_liquidation.assets[0].stored_pos_count_long > 0,
+        "the zero-effective-OI long still needs dead-leg cleanup",
+    );
+
+    env.svm.warp_to_slot(31);
+    env.push_auth_mark_with_cu(31, 2_000_000);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 31)
+        .expect("asset shutdown creates the abandoned-asset recovery window");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery,
+    );
+
+    let cranker = Keypair::new();
+    env.ensure_signer_account(cranker.pubkey());
+    let send_forfeit = |env: &mut V16CuEnv| {
+        env.send(
+            ProgInstruction::ForfeitRecoveryLeg {
+                asset_index: 0,
+                b_delta_budget: percolator::MAX_VAULT_TVL,
+            },
+            vec![
+                AccountMeta::new(cranker.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[&cranker],
+        )
+    };
+
+    env.svm.warp_to_slot(35);
+    let market_before_early = env.svm.get_account(&env.market).unwrap();
+    let long_before_early = env.svm.get_account(&long).unwrap();
+    env.svm.expire_blockhash();
+    assert!(
+        send_forfeit(&mut env).is_err(),
+        "a non-owner cannot forfeit the leg before the configured grace period",
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_early
+    );
+    assert_eq!(env.svm.get_account(&long).unwrap(), long_before_early);
+
+    env.svm.warp_to_slot(37);
+    assert!(
+        env.try_force_close_abandoned_asset_with_cu(&cranker, long, short, 0, 37, 2 * POS_SCALE,)
+            .is_err(),
+        "paired force-close has no opposite stored leg",
+    );
+    let orphan_before = env.svm.get_account(&long).unwrap();
+    env.svm.expire_blockhash();
+    let recovery_crank = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 37,
+            close_q: 0,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long, false),
+        ],
+        &[],
+    );
+    assert!(recovery_crank.is_err());
+    assert_eq!(env.svm.get_account(&long).unwrap(), orphan_before);
+
+    let long_before_forfeit = env.portfolio_state(long);
+    let capital_before_forfeit = long_before_forfeit.capital.get();
+    let pnl_before_forfeit = long_before_forfeit.pnl.get();
+    env.svm.expire_blockhash();
+    let forfeit_cu = send_forfeit(&mut env)
+        .expect("after the grace period, any keeper must be able to clear the dead leg");
+    assert_cu_within(
+        "delayed permissionless dead-leg forfeit",
+        forfeit_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
+    assert_eq!(env.market_state().1.assets[0].stored_pos_count_long, 0);
+    assert_eq!(
+        env.portfolio_state(long).capital.get(),
+        capital_before_forfeit,
+        "dead-leg cleanup cannot take account principal",
+    );
+    assert!(
+        env.portfolio_state(long).pnl.get() > pnl_before_forfeit,
+        "the profitable orphan's latent mark PnL must be booked, not forfeited",
+    );
+
+    for side in [0, 1] {
+        env.svm.expire_blockhash();
+        let finalize_cu = env.finalize_reset_side_with_cu(0, side);
+        assert_cu_within(
+            "post-forfeit side reset finalization",
+            finalize_cu,
+            CUSTODY_CU_LIMIT,
+        );
+    }
+
+    let (_, finalized) = env.market_state();
+    assert_eq!(finalized.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(finalized.assets[0].mode_short, SideModeV16::Normal);
+
+    let mut exposed_env = V16CuEnv::new_with_init_params(production_risk_params());
+    exposed_env.configure_permissionless_resolve_with_cu(1_000, 5);
+    exposed_env.configure_auth_mark_with_cu(0, 1_000_000);
+    let exposed_long_owner = Keypair::new();
+    let exposed_short_owner = Keypair::new();
+    let exposed_long = exposed_env.create_portfolio(&exposed_long_owner);
+    let exposed_short = exposed_env.create_portfolio(&exposed_short_owner);
+    exposed_env.deposit(&exposed_long_owner, exposed_long, 10_000_000);
+    exposed_env.deposit(&exposed_short_owner, exposed_short, 10_000_000);
+    exposed_env.trade_asset_with_cu(
+        0,
+        &exposed_long_owner,
+        exposed_long,
+        &exposed_short_owner,
+        exposed_short,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+    exposed_env.svm.warp_to_slot(1);
+    exposed_env.push_auth_mark_with_cu(1, 1_000_000);
+    let exposed_admin = exposed_env.admin.insecure_clone();
+    exposed_env.svm.expire_blockhash();
+    exposed_env
+        .try_shutdown_asset_with_authority(&exposed_admin, 0, 1)
+        .expect("shutdown permits paired positions to enter bounded recovery");
+    exposed_env.svm.warp_to_slot(7);
+    let exposed_keeper = Keypair::new();
+    exposed_env.ensure_signer_account(exposed_keeper.pubkey());
+    let exposed_market_before = exposed_env.svm.get_account(&exposed_env.market).unwrap();
+    let exposed_long_before = exposed_env.svm.get_account(&exposed_long).unwrap();
+    exposed_env.svm.expire_blockhash();
+    let exposed_forfeit = exposed_env.send(
+        ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: 0,
+            b_delta_budget: percolator::MAX_VAULT_TVL,
+        },
+        vec![
+            AccountMeta::new(exposed_keeper.pubkey(), true),
+            AccountMeta::new(exposed_env.market, false),
+            AccountMeta::new(exposed_long, false),
+        ],
+        &[&exposed_keeper],
+    );
+    assert!(
+        exposed_forfeit.is_err(),
+        "elapsed time cannot make a live-effective Recovery position forfeitable",
+    );
+    assert_eq!(
+        exposed_env.svm.get_account(&exposed_env.market).unwrap(),
+        exposed_market_before,
+    );
+    assert_eq!(
+        exposed_env.svm.get_account(&exposed_long).unwrap(),
+        exposed_long_before,
+    );
 }
 
 // security.md sweep — leveraged bad-debt socialization (#9/#22/#33): at 20x leverage (5% margin) a
@@ -54129,10 +54366,9 @@ fn v16_bpf_oracle_composite_divide_legs_produce_correct_cross_rate() {
     );
 }
 
-// ForfeitRecoveryLeg owner-gating + input guard (sibling of v16_attack_rebalance_reduce_owner_gated, which
-// was tested while ForfeitRecoveryLeg was not). handle_forfeit_recovery_leg uses with_one_portfolio_view
-// (owner_must_sign=true), so a non-owner forfeiting a victim's recovery leg -- which would force the victim
-// to realize a loss -- must reject before any engine mutation. Also guards the b_delta_budget==0 reject.
+// ForfeitRecoveryLeg pre-delay owner gate + input guard. On an active asset, a non-owner forfeiting a
+// victim's leg must reject before any engine mutation. The abandoned-asset exception is covered by the
+// delayed Recovery regression above. Also guards the b_delta_budget==0 reject.
 #[test]
 fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 5_000, 10_000, 1_000);
@@ -54178,7 +54414,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
         "vault unchanged by rejected griefing forfeit"
     );
 
-    // INPUT GUARD: b_delta_budget == 0 rejected (checked before with_one_portfolio_view).
+    // INPUT GUARD: b_delta_budget == 0 rejects before account processing.
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ForfeitRecoveryLeg {


### PR DESCRIPTION
## Finding

A public full liquidation can reduce both sides' effective OI to zero while leaving the profitable opposite account's raw leg stored on a `ResetPending` side. If that asset is then shut down, the absent losing owner leaves no paired leg for `ForceCloseAbandonedAsset`, ordinary account refresh/B cranks cannot detach the stored leg, and the owner-only `ForfeitRecoveryLeg` prevents side reset and asset restart indefinitely.

The rebased LiteSVM PDD reaches this state exclusively through public trade, authenticated mark movement, engine-selected liquidation, shutdown, and bounded permissionless crank transactions. With the parent owner-only handler, the final keeper detach fails exactly with `Custom(8)` (`Unauthorized`) after all refresh and B work is complete.

## Fix

After the authenticated force-close delay, permit any signer to detach only a Recovery leg whose side is `ResetPending` with zero effective OI. The wrapper delegates refresh and detach to the existing zero-copy engine APIs. A non-owner transaction commits only if the engine reports a detached leg and zero forfeited PnL, settled loss, support, junior burn, principal, insurance, residual, or explicit-loss flow. Every rejected transaction is atomically rolled back by SVM.

Owner-authorized forfeits retain their existing behavior. Pre-delay calls, cross-market substitutions, resolve-matured calls, and Recovery positions with nonzero effective OI remain rejected.

## PDD coverage

- Rebased to current `main` and current engine-selected liquidation/crank API; no keeper-controlled `close_q` remains.
- The public setup proves non-vacuous Recovery lifecycle, zero effective OI, `ResetPending`, shutdown slot, configured delay, authenticated clock, and multi-transaction B progress.
- Parent handler: exact regression fails at the final keeper call with `Unauthorized` after all prerequisite progress succeeds.
- Fixed handler: exact regression passes under the custody CU guard, leaves account capital and PnL unchanged, removes the stored leg, and finalizes both side resets.
- A live-effective Recovery position and every pre-delay keeper attempt reject without mutation.

## Validation

- `cargo build-sbf --no-default-features`: passed
- `cargo test --test v16_cu v16_attack_delayed_permissionless_forfeit_clears_zero_oi_orphan -- --nocapture`: passed
- parent-code red run of the same test: failed at final detach with `Custom(8)` as expected
- `cargo test --test v16_cu forfeit_recovery_leg -- --nocapture`: 3 passed
- `cargo test --test v16_cu v16_attack_recovery_tools_owner_gated -- --nocapture`: passed
- `cargo test --all-targets`: 569 passed, 0 failed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --all-targets`: passed with existing warnings only

Head: `6156a46f7255974ebad58a8c87b84bdf41984612`
