### PR TITLE
Bound max-source lien trading CU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5419f45ac50a29cea52a2f72e5b03aa53cc95538#5419f45ac50a29cea52a2f72e5b03aa53cc95538"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
+source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4#22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5997d84eb00c21cb28c49f05e5e2786f5ee2e54e#5997d84eb00c21cb28c49f05e5e2786f5ee2e54e"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a154433e1bdb08a50b9fd969eb4dba938a35764a#a154433e1bdb08a50b9fd969eb4dba938a35764a"
+source = "git+https://github.com/aeyakovenko/percolator?rev=3bc7a54f16d0a579378f29f0bc8e8f450286893d#3bc7a54f16d0a579378f29f0bc8e8f450286893d"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=5419f45ac50a29cea52a2f72e5b03aa53cc95538#5419f45ac50a29cea52a2f72e5b03aa53cc95538"
+source = "git+https://github.com/aeyakovenko/percolator?rev=22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4#22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
+source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=5997d84eb00c21cb28c49f05e5e2786f5ee2e54e#5997d84eb00c21cb28c49f05e5e2786f5ee2e54e"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a154433e1bdb08a50b9fd969eb4dba938a35764a#a154433e1bdb08a50b9fd969eb4dba938a35764a"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
+source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
+source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
+source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=3bc7a54f16d0a579378f29f0bc8e8f450286893d#3bc7a54f16d0a579378f29f0bc8e8f450286893d"
+source = "git+https://github.com/aeyakovenko/percolator?rev=72569561ba6028a07627274675a552749c4e803b#72569561ba6028a07627274675a552749c4e803b"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3bc7a54f16d0a579378f29f0bc8e8f450286893d" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "72569561ba6028a07627274675a552749c4e803b" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3bc7a54f16d0a579378f29f0bc8e8f450286893d" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "72569561ba6028a07627274675a552749c4e803b" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a154433e1bdb08a50b9fd969eb4dba938a35764a" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a154433e1bdb08a50b9fd969eb4dba938a35764a" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a154433e1bdb08a50b9fd969eb4dba938a35764a" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3bc7a54f16d0a579378f29f0bc8e8f450286893d" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a154433e1bdb08a50b9fd969eb4dba938a35764a" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3bc7a54f16d0a579378f29f0bc8e8f450286893d" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5206,7 +5206,7 @@ pub mod processor {
                 handle_convert_released_pnl(program_id, accounts, amount)
             }
             Instruction::CloseResolved { fee_rate_per_slot } => {
-                handle_close_resolved(program_id, accounts, fee_rate_per_slot)
+                handle_close_resolved(program_id, accounts, fee_rate_per_slot, true)
             }
             Instruction::UpdateAuthority { new_pubkey } => {
                 handle_update_authority(program_id, accounts, new_pubkey)
@@ -10240,6 +10240,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         _fee_rate_per_slot: u128,
+        require_payout_accounts: bool,
     ) -> ProgramResult {
         let owner = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10290,7 +10291,7 @@ pub mod processor {
             };
             (cfg, payout)
         };
-        if payout != 0 {
+        if require_payout_accounts || payout != 0 {
             let dest_token = account(accounts, 3)?;
             let vault_token = account(accounts, 4)?;
             let vault_authority_ai = account(accounts, 5)?;
@@ -10308,18 +10309,20 @@ pub mod processor {
                 &cfg_after,
             )?;
             verify_permissionless_payout_dest_token_account(dest_token)?;
-            let payout_u64 = amount_to_u64(payout)?;
-            require_token_balance(vault_token, payout_u64)?;
-            let bump_arr = [bump];
-            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-            transfer_tokens_signed(
-                token_program,
-                vault_token,
-                dest_token,
-                vault_authority_ai,
-                payout_u64,
-                signer_seeds,
-            )?;
+            if payout != 0 {
+                let payout_u64 = amount_to_u64(payout)?;
+                require_token_balance(vault_token, payout_u64)?;
+                let bump_arr = [bump];
+                let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+                transfer_tokens_signed(
+                    token_program,
+                    vault_token,
+                    dest_token,
+                    vault_authority_ai,
+                    payout_u64,
+                    signer_seeds,
+                )?;
+            }
         }
         Ok(())
     }
@@ -10713,7 +10716,7 @@ pub mod processor {
         let (_, mode, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         if mode == MarketModeV16::Resolved {
-            return handle_close_resolved(program_id, accounts, 0);
+            return handle_close_resolved(program_id, accounts, 0, false);
         }
         handle_permissionless_crank_zero_copy(
             program_id,

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6337,6 +6337,37 @@ pub mod processor {
         account_b
             .validate_with_market(&group.as_view())
             .map_err(map_v16_error)?;
+        let position_a = signed_position_for_asset_view(&group, &account_a, asset_index_usize)?;
+        let position_b = signed_position_for_asset_view(&group, &account_b, asset_index_usize)?;
+        if position_a == 0 || position_b == 0 {
+            let (residue, residue_position) = match (position_a != 0, position_b != 0) {
+                (true, false) => (&mut account_a, position_a),
+                (false, true) => (&mut account_b, position_b),
+                _ => return Err(PercolatorError::EngineNonProgress.into()),
+            };
+            let side_oi = if residue_position > 0 {
+                asset.oi_eff_long_q.get()
+            } else {
+                asset.oi_eff_short_q.get()
+            };
+            if side_oi != 0 {
+                return Err(PercolatorError::EngineInvalidLeg.into());
+            }
+            // A prior matched force-close can consume the final effective OI
+            // while leaving one ADL terminal residue and no opposite leg to
+            // pair. After the same abandonment delay, settle that dead leg via
+            // the engine's recovery-forfeit path without requiring its owner.
+            group
+                .forfeit_recovery_leg_not_atomic(residue, asset_index_usize, close_q)
+                .map_err(map_v16_error)?;
+            group.validate_shape().map_err(map_v16_error)?;
+            account_a
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error)?;
+            return account_b
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error);
+        }
         let leg_a = active_leg_for_asset_view(&account_a, asset_index_usize)?;
         let leg_b = active_leg_for_asset_view(&account_b, asset_index_usize)?;
         if leg_a.side == leg_b.side {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12921,6 +12921,173 @@ fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
     );
 }
 
+// A public ADL reset must not leave an abandoned winner able to block either a
+// later cross-margin liquidation or permissionless side-reset finalization.
+#[test]
+fn v16_attack_prior_reset_obligation_cannot_block_live_asset_liquidation() {
+    let params = V16CuMarketParams {
+        max_portfolio_assets: 2,
+        max_price_move_bps_per_slot: 10_000,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let target_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_loser_owner = Keypair::new();
+    let asset0_loser = env.create_portfolio(&asset0_loser_owner);
+    let asset1_winner_owner = Keypair::new();
+    let asset1_winner = env.create_portfolio(&asset1_winner_owner);
+    env.deposit(&target_owner, target, 300);
+    env.deposit(&asset0_loser_owner, asset0_loser, 290);
+    env.deposit(&asset1_winner_owner, asset1_winner, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_loser_owner,
+        asset0_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &asset1_winner_owner,
+        asset1_winner,
+        &target_owner,
+        target,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_for_asset_as_admin(0, 1, 200);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(asset0_loser, false),
+        ],
+        &[],
+    )
+    .expect("first asset-0 move refreshes the future loser");
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 400);
+    for label in ["asset-0 refresh", "asset-0 liquidation"] {
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(asset0_loser, false),
+                ],
+                &[],
+            )
+            .expect(label);
+        assert_cu_within(label, cu, CRANK_CU_LIMIT);
+    }
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(asset0_loser),
+        0
+    ));
+    let group_after_asset0 = env.market_state().1;
+    assert_eq!(
+        group_after_asset0.assets[0].mode_long,
+        SideModeV16::ResetPending,
+    );
+    assert_eq!(group_after_asset0.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group_after_asset0.assets[0].oi_eff_short_q, 0);
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(target), 0),
+        "the public liquidation leaves the winner's prior-reset obligation stored",
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(1, 3, 200);
+    let crank_target = |env: &mut V16CuEnv| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+    };
+    let live_before = active_leg_for_asset(&env.portfolio_state(target), 1)
+        .basis_pos_q
+        .unsigned_abs();
+    let cleanup_cu = crank_target(&mut env)
+        .expect("a keeper must settle and detach the prior-reset obligation without the owner");
+    assert_cu_within(
+        "prior-reset obligation auto-cleanup",
+        cleanup_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_cleanup = env.portfolio_state(target);
+    assert!(
+        !has_active_leg_for_asset(&after_cleanup, 0),
+        "the inert asset-0 obligation no longer blocks reset finalization",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_cleanup, 1)
+            .basis_pos_q
+            .unsigned_abs(),
+        live_before,
+        "cleanup does not mutate the later live position",
+    );
+    assert!(
+        health_cert(&after_cleanup).certified_liq_deficit > 0,
+        "the remaining live asset is independently liquidatable",
+    );
+
+    let liquidation_cu = crank_target(&mut env)
+        .expect("the next keeper call must liquidate the remaining live asset");
+    assert_cu_within(
+        "post-reset-obligation live liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let live_after = if has_active_leg_for_asset(&env.portfolio_state(target), 1) {
+        active_leg_for_asset(&env.portfolio_state(target), 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(live_after < live_before);
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "permissionless finalization after obligation cleanup",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::Normal,
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();
@@ -29318,6 +29485,14 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
             observations: Vec::new(),
         },
     );
