### PR TITLE
Fix mixed-lifecycle auto-crank selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
+source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12777,6 +12777,155 @@ fn v16_bpf_hybrid_fresh_oracle_trade_devnet_difference_axes() {
     }
 }
 
+// A Recovery leg sorted before an unhealthy live leg must not poison auto-crank dispatch.
+#[test]
+fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(10_000, 1_000);
+    env.configure_auth_mark_for_asset_as_admin(0, 2, 1_000_000);
+    env.configure_auth_mark_for_asset_as_admin(1, 2, 1_000_000);
+
+    let target_owner = Keypair::new();
+    let asset0_counterparty_owner = Keypair::new();
+    let asset1_counterparty_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_counterparty = env.create_portfolio(&asset0_counterparty_owner);
+    let asset1_counterparty = env.create_portfolio(&asset1_counterparty_owner);
+    env.deposit(&target_owner, target, 160_000);
+    env.deposit(&asset0_counterparty_owner, asset0_counterparty, 100_000_000);
+    env.deposit(&asset1_counterparty_owner, asset1_counterparty, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_counterparty_owner,
+        asset0_counterparty,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &target_owner,
+        target,
+        &asset1_counterparty_owner,
+        asset1_counterparty,
+        -(2 * POS_SCALE as i128),
+        1_000_000,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(0, 3, 1_000_000);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 3)
+        .expect("asset 0 enters Recovery while the cross-margin account is open");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery,
+    );
+
+    for slot in 3..=31u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(1, slot, 2_000_000);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(asset1_counterparty, false),
+            ],
+            &[],
+        )
+        .expect("an account whose first leg is live can apply the asset-1 mark");
+    }
+    assert!(
+        env.market_state().1.assets[1].effective_price > 1_050_000,
+        "asset 1 moved enough to make the target short unhealthy",
+    );
+
+    let before_refresh = env.portfolio_state(target);
+    let recovery_basis_before = active_leg_for_asset(&before_refresh, 0).basis_pos_q;
+    let live_basis_before = active_leg_for_asset(&before_refresh, 1).basis_pos_q;
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the selector must skip the Recovery first leg and refresh on live asset 1");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_refresh = env.portfolio_state(target);
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 0).basis_pos_q,
+        recovery_basis_before,
+        "refresh leaves the Recovery leg present and unchanged",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 1).basis_pos_q,
+        live_basis_before,
+        "the first step only refreshes the live leg",
+    );
+    assert!(
+        health_cert(&after_refresh).certified_liq_deficit > 0,
+        "the refreshed cross-margin account is liquidatable on live asset 1",
+    );
+
+    env.svm.expire_blockhash();
+    let liquidation_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the next auto-crank must liquidate the dispatchable live leg");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_liquidation = env.portfolio_state(target);
+    let remaining = if has_active_leg_for_asset(&after_liquidation, 1) {
+        active_leg_for_asset(&after_liquidation, 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(remaining < live_basis_before.unsigned_abs());
+    assert_eq!(
+        active_leg_for_asset(&after_liquidation, 0).basis_pos_q,
+        recovery_basis_before,
+        "liquidating asset 1 does not mutate the Recovery asset-0 leg",
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();


### PR DESCRIPTION
## Summary

- Pin the wrapper to the mixed-lifecycle selector fix from engine PR #98 at `35f6ffec9c52e6237a356af724a04ad7f546e744`.
- Add a public LiteSVM regression for an account whose first leg is in `Recovery` while a later live leg is liquidatable.
- Prove permissionless crank skips the non-dispatchable recovery leg, refreshes the live leg, then liquidates it without mutating the recovery obligation.

Engine PR: https://github.com/aeyakovenko/percolator/pull/98

## Public repro

The old selector chose the first active portfolio leg without requiring that its asset lifecycle could accept the selected action. A normally constructed cross-margin account with a recovery leg before an unhealthy live leg therefore retried an action that always returned `EngineLockActive`; one honest cranker could not reach the later liquidation.

The engine now filters ordinary refresh/liquidation candidates to dispatchable lifecycles while retaining recovery legs for their valid settlement work.

## Validation

- rebased directly onto wrapper `main` at `da64be639168b496833dd4c701607a94fcb06b6c`
- aggregate through wrapper #266: 6 unit + 568 serialized LiteSVM/CU tests passed
- all existing full-14-leg and 10 MiB CU tests pass
- `cargo fmt --all -- --check`
- `git diff --check`

Head: `3b9c8c293b601b2f3f64f183c423ad7cde6cd105`.
