### PR TITLE
[BLOCKER DoS] Force-close abandoned ADL Recovery residues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
+source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6337,6 +6337,37 @@ pub mod processor {
         account_b
             .validate_with_market(&group.as_view())
             .map_err(map_v16_error)?;
+        let position_a = signed_position_for_asset_view(&group, &account_a, asset_index_usize)?;
+        let position_b = signed_position_for_asset_view(&group, &account_b, asset_index_usize)?;
+        if position_a == 0 || position_b == 0 {
+            let (residue, residue_position) = match (position_a != 0, position_b != 0) {
+                (true, false) => (&mut account_a, position_a),
+                (false, true) => (&mut account_b, position_b),
+                _ => return Err(PercolatorError::EngineNonProgress.into()),
+            };
+            let side_oi = if residue_position > 0 {
+                asset.oi_eff_long_q.get()
+            } else {
+                asset.oi_eff_short_q.get()
+            };
+            if side_oi != 0 {
+                return Err(PercolatorError::EngineInvalidLeg.into());
+            }
+            // A prior matched force-close can consume the final effective OI
+            // while leaving one ADL terminal residue and no opposite leg to
+            // pair. After the same abandonment delay, settle that dead leg via
+            // the engine's recovery-forfeit path without requiring its owner.
+            group
+                .forfeit_recovery_leg_not_atomic(residue, asset_index_usize, close_q)
+                .map_err(map_v16_error)?;
+            group.validate_shape().map_err(map_v16_error)?;
+            account_a
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error)?;
+            return account_b
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error);
+        }
         let leg_a = active_leg_for_asset_view(&account_a, asset_index_usize)?;
         let leg_b = active_leg_for_asset_view(&account_b, asset_index_usize)?;
         if leg_a.side == leg_b.side {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38283,6 +38283,160 @@ fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
     assert!(done.vault >= done.c_tot + done.insurance);
 }
 
+// A partial ADL can leave stored basis larger than matched effective OI. If the oracle then dies,
+// the delayed permissionless force-close must not require the abandoned owner to clean the final
+// zero-OI residue: one call nets the matched lot and a second singleton call settles/detaches the
+// residue, after which the side can be finalized without consuming the user's separate PnL claim.
+#[test]
+fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation before recovery",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let matched_oi_after_adl = env.market_state().1.assets[0].oi_eff_long_q;
+    assert_eq!(
+        env.market_state().1.assets[0].oi_eff_short_q,
+        matched_oi_after_adl
+    );
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0).basis_pos_q,
+        (2 * POS_SCALE) as i128,
+    );
+    env.svm.warp_to_slot(7);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 7)
+        .expect("public shutdown enters asset recovery");
+    env.svm.warp_to_slot(8);
+    let cranker = Keypair::new();
+    env.svm.expire_blockhash();
+    let vault_before = env.market_state().1.vault;
+    let first_cu = env
+        .try_force_close_abandoned_asset_with_cu(&cranker, long, short, 0, 8, 2 * POS_SCALE)
+        .expect("the first force close nets the remaining matched exposure");
+    assert_cu_within(
+        "partial-ADL Recovery matched force close",
+        first_cu,
+        TRADE_CU_LIMIT,
+    );
+    let group = env.market_state().1;
+    let long_state = env.portfolio_state(long);
+    let short_state = env.portfolio_state(short);
+    let long_capital_before_cleanup = long_state.capital.get();
+    let long_pnl_before_cleanup = long_state.pnl.get();
+    assert_eq!(group.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group.assets[0].oi_eff_short_q, 0);
+    assert_eq!(
+        active_leg_for_asset(&long_state, 0).basis_pos_q,
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "the matched close leaves only the ADL terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&short_state, 0),
+        "the matched short is fully closed",
+    );
+
+    env.svm.expire_blockhash();
+    let cleanup_cu = env
+        .try_force_close_abandoned_asset_with_cu(
+            &cranker,
+            long,
+            short,
+            0,
+            8,
+            percolator::MAX_VAULT_TVL,
+        )
+        .expect("a singleton zero-OI Recovery residue must be permissionlessly detachable");
+    assert_cu_within(
+        "partial-ADL Recovery singleton cleanup",
+        cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(long), 0),
+        "the abandoned owner is no longer required to detach the terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(short), 0),
+        "both public portfolios are detached",
+    );
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "partial-ADL Recovery side finalization",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.assets[0].lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_before,
+        "Recovery cleanup moves no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert_eq!(
+        env.portfolio_state(long).capital.get(),
+        long_capital_before_cleanup,
+    );
+    assert_eq!(
+        env.portfolio_state(long).pnl.get(),
+        long_pnl_before_cleanup,
+        "terminal position cleanup preserves the independent user claim",
+    );
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.


### PR DESCRIPTION
## What changed

- Extend the delayed `ForceCloseAbandonedAsset` route to settle a singleton zero-effective-OI residue after its opposite leg has already been closed.
- Pin engine PR aeyakovenko/percolator#101, which migrates that legacy residue into the reset epoch before recovery forfeit clears it.
- Add a public LiteSVM regression covering deposits, trade, partial ADL, shutdown, two unsigned force-close calls, side finalization, CU bounds, custody conservation, and preservation of the user's independent PnL claim.

## Root cause

Partial ADL can leave a winner's stored basis larger than matched effective OI. After asset shutdown, the first paired force close consumed the final matched lot and cleared the short, but left a nonzero long residue with both OI sides at zero. Every later paired force close failed because no opposite leg remained, while recovery forfeit tried to subtract the stored basis from zero OI.

With the wrapper route held fixed and the engine pinned to parent `f87ca00`, the public regression fails on the second unsigned call at 97,660 CU with `Custom(25)` (`0x19`); the transaction rolls back and leaves the residue stuck.

## Validation

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 563 LiteSVM tests and 5 wrapper unit tests pass.
- New path remains bounded: matched force close under the trade CU limit; singleton cleanup and side finalization under the custody CU limit.
- Engine Kani reset+clear composition theorem: 649/649 checks passed, 6/6 covers satisfied, 4.46s.