+    let (_, group_after_cleanup) = env.market_state();
+    let reset_pending_after_cleanup = group_after_cleanup.assets[0];
+    assert_eq!(
+        reset_pending_after_cleanup.mode_long,
+        SideModeV16::ResetPending
+    );
+    assert_eq!(reset_pending_after_cleanup.stored_pos_count_long, 0);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
     let fresh_short_owner = Keypair::new();
     let fresh_short = env.create_portfolio(&fresh_short_owner);
     env.deposit(&fresh_short_owner, fresh_short, 20_000);
@@ -29352,13 +29527,11 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 
     let (_, group) = env.market_state();
-    assert_eq!(group.assets[0], reset_pending);
+    assert_eq!(group.assets[0], reset_pending_after_cleanup);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(
         &env.portfolio_state(fresh_short)
     )));
 
-    let forfeit_cu = env.forfeit_recovery_leg_with_cu(&long_owner, long, 0, 1);
-    assert_cu_within("ForfeitRecoveryLeg", forfeit_cu, CUSTODY_CU_LIMIT);
     let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
     assert_cu_within("FinalizeResetSide", finalize_cu, CUSTODY_CU_LIMIT);
     let (_, finalized) = env.market_state();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12772,6 +12772,155 @@ fn v16_bpf_hybrid_fresh_oracle_trade_devnet_difference_axes() {
     }
 }
 
+// A Recovery leg sorted before an unhealthy live leg must not poison auto-crank dispatch.
+#[test]
+fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(10_000, 1_000);
+    env.configure_auth_mark_for_asset_as_admin(0, 2, 1_000_000);
+    env.configure_auth_mark_for_asset_as_admin(1, 2, 1_000_000);
+
+    let target_owner = Keypair::new();
+    let asset0_counterparty_owner = Keypair::new();
+    let asset1_counterparty_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_counterparty = env.create_portfolio(&asset0_counterparty_owner);
+    let asset1_counterparty = env.create_portfolio(&asset1_counterparty_owner);
+    env.deposit(&target_owner, target, 160_000);
+    env.deposit(&asset0_counterparty_owner, asset0_counterparty, 100_000_000);
+    env.deposit(&asset1_counterparty_owner, asset1_counterparty, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_counterparty_owner,
+        asset0_counterparty,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &target_owner,
+        target,
+        &asset1_counterparty_owner,
+        asset1_counterparty,
+        -(2 * POS_SCALE as i128),
+        1_000_000,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(0, 3, 1_000_000);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 3)
+        .expect("asset 0 enters Recovery while the cross-margin account is open");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery,
+    );
+
+    for slot in 3..=31u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(1, slot, 2_000_000);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(asset1_counterparty, false),
+            ],
+            &[],
+        )
+        .expect("an account whose first leg is live can apply the asset-1 mark");
+    }
+    assert!(
+        env.market_state().1.assets[1].effective_price > 1_050_000,
+        "asset 1 moved enough to make the target short unhealthy",
+    );
+
+    let before_refresh = env.portfolio_state(target);
+    let recovery_basis_before = active_leg_for_asset(&before_refresh, 0).basis_pos_q;
+    let live_basis_before = active_leg_for_asset(&before_refresh, 1).basis_pos_q;
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the selector must skip the Recovery first leg and refresh on live asset 1");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_refresh = env.portfolio_state(target);
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 0).basis_pos_q,
+        recovery_basis_before,
+        "refresh leaves the Recovery leg present and unchanged",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 1).basis_pos_q,
+        live_basis_before,
+        "the first step only refreshes the live leg",
+    );
+    assert!(
+        health_cert(&after_refresh).certified_liq_deficit > 0,
+        "the refreshed cross-margin account is liquidatable on live asset 1",
+    );
+
+    env.svm.expire_blockhash();
+    let liquidation_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the next auto-crank must liquidate the dispatchable live leg");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_liquidation = env.portfolio_state(target);
+    let remaining = if has_active_leg_for_asset(&after_liquidation, 1) {
+        active_leg_for_asset(&after_liquidation, 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(remaining < live_basis_before.unsigned_abs());
+    assert_eq!(
+        active_leg_for_asset(&after_liquidation, 0).basis_pos_q,
+        recovery_basis_before,
+        "liquidating asset 1 does not mutate the Recovery asset-0 leg",
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38283,6 +38283,160 @@ fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
     assert!(done.vault >= done.c_tot + done.insurance);
 }
 
+// A partial ADL can leave stored basis larger than matched effective OI. If the oracle then dies,
+// the delayed permissionless force-close must not require the abandoned owner to clean the final
+// zero-OI residue: one call nets the matched lot and a second singleton call settles/detaches the
+// residue, after which the side can be finalized without consuming the user's separate PnL claim.
+#[test]
+fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation before recovery",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let matched_oi_after_adl = env.market_state().1.assets[0].oi_eff_long_q;
+    assert_eq!(
+        env.market_state().1.assets[0].oi_eff_short_q,
+        matched_oi_after_adl
+    );
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0).basis_pos_q,
+        (2 * POS_SCALE) as i128,
+    );
+    env.svm.warp_to_slot(7);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 7)
+        .expect("public shutdown enters asset recovery");
+    env.svm.warp_to_slot(8);
+    let cranker = Keypair::new();
+    env.svm.expire_blockhash();
+    let vault_before = env.market_state().1.vault;
+    let first_cu = env
+        .try_force_close_abandoned_asset_with_cu(&cranker, long, short, 0, 8, 2 * POS_SCALE)
+        .expect("the first force close nets the remaining matched exposure");
+    assert_cu_within(
+        "partial-ADL Recovery matched force close",
+        first_cu,
+        TRADE_CU_LIMIT,
+    );
+    let group = env.market_state().1;
+    let long_state = env.portfolio_state(long);
+    let short_state = env.portfolio_state(short);
+    let long_capital_before_cleanup = long_state.capital.get();
+    let long_pnl_before_cleanup = long_state.pnl.get();
+    assert_eq!(group.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group.assets[0].oi_eff_short_q, 0);
+    assert_eq!(
+        active_leg_for_asset(&long_state, 0).basis_pos_q,
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "the matched close leaves only the ADL terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&short_state, 0),
+        "the matched short is fully closed",
+    );
+
+    env.svm.expire_blockhash();
+    let cleanup_cu = env
+        .try_force_close_abandoned_asset_with_cu(
+            &cranker,
+            long,
+            short,
+            0,
+            8,
+            percolator::MAX_VAULT_TVL,
+        )
+        .expect("a singleton zero-OI Recovery residue must be permissionlessly detachable");
+    assert_cu_within(
+        "partial-ADL Recovery singleton cleanup",
+        cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(long), 0),
+        "the abandoned owner is no longer required to detach the terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(short), 0),
+        "both public portfolios are detached",
+    );
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "partial-ADL Recovery side finalization",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.assets[0].lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_before,
+        "Recovery cleanup moves no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert_eq!(
+        env.portfolio_state(long).capital.get(),
+        long_capital_before_cleanup,
+    );
+    assert_eq!(
+        env.portfolio_state(long).pnl.get(),
+        long_pnl_before_cleanup,
+        "terminal position cleanup preserves the independent user claim",
+    );
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38542,7 +38542,7 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
         )
         .expect("permissionless refresh must expire lapsed Live backing and commit");
     assert_cu_within(
-        "lapsed source-backing auto-crank refresh",
+        "lapsed source-backing expiry step",
         refresh_cu,
         CRANK_CU_LIMIT,
     );
