### PR TITLE
Pin oracle-target certificate invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=876fa9ff94c5cdfb42483930a5467815ae840f4a#876fa9ff94c5cdfb42483930a5467815ae840f4a"
+source = "git+https://github.com/aeyakovenko/percolator?rev=7388645063e3f712bd2c21d2f42f1e4b016b85b5#7388645063e3f712bd2c21d2f42f1e4b016b85b5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "876fa9ff94c5cdfb42483930a5467815ae840f4a" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "7388645063e3f712bd2c21d2f42f1e4b016b85b5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "876fa9ff94c5cdfb42483930a5467815ae840f4a" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "7388645063e3f712bd2c21d2f42f1e4b016b85b5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7831,6 +7831,102 @@ fn v16_bpf_stale_asset_does_not_block_current_unrelated_trade() {
 }
 
 #[test]
+fn v16_attack_target_only_lag_invalidates_unrelated_single_trade_cert() {
+    const PRICE: u64 = 100;
+    const TARGET: u64 = 90;
+    const ASSET1_SIZE_Q: i128 = (10 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 10_000, 10_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 1_000_000_000);
+    env.deposit(&short_owner, short_account, 1_000_000_000);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        ASSET1_SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    let (_, before_target) = env.market_state();
+    let long_before = env.portfolio_state(long_account);
+    let short_before = env.portfolio_state(short_account);
+    assert_eq!(
+        health_cert(&long_before).cert_oracle_epoch,
+        before_target.oracle_epoch
+    );
+    assert_eq!(
+        health_cert(&short_before).cert_oracle_epoch,
+        before_target.oracle_epoch
+    );
+
+    let cranker_owner = Keypair::new();
+    let cranker_account = env.create_portfolio(&cranker_owner);
+    env.push_auth_mark_for_asset_as_admin(1, 0, TARGET);
+    env.crank(
+        cranker_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: crank_observations(1),
+        },
+    );
+
+    let (_, lagged_group) = env.market_state();
+    let stale_long = env.portfolio_state(long_account);
+    let stale_short = env.portfolio_state(short_account);
+    assert_eq!(lagged_group.assets[1].raw_oracle_target_price, TARGET);
+    assert_eq!(
+        lagged_group.assets[1].effective_price, PRICE,
+        "same-slot crank must create target-only lag without an effective-price move"
+    );
+    assert_eq!(lagged_group.oracle_epoch, before_target.oracle_epoch + 1);
+    assert!(
+        health_cert(&stale_long).cert_oracle_epoch < lagged_group.oracle_epoch
+            && health_cert(&stale_short).cert_oracle_epoch < lagged_group.oracle_epoch,
+        "target-only lag must invalidate every prior portfolio certificate in O(1)"
+    );
+
+    let trade_cu = env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+    assert_cu_within(
+        "unrelated single trade after target-only lag",
+        trade_cu,
+        MULTI_ASSET_OPEN_TRADE_CU_LIMIT,
+    );
+
+    let (_, after_trade_group) = env.market_state();
+    let long_after = env.portfolio_state(long_account);
+    let short_after = env.portfolio_state(short_account);
+    let long_cert = health_cert(&long_after);
+    let short_cert = health_cert(&short_after);
+    assert_eq!(long_cert.cert_oracle_epoch, after_trade_group.oracle_epoch);
+    assert_eq!(short_cert.cert_oracle_epoch, after_trade_group.oracle_epoch);
+    assert_eq!(
+        long_cert.certified_maintenance_req,
+        short_cert.certified_maintenance_req + 100,
+        "the unrelated trade must retain asset 1's adverse long lag penalty"
+    );
+    assert_eq!(long_cert.certified_maintenance_req, 1_200);
+    assert_eq!(short_cert.certified_maintenance_req, 1_100);
+}
+
+#[test]
 fn v16_bpf_trade_refreshes_stale_related_portfolio_leg_on_demand() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(4, 1_000, 1_000, 500);
     env.configure_auth_mark_for_asset_as_admin(1, 0, 100);


### PR DESCRIPTION
Integrates the engine fix for aeyakovenko/percolator#93 (engine PR aeyakovenko/percolator#107).

The wrapper now pins engine commit `7388645063e3f712bd2c21d2f42f1e4b016b85b5` and adds a LiteSVM regression that:
- creates target/effective lag at zero accrual delta,
- proves the raw-target-only transition invalidates prior account certificates,
- executes a single trade on an unrelated asset,
- verifies the adverse lag penalty remains in the final maintenance certificate,
- checks the transaction stays under the multi-asset trade CU guardrail.

Validation:
- `cargo build-sbf --no-default-features`: PASS.
- auth and hostile matcher `cargo build-sbf`: PASS.
- targeted LiteSVM regression: PASS.
- `cargo test --tests --no-default-features`: PASS (561 LiteSVM/CU + 5 unit tests).
- `cargo fmt --all -- --check` and `git diff --check`: PASS.