### PR TITLE
[HARDENING] Cover prior-reset auto-crank progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
+source = "git+https://github.com/aeyakovenko/percolator?rev=28a7338bd8c0dff7134ea0aa06404795bbb8557b#28a7338bd8c0dff7134ea0aa06404795bbb8557b"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "28a7338bd8c0dff7134ea0aa06404795bbb8557b" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "28a7338bd8c0dff7134ea0aa06404795bbb8557b" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12926,6 +12926,173 @@ fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
     );
 }
 
+// A public ADL reset must not leave an abandoned winner able to block either a
+// later cross-margin liquidation or permissionless side-reset finalization.
+#[test]
+fn v16_attack_prior_reset_obligation_cannot_block_live_asset_liquidation() {
+    let params = V16CuMarketParams {
+        max_portfolio_assets: 2,
+        max_price_move_bps_per_slot: 10_000,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let target_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_loser_owner = Keypair::new();
+    let asset0_loser = env.create_portfolio(&asset0_loser_owner);
+    let asset1_winner_owner = Keypair::new();
+    let asset1_winner = env.create_portfolio(&asset1_winner_owner);
+    env.deposit(&target_owner, target, 300);
+    env.deposit(&asset0_loser_owner, asset0_loser, 290);
+    env.deposit(&asset1_winner_owner, asset1_winner, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_loser_owner,
+        asset0_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &asset1_winner_owner,
+        asset1_winner,
+        &target_owner,
+        target,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_for_asset_as_admin(0, 1, 200);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(asset0_loser, false),
+        ],
+        &[],
+    )
+    .expect("first asset-0 move refreshes the future loser");
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 400);
+    for label in ["asset-0 refresh", "asset-0 liquidation"] {
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(asset0_loser, false),
+                ],
+                &[],
+            )
+            .expect(label);
+        assert_cu_within(label, cu, CRANK_CU_LIMIT);
+    }
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(asset0_loser),
+        0
+    ));
+    let group_after_asset0 = env.market_state().1;
+    assert_eq!(
+        group_after_asset0.assets[0].mode_long,
+        SideModeV16::ResetPending,
+    );
+    assert_eq!(group_after_asset0.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group_after_asset0.assets[0].oi_eff_short_q, 0);
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(target), 0),
+        "the public liquidation leaves the winner's prior-reset obligation stored",
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(1, 3, 200);
+    let crank_target = |env: &mut V16CuEnv| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+    };
+    let live_before = active_leg_for_asset(&env.portfolio_state(target), 1)
+        .basis_pos_q
+        .unsigned_abs();
+    let cleanup_cu = crank_target(&mut env)
+        .expect("a keeper must settle and detach the prior-reset obligation without the owner");
+    assert_cu_within(
+        "prior-reset obligation auto-cleanup",
+        cleanup_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_cleanup = env.portfolio_state(target);
+    assert!(
+        !has_active_leg_for_asset(&after_cleanup, 0),
+        "the inert asset-0 obligation no longer blocks reset finalization",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_cleanup, 1)
+            .basis_pos_q
+            .unsigned_abs(),
+        live_before,
+        "cleanup does not mutate the later live position",
+    );
+    assert!(
+        health_cert(&after_cleanup).certified_liq_deficit > 0,
+        "the remaining live asset is independently liquidatable",
+    );
+
+    let liquidation_cu = crank_target(&mut env)
+        .expect("the next keeper call must liquidate the remaining live asset");
+    assert_cu_within(
+        "post-reset-obligation live liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let live_after = if has_active_leg_for_asset(&env.portfolio_state(target), 1) {
+        active_leg_for_asset(&env.portfolio_state(target), 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(live_after < live_before);
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "permissionless finalization after obligation cleanup",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::Normal,
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();
@@ -29448,6 +29615,14 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
             observations: Vec::new(),
         },
     );
+    let (_, group_after_cleanup) = env.market_state();
+    let reset_pending_after_cleanup = group_after_cleanup.assets[0];
+    assert_eq!(
+        reset_pending_after_cleanup.mode_long,
+        SideModeV16::ResetPending
+    );
+    assert_eq!(reset_pending_after_cleanup.stored_pos_count_long, 0);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
     let fresh_short_owner = Keypair::new();
     let fresh_short = env.create_portfolio(&fresh_short_owner);
     env.deposit(&fresh_short_owner, fresh_short, 20_000);
@@ -29482,13 +29657,11 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 
     let (_, group) = env.market_state();
-    assert_eq!(group.assets[0], reset_pending);
+    assert_eq!(group.assets[0], reset_pending_after_cleanup);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(
         &env.portfolio_state(fresh_short)
     )));
 
-    let forfeit_cu = env.forfeit_recovery_leg_with_cu(&long_owner, long, 0, 1);
-    assert_cu_within("ForfeitRecoveryLeg", forfeit_cu, CUSTODY_CU_LIMIT);
     let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
     assert_cu_within("FinalizeResetSide", finalize_cu, CUSTODY_CU_LIMIT);
     let (_, finalized) = env.market_state();


### PR DESCRIPTION
## Summary

- Pin the wrapper to engine PR #99 at `28a7338bd8c0dff7134ea0aa06404795bbb8557b`.
- Add a public LiteSVM lifecycle where an ADL-created prior-reset obligation precedes a separately liquidatable live leg.
- Prove unsigned cranks detach the inert obligation, liquidate the live leg, and leave reset finalization permissionless.

This PR is stacked on wrapper #200 and contains no wrapper program-code change.

Engine PR: https://github.com/aeyakovenko/percolator/pull/99

## Public repro

The test opens two assets in one portfolio, publicly liquidates the asset-0 counterparty to create a prior-reset obligation, then moves asset 1 against the target. Before the engine fix, repeated honest cranks selected the inert first leg and returned `EngineInvalidLeg`; owner-only forfeit was required before the later liquidation could progress.

With the fix, one bounded crank settles and detaches the prior-reset obligation, the next liquidates the current live risk, and side-reset finalization succeeds without the abandoned owner.

## CU correction

The final engine head reuses the selector's first bounded leg scan during dispatch. On current wrapper `main`, the existing issue-103 liquidation path is 318,594 CU versus 328,570 CU before that correction, restoring the 325,000-CU guard.

## Validation

- rebased onto current `main` through wrapper #200
- paired engine runtime suite: 131 passed
- paired selector/liveness Kani harnesses: passed
- aggregate through wrapper #266: 6 unit + 568 serialized LiteSVM/CU tests passed
- all existing full-14-leg and 10 MiB CU tests pass
- `cargo fmt --all -- --check`
- `git diff --check`

Head: `b976a0a6009f5766226a146da7fc31947119bd1d`.