@@ -38551,9 +38551,35 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     let expired = after_refresh.source_backing_buckets[1];
     assert_eq!(expired.status, BackingBucketStatusV16::Expired);
     assert_eq!(expired.fresh_unliened_backing_num, 0);
-    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_ne!(
+        health_cert(&env.portfolio_state(long)).cert_risk_epoch,
+        after_refresh.risk_epoch,
+        "expiry advances risk state, so another bounded crank remains actionable"
+    );
     assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
     assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    env.svm.expire_blockhash();
+    let certify_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("the next bounded auto-crank must certify after expiry");
+    assert_cu_within(
+        "post-expiry account certification",
+        certify_cu,
+        CRANK_CU_LIMIT,
+    );
+    assert!(health_cert(&env.portfolio_state(long)).valid);
 
     let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
         .basis_pos_q

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60938,3 +60938,151 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+#[test]
+fn v16_attack_public_20_source_second_lien_trade_has_bounded_cu() {
+    const N: u16 = 10;
+    const LOW: u64 = 100;
+    const HIGH: u64 = 200;
+    const Q: i128 = (100 * POS_SCALE) as i128;
+    const FIRST_INCREASE_Q: i128 = (100 * POS_SCALE) as i128;
+    const BACKING_EXPIRY_SLOT: u64 = 60;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        max_portfolio_assets: N,
+        maintenance_margin_bps: 10_000,
+        initial_margin_bps: 10_000,
+        max_price_move_bps_per_slot: 500,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    for asset_index in 0..N {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, LOW);
+        env.top_up_backing_bucket(2 * asset_index, 100_000, BACKING_EXPIRY_SLOT);
+        env.top_up_backing_bucket(2 * asset_index + 1, 100_000, BACKING_EXPIRY_SLOT);
+    }
+
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    env.deposit(&winner_owner, winner, N as u128 * 10_000 + 1);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    let mut counterparties = Vec::new();
+    for asset_index in 0..N {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        env.deposit(&owner, portfolio, 100_000);
+        env.trade_asset_with_cu(
+            asset_index,
+            &winner_owner,
+            winner,
+            &owner,
+            portfolio,
+            Q,
+            LOW,
+            0,
+        );
+        counterparties.push((owner, portfolio));
+    }
+
+    let accrue_all = |env: &mut V16CuEnv, slot: u64, price: u64| {
+        env.svm.warp_to_slot(slot);
+        for asset_index in 0..N {
+            env.push_auth_mark_for_asset_as_admin(asset_index, slot, price);
+            env.crank(
+                keeper,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+    };
+    let refresh_counterparties =
+        |env: &mut V16CuEnv, counterparties: &[(Keypair, Pubkey)], slot: u64| {
+            for (_, portfolio) in counterparties {
+                env.crank(
+                    *portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: slot,
+                        observations: vec![],
+                    },
+                );
+            }
+        };
+
+    accrue_all(&mut env, 20, HIGH);
+    refresh_counterparties(&mut env, &counterparties, 20);
+    drive_portfolio_cert_current(&mut env, winner, 20, 0, N as usize + 1);
+    for (asset_index, (owner, portfolio)) in counterparties.iter().enumerate() {
+        env.trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            -2 * Q,
+            HIGH,
+            0,
+        );
+    }
+
+    accrue_all(&mut env, 40, LOW);
+    refresh_counterparties(&mut env, &counterparties, 40);
+    drive_portfolio_cert_current(&mut env, winner, 40, 0, N as usize + 1);
+    let won = env.portfolio_state(winner);
+    assert_eq!(
+        won.source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        2 * N as usize,
+    );
+    assert_eq!(won.pnl.get(), 2 * N as i128 * 10_000);
+
+    let first_cu = env
+        .try_trade_asset_with_cu(
+            0,
+            &winner_owner,
+            winner,
+            &counterparties[0].0,
+            counterparties[0].1,
+            -FIRST_INCREASE_Q,
+            LOW,
+            0,
+        )
+        .expect("the first public source-lien allocation must fit");
+    assert_cu_within("20-source first lien trade", first_cu, 1_375_000);
+    let first_lien = env.portfolio_state(winner);
+    assert_eq!(
+        first_lien
+            .source_domains
+            .iter()
+            .filter(|source| source.source_lien_counterparty_backing_num.get() != 0)
+            .count(),
+        1,
+    );
+
+    let second_cu = env
+        .try_trade_asset_with_cu(
+            1,
+            &winner_owner,
+            winner,
+            &counterparties[1].0,
+            counterparties[1].1,
+            -(POS_SCALE as i128),
+            LOW,
+            0,
+        )
+        .expect("a second source lien must not make a valid public trade exceed SVM CU");
+    assert_cu_within("20-source second lien trade", second_cu, 1_375_000);
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_lien_counterparty_backing_num.get() != 0)
+            .count(),
+        2,
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3779,6 +3779,43 @@ fn assert_cu_within(label: &str, cu: u64, limit: u64) {
     );
 }
 
+fn portfolio_cert_is_current(env: &V16CuEnv, portfolio: Pubkey) -> bool {
+    let account = env.portfolio_state(portfolio);
+    let group = env.market_state().1;
+    let cert = health_cert(&account);
+    cert.valid
+        && account.stale_state == 0
+        && account.b_stale_state == 0
+        && cert.cert_oracle_epoch == group.oracle_epoch
+        && cert.cert_funding_epoch == group.funding_epoch
+        && cert.cert_risk_epoch == group.risk_epoch
+        && cert.cert_asset_set_epoch == group.asset_set_epoch
+        && cert.active_bitmap_at_cert == active_bitmap(&account)
+}
+
+fn drive_portfolio_cert_current(
+    env: &mut V16CuEnv,
+    portfolio: Pubkey,
+    now_slot: u64,
+    asset_index: u16,
+    max_steps: usize,
+) -> (usize, u64) {
+    let mut calls = 0usize;
+    let mut max_cu = 0u64;
+    while !portfolio_cert_is_current(env, portfolio) {
+        max_cu = max_cu.max(env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot,
+                observations: crank_observations(asset_index),
+            },
+        ));
+        calls += 1;
+        assert!(calls <= max_steps, "account refresh exceeded bounded rank");
+    }
+    (calls, max_cu)
+}
+
 #[test]
 fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
     let mut svm = LiteSVM::new();
@@ -16688,6 +16725,25 @@ fn v16_attack_insolvency_bad_debt_is_socialized_not_printed() {
         ],
         &[],
     );
