### PR TITLE
Reject stale matcher replay after market reinit

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -1374,13 +1374,25 @@ pub mod state {
     }
 
     pub fn bump_matcher_req_seq(data: &mut [u8]) -> Result<u64, ProgramError> {
+        bump_matcher_req_seq_avoiding(data, None)
+    }
+
+    pub fn bump_matcher_req_seq_avoiding(
+        data: &mut [u8],
+        avoid_req_id: Option<u64>,
+    ) -> Result<u64, ProgramError> {
         check_header(data, KIND_MARKET)?;
         let mut config = read_wrapper_config_from_bytes(data)?;
-        config.matcher_req_seq = config
+        let mut req_id = config
             .matcher_req_seq
             .checked_add(1)
             .ok_or(PercolatorError::InvalidInstruction)?;
-        let req_id = config.matcher_req_seq;
+        if Some(req_id) == avoid_req_id {
+            req_id = req_id
+                .checked_add(1)
+                .ok_or(PercolatorError::InvalidInstruction)?;
+        }
+        config.matcher_req_seq = req_id;
         write_wrapper_config_to_bytes(data, &config)?;
         Ok(req_id)
     }
@@ -6549,12 +6561,20 @@ pub mod processor {
             max_market_slots,
             &cpi_requests,
         )?;
+        // The matcher context can outlive a closed/reinitialized market, whose
+        // request sequence starts over. Never issue the request id already in
+        // the context, so unchanged bytes cannot validate as a fresh response.
+        let context_req_id = {
+            let data = matcher_ctx.try_borrow_data()?;
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(&data[32..40]);
+            u64::from_le_bytes(bytes)
+        };
         let req_id = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
-            state::bump_matcher_req_seq(&mut market_data)?
+            state::bump_matcher_req_seq_avoiding(&mut market_data, Some(context_req_id))?
         };
         let lp_account_id = matcher_lp_account_id(&delegate);
