### PR TITLE
[REAL DoS] Keep partially ADL-reduced users exit-live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
+source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
+source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
+source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12921,6 +12921,173 @@ fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
     );
 }
 
+// A public ADL reset must not leave an abandoned winner able to block either a
+// later cross-margin liquidation or permissionless side-reset finalization.
+#[test]
+fn v16_attack_prior_reset_obligation_cannot_block_live_asset_liquidation() {
+    let params = V16CuMarketParams {
+        max_portfolio_assets: 2,
+        max_price_move_bps_per_slot: 10_000,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let target_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_loser_owner = Keypair::new();
+    let asset0_loser = env.create_portfolio(&asset0_loser_owner);
+    let asset1_winner_owner = Keypair::new();
+    let asset1_winner = env.create_portfolio(&asset1_winner_owner);
+    env.deposit(&target_owner, target, 300);
+    env.deposit(&asset0_loser_owner, asset0_loser, 290);
+    env.deposit(&asset1_winner_owner, asset1_winner, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_loser_owner,
+        asset0_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &asset1_winner_owner,
+        asset1_winner,
+        &target_owner,
+        target,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_for_asset_as_admin(0, 1, 200);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(asset0_loser, false),
+        ],
+        &[],
+    )
+    .expect("first asset-0 move refreshes the future loser");
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 400);
+    for label in ["asset-0 refresh", "asset-0 liquidation"] {
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(asset0_loser, false),
+                ],
+                &[],
+            )
+            .expect(label);
+        assert_cu_within(label, cu, CRANK_CU_LIMIT);
+    }
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(asset0_loser),
+        0
+    ));
+    let group_after_asset0 = env.market_state().1;
+    assert_eq!(
+        group_after_asset0.assets[0].mode_long,
+        SideModeV16::ResetPending,
+    );
+    assert_eq!(group_after_asset0.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group_after_asset0.assets[0].oi_eff_short_q, 0);
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(target), 0),
+        "the public liquidation leaves the winner's prior-reset obligation stored",
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(1, 3, 200);
+    let crank_target = |env: &mut V16CuEnv| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+    };
+    let live_before = active_leg_for_asset(&env.portfolio_state(target), 1)
+        .basis_pos_q
+        .unsigned_abs();
+    let cleanup_cu = crank_target(&mut env)
+        .expect("a keeper must settle and detach the prior-reset obligation without the owner");
+    assert_cu_within(
+        "prior-reset obligation auto-cleanup",
+        cleanup_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_cleanup = env.portfolio_state(target);
+    assert!(
+        !has_active_leg_for_asset(&after_cleanup, 0),
+        "the inert asset-0 obligation no longer blocks reset finalization",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_cleanup, 1)
+            .basis_pos_q
+            .unsigned_abs(),
+        live_before,
+        "cleanup does not mutate the later live position",
+    );
+    assert!(
+        health_cert(&after_cleanup).certified_liq_deficit > 0,
+        "the remaining live asset is independently liquidatable",
+    );
+
+    let liquidation_cu = crank_target(&mut env)
+        .expect("the next keeper call must liquidate the remaining live asset");
+    assert_cu_within(
+        "post-reset-obligation live liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let live_after = if has_active_leg_for_asset(&env.portfolio_state(target), 1) {
+        active_leg_for_asset(&env.portfolio_state(target), 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(live_after < live_before);
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "permissionless finalization after obligation cleanup",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::Normal,
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();
@@ -29318,6 +29485,14 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
             observations: Vec::new(),
         },
     );
+    let (_, group_after_cleanup) = env.market_state();
+    let reset_pending_after_cleanup = group_after_cleanup.assets[0];
+    assert_eq!(
+        reset_pending_after_cleanup.mode_long,
+        SideModeV16::ResetPending
+    );
+    assert_eq!(reset_pending_after_cleanup.stored_pos_count_long, 0);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
     let fresh_short_owner = Keypair::new();
     let fresh_short = env.create_portfolio(&fresh_short_owner);
     env.deposit(&fresh_short_owner, fresh_short, 20_000);