+    let paper_winner = env.portfolio_state(long_account);
+    let paper_short = env.portfolio_state(short_account);
+    let paper_group = env.market_state().1;
+    let paper_residual = paper_group
+        .vault
+        .saturating_sub(paper_group.c_tot)
+        .saturating_sub(paper_group.insurance);
+    let paper_positive_pnl =
+        paper_winner.pnl.get().max(0) as u128 + paper_short.pnl.get().max(0) as u128;
+    assert!(
+        paper_positive_pnl > paper_residual,
+        "setup must create unbacked paper PnL before bounded settlement"
+    );
+    let (_, winner_refresh_cu) = drive_portfolio_cert_current(&mut env, long_account, 2, 0, 8);
+    assert_cu_within(
+        "insolvency winner bounded refresh",
+        winner_refresh_cu,
+        CRANK_CU_LIMIT,
+    );
 
     let lo = state::read_portfolio(&env.svm.get_account(&long_account).unwrap().data).unwrap();
     let sh = state::read_portfolio(&env.svm.get_account(&short_account).unwrap().data).unwrap();
@@ -16711,10 +16767,8 @@ fn v16_attack_insolvency_bad_debt_is_socialized_not_printed() {
     let residual = g.vault.saturating_sub(g.c_tot).saturating_sub(g.insurance);
     let pos_pnl = lo.pnl.get().max(0) as u128 + sh.pnl.get().max(0) as u128;
     assert!(
-        pos_pnl > residual,
-        "setup must create more positive paper pnl than backed residual (residual {} pos_pnl {})",
-        residual,
-        pos_pnl
+        pos_pnl <= paper_positive_pnl,
+        "bounded settlement cannot increase positive paper PnL"
     );
     assert!(health_cert(&lo).valid, "winner cert refreshed");
     assert!(
@@ -38582,23 +38636,10 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
     assert_eq!(env.token_amount(env.vault), vault_tokens_before);
 
-    env.svm.expire_blockhash();
-    let certify_cu = env
-        .send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 160,
-                observations: vec![],
-            },
-            vec![
-                AccountMeta::new(env.payer.pubkey(), true),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(long, false),
-            ],
-            &[],
-        )
-        .expect("the next bounded auto-crank must certify after expiry");
+    let (certify_calls, certify_cu) = drive_portfolio_cert_current(&mut env, long, 160, 0, 4);
+    assert!(certify_calls > 0);
     assert_cu_within(
-        "post-expiry account certification",
+        "post-expiry account certification steps",
         certify_cu,
         CRANK_CU_LIMIT,
     );
@@ -38690,6 +38731,18 @@ fn run_resolved_close_28_public_source_domains(
             observations: crank_observations(0),
         },
     );
+    let mut first_cycle_refresh_calls = 1usize;
+    while !portfolio_cert_is_current(&env, winner) {
+        env.crank(
+            winner,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: vec![],
+            },
+        );
+        first_cycle_refresh_calls += 1;
+        assert!(first_cycle_refresh_calls <= N as usize + 1);
+    }
     assert_eq!(
         env.portfolio_state(winner)
             .source_domains
@@ -38747,6 +38800,18 @@ fn run_resolved_close_28_public_source_domains(
             observations: crank_observations(0),
         },
     );
