### PR TITLE
[PRIVILEGED LoF] Require matcher consent for CPI backing fees

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -3412,6 +3412,8 @@ pub mod matcher_abi {
     pub const FLAG_VALID: u32 = 1;
     pub const FLAG_PARTIAL_OK: u32 = 2;
     pub const FLAG_REJECTED: u32 = 4;
+    pub const FLAG_BACKING_FEE_CAP_SHIFT: u32 = 8;
+    pub const FLAG_BACKING_FEE_CAP_MASK: u32 = 0x3fff << FLAG_BACKING_FEE_CAP_SHIFT;
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct MatcherReturn {
@@ -3423,6 +3425,12 @@ pub mod matcher_abi {
         pub lp_account_id: u64,
         pub oracle_price_e6: u64,
         pub asset_index: u64,
+    }
+
+    impl MatcherReturn {
+        pub fn backing_fee_cap_bps(&self) -> u16 {
+            ((self.flags & FLAG_BACKING_FEE_CAP_MASK) >> FLAG_BACKING_FEE_CAP_SHIFT) as u16
+        }
     }
 
     pub fn read_matcher_return(ctx: &[u8]) -> Result<MatcherReturn, ProgramError> {
@@ -3452,10 +3460,12 @@ pub mod matcher_abi {
         if ret.abi_version != MATCHER_ABI_VERSION {
             return Err(ProgramError::InvalidAccountData);
         }
-        const KNOWN_FLAGS: u32 = FLAG_VALID | FLAG_PARTIAL_OK | FLAG_REJECTED;
+        const KNOWN_FLAGS: u32 =
+            FLAG_VALID | FLAG_PARTIAL_OK | FLAG_REJECTED | FLAG_BACKING_FEE_CAP_MASK;
         if (ret.flags & !KNOWN_FLAGS) != 0
             || (ret.flags & FLAG_VALID) == 0
             || (ret.flags & FLAG_REJECTED) != 0
+            || ret.backing_fee_cap_bps() > 10_000
         {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -5719,6 +5729,7 @@ pub mod processor {
         size_q: i128,
         exec_price: u64,
         fee_bps: u64,
+        account_b_backing_fee_cap_bps: Option<u16>,
         max_market_slots: usize,
     ) -> ProgramResult {
         ensure_portfolio_storage_for_market_slots(account_a_ai, max_market_slots)?;
@@ -5822,6 +5833,7 @@ pub mod processor {
                     backing_before_a.as_ref(),
                     &mut account_b,
                     backing_before_b.as_ref(),
+                    account_b_backing_fee_cap_bps,
                 )?;
             }
             credit_trade_fees_to_market_budgets_view(
@@ -6152,6 +6164,7 @@ pub mod processor {
             size_q,
             exec_price,
             fee_bps,
+            None,
             max_market_slots,
         )
     }
@@ -6614,6 +6627,7 @@ pub mod processor {
             ret.exec_size,
             ret.exec_price_e6,
             fee_bps,
+            Some(ret.backing_fee_cap_bps()),
             max_market_slots,
         )
     }
@@ -11184,6 +11198,7 @@ pub mod processor {
         cfg: &WrapperConfigV16,
         account: &percolator::PortfolioV16ViewMut<'_>,
         before: &[(u32, u128)],
+        backing_fee_cap_bps: Option<u16>,
         fees_by_domain: &mut DomainFeeTotals,
     ) -> Result<u128, ProgramError> {
         // Iterate only the OCCUPIED source-domain slots (after-state, <= CAP). For each, compute the
@@ -11208,6 +11223,11 @@ pub mod processor {
                 )
                 .map_err(map_v16_error)?;
                 if split.total_fee != 0 {
+                    // CPI passes the unsigned LP's matcher cap here. Check only an actual positive
+                    // backing delta, so fee-free and risk-reducing fills remain executable.
+                    if backing_fee_cap_bps.is_some_and(|cap| bps > cap) {
+                        return Err(PercolatorError::Unauthorized.into());
+                    }
                     domain_fee_add(
                         fees_by_domain,
                         domain,
@@ -11260,6 +11280,7 @@ pub mod processor {
         before_a: &[(u32, u128)],
         account_b: &mut percolator::PortfolioV16ViewMut<'_>,
         before_b: &[(u32, u128)],
+        account_b_backing_fee_cap_bps: Option<u16>,
     ) -> Result<u128, ProgramError> {
         let mut fees_a_by_domain: DomainFeeTotals = Vec::new();
         let fee_a = collect_backing_domain_fees_for_account_view(
@@ -11267,6 +11288,7 @@ pub mod processor {
             cfg,
             account_a,
             before_a,
+            None,
             &mut fees_a_by_domain,
         )?;
         let mut fees_b_by_domain: DomainFeeTotals = Vec::new();
@@ -11275,6 +11297,7 @@ pub mod processor {
             cfg,
             account_b,
             before_b,
+            account_b_backing_fee_cap_bps,
             &mut fees_b_by_domain,
         )?;
         if fee_a == 0 && fee_b == 0 {
@@ -12296,6 +12319,7 @@ pub mod processor {
                     before_a,
                     &mut account_b,
                     before_b,
+                    None,
                 )
                 .unwrap();
                 assert_eq!(charged, 10);

--- a/tests/fixtures/auth_matcher/src/lib.rs
+++ b/tests/fixtures/auth_matcher/src/lib.rs
@@ -2,16 +2,21 @@
 
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
-    entrypoint, entrypoint::ProgramResult, program::set_return_data,
-    program_error::ProgramError, pubkey::Pubkey,
+    entrypoint,
+    entrypoint::ProgramResult,
+    program::set_return_data,
+    program_error::ProgramError,
+    pubkey::Pubkey,
 };
 
 entrypoint!(process);
 
 const ABI: u32 = 3;
 const FLAG_VALID: u32 = 1;
+const FLAG_BACKING_FEE_CAP_SHIFT: u32 = 8;
 const CTX_STATE_OFFSET: usize = 64;
-const CTX_MIN_LEN: usize = CTX_STATE_OFFSET + 33;
+const CTX_BACKING_FEE_CAP_OFFSET: usize = CTX_STATE_OFFSET + 33;
+const CTX_MIN_LEN: usize = CTX_BACKING_FEE_CAP_OFFSET + 2;
 
 fn write_return(
     out: &mut [u8],
@@ -20,9 +25,11 @@ fn write_return(
     asset: u64,
     oracle: u64,
     size: i128,
+    backing_fee_cap_bps: u16,
 ) {
+    let flags = FLAG_VALID | ((backing_fee_cap_bps as u32) << FLAG_BACKING_FEE_CAP_SHIFT);
     out[0..4].copy_from_slice(&ABI.to_le_bytes());
-    out[4..8].copy_from_slice(&FLAG_VALID.to_le_bytes());
+    out[4..8].copy_from_slice(&flags.to_le_bytes());
     out[8..16].copy_from_slice(&oracle.to_le_bytes());
     out[16..32].copy_from_slice(&size.to_le_bytes());
     out[32..40].copy_from_slice(&req_id.to_le_bytes());
@@ -33,14 +40,14 @@ fn write_return(
 
 fn process(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     match data.first() {
-        Some(&2) => process_init(program_id, accounts),
+        Some(&2) => process_init(program_id, accounts, data),
         Some(&0) => process_single(program_id, accounts, data),
         Some(&3) => process_batch(program_id, accounts, data),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }
 
-fn process_init(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+fn process_init(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let account_iter = &mut accounts.iter();
     let lp_owner = next_account_info(account_iter)?;
     let delegate = next_account_info(account_iter)?;
@@ -49,8 +56,20 @@ fn process_init(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult 
     let market = next_account_info(account_iter)?;
     let lp_portfolio = next_account_info(account_iter)?;
 
-    if !lp_owner.is_signer || !ctx.is_writable || ctx.owner != program_id || ctx.data_len() < CTX_MIN_LEN {
+    if !lp_owner.is_signer
+        || !ctx.is_writable
+        || ctx.owner != program_id
+        || ctx.data_len() < CTX_MIN_LEN
+    {
         return Err(ProgramError::InvalidAccountData);
+    }
+    let backing_fee_cap_bps = match data.len() {
+        1 => 0,
+        3 => u16::from_le_bytes(data[1..3].try_into().unwrap()),
+        _ => return Err(ProgramError::InvalidInstructionData),
+    };
+    if backing_fee_cap_bps > 10_000 {
+        return Err(ProgramError::InvalidInstructionData);
     }
 
     let expected = Pubkey::find_program_address(
@@ -75,6 +94,8 @@ fn process_init(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult 
     }
     ctx_data[CTX_STATE_OFFSET] = 1;
     ctx_data[CTX_STATE_OFFSET + 1..CTX_STATE_OFFSET + 33].copy_from_slice(delegate.key.as_ref());
+    ctx_data[CTX_BACKING_FEE_CAP_OFFSET..CTX_BACKING_FEE_CAP_OFFSET + 2]
+        .copy_from_slice(&backing_fee_cap_bps.to_le_bytes());
     Ok(())
 }
 
@@ -93,6 +114,15 @@ fn check_ctx(program_id: &Pubkey, delegate: &AccountInfo, ctx: &AccountInfo) -> 
     Ok(())
 }
 
+fn backing_fee_cap_bps(ctx: &AccountInfo) -> Result<u16, ProgramError> {
+    let data = ctx.try_borrow_data()?;
+    Ok(u16::from_le_bytes(
+        data[CTX_BACKING_FEE_CAP_OFFSET..CTX_BACKING_FEE_CAP_OFFSET + 2]
+            .try_into()
+            .unwrap(),
+    ))
+}
+
 fn process_single(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     if data.len() < 67 {
         return Err(ProgramError::InvalidInstructionData);
@@ -106,8 +136,17 @@ fn process_single(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) ->
     let lp = u64::from_le_bytes(data[11..19].try_into().unwrap());
     let oracle = u64::from_le_bytes(data[19..27].try_into().unwrap());
     let req = i128::from_le_bytes(data[27..43].try_into().unwrap());
+    let backing_fee_cap_bps = backing_fee_cap_bps(ctx)?;
     let mut ctx_data = ctx.try_borrow_mut_data()?;
-    write_return(&mut ctx_data[0..64], req_id, lp, asset, oracle, req);
+    write_return(
+        &mut ctx_data[0..64],
+        req_id,
+        lp,
+        asset,
+        oracle,
+        req,
+        backing_fee_cap_bps,
+    );
     Ok(())
 }
 
@@ -125,13 +164,22 @@ fn process_batch(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> 
     check_ctx(program_id, delegate, ctx)?;
     let req_id = u64::from_le_bytes(data[2..10].try_into().unwrap());
     let lp = u64::from_le_bytes(data[10..18].try_into().unwrap());
+    let backing_fee_cap_bps = backing_fee_cap_bps(ctx)?;
     let mut out = [0u8; 16 * 64];
     for i in 0..n {
         let base = 18 + i * 26;
         let asset = u16::from_le_bytes(data[base..base + 2].try_into().unwrap()) as u64;
         let oracle = u64::from_le_bytes(data[base + 2..base + 10].try_into().unwrap());
         let req = i128::from_le_bytes(data[base + 10..base + 26].try_into().unwrap());
-        write_return(&mut out[i * 64..i * 64 + 64], req_id, lp, asset, oracle, req);
+        write_return(
+            &mut out[i * 64..i * 64 + 64],
+            req_id,
+            lp,
+            asset,
+            oracle,
+            req,
+            backing_fee_cap_bps,
+        );
     }
     set_return_data(&out[..n * 64]);
     Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,266 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+#[test]
+fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
+    const INITIAL_PRICE: u64 = 100;
+    const LP_DEPOSIT: u128 = 3_130;
+    const ATTACKER_DEPOSIT: u128 = 10_000;
+    const WINNING_SIZE_Q: i128 = 200 * POS_SCALE as i128;
+    const LOSING_SIZE_Q: i128 = 100 * POS_SCALE as i128;
+    const INCREASE_Q: i128 = 20 * POS_SCALE as i128;
+    const WINNING_DOMAIN: u16 = 3;
+
+    let mut env =
+        V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(2, 1_000, 1_000, 500, 30);
+    assert_eq!(env.market_state().0.maintenance_fee_per_slot, 30);
+    env.update_market_init_fee_policy_with_cu(1);
+    let attacker = Keypair::new();
+    let market_trader = Keypair::new();
+    let lp = Keypair::new();
+
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, INITIAL_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, INITIAL_PRICE);
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        2,
+        0,
+    );
+    env.svm.warp_to_slot(3);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        3,
+        INITIAL_PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &attacker, 3, INITIAL_PRICE);
+
+    let attacker_account = env.create_portfolio(&attacker);
+    let market_trader_account = env.create_portfolio(&market_trader);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&attacker, attacker_account, ATTACKER_DEPOSIT);
+    env.deposit(&market_trader, market_trader_account, ATTACKER_DEPOSIT);
+    env.deposit(&lp, lp_account, LP_DEPOSIT);
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let (matcher_ctx, matcher_delegate, _) =
+        env.init_auth_matcher_context(matcher_program, &lp, lp_account);
+
+    let ledger = Keypair::new();
+    let payer = env.payer.insecure_clone();
+    system_create_account_for_test(
+        &mut env.svm,
+        &payer,
+        &ledger,
+        state::backing_domain_ledger_account_len(),
+        env.program_id,
+    );
+    let backing_source = env.token_account(attacker.pubkey(), 5_000);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: WINNING_DOMAIN,
+            amount: 5_000,
+            expiry_slot: 100,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger.pubkey(), false),
+        ],
+        &[&attacker],
+    )
+    .expect("attacker funds its backing domain");
+
+    // Asset 1 makes the LP's short profitable; asset 0 makes its long lose.
+    env.try_trade_cpi_with_cu_on_asset(
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        1,
+        -WINNING_SIZE_Q,
+        0,
+    )
+    .expect("initial profitable LP leg");
+    env.try_trade_cpi_with_cu_on_asset(
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        0,
+        -LOSING_SIZE_Q,
+        0,
+    )
+    .expect("initial losing LP leg");
+
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_for_asset_with_authority(1, &attacker, 4, INITIAL_PRICE);
+    env.push_auth_mark_for_asset_as_admin(0, 4, INITIAL_PRICE);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+        (lp_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 4,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    env.sync_maintenance_fee_with_cu(lp_account, None, 4);
+    assert_eq!(
+        env.portfolio_state(lp_account).capital.get(),
+        3_100,
+        "the configured one-slot maintenance fee reaches the organic low-capital state"
+    );
+
+    env.svm.warp_to_slot(5);
+    env.push_auth_mark_for_asset_with_authority(1, &attacker, 5, 105);
+    env.push_auth_mark_for_asset_as_admin(0, 5, 95);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 5,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    assert_eq!(
+        env.portfolio_state(lp_account).pnl.get(),
+        1_000,
+        "normal price movement creates the LP's source-backed positive PnL"
+    );
+
+    // The LP authorized the matcher before the permissionless authority installed this fee.
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateBackingFeePolicy {
+            domain: WINNING_DOMAIN,
+            fee_bps: 5_000,
+            insurance_share_bps: 0,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&attacker],
+    )
+    .expect("permissionless asset authority installs backing fee");
+
+    let lp_before = env.portfolio_state(lp_account).capital.get();
+    let attacker_before = env.portfolio_state(attacker_account).capital.get();
+    let provider_before = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings;
+    env.svm.warp_to_slot(6);
+    env.try_trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp,
+        lp_account,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        0,
+        -INCREASE_Q,
+        0,
+    )
+    .expect("fee-bearing CPI risk increase");
+    let lp_after = env.portfolio_state(lp_account).capital.get();
+    let attacker_after = env.portfolio_state(attacker_account).capital.get();
+    let provider_after = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings;
+    println!(
+        "backing fee probe: lp {}->{}, attacker {}->{}, provider {}->{}",
+        lp_before, lp_after, attacker_before, attacker_after, provider_before, provider_after
+    );
+    assert!(
+        provider_after > provider_before,
+        "probe must charge provider fee"
+    );
+    let extracted = provider_after - provider_before;
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp,
+        lp_account,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        0,
+        INCREASE_Q,
+        0,
+    )
+    .expect("attacker reverses the incremental leg at the same mark");
+    let attacker_flat = env.portfolio_state(attacker_account);
+    let lp_reversed = env.portfolio_state(lp_account);
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &attacker_flat
+    )));
+    assert_eq!(attacker_flat.capital.get(), attacker_before);
+    assert_eq!(attacker_flat.pnl.get(), 0);
+    assert_eq!(lp_reversed.capital.get(), lp_after);
+    assert_eq!(
+        active_leg_for_asset(&lp_reversed, 0).basis_pos_q,
+        LOSING_SIZE_Q,
+        "the LP returns to its pre-attack asset-0 exposure"
+    );
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+            .utilization_fee_earnings,
+        provider_after,
+        "reversing the attack leg does not refund the extracted fee"
+    );
+
+    let earnings_dest = env.token_account(attacker.pubkey(), 0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::WithdrawBackingBucketEarnings {
+            domain: WINNING_DOMAIN,
+            amount: extracted,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ledger.pubkey(), false),
+            AccountMeta::new(earnings_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&attacker],
+    )
+    .expect("attacker withdraws the LP-funded provider earnings");
+    assert_eq!(env.token_amount(earnings_dest) as u128, extracted);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1888,6 +1888,21 @@ impl V16CuEnv {
         maker_owner: &Keypair,
         maker_account: Pubkey,
     ) -> (Pubkey, Pubkey, u64) {
+        self.init_auth_matcher_context_with_backing_fee_cap(
+            matcher_program,
+            maker_owner,
+            maker_account,
+            0,
+        )
+    }
+
+    fn init_auth_matcher_context_with_backing_fee_cap(
+        &mut self,
+        matcher_program: Pubkey,
+        maker_owner: &Keypair,
+        maker_account: Pubkey,
+        backing_fee_cap_bps: u16,
+    ) -> (Pubkey, Pubkey, u64) {
         let ctx = Pubkey::new_unique();
         let delegate = matcher_delegate_key(
             &self.program_id,
@@ -1898,12 +1913,13 @@ impl V16CuEnv {
             &ctx,
         );
         let cu = self
-            .try_init_auth_matcher_context_with_delegate(
+            .try_init_auth_matcher_context_with_delegate_and_backing_fee_cap(
                 matcher_program,
                 maker_owner,
                 maker_account,
                 ctx,
                 delegate,
+                backing_fee_cap_bps,
             )
             .expect("init auth matcher context");
         self.set_matcher_config(
@@ -2033,6 +2049,25 @@ impl V16CuEnv {
         ctx: Pubkey,
         delegate: Pubkey,
     ) -> Result<u64, String> {
+        self.try_init_auth_matcher_context_with_delegate_and_backing_fee_cap(
+            matcher_program,
+            maker_owner,
+            maker_account,
+            ctx,
+            delegate,
+            0,
+        )
+    }
+
+    fn try_init_auth_matcher_context_with_delegate_and_backing_fee_cap(
+        &mut self,
+        matcher_program: Pubkey,
+        maker_owner: &Keypair,
+        maker_account: Pubkey,
+        ctx: Pubkey,
+        delegate: Pubkey,
+        backing_fee_cap_bps: u16,
+    ) -> Result<u64, String> {
         self.ensure_signer_account(maker_owner.pubkey());
         self.svm
             .set_account(
@@ -2058,6 +2093,8 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let mut init_data = vec![2];
+        init_data.extend_from_slice(&backing_fee_cap_bps.to_le_bytes());
         send_raw_tx(
             &mut self.svm,
             &self.payer,
@@ -2071,7 +2108,7 @@ impl V16CuEnv {
                     AccountMeta::new_readonly(self.market, false),
                     AccountMeta::new_readonly(maker_account, false),
                 ],
-                data: vec![2],
+                data: init_data,
             },
             &[maker_owner],
         )
@@ -51873,7 +51910,8 @@ fn v16_attack_batch_nocpi_stale_reject_rolls_back_legacy_realloc() {
 #[test]
 fn v16_attack_matcher_return_antispoof_rejections() {
     use percolator_prog::matcher_abi::{
-        validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
+        validate_matcher_return, MatcherReturn, FLAG_BACKING_FEE_CAP_SHIFT, FLAG_PARTIAL_OK,
+        FLAG_REJECTED, FLAG_VALID,
     };
     const LP: u64 = 7;
     const ASSET: u16 = 1;
@@ -51898,6 +51936,10 @@ fn v16_attack_matcher_return_antispoof_rejections() {
     partial.exec_size = (5 * POS_SCALE) as i128;
     partial.flags = FLAG_VALID | FLAG_PARTIAL_OK;
     assert!(chk(&partial).is_ok(), "flagged partial fill validates");
+    let mut capped = valid;
+    capped.flags = FLAG_VALID | (5_000u32 << FLAG_BACKING_FEE_CAP_SHIFT);
+    assert!(chk(&capped).is_ok(), "an in-range LP fee cap validates");
+    assert_eq!(capped.backing_fee_cap_bps(), 5_000);
 
     // --- hostile replies, each must REJECT ---
     let cases: &[(&str, fn(MatcherReturn) -> MatcherReturn)] = &[
@@ -51938,7 +51980,11 @@ fn v16_attack_matcher_return_antispoof_rejections() {
             r
         }),
         ("unknown flag bit", |mut r| {
-            r.flags = FLAG_VALID | 0x100;
+            r.flags = FLAG_VALID | (1 << 31);
+            r
+        }),
+        ("backing fee cap above 10000 bps", |mut r| {
+            r.flags = FLAG_VALID | (10_001 << FLAG_BACKING_FEE_CAP_SHIFT);
             r
         }),
         ("zero exec_price", |mut r| {
@@ -59472,6 +59518,10 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
     );
 }
 
+// LoF: only the taker signs TradeCpi. A permissionless backing authority must not be able to make
+// an unsigned LP pay a newly-installed source-backing fee unless the LP's matcher explicitly
+// returns a sufficient cap. The rejected path is byte-atomic; an opted-in fill and a zero-cap risk
+// reduction remain live.
 #[test]
 fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
     const INITIAL_PRICE: u64 = 100;
@@ -59524,7 +59574,7 @@ fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
     let matcher_program = Pubkey::new_unique();
     let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
     env.svm.add_program(matcher_program, &matcher_bytes);
-    let (matcher_ctx, matcher_delegate, _) =
+    let (zero_cap_matcher_ctx, zero_cap_matcher_delegate, _) =
         env.init_auth_matcher_context(matcher_program, &lp, lp_account);
 
     let ledger = Keypair::new();
@@ -59556,15 +59606,15 @@ fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
     )
     .expect("attacker funds its backing domain");
 
-    // Asset 1 makes the LP's short profitable; asset 0 makes its long lose.
+    // Asset 1 makes the LP's long profitable; asset 0 makes its other long lose.
     env.try_trade_cpi_with_cu_on_asset(
         &market_trader,
         market_trader_account,
         &lp,
         lp_account,
         matcher_program,
-        matcher_ctx,
-        matcher_delegate,
+        zero_cap_matcher_ctx,
+        zero_cap_matcher_delegate,
         1,
         -WINNING_SIZE_Q,
         0,
@@ -59576,8 +59626,8 @@ fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
         &lp,
         lp_account,
         matcher_program,
-        matcher_ctx,
-        matcher_delegate,
+        zero_cap_matcher_ctx,
+        zero_cap_matcher_delegate,
         0,
         -LOSING_SIZE_Q,
         0,
@@ -59648,37 +59698,50 @@ fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
     )
     .expect("permissionless asset authority installs backing fee");
 
-    let lp_before = env.portfolio_state(lp_account).capital.get();
-    let attacker_before = env.portfolio_state(attacker_account).capital.get();
     let provider_before = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
         .utilization_fee_earnings;
+    let market_before_reject = env.svm.get_account(&env.market).unwrap();
+    let attacker_before_reject = env.svm.get_account(&attacker_account).unwrap();
+    let lp_before_reject = env.svm.get_account(&lp_account).unwrap();
+    let matcher_before_reject = env.svm.get_account(&zero_cap_matcher_ctx).unwrap();
     env.svm.warp_to_slot(6);
-    env.try_trade_cpi_with_cu_on_asset(
+    let rejected = env.try_trade_cpi_with_cu_on_asset(
         &attacker,
         attacker_account,
         &lp,
         lp_account,
         matcher_program,
-        matcher_ctx,
-        matcher_delegate,
+        zero_cap_matcher_ctx,
+        zero_cap_matcher_delegate,
         0,
         -INCREASE_Q,
         0,
-    )
-    .expect("fee-bearing CPI risk increase");
-    let lp_after = env.portfolio_state(lp_account).capital.get();
-    let attacker_after = env.portfolio_state(attacker_account).capital.get();
-    let provider_after = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
-        .utilization_fee_earnings;
-    println!(
-        "backing fee probe: lp {}->{}, attacker {}->{}, provider {}->{}",
-        lp_before, lp_after, attacker_before, attacker_after, provider_before, provider_after
     );
     assert!(
-        provider_after > provider_before,
-        "probe must charge provider fee"
+        rejected.is_err(),
+        "a zero-cap matcher must reject an LP backing fee"
     );
-    let extracted = provider_after - provider_before;
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_reject
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_account).unwrap(),
+        attacker_before_reject
+    );
+    assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before_reject);
+    assert_eq!(
+        env.svm.get_account(&zero_cap_matcher_ctx).unwrap(),
+        matcher_before_reject,
+        "the rejected post-engine consent check rolls the matcher CPI back too"
+    );
+
+    // The LP can opt in explicitly. The cap is signed into its matcher context and echoed on
+    // every fill; it is not supplied by the taker.
+    let (consent_matcher_ctx, consent_matcher_delegate, _) =
+        env.init_auth_matcher_context_with_backing_fee_cap(matcher_program, &lp, lp_account, 5_000);
+    let lp_before = env.portfolio_state(lp_account).capital.get();
+    let attacker_before = env.portfolio_state(attacker_account).capital.get();
     env.svm.expire_blockhash();
     env.try_trade_cpi_with_cu_on_asset(
         &attacker,
@@ -59686,13 +59749,48 @@ fn v16_attack_cpi_lp_backing_fee_requires_matcher_consent() {
         &lp,
         lp_account,
         matcher_program,
-        matcher_ctx,
-        matcher_delegate,
+        consent_matcher_ctx,
+        consent_matcher_delegate,
+        0,
+        -INCREASE_Q,
+        0,
+    )
+    .expect("LP-consented backing fee CPI risk increase");
+    let lp_after = env.portfolio_state(lp_account).capital.get();
+    let attacker_after = env.portfolio_state(attacker_account).capital.get();
+    let provider_after = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings;
+    println!(
+        "consented backing fee: lp {}->{}, attacker {}->{}, provider {}->{}",
+        lp_before, lp_after, attacker_before, attacker_after, provider_before, provider_after
+    );
+    assert!(
+        provider_after > provider_before,
+        "the explicitly consented fill must charge the provider fee"
+    );
+    let extracted = provider_after - provider_before;
+    env.set_matcher_config(
+        matcher_program,
+        &lp,
+        lp_account,
+        zero_cap_matcher_ctx,
+        zero_cap_matcher_delegate,
+        1,
+    );
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp,
+        lp_account,
+        matcher_program,
+        zero_cap_matcher_ctx,
+        zero_cap_matcher_delegate,
         0,
         INCREASE_Q,
         0,
     )
-    .expect("attacker reverses the incremental leg at the same mark");
+    .expect("a zero-cap matcher still permits a fee-free risk reduction");
     let attacker_flat = env.portfolio_state(attacker_account);
     let lp_reversed = env.portfolio_state(lp_account);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -4,7 +4,8 @@ extern crate kani;
 
 use percolator_prog::ix::{CrankObservationHint, Instruction};
 use percolator_prog::matcher_abi::{
-    validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
+    validate_matcher_return, MatcherReturn, FLAG_BACKING_FEE_CAP_MASK, FLAG_BACKING_FEE_CAP_SHIFT,
+    FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
 use percolator_prog::policy_v16;
 
@@ -489,6 +490,9 @@ fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
     if abi_version != percolator_prog::constants::MATCHER_ABI_VERSION
         || (flags & FLAG_VALID) == 0
         || (flags & FLAG_REJECTED) != 0
+        || (flags & !(FLAG_VALID | FLAG_PARTIAL_OK | FLAG_REJECTED | FLAG_BACKING_FEE_CAP_MASK))
+            != 0
+        || ((flags & FLAG_BACKING_FEE_CAP_MASK) >> FLAG_BACKING_FEE_CAP_SHIFT) > 10_000
         || lp_ret != lp_account_id
         || oracle_ret != oracle_price_e6
         || asset_ret != asset_index as u64
@@ -503,6 +507,7 @@ fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
     if result.is_ok() {
         assert!((flags & FLAG_VALID) != 0);
         assert!((flags & FLAG_REJECTED) == 0);
+        assert!(ret.backing_fee_cap_bps() <= 10_000);
         assert_eq!(lp_ret, lp_account_id);
         assert_eq!(oracle_ret, oracle_price_e6);
         assert_eq!(asset_ret, asset_index as u64);


### PR DESCRIPTION
## Summary

- reserve matcher-return flag bits for an LP-selected backing-fee cap (0-10,000 bps)
- reject only a nonzero unsigned-LP backing fee whose actual post-trade source-lien delta exceeds that cap
- keep legacy matchers fail-closed at cap zero while preserving fee-free and risk-reducing CPI fills
- add a fully public LiteSVM exploit/regression and extend the matcher-return Kani contract

## Security impact

`TradeCpi` is signed only by the taker. Backing-domain fees were calculated after the matcher returned, so no matcher could inspect or cap the fee charged to its unsigned LP.

The public red sequence creates ordinary cross-margin source PnL, then lets a permissionless asset authority install a 5,000 bps backing fee after the LP authorized its matcher. The attacker opens and reverses only a 20-unit incremental CPI leg at the same price. Its portfolio returns flat with unchanged capital, while the LP falls from 3,100 to 3,030 atoms and the attacker-controlled provider bucket rises from 0 to 70 atoms. The attacker then withdraws those 70 atoms through `WithdrawBackingBucketEarnings`. No protocol account bytes are injected.

The fix makes the matcher return an explicit maximum backing-fee policy. Existing matchers return zero in the reserved bits and therefore fail closed. Enforcement happens only after the engine has identified a positive source-backing delta and a nonzero fee; an error reverts the engine and matcher CPI under SVM semantics. The regression proves byte-for-byte rollback, explicit 5,000 bps opt-in, and a subsequent zero-cap risk reduction.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo build-sbf` in `tests/fixtures/auth_matcher`
- `cargo build-sbf` in `tests/fixtures/hostile_matcher`
- `cargo test`: 5 unit + 564 LiteSVM tests passed, including all CU tests
- `cargo kani --tests --harness kani_v16_matcher_return_accepts_only_bound_echoed_fills`: 224/224 checks passed; accept-path cover satisfied
- `cargo fmt --all -- --check`
- `git diff --check`

The engine dependency and pin are unchanged.