@@ -29352,13 +29527,11 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 
     let (_, group) = env.market_state();
-    assert_eq!(group.assets[0], reset_pending);
+    assert_eq!(group.assets[0], reset_pending_after_cleanup);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(
         &env.portfolio_state(fresh_short)
     )));
 
-    let forfeit_cu = env.forfeit_recovery_leg_with_cu(&long_owner, long, 0, 1);
-    assert_cu_within("ForfeitRecoveryLeg", forfeit_cu, CUSTODY_CU_LIMIT);
     let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
     assert_cu_within("FinalizeResetSide", finalize_cu, CUSTODY_CU_LIMIT);
     let (_, finalized) = env.market_state();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12772,6 +12772,155 @@ fn v16_bpf_hybrid_fresh_oracle_trade_devnet_difference_axes() {
     }
 }
 
+// A Recovery leg sorted before an unhealthy live leg must not poison auto-crank dispatch.
+#[test]
+fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(10_000, 1_000);
+    env.configure_auth_mark_for_asset_as_admin(0, 2, 1_000_000);
+    env.configure_auth_mark_for_asset_as_admin(1, 2, 1_000_000);
+
+    let target_owner = Keypair::new();
+    let asset0_counterparty_owner = Keypair::new();
+    let asset1_counterparty_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_counterparty = env.create_portfolio(&asset0_counterparty_owner);
+    let asset1_counterparty = env.create_portfolio(&asset1_counterparty_owner);
+    env.deposit(&target_owner, target, 160_000);
+    env.deposit(&asset0_counterparty_owner, asset0_counterparty, 100_000_000);
+    env.deposit(&asset1_counterparty_owner, asset1_counterparty, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_counterparty_owner,
+        asset0_counterparty,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &target_owner,
+        target,
+        &asset1_counterparty_owner,
+        asset1_counterparty,
+        -(2 * POS_SCALE as i128),
+        1_000_000,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(0, 3, 1_000_000);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 3)
+        .expect("asset 0 enters Recovery while the cross-margin account is open");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery,
+    );
+
+    for slot in 3..=31u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(1, slot, 2_000_000);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(asset1_counterparty, false),
+            ],
+            &[],
+        )
+        .expect("an account whose first leg is live can apply the asset-1 mark");
+    }
+    assert!(
+        env.market_state().1.assets[1].effective_price > 1_050_000,
+        "asset 1 moved enough to make the target short unhealthy",
+    );
+
+    let before_refresh = env.portfolio_state(target);
+    let recovery_basis_before = active_leg_for_asset(&before_refresh, 0).basis_pos_q;
+    let live_basis_before = active_leg_for_asset(&before_refresh, 1).basis_pos_q;
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the selector must skip the Recovery first leg and refresh on live asset 1");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_refresh = env.portfolio_state(target);
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 0).basis_pos_q,
+        recovery_basis_before,
+        "refresh leaves the Recovery leg present and unchanged",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 1).basis_pos_q,
+        live_basis_before,
+        "the first step only refreshes the live leg",
+    );
+    assert!(
+        health_cert(&after_refresh).certified_liq_deficit > 0,
+        "the refreshed cross-margin account is liquidatable on live asset 1",
+    );
+
+    env.svm.expire_blockhash();
+    let liquidation_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the next auto-crank must liquidate the dispatchable live leg");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_liquidation = env.portfolio_state(target);
+    let remaining = if has_active_leg_for_asset(&after_liquidation, 1) {
+        active_leg_for_asset(&after_liquidation, 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(remaining < live_basis_before.unsigned_abs());
+    assert_eq!(
+        active_leg_for_asset(&after_liquidation, 0).basis_pos_q,
+        recovery_basis_before,
+        "liquidating asset 1 does not mutate the Recovery asset-0 leg",
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38147,6 +38147,142 @@ fn v16_attack_adl_deleverage_conserves_and_shrinks_winner_claim() {
     );
 }
 
+// Public LoF/DoS regression: partial ADL leaves the winner's stored basis larger than matched
+// effective OI. Before the fix, a normal max-work RebalanceReduce aborts with
+// EngineCounterUnderflow; reducing exactly the remaining effective OI once instead leaves a
+// Normal-mode, zero-OI residue that every later reduction also rejects. The exit must clamp to
+// matched OI, establish the reset epoch, and leave both residual accounts finitely crankable.
+#[test]
+fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let (_, adl) = env.market_state();
+    let winner = env.portfolio_state(long);
+    assert_eq!(winner.legs[0].basis_pos_q.get(), (2 * POS_SCALE) as i128);
+    let matched_oi_after_adl = adl.assets[0].oi_eff_long_q;
+    assert_eq!(adl.assets[0].oi_eff_short_q, matched_oi_after_adl);
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(adl.assets[0].mode_long, SideModeV16::Normal);
+    let vault_after_adl = adl.vault;
+
+    // This max-work request is the old red path. It must consume only the remaining matched
+    // exposure rather than subtracting the full stored basis from smaller effective OI.
+    let reduce_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, 2 * POS_SCALE);
+    assert_cu_within(
+        "partial-ADL max RebalanceReduce",
+        reduce_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let (_, reset) = env.market_state();
+    assert_eq!(reset.assets[0].oi_eff_long_q, 0);
+    assert_eq!(reset.assets[0].oi_eff_short_q, 0);
+    assert_eq!(reset.assets[0].mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.assets[0].mode_short, SideModeV16::ResetPending);
+    assert_eq!(
+        env.portfolio_state(long).legs[0].basis_pos_q.get(),
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "only effective exposure is reduced; terminal stored residue remains for settlement"
+    );
+
+    let mut max_cleanup_cu = 0;
+    for portfolio in [long, short] {
+        for _ in 0..3 {
+            if percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))) {
+                break;
+            }
+            max_cleanup_cu = max_cleanup_cu.max(env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 6,
+                    observations: crank_observations(0),
+                },
+            ));
+        }
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))),
+            "each prior-reset residue must detach in finitely many unsigned cranks"
+        );
+    }
+    assert_cu_within(
+        "partial-ADL residue cleanup",
+        max_cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let long_finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    let short_finalize_cu = env.finalize_reset_side_with_cu(0, 1);
+    assert_cu_within(
+        "partial-ADL long finalize",
+        long_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_cu_within(
+        "partial-ADL short finalize",
+        short_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let (_, done) = env.market_state();
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_after_adl,
+        "exit and cleanup move no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert!(done.vault >= done.c_tot + done.insurance);
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.


### PR DESCRIPTION
## Public TDD

The test reaches the failure using only public LiteSVM instructions:

1. deposit two users;
2. open a balanced two-lot trade;
3. authenticate a 5x mark move;
4. partially liquidate the loser, ADL-reducing matched OI to one lot while the winner retains two lots of stored basis;
5. submit the normal max-work owner `RebalanceReduce`;
6. unsigned-crank both terminal residues and finalize both reset sides.

At parent engine `a9baa08`, step 5 fails at 121,431 program CU with wrapper `Custom(25)` / `EngineCounterUnderflow`. With engine PR #100, work clamps to matched effective OI, both residues detach permissionlessly in bounded calls, both sides finalize, and real SPL vault custody remains conserved.

## Scope

- Engine pin to `6d1d9d7f653dec327e9b95941933afcb8b249432`.
- One net-new public LiteSVM regression.
- No wrapper program-code change.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 5 unit + 562 LiteSVM tests green.
- New path explicitly checks CU bounds for reduction, cleanup, and both finalizations.
- Clippy still reports the branch's existing warning baseline; this change adds no new clippy finding.