-
         invoke_matcher(
             matcher_prog,
             matcher_ctx,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,214 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+#[test]
+fn v16_attack_single_matcher_response_cannot_replay_after_market_reinit() {
+    let params = V16CuMarketParams {
+        maintenance_margin_bps: 1_000,
+        initial_margin_bps: 1_000,
+        max_price_move_bps_per_slot: 500,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+    let hostile = Pubkey::new_unique();
+    env.svm.add_program(
+        hostile,
+        &std::fs::read(hostile_matcher_program_path()).unwrap(),
+    );
+    let taker = Keypair::new();
+    let lp = Keypair::new();
+    let taker_account = env.create_portfolio(&taker);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&taker, taker_account, 10_000_000);
+    env.deposit(&lp, lp_account, 10_000_000);
+
+    let ctx = Pubkey::new_unique();
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp_account,
+        &lp.pubkey(),
+        &hostile,
+        &ctx,
+    );
+    env.svm
+        .set_account(
+            delegate,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![],
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let mut ctx_data = vec![0u8; MATCHER_CONTEXT_LEN];
+    ctx_data[0] = 10;
+    env.svm
+        .set_account(
+            ctx,
+            Account {
+                lamports: 1_000_000_000,
+                data: ctx_data,
+                owner: hostile,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        0,
+    )
+    .expect("first market writes a valid req_id=1 response");
+    assert_eq!(env.market_state().0.matcher_req_seq, 1);
+    assert_eq!(
+        u64::from_le_bytes(
+            env.svm.get_account(&ctx).unwrap().data[32..40]
+                .try_into()
+                .unwrap()
+        ),
+        1
+    );
+
+    env.trade_asset_with_cu(
+        0,
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        -((2 * POS_SCALE) as i128),
+        100,
+        0,
+    );
+    let old_slot = env.svm.get_sysvar::<Clock>().slot;
+    env.push_auth_mark_for_asset_as_admin(0, old_slot, 100);
+    let taker_capital = env.portfolio_state(taker_account).capital.get();
+    let lp_capital = env.portfolio_state(lp_account).capital.get();
+    env.withdraw(&taker, taker_account, taker_capital);
+    env.withdraw(&lp, lp_account, lp_capital);
+    env.close_portfolio_with_cu(&taker, taker_account);
+    env.close_portfolio_with_cu(&lp, lp_account);
+    env.resolve();
+    env.close_slab_with_cu();
+
+    let closed_market = env.svm.get_account(&env.market).unwrap();
+    assert_eq!(closed_market.lamports, 0);
+    assert!(closed_market.data.iter().all(|byte| *byte == 0));
+    env.svm.warp_to_slot(old_slot + 10);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.send(
+        init_market_instruction(&params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+        ],
+        &[&admin],
+    )
+    .expect("same market address is publicly reinitialized after account recreation");
+    assert_eq!(env.market_state().0.matcher_req_seq, 0);
+    env.configure_auth_mark_for_asset_as_admin(0, old_slot + 10, 100);
+
+    for (owner, portfolio) in [(&taker, taker_account), (&lp, lp_account)] {
+        env.svm
+            .set_account(
+                portfolio,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: vec![0u8; env.portfolio_account_len],
+                    owner: env.program_id,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::InitPortfolio,
+            vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[owner],
+        )
+        .expect("same portfolio address is publicly reinitialized");
+    }
+    env.deposit(&taker, taker_account, 10_000_000);
+    env.deposit(&lp, lp_account, 10_000_000);
+    env.set_matcher_config(hostile, &lp, lp_account, ctx, delegate, 1);
+
+    let mut stale_no_write_ctx = env.svm.get_account(&ctx).unwrap();
+    stale_no_write_ctx.data[64] = 13;
+    stale_no_write_ctx.data[65] = 1;
+    env.svm.set_account(ctx, stale_no_write_ctx).unwrap();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker_account).unwrap();
+    let lp_before = env.svm.get_account(&lp_account).unwrap();
+    let ctx_before = env.svm.get_account(&ctx).unwrap();
+    env.svm.expire_blockhash();
+    let replay = env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        0,
+    );
+    assert!(
+        replay.is_err(),
+        "a prior market incarnation's matcher response must not authorize a new LP fill: {replay:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&taker_account).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before);
+    assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59681,4 +59681,27 @@ fn v16_attack_single_matcher_response_cannot_replay_after_market_reinit() {
     assert_eq!(env.svm.get_account(&taker_account).unwrap(), taker_before);
     assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before);
     assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_before);
+
+    let mut live_ctx = env.svm.get_account(&ctx).unwrap();
+    live_ctx.data[64] = 10;
+    env.svm.set_account(ctx, live_ctx).unwrap();
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &taker,
+        taker_account,
+        &lp,
+        lp_account,
+        hostile,
+        ctx,
+        delegate,
+        0,
+        (2 * POS_SCALE) as i128,
+        0,
+    )
+    .expect("a matcher that writes a fresh response must remain live");
+    assert_eq!(env.market_state().0.matcher_req_seq, 2);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(taker_account), 0).basis_pos_q,
+        (2 * POS_SCALE) as i128
+    );
 }


### PR DESCRIPTION
## What changed

- Add a public LiteSVM lifecycle regression that closes a market and its portfolios, recreates the same account addresses, and re-enables the same external matcher context.
- Prevent single-fill `TradeCpi` from issuing the request ID already stored in that persistent context.
- Verify that an unchanged stale response rejects atomically and that a matcher which writes a fresh response remains live.

## Impact

Before the fix, closing and reinitializing a market reset the market-local matcher sequence to zero. An external matcher context could survive that lifecycle. If its old response had request ID 1 and the matcher returned `Ok` without writing on the new market's first request, the wrapper accepted the old response as fresh and opened positions at its stale execution price.

The red test reproduced this through public wrapper instructions; the stale second-incarnation fill returned `Ok` and consumed about 385k CU before the fix. Account provisioning in the test only models recreating accounts after public `ClosePortfolio`/`CloseSlab` zeroed them; no protocol state is forged.

The fix preserves the existing matcher ABI. A normal new context still starts at request ID 1. When a context already contains the next candidate ID, the market skips that one ID, so unchanged bytes cannot satisfy the existing echoed-request validation. A correctly invoked matcher writes the new ID and proceeds normally.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 5 unit and 564 LiteSVM tests passed
- matcher-focused LiteSVM sweep: 37 passed
- targeted Kani matcher-binding harness: 1 passed, 215 checks, 0 failures
- `git diff --check`