+    let mut second_cycle_refresh_calls = 1usize;
+    while !portfolio_cert_is_current(&env, winner) {
+        env.crank(
+            winner,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: vec![],
+            },
+        );
+        second_cycle_refresh_calls += 1;
+        assert!(second_cycle_refresh_calls <= N as usize + 1);
+    }
     assert_eq!(
         env.portfolio_state(winner)
             .source_domains
@@ -38822,9 +38887,9 @@ fn run_resolved_close_28_public_source_domains(
     let mut rank = 2 * N as usize + lapsed_initial + active_legs_initial;
     let expected_calls = rank + 1;
     let continuation_cu_limit = if retain_active_legs {
-        1_300_000
+        1_390_000
     } else {
-        1_000_000
+        1_050_000
     };
     let mut calls = 0usize;
     let mut max_cu = 0u64;
@@ -38939,6 +39004,294 @@ fn v16_attack_resolved_close_14_active_legs_and_28_source_domains_is_bounded() {
 #[test]
 fn v16_attack_resolved_autocrank_14_active_legs_and_28_source_domains_is_bounded() {
     run_resolved_close_28_public_source_domains(40, 0, true, true);
+}
+
+#[test]
+fn v16_attack_public_14_leg_28_source_domain_liquidation_progress_is_bounded() {
+    const N: u16 = 14;
+    const LOW: u64 = 100;
+    const HIGH: u64 = 200;
+    const ADVERSE: u64 = 199;
+    const Q: i128 = (100 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        max_portfolio_assets: N,
+        maintenance_margin_bps: 10_000,
+        initial_margin_bps: 10_000,
+        max_price_move_bps_per_slot: 500,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        maintenance_fee_per_slot: 150,
+        ..V16CuMarketParams::default()
+    });
+    for asset_index in 0..N {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, LOW);
+    }
+
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    env.deposit(&winner_owner, winner, 140_001);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    let mut counterparties = Vec::new();
+    for asset_index in 0..N {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        env.deposit(&owner, portfolio, 50_000);
+        let opened = env.try_trade_asset_with_cu(
+            asset_index,
+            &winner_owner,
+            winner,
+            &owner,
+            portfolio,
+            Q,
+            LOW,
+            0,
+        );
+        assert!(
+            opened.is_ok(),
+            "open asset {asset_index} failed: {opened:?}"
+        );
+        counterparties.push((owner, portfolio));
+    }
+
+    let accrue_all = |env: &mut V16CuEnv, keeper: Pubkey, slot: u64, price: u64| {
+        env.svm.warp_to_slot(slot);
+        for asset_index in 0..N {
+            env.push_auth_mark_for_asset_as_admin(asset_index, slot, price);
+            env.crank(
+                keeper,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+    };
+    let refresh_counterparties =
+        |env: &mut V16CuEnv, counterparties: &[(Keypair, Pubkey)], slot: u64| {
+            for (asset_index, (_, portfolio)) in counterparties.iter().enumerate() {
+                env.crank(
+                    *portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: slot,
+                        observations: crank_observations(asset_index as u16),
+                    },
+                );
+            }
+        };
+    accrue_all(&mut env, keeper, 20, HIGH);
+    refresh_counterparties(&mut env, &counterparties, 20);
+    let (first_refresh_calls, first_refresh_cu) =
+        drive_portfolio_cert_current(&mut env, winner, 20, 0, N as usize + 1);
+    assert!(first_refresh_calls > 0);
+    assert_cu_within(
+        "14-leg first winner refresh steps",
+        first_refresh_cu,
+        1_300_000,
+    );
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        N as usize,
+    );
+
+    for (asset_index, (owner, portfolio)) in counterparties.iter().enumerate() {
+        let flipped = env.try_trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            -2 * Q,
+            HIGH,
+            0,
+        );
+        assert!(
+            flipped.is_ok(),
+            "flip asset {asset_index} failed: {flipped:?}",
+        );
+    }
+
+    env.svm.warp_to_slot(40);
+    let mut second_cycle_max_cu = 0u64;
+    for (asset_index, (_, portfolio)) in counterparties.iter().enumerate() {
+        let asset_index = asset_index as u16;
+        env.push_auth_mark_for_asset_as_admin(asset_index, 40, LOW);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index),
+            },
+        );
+        env.crank(
+            *portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index),
+            },
+        );
+        let (calls, cu) = drive_portfolio_cert_current(&mut env, winner, 40, asset_index, 3);
+        assert!(calls > 0);
+        second_cycle_max_cu = second_cycle_max_cu.max(cu);
+        if asset_index == 1 {
+            let fee_cu = env.sync_maintenance_fee_with_cu(winner, None, 40);
+            assert_cu_within("16-source maintenance fee sync", fee_cu, 1_375_000);
+            let (post_fee_calls, post_fee_cu) =
+                drive_portfolio_cert_current(&mut env, winner, 40, asset_index, 2);
+            assert_eq!(post_fee_calls, 1);
+            second_cycle_max_cu = second_cycle_max_cu.max(post_fee_cu);
+        }
+    }
+    assert_cu_within(
+        "incremental 28-source construction",
+        second_cycle_max_cu,
+        1_300_000,
+    );
+    let won = env.portfolio_state(winner);
+    assert_eq!(
+        won.source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        (2 * N) as usize,
+    );
+    assert_eq!(won.capital.get(), 137_001);
+    assert_eq!(won.pnl.get(), 280_000);
+    assert_eq!(
+        won.source_domains
+            .iter()
+            .filter(|source| source.source_claim_liened_num.get() != 0)
+            .count(),
+        0,
+    );
+
+    accrue_all(&mut env, keeper, 60, ADVERSE);
+    refresh_counterparties(&mut env, &counterparties, 60);
+    let vault_before_refresh = env.market_state().1.vault;
+    let token_vault_before_refresh = env.token_amount(env.vault);
+    let mut refresh_calls = 0usize;
+    let mut max_refresh_cu = 0u64;
+    while !portfolio_cert_is_current(&env, winner) {
+        let before = env.portfolio_state(winner);
+        let claims_before = before
+            .source_domains
+            .iter()
+            .map(|source| source.source_claim_bound_num.get())
+            .sum::<u128>();
+        let pnl_before = before.pnl.get();
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 60,
+                    observations: vec![],
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(winner, false),
+                ],
+                &[],
+            )
+            .unwrap_or_else(|err| {
+                panic!(
+                    "max-source stale-leg continuation {} with {claims_before} claims failed: {err}",
+                    refresh_calls + 1,
+                )
+            });
+        refresh_calls += 1;
+        max_refresh_cu = max_refresh_cu.max(cu);
+        let after = env.portfolio_state(winner);
+        let claims_after = after
+            .source_domains
+            .iter()
+            .map(|source| source.source_claim_bound_num.get())
+            .sum::<u128>();
+        if portfolio_cert_is_current(&env, winner) {
+            assert_eq!(claims_after, claims_before);
+            assert_eq!(after.pnl.get(), pnl_before);
+        } else {
+            assert!(claims_after < claims_before);
+            assert!(after.pnl.get() < pnl_before);
+        }
+        assert!(refresh_calls <= N as usize + 1);
+    }
+    assert!(refresh_calls > 1);
+    assert_cu_within(
+        "14-leg 28-source stale-leg continuation",
+        max_refresh_cu,
+        1_300_000,
+    );
+    assert_eq!(env.market_state().1.vault, vault_before_refresh);
+    assert_eq!(env.token_amount(env.vault), token_vault_before_refresh);
+
+    let adverse = env.portfolio_state(winner);
+    let adverse_cert = health_cert(&adverse);
+    assert_eq!(adverse.capital.get(), 137_001);
+    assert!(adverse.pnl.get() > 0);
+    assert_eq!(
+        adverse_cert.certified_equity,
+        adverse.capital.get() as i128 + adverse.pnl.get(),
+    );
+    assert_eq!(adverse_cert.certified_maintenance_req, 278_600);
+    assert_eq!(
+        adverse_cert.certified_liq_deficit,
+        adverse_cert
+            .certified_maintenance_req
+            .saturating_sub(adverse_cert.certified_equity as u128),
+    );
+    assert!(adverse_cert.certified_liq_deficit > 0);
+    let adverse_source_domains = adverse
+        .source_domains
+        .iter()
+        .filter(|source| source.source_claim_bound_num.get() != 0)
+        .count();
+    assert_eq!(adverse_source_domains, 8);
+
+    let exposure_before = adverse
+        .legs
+        .iter()
+        .filter_map(|leg| leg.try_to_runtime().ok())
+        .filter(|leg| leg.active)
+        .map(|leg| leg.basis_pos_q.unsigned_abs())
+        .sum::<u128>();
+    env.svm.expire_blockhash();
+    let liquidation_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 60,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(winner, false),
+            ],
+            &[],
+        )
+        .expect("the current max-source account must be permissionlessly liquidatable");
+    assert_cu_within("14-leg 8-source liquidation", liquidation_cu, 1_375_000);
+    let after_liquidation = env.portfolio_state(winner);
+    let exposure_after = after_liquidation
+        .legs
+        .iter()
+        .filter_map(|leg| leg.try_to_runtime().ok())
+        .filter(|leg| leg.active)
+        .map(|leg| leg.basis_pos_q.unsigned_abs())
+        .sum::<u128>();
+    assert!(
+        exposure_after < exposure_before,
+        "engine-selected liquidation must strictly reduce aggregate active exposure",
+    );
+    assert_eq!(
+        env.market_state().1.vault as u64,
+        env.token_amount(env.vault),
+    );
 }
 
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
@@ -39389,12 +39742,13 @@ fn v16_attack_adl_then_settlement_winner_cannot_escape_deleverage() {
     // SECOND mark move + crank the winner: this settles the deleveraged leg (a_basis vs reduced a_long).
     env.svm.warp_to_slot(7);
     env.push_auth_mark_with_cu(7, 800);
-    env.crank(
-        a,
-        ProgInstruction::PermissionlessCrank {
-            now_slot: 7,
-            observations: crank_observations(0),
-        },
+    let (winner_refresh_calls, winner_refresh_cu) =
+        drive_portfolio_cert_current(&mut env, a, 7, 0, 4);
+    assert!(winner_refresh_calls > 0);
+    assert_cu_within(
+        "post-ADL winner refresh steps",
+        winner_refresh_cu,
+        CRANK_CU_LIMIT,
     );
 
     let win = env.portfolio_state(a);
@@ -41401,21 +41755,18 @@ fn v16_attack_cross_margin_netting_conserves() {
         ],
         &[&admin],
     );
-    for ai in [0u16, 1] {
-        env.svm.expire_blockhash();
-        let _ = env.send(
+    for (ai, counterparty) in [(0u16, y0), (1, y1)] {
+        env.crank(
+            counterparty,
             ProgInstruction::PermissionlessCrank {
                 now_slot: 2,
                 observations: crank_observations(ai),
             },
-            vec![
-                AccountMeta::new(env.payer.pubkey(), true),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(x, false),
-            ],
-            &[],
         );
     }
+    let (refresh_calls, refresh_cu) = drive_portfolio_cert_current(&mut env, x, 2, 0, 4);
+    assert!(refresh_calls > 0);
+    assert_cu_within("two-leg cross-margin refresh", refresh_cu, CRANK_CU_LIMIT);
 
     let xs = env.portfolio_state(x);
     let g = env.market_state().1;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38437,6 +38437,140 @@ fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
     );
 }
 
+// Live source-backing expiry liveness: this is a fully public path to a source-backed claim.
+// A partial ADL realizes the loser's capital as Fresh backing for the winner. Once that bucket
+// expires, a later adverse move must not make RefreshAccount return EngineStale forever: SVM
+// rollback would restore the same lapsed-Fresh predicate after every keeper attempt and block the
+// owner's risk-reducing trade. Auto-crank must apply the canonical expiry transition, preserve
+// custody, certify both accounts, and leave the owner able to reduce the position.
+#[test]
+fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    env.deposit(&long_owner, long, 40);
+    env.deposit(&short_owner, short, 410);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    for slot in 2..=30 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 300);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    for portfolio in [short, long] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 30,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+    );
+    let after_short_group = env.market_state().1;
+    let after_short_long = active_leg_for_asset(&env.portfolio_state(long), 0);
+    let after_short_short = active_leg_for_asset(&env.portfolio_state(short), 0);
+    assert_eq!(after_short_group.assets[0].b_long_num, 0);
+    assert_eq!(after_short_group.assets[0].b_short_num, 0);
+    assert!(!after_short_long.b_stale && !after_short_short.b_stale);
+    let generated_backing = after_short_group.source_backing_buckets[1];
+    assert_eq!(generated_backing.status, BackingBucketStatusV16::Fresh);
+    assert!(
+        generated_backing.fresh_unliened_backing_num > 0,
+        "public partial ADL must create real source backing for the winner"
+    );
+
+    for slot in 31..=160 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 1);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    let before_refresh = env.market_state().1;
+    let lapsed = before_refresh.source_backing_buckets[1];
+    assert_eq!(lapsed.status, BackingBucketStatusV16::Fresh);
+    assert!(lapsed.expiry_slot < 160, "backing is observably lapsed");
+    assert!(env.portfolio_state(long).pnl.get() > 0);
+    let vault_before = before_refresh.vault;
+    let vault_tokens_before = env.token_amount(env.vault);
+
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("permissionless refresh must expire lapsed Live backing and commit");
+    assert_cu_within(
+        "lapsed source-backing auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let after_refresh = env.market_state().1;
+    let expired = after_refresh.source_backing_buckets[1];
+    assert_eq!(expired.status, BackingBucketStatusV16::Expired);
+    assert_eq!(expired.fresh_unliened_backing_num, 0);
+    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    let exit_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, POS_SCALE / 4);
+    assert_cu_within("post-expiry user risk reduction", exit_cu, CUSTODY_CU_LIMIT);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0)
+            .basis_pos_q
+            .unsigned_abs(),
+        long_before_exit - POS_SCALE / 4,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.vault, vault_before);
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38147,6 +38147,142 @@ fn v16_attack_adl_deleverage_conserves_and_shrinks_winner_claim() {
     );
 }
 
