### PR TITLE
[BLOCKER DoS] Reset both zero-OI sides to preserve exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=552e9ac76a2288fb5a91c40e1cce7e952a6ab4a5#552e9ac76a2288fb5a91c40e1cce7e952a6ab4a5"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f97194677901e38bc8b2b87a67ac878c74dbfa99#f97194677901e38bc8b2b87a67ac878c74dbfa99"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "552e9ac76a2288fb5a91c40e1cce7e952a6ab4a5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f97194677901e38bc8b2b87a67ac878c74dbfa99" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "552e9ac76a2288fb5a91c40e1cce7e952a6ab4a5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f97194677901e38bc8b2b87a67ac878c74dbfa99" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59865,4 +59865,49 @@ fn v16_attack_reset_remainder_carry_cannot_block_bankruptcy_progress() {
     assert_eq!(end.c_tot + 5, after_exit.c_tot);
     assert_eq!(end.vault as u64, env.token_amount(env.vault));
     assert!(end.vault >= end.c_tot + end.insurance);
+    assert_eq!(
+        end.assets[0].mode_short,
+        SideModeV16::ResetPending,
+        "the liquidated side must expose its surviving zero-OI leg as dead"
+    );
+    assert_eq!(end.assets[0].stored_pos_count_short, 1);
+
+    env.svm.expire_blockhash();
+    let s3_forfeit_cu = env
+        .send(
+            ProgInstruction::ForfeitRecoveryLeg {
+                asset_index: 0,
+                b_delta_budget: percolator::MAX_VAULT_TVL,
+            },
+            vec![
+                AccountMeta::new(s3o.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(s3, false),
+            ],
+            &[&s3o],
+        )
+        .expect("the surviving zero-OI short must have a public dead-leg exit");
+    assert_cu_within(
+        "bilateral zero-OI dead-leg exit",
+        s3_forfeit_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(s3), 0));
+    assert_eq!(env.market_state().1.assets[0].stored_pos_count_short, 0);
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 1);
+    assert_cu_within(
+        "bilateral zero-OI reset finalization",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_short,
+        SideModeV16::Normal
+    );
+    let recoverable_capital = env.portfolio_state(s3).capital.get();
+    assert_ne!(recoverable_capital, 0);
+    let dest = env.withdraw(&s3o, s3, recoverable_capital);
+    assert_eq!(env.token_amount(dest), recoverable_capital as u64);
+    assert_eq!(env.portfolio_state(s3).capital.get(), 0);
 }


### PR DESCRIPTION
## Summary

- Pin the stacked wrapper PDD to engine PR #118 at `f97194677901e38bc8b2b87a67ac878c74dbfa99`.
- Extend the public reset-carry lifecycle through the surviving liquidated-side user's complete exit.
- Verify dead-leg forfeit, reset finalization, CU bounds, and complete SPL capital withdrawal.

## Public red case

After the public two-bankruptcy sequence from PR #218, both effective-OI sides are zero but one short account remains stored. On the parent engine, the short side remains `Normal`, account-local auto-crank cannot detach the leg, and owner `ForfeitRecoveryLeg` repeatedly returns `Custom(21)` at about 24k CU. The user remains non-flat and cannot withdraw.

With engine PR #118, the short side enters `ResetPending`, owner forfeit succeeds at about 77k CU, public reset finalization succeeds, and the account withdraws all remaining SPL capital. Every call stays below the custody CU limit.

The engine companion theorem executes the actual zero-copy unilateral-close mutation for symbolic long/short orientation. Disabling only the fixed production transition makes that theorem fail.

## Validation

- `cargo build-sbf --no-default-features`
- auth and hostile matcher SBF fixtures built
- focused public lifecycle passed
- `cargo test --all-targets`: 5 unit + 565 LiteSVM/SBF tests passed
- engine production composition theorem: 4,794 checks, 2/2 orientation covers, passed in 143s
- engine scalar contract: 105 checks, 2/2 covers, passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

Base: wrapper PR #218
Engine: https://github.com/aeyakovenko/percolator/pull/118
