### PR TITLE
[REAL DoS] Unstick Live auto-crank after source-backing expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5419f45ac50a29cea52a2f72e5b03aa53cc95538#5419f45ac50a29cea52a2f72e5b03aa53cc95538"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
+source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38542,7 +38542,7 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
         )
         .expect("permissionless refresh must expire lapsed Live backing and commit");
     assert_cu_within(
-        "lapsed source-backing auto-crank refresh",
+        "lapsed source-backing expiry step",
         refresh_cu,
         CRANK_CU_LIMIT,
     );
@@ -38551,9 +38551,35 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     let expired = after_refresh.source_backing_buckets[1];
     assert_eq!(expired.status, BackingBucketStatusV16::Expired);
     assert_eq!(expired.fresh_unliened_backing_num, 0);
-    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_ne!(
+        health_cert(&env.portfolio_state(long)).cert_risk_epoch,
+        after_refresh.risk_epoch,
+        "expiry advances risk state, so another bounded crank remains actionable"
+    );
     assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
     assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    env.svm.expire_blockhash();
+    let certify_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("the next bounded auto-crank must certify after expiry");
+    assert_cu_within(
+        "post-expiry account certification",
+        certify_cu,
+        CRANK_CU_LIMIT,
+    );
+    assert!(health_cert(&env.portfolio_state(long)).valid);
 
     let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
         .basis_pos_q

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38437,6 +38437,140 @@ fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
     );
 }
 
+// Live source-backing expiry liveness: this is a fully public path to a source-backed claim.
+// A partial ADL realizes the loser's capital as Fresh backing for the winner. Once that bucket
+// expires, a later adverse move must not make RefreshAccount return EngineStale forever: SVM
+// rollback would restore the same lapsed-Fresh predicate after every keeper attempt and block the
+// owner's risk-reducing trade. Auto-crank must apply the canonical expiry transition, preserve
+// custody, certify both accounts, and leave the owner able to reduce the position.
+#[test]
+fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    env.deposit(&long_owner, long, 40);
+    env.deposit(&short_owner, short, 410);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    for slot in 2..=30 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 300);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    for portfolio in [short, long] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 30,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+    );
+    let after_short_group = env.market_state().1;
+    let after_short_long = active_leg_for_asset(&env.portfolio_state(long), 0);
+    let after_short_short = active_leg_for_asset(&env.portfolio_state(short), 0);
+    assert_eq!(after_short_group.assets[0].b_long_num, 0);
+    assert_eq!(after_short_group.assets[0].b_short_num, 0);
+    assert!(!after_short_long.b_stale && !after_short_short.b_stale);
+    let generated_backing = after_short_group.source_backing_buckets[1];
+    assert_eq!(generated_backing.status, BackingBucketStatusV16::Fresh);
+    assert!(
+        generated_backing.fresh_unliened_backing_num > 0,
+        "public partial ADL must create real source backing for the winner"
+    );
+
+    for slot in 31..=160 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 1);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    let before_refresh = env.market_state().1;
+    let lapsed = before_refresh.source_backing_buckets[1];
+    assert_eq!(lapsed.status, BackingBucketStatusV16::Fresh);
+    assert!(lapsed.expiry_slot < 160, "backing is observably lapsed");
+    assert!(env.portfolio_state(long).pnl.get() > 0);
+    let vault_before = before_refresh.vault;
+    let vault_tokens_before = env.token_amount(env.vault);
+
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("permissionless refresh must expire lapsed Live backing and commit");
+    assert_cu_within(
+        "lapsed source-backing auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let after_refresh = env.market_state().1;
+    let expired = after_refresh.source_backing_buckets[1];
+    assert_eq!(expired.status, BackingBucketStatusV16::Expired);
+    assert_eq!(expired.fresh_unliened_backing_num, 0);
+    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    let exit_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, POS_SCALE / 4);
+    assert_cu_within("post-expiry user risk reduction", exit_cu, CUSTODY_CU_LIMIT);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0)
+            .basis_pos_q
+            .unsigned_abs(),
+        long_before_exit - POS_SCALE / 4,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.vault, vault_before);
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.


### PR DESCRIPTION
## Confirmed public DoS

A public `TradeNoCpi` position followed by a public partial liquidation/ADL creates Fresh source backing for the winning account. After the engine-assigned backing expiry, a reverse price move makes that winner's refresh value the source claim. The parent engine returns `Stale`; SVM rollback restores the lapsed bucket as Fresh, so every permissionless crank repeats identically. The wrapper exposes no permissionless backing-expiry instruction, leaving the user's open position dependent on a privileged backing authority or terminal market resolution.

## TDD

`v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank` uses only public instructions to deposit/trade, drive partial ADL, advance beyond the generated expiry, reverse the mark, and crank the winner. It proves:

- one auto-crank commits exactly one canonical expiry step under `CRANK_CU_LIMIT`;
- expiry moves no custody and advances risk state, leaving refresh actionable;
- the next bounded auto-crank certifies the account; and
- the owner immediately reduces the same position through public `RebalanceReduce` under its CU ceiling.

On the parent engine the first expiry crank returns `EngineStale` (`Custom(19)`) and rolls all bytes back. This PR pins engine `58efade22cdc5147f09ad8fabadb6fdaaf7bb144` (engine PR #102), whose explicit `SourceBackingExpired` outcome limits cleanup to one domain per call rather than introducing a multi-domain CU cliff.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 564 LiteSVM + 5 unit tests, all green
- Expiry, certification, and owner reduction all remain under existing CU ceilings.
- Engine Kani expiry conservation theorem: 172/172 checks passed, 4/4 covers satisfied, 2.84s.