+// Public LoF/DoS regression: partial ADL leaves the winner's stored basis larger than matched
+// effective OI. Before the fix, a normal max-work RebalanceReduce aborts with
+// EngineCounterUnderflow; reducing exactly the remaining effective OI once instead leaves a
+// Normal-mode, zero-OI residue that every later reduction also rejects. The exit must clamp to
+// matched OI, establish the reset epoch, and leave both residual accounts finitely crankable.
+#[test]
+fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let (_, adl) = env.market_state();
+    let winner = env.portfolio_state(long);
+    assert_eq!(winner.legs[0].basis_pos_q.get(), (2 * POS_SCALE) as i128);
+    let matched_oi_after_adl = adl.assets[0].oi_eff_long_q;
+    assert_eq!(adl.assets[0].oi_eff_short_q, matched_oi_after_adl);
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(adl.assets[0].mode_long, SideModeV16::Normal);
+    let vault_after_adl = adl.vault;
+
+    // This max-work request is the old red path. It must consume only the remaining matched
+    // exposure rather than subtracting the full stored basis from smaller effective OI.
+    let reduce_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, 2 * POS_SCALE);
+    assert_cu_within(
+        "partial-ADL max RebalanceReduce",
+        reduce_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let (_, reset) = env.market_state();
+    assert_eq!(reset.assets[0].oi_eff_long_q, 0);
+    assert_eq!(reset.assets[0].oi_eff_short_q, 0);
+    assert_eq!(reset.assets[0].mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.assets[0].mode_short, SideModeV16::ResetPending);
+    assert_eq!(
+        env.portfolio_state(long).legs[0].basis_pos_q.get(),
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "only effective exposure is reduced; terminal stored residue remains for settlement"
+    );
+
+    let mut max_cleanup_cu = 0;
+    for portfolio in [long, short] {
+        for _ in 0..3 {
+            if percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))) {
+                break;
+            }
+            max_cleanup_cu = max_cleanup_cu.max(env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 6,
+                    observations: crank_observations(0),
+                },
+            ));
+        }
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))),
+            "each prior-reset residue must detach in finitely many unsigned cranks"
+        );
+    }
+    assert_cu_within(
+        "partial-ADL residue cleanup",
+        max_cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let long_finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    let short_finalize_cu = env.finalize_reset_side_with_cu(0, 1);
+    assert_cu_within(
+        "partial-ADL long finalize",
+        long_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_cu_within(
+        "partial-ADL short finalize",
+        short_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let (_, done) = env.market_state();
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_after_adl,
+        "exit and cleanup move no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert!(done.vault >= done.c_tot + done.insurance);
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -17606,29 +17606,38 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
     );
     env.resolve();
 
-    env.svm.expire_blockhash();
-    let loser_crank_cu = env
-        .send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: u64::MAX,
-                observations: vec![CrankObservationHint {
-                    asset_index: u16::MAX,
-                    oracle_accounts: u8::MAX,
-                }],
-            },
-            vec![
-                AccountMeta::new_readonly(victim_owner.pubkey(), false),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(victim, false),
-            ],
-            &[],
-        )
-        .expect("resolved deep cross-margin bad debt has public progress");
-    assert_cu_within(
-        "Resolved PermissionlessCrank unattributed bad debt",
-        loser_crank_cu,
-        CRANK_CU_LIMIT,
-    );
+    let mut active_legs = 2u32;
+    for _ in 0..2 {
+        env.svm.expire_blockhash();
+        let loser_crank_cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: u64::MAX,
+                    observations: vec![CrankObservationHint {
+                        asset_index: u16::MAX,
+                        oracle_accounts: u8::MAX,
+                    }],
+                },
+                vec![
+                    AccountMeta::new_readonly(victim_owner.pubkey(), false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                &[],
+            )
+            .expect("resolved deep cross-margin bad debt has public progress");
+        assert_cu_within(
+            "Resolved PermissionlessCrank unattributed bad debt",
+            loser_crank_cu,
+            CRANK_CU_LIMIT,
+        );
+        let next_active_legs = active_bitmap(&env.portfolio_state(victim))
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>();
+        assert_eq!(next_active_legs + 1, active_legs);
+        active_legs = next_active_legs;
+    }
     let victim_after = env.portfolio_state(victim);
     assert_eq!(
         victim_after.capital.get(),
@@ -38614,7 +38623,12 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
 // Public max-shape regression: ordinary trades can leave one winner with both
 // historical source domains for all 14 portfolio assets. Before the fix, both
 // fresh and lapsed backing variants exhausted the 1.4M-CU SVM ceiling forever.
-fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed: usize) {
+fn run_resolved_close_28_public_source_domains(
+    close_slot: u64,
+    expected_lapsed: usize,
+    retain_active_legs: bool,
+    use_permissionless_crank: bool,
+) {
     const N: u16 = 14;
     const OPEN_PRICE: u64 = 100;
     const HIGH_PRICE: u64 = 200;
@@ -38742,21 +38756,31 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
         (2 * N) as usize,
         "the public short-winning cycle adds every even source domain",
     );
-    for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
-        env.trade_asset_with_cu(
-            asset_index as u16,
-            &winner_owner,
-            winner,
-            owner,
-            *portfolio,
-            POS_SCALE as i128,
-            OPEN_PRICE,
-            0,
+    if !retain_active_legs {
+        for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
+            env.trade_asset_with_cu(
+                asset_index as u16,
+                &winner_owner,
+                winner,
+                owner,
+                *portfolio,
+                POS_SCALE as i128,
+                OPEN_PRICE,
+                0,
+            );
+        }
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &env.portfolio_state(winner)
+        )));
+    } else {
+        assert_eq!(
+            active_bitmap(&env.portfolio_state(winner))
+                .iter()
+                .map(|word| word.count_ones())
+                .sum::<u32>(),
+            N as u32,
         );
     }
-    assert!(percolator::active_bitmap_is_empty(active_bitmap(
-        &env.portfolio_state(winner)
-    )));
 
     let live = env.market_state().1;
     for domain in 0..(2 * N) as usize {
@@ -38772,12 +38796,36 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
     assert_eq!(lapsed_initial, expected_lapsed);
     env.svm.warp_to_slot(close_slot);
     env.resolve();
+    if retain_active_legs {
+        for (owner, portfolio) in &short_losers {
+            let dest = env.token_account_for_mint(env.mint, owner.pubkey(), 0);
+            env.drive_close_resolved_with_cu(owner.pubkey(), *portfolio, dest, env.vault)
+                .expect("publicly wind down losing counterparty before last winner");
+        }
+        assert_eq!(
+            active_bitmap(&env.portfolio_state(winner))
+                .iter()
+                .map(|word| word.count_ones())
+                .sum::<u32>(),
+            N as u32,
+            "winner remains the last max-shape active account",
+        );
+    }
     let dest = env.token_account_for_mint(env.mint, winner_owner.pubkey(), 0);
     let internal_vault_before = env.market_state().1.vault;
     let token_vault_before = env.token_amount(env.vault);
     let dest_before = env.token_amount(dest);
-    let mut rank = 2 * N as usize + lapsed_initial;
+    let active_legs_initial = active_bitmap(&env.portfolio_state(winner))
+        .iter()
+        .map(|word| word.count_ones() as usize)
+        .sum::<usize>();
+    let mut rank = 2 * N as usize + lapsed_initial + active_legs_initial;
     let expected_calls = rank + 1;
+    let continuation_cu_limit = if retain_active_legs {
+        1_300_000
+    } else {
+        1_000_000
+    };
     let mut calls = 0usize;
     let mut max_cu = 0u64;
     loop {
@@ -38786,11 +38834,19 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
         let vault_before = env.token_amount(env.vault);
         let destination_before = env.token_amount(dest);
         env.svm.expire_blockhash();
+        let instruction = if use_permissionless_crank {
+            ProgInstruction::PermissionlessCrank {
+                now_slot: close_slot,
+                observations: crank_observations(0),
+            }
+        } else {
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            }
+        };
         let cu = env
             .send(
-                ProgInstruction::CloseResolved {
-                    fee_rate_per_slot: 0,
-                },
+                instruction,
                 vec![
                     AccountMeta::new_readonly(winner_owner.pubkey(), false),
                     AccountMeta::new(env.market, false),
@@ -38806,7 +38862,7 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
         calls += 1;
         max_cu = max_cu.max(cu);
         assert!(
-            cu <= 1_000_000,
+            cu <= continuation_cu_limit,
             "bounded resolved-close continuation consumed {cu} CU",
         );
         let portfolio_after = env.portfolio_state(winner);
@@ -38816,15 +38872,20 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
             .filter(|source| source.source_claim_bound_num.get() != 0)
             .count();
         let market_after = env.market_state().1;
+        let active_legs_after = active_bitmap(&portfolio_after)
+            .iter()
+            .map(|word| word.count_ones() as usize)
+            .sum::<usize>();
         let lapsed_fresh_after = market_after.source_backing_buckets[..(2 * N) as usize]
             .iter()
             .filter(|bucket| {
                 bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= close_slot
             })
             .count();
-        let next_rank = source_claims_after + lapsed_fresh_after;
+        let next_rank = active_legs_after + source_claims_after + lapsed_fresh_after;
         let closed = portfolio_after.capital.get() == 0
             && portfolio_after.pnl.get() == 0
+            && active_legs_after == 0
             && source_claims_after == 0;
         if closed {
             assert_eq!(next_rank, 0);
@@ -38862,12 +38923,22 @@ fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed:
 
 #[test]
 fn v16_attack_resolved_close_28_fresh_source_domains_makes_bounded_progress() {
-    run_resolved_close_28_public_source_domains(40, 0);
+    run_resolved_close_28_public_source_domains(40, 0, false, false);
 }
 
 #[test]
 fn v16_attack_resolved_close_28_lapsed_source_domains_makes_bounded_progress() {
-    run_resolved_close_28_public_source_domains(200, 28);
+    run_resolved_close_28_public_source_domains(200, 28, false, false);
+}
+
+#[test]
+fn v16_attack_resolved_close_14_active_legs_and_28_source_domains_is_bounded() {
+    run_resolved_close_28_public_source_domains(40, 0, true, false);
+}
+
+#[test]
+fn v16_attack_resolved_autocrank_14_active_legs_and_28_source_domains_is_bounded() {
+    run_resolved_close_28_public_source_domains(40, 0, true, true);
 }
 
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2729,24 +2729,67 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
-        let cu = self
-            .send(
+        let max_cu = self
+            .drive_close_resolved_with_cu(owner.pubkey(), portfolio, dest, self.vault)
+            .expect("close resolved");
+        (dest, max_cu)
+    }
+
+    fn drive_close_resolved_with_cu(
+        &mut self,
+        owner: Pubkey,
+        portfolio: Pubkey,
+        dest: Pubkey,
+        vault: Pubkey,
+    ) -> Result<u64, String> {
+        let max_steps = 3 * percolator::PORTFOLIO_SOURCE_DOMAIN_CAP
+            + 2 * percolator::V16_MAX_PORTFOLIO_ASSETS_N
+            + 16;
+        let mut max_cu = 0u64;
+        for _ in 0..max_steps {
+            let market_before = self.svm.get_account(&self.market).unwrap();
+            let portfolio_before = self.svm.get_account(&portfolio).unwrap();
+            self.svm.expire_blockhash();
+            let cu = self.send(
                 ProgInstruction::CloseResolved {
                     fee_rate_per_slot: 0,
                 },
                 vec![
-                    AccountMeta::new_readonly(owner.pubkey(), false),
+                    AccountMeta::new_readonly(owner, false),
                     AccountMeta::new(self.market, false),
                     AccountMeta::new(portfolio, false),
                     AccountMeta::new(dest, false),
-                    AccountMeta::new(self.vault, false),
+                    AccountMeta::new(vault, false),
                     AccountMeta::new_readonly(self.vault_authority, false),
                     AccountMeta::new_readonly(spl_token::ID, false),
                 ],
                 &[],
-            )
-            .expect("close resolved");
-        (dest, cu)
+            )?;
+            max_cu = max_cu.max(cu);
+
+            let state = self.portfolio_state(portfolio);
+            let terminal = state.capital.get() == 0
+                && state.pnl.get() == 0
+                && percolator::active_bitmap_is_empty(active_bitmap(&state))
+                && state
+                    .source_domains
+                    .iter()
+                    .all(|source| source.source_claim_bound_num.get() == 0)
+                && state.stale_state == 0
+                && state.b_stale_state == 0;
+            if terminal {
+                return Ok(max_cu);
+            }
+
+            let made_progress = self.svm.get_account(&self.market).unwrap() != market_before
+                || self.svm.get_account(&portfolio).unwrap() != portfolio_before;
+            if !made_progress {
+                // Another account still gates the global resolved payout. Let
+                // the caller advance that account before retrying this one.
+                return Ok(max_cu);
+            }
+        }
+        Err("resolved close exceeded its bounded progress rank".to_string())
     }
 
     fn top_up_insurance(&mut self, amount: u128) -> Pubkey {
@@ -18175,23 +18218,8 @@ fn v16_attack_resolved_payout_dual_mint_replay_extracts_nothing() {
     );
 
     let secondary_dest = env.token_account_for_mint(secondary, lo_owner.pubkey(), 0);
-    env.svm.expire_blockhash();
     let secondary_close_cu = env
-        .send(
-            ProgInstruction::CloseResolved {
-                fee_rate_per_slot: 0,
-            },
-            vec![
-                AccountMeta::new_readonly(lo_owner.pubkey(), false),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(lo, false),
-                AccountMeta::new(secondary_dest, false),
-                AccountMeta::new(secondary_vault, false),
-                AccountMeta::new_readonly(env.vault_authority, false),
-                AccountMeta::new_readonly(spl_token::ID, false),
-            ],
-            &[],
-        )
+        .drive_close_resolved_with_cu(lo_owner.pubkey(), lo, secondary_dest, secondary_vault)
         .expect("close resolved through secondary reserve");
     assert_cu_within(
         "CloseResolved secondary payout",
@@ -18550,22 +18578,8 @@ fn v16_attack_terminal_secondary_payouts_reject_noncanonical_vault() {
         "owner receives no payout from rejected non-canonical close"
     );
 
-    env.svm.expire_blockhash();
-    let accepted_close = env.send(
-        ProgInstruction::CloseResolved {
-            fee_rate_per_slot: 0,
-        },
-        vec![
-            AccountMeta::new_readonly(lo_owner.pubkey(), false),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(lo, false),
-            AccountMeta::new(secondary_dest, false),
-            AccountMeta::new(secondary_vault, false),
-            AccountMeta::new_readonly(env.vault_authority, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-        ],
-        &[],
-    );
+    let accepted_close =
+        env.drive_close_resolved_with_cu(lo_owner.pubkey(), lo, secondary_dest, secondary_vault);
     assert!(
         accepted_close.is_ok(),
         "canonical secondary CloseResolved still pays: {accepted_close:?}"
@@ -38595,6 +38609,265 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     let done = env.market_state().1;
     assert_eq!(done.vault, vault_before);
     assert_eq!(done.vault as u64, env.token_amount(env.vault));
+}
+
+// Public max-shape regression: ordinary trades can leave one winner with both
+// historical source domains for all 14 portfolio assets. Before the fix, both
+// fresh and lapsed backing variants exhausted the 1.4M-CU SVM ceiling forever.
+fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed: usize) {
+    const N: u16 = 14;
+    const OPEN_PRICE: u64 = 100;
+    const HIGH_PRICE: u64 = 200;
+    const WINNER_CAPITAL: u128 = 100_000;
+    const LOSER_CAPITAL: u128 = 1_000;
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(N, 1_000, 1_000, 500);
+    for asset_index in 0..N {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, OPEN_PRICE);
+    }
+
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    env.deposit(&winner_owner, winner, WINNER_CAPITAL);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+
+    let mut short_losers = Vec::new();
+    for asset_index in 0..N {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        env.deposit(&owner, portfolio, LOSER_CAPITAL);
+        env.trade_asset_with_cu(
+            asset_index,
+            &winner_owner,
+            winner,
+            &owner,
+            portfolio,
+            POS_SCALE as i128,
+            OPEN_PRICE,
+            0,
+        );
+        short_losers.push((owner, portfolio));
+    }
+
+    env.svm.warp_to_slot(20);
+    for asset_index in 0..N {
+        env.push_auth_mark_for_asset_as_admin(asset_index, 20, HIGH_PRICE);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: crank_observations(asset_index),
+            },
+        );
+    }
+    for (asset_index, (_, portfolio)) in short_losers.iter().enumerate() {
+        env.crank(
+            *portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: crank_observations(asset_index as u16),
+            },
+        );
+    }
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        N as usize,
+        "the public long-winning cycle creates one odd source domain per asset",
+    );
+    for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
+        env.trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            -((2 * POS_SCALE) as i128),
+            HIGH_PRICE,
+            0,
+        );
+    }
+    assert_eq!(
+        active_bitmap(&env.portfolio_state(winner))
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>(),
+        N as u32,
+        "the risk-neutral flips keep one short leg per asset",
+    );
+
+    env.svm.warp_to_slot(40);
+    for asset_index in 0..N {
+        env.push_auth_mark_for_asset_as_admin(asset_index, 40, OPEN_PRICE);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index),
+            },
+        );
+    }
+    for (asset_index, (_, portfolio)) in short_losers.iter().enumerate() {
+        env.crank(
+            *portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index as u16),
+            },
+        );
+    }
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        (2 * N) as usize,
+        "the public short-winning cycle adds every even source domain",
+    );
+    for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
+        env.trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            POS_SCALE as i128,
+            OPEN_PRICE,
+            0,
+        );
+    }
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &env.portfolio_state(winner)
+    )));
+
+    let live = env.market_state().1;
+    for domain in 0..(2 * N) as usize {
+        assert_eq!(
+            live.source_backing_buckets[domain].status,
+            BackingBucketStatusV16::Fresh,
+        );
+    }
+    let lapsed_initial = live.source_backing_buckets[..(2 * N) as usize]
+        .iter()
+        .filter(|bucket| bucket.expiry_slot <= close_slot)
+        .count();
+    assert_eq!(lapsed_initial, expected_lapsed);
+    env.svm.warp_to_slot(close_slot);
+    env.resolve();
+    let dest = env.token_account_for_mint(env.mint, winner_owner.pubkey(), 0);
+    let internal_vault_before = env.market_state().1.vault;
+    let token_vault_before = env.token_amount(env.vault);
+    let dest_before = env.token_amount(dest);
+    let mut rank = 2 * N as usize + lapsed_initial;
+    let expected_calls = rank + 1;
+    let mut calls = 0usize;
+    let mut max_cu = 0u64;
+    loop {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let winner_before = env.svm.get_account(&winner).unwrap();
+        let vault_before = env.token_amount(env.vault);
+        let destination_before = env.token_amount(dest);
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::CloseResolved {
+                    fee_rate_per_slot: 0,
+                },
+                vec![
+                    AccountMeta::new_readonly(winner_owner.pubkey(), false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(winner, false),
+                    AccountMeta::new(dest, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                &[],
+            )
+            .expect("every bounded resolved-close continuation must land");
+        calls += 1;
+        max_cu = max_cu.max(cu);
+        assert!(
+            cu <= 1_000_000,
+            "bounded resolved-close continuation consumed {cu} CU",
+        );
+        let portfolio_after = env.portfolio_state(winner);
+        let source_claims_after = portfolio_after
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count();
+        let market_after = env.market_state().1;
+        let lapsed_fresh_after = market_after.source_backing_buckets[..(2 * N) as usize]
+            .iter()
+            .filter(|bucket| {
+                bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= close_slot
+            })
+            .count();
+        let next_rank = source_claims_after + lapsed_fresh_after;
+        let closed = portfolio_after.capital.get() == 0
+            && portfolio_after.pnl.get() == 0
+            && source_claims_after == 0;
+        if closed {
+            assert_eq!(next_rank, 0);
+            break;
+        }
+        assert_eq!(
+            next_rank + 1,
+            rank,
+            "every successful continuation must strictly decrease the public terminal rank",
+        );
+        assert!(
+            env.svm.get_account(&env.market).unwrap() != market_before
+                || env.svm.get_account(&winner).unwrap() != winner_before,
+            "a nonterminal successful close must mutate its progress state",
+        );
+        assert_eq!(env.token_amount(env.vault), vault_before);
+        assert_eq!(env.token_amount(dest), destination_before);
+        rank = next_rank;
+        assert!(calls <= expected_calls);
+    }
+    assert_eq!(calls, expected_calls);
+    assert!(max_cu > 0);
+    let payout = env.token_amount(dest) - dest_before;
+    assert!(payout > 0);
+    assert_eq!(token_vault_before - env.token_amount(env.vault), payout);
+    assert_eq!(
+        internal_vault_before - env.market_state().1.vault,
+        payout as u128,
+    );
+    assert_eq!(
+        env.market_state().1.vault as u64,
+        env.token_amount(env.vault)
+    );
+}
+
+#[test]
+fn v16_attack_resolved_close_28_fresh_source_domains_makes_bounded_progress() {
+    run_resolved_close_28_public_source_domains(40, 0);
+}
+
+#[test]
+fn v16_attack_resolved_close_28_lapsed_source_domains_makes_bounded_progress() {
+    run_resolved_close_28_public_source_domains(200, 28);
 }
 
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open


### PR DESCRIPTION
A normal public lifecycle retains 20 source-claim domains across ten active assets. The first risk-increasing TradeNoCpi creates one backed source lien, but a one-position follow-up requiring a second lien consumed the full 1.4M CU budget and aborted. Splitting the requested size does not cross the second-lien boundary.\n\nPin engine PR #113, whose allocator removes redundant per-domain full-state validation while retaining the allocator-entry validation and the trade's committed-state audit. The same public call now uses 898,270 CU.\n\nTDD is entirely public LiteSVM setup: InitMarket/asset activation, backing topups, portfolios, deposits, trades, authenticated mark cranks, then the two risk increases. No state injection.\n\nVerification:\n- cargo build-sbf --tools-version v1.52\n- cargo test --all-targets: 5/5 + 570/570\n- engine cargo test --all-targets: 132/132\n- targeted source-lien Kani: 121 checks, 2/2 covers\n\nStacked on PR #212 because its max-source refresh work makes this 20-domain public lifecycle reachable.