### PR TITLE
[BLOCKER LoF] Prevent CPI caller-fee LP siphon

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6613,7 +6613,10 @@ pub mod processor {
             asset_index,
             ret.exec_size,
             ret.exec_price_e6,
-            fee_bps,
+            // Only the taker signs this fill, and the matcher ABI does not carry a fee for the LP
+            // to approve. Start CPI fee derivation at the market-configured base; hybrid/EWMA
+            // movement may still raise it deterministically inside the shared trade path.
+            cfg_pre.trade_fee_base_bps,
             max_market_slots,
         )
     }
@@ -6789,6 +6792,7 @@ pub mod processor {
             stale_matured,
             backing_fee_policy_active,
             fee_bounds_ok,
+            cpi_fee_bps,
         ) = {
             let market_data = market_ai.try_borrow_data()?;
             let (
@@ -6825,6 +6829,7 @@ pub mod processor {
                 stale_matured,
                 cfg_pre.backing_trade_fee_policy_count != 0,
                 fee_bounds_ok,
+                cfg_pre.trade_fee_base_bps,
             )
         };
         if mode_pre != MarketModeV16::Live {
@@ -6970,7 +6975,9 @@ pub mod processor {
                 asset_index: leg.asset_index,
                 size_q: ret.exec_size,
                 exec_price: ret.exec_price_e6,
-                fee_bps: leg.fee_bps,
+                // Batch LPs are unsigned too. Caller fee fields are validated above but cannot
+                // increase their charge without matcher-side fee consent in the ABI.
+                fee_bps: cpi_fee_bps,
             });
         }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -8974,7 +8974,10 @@ fn v16_attack_close_portfolio_rejects_occupied_source_domain_without_claim_bound
 
 #[test]
 fn v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded() {
-    let mut env = V16CuEnv::new();
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        trade_fee_base_bps: 100,
+        ..V16CuMarketParams::default()
+    });
     let matcher_program = Pubkey::new_unique();
     let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
     env.svm.add_program(matcher_program, &matcher_bytes);
@@ -9042,7 +9045,10 @@ fn v16_bpf_tradecpi_executes_through_external_matcher_and_is_bounded() {
 
 #[test]
 fn v16_bpf_tradecpi_external_matcher_executes_on_added_asset() {
-    let mut env = V16CuEnv::new();
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        trade_fee_base_bps: 100,
+        ..V16CuMarketParams::default()
+    });
     let matcher_program = Pubkey::new_unique();
     let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
     env.svm.add_program(matcher_program, &matcher_bytes);
@@ -40499,7 +40505,10 @@ fn v16_attack_tradecpi_short_fill_rejects_atomically() {
 #[test]
 fn v16_attack_tradecpi_fee_is_mark_pinned_not_matcher_quoted() {
     let fee_for_spread = |base_spread: u32, max_total: u32| -> u128 {
-        let mut env = V16CuEnv::new();
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            trade_fee_base_bps: 100,
+            ..V16CuMarketParams::default()
+        });
         let matcher_program = Pubkey::new_unique();
         let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
         env.svm.add_program(matcher_program, &matcher_bytes);
@@ -50137,8 +50146,8 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
 }
 
 // security.md sweep — BatchTradeCpi fee bounds on permissionless LP fills (#37/#49): in CPI mode the
-// taker supplies fee_bps while the LP owner does not sign the fill. An over-max fee must therefore
-// reject the whole batch, or a taker could drain an LP into protocol insurance through a matcher fill.
+// taker supplies fee_bps while the LP owner does not sign the fill. Over-max values are malformed, and
+// an in-range caller value cannot raise the unsigned LP's charge above the market-derived fee.
 #[test]
 fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
     let mut env = V16CuEnv::new();
@@ -50217,14 +50226,13 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
         "max allowed BatchTradeCpi fee_bps should still execute: {ok:?}"
     );
     let group = env.market_state().1;
-    assert!(
-        group.insurance > before.insurance,
-        "valid max fee accrues to insurance"
-    );
     assert_eq!(
-        group.vault, before.vault,
-        "valid fee is internal capital->insurance"
+        group.insurance, before.insurance,
+        "an in-range caller fee cannot charge the unsigned LP"
     );
+    assert_eq!(env.portfolio_state(taker_account).capital.get(), 1_000_000);
+    assert_eq!(env.portfolio_state(lp_account).capital.get(), 1_000_000);
+    assert_eq!(group.vault, before.vault, "caller fee moves no custody");
     assert!(
         group.vault >= group.c_tot + group.insurance,
         "senior conservation"
@@ -50258,8 +50266,7 @@ fn v16_attack_cpi_taker_cannot_siphon_unsigned_lp_with_caller_fee() {
 
         // The LP authorizes its matcher before the attacker creates asset 1. The matcher request
         // binds asset/size/price, but carries no fee field for the LP to inspect or reject.
-        let (ctx, delegate, _) =
-            env.init_auth_matcher_context(matcher_program, &lp, lp_account);
+        let (ctx, delegate, _) = env.init_auth_matcher_context(matcher_program, &lp, lp_account);
         let attacker_key = attacker.pubkey();
         env.svm.warp_to_slot(1);
         env.activate_permissionless_asset_with_fee(
@@ -50327,8 +50334,8 @@ fn v16_attack_cpi_taker_cannot_siphon_unsigned_lp_with_caller_fee() {
         let attacker_after = env.portfolio_state(attacker_account);
         let lp_after = env.portfolio_state(lp_account);
         let (_, group_after) = env.market_state();
-        let asset1_budget = group_after.insurance_domain_budget[2]
-            + group_after.insurance_domain_budget[3];
+        let asset1_budget =
+            group_after.insurance_domain_budget[2] + group_after.insurance_domain_budget[3];
         println!(
             "{} caller-fee round trip: attacker_capital={}, lp_capital={}, asset1_budget={asset1_budget}",
             if batch { "batch" } else { "single" },

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -50231,6 +50231,159 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
     );
 }
 
+// LoF: the taker is the only owner signing a CPI fill. A caller-selected fee therefore cannot
+// increase the unsigned LP's charge. Otherwise a permissionless asset creator can trade a full
+// round trip against an LP's pre-existing matcher authorization, withdraw both sides' fees through
+// the creator-controlled asset insurance budget, and keep the LP's half as profit.
+#[test]
+fn v16_attack_cpi_taker_cannot_siphon_unsigned_lp_with_caller_fee() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (100 * POS_SCALE) as i128;
+    const CALLER_FEE_BPS: u64 = 10_000;
+
+    for batch in [false, true] {
+        let mut env = V16CuEnv::new();
+        env.update_market_init_fee_policy_with_cu(1);
+
+        let matcher_program = Pubkey::new_unique();
+        let matcher_bytes =
+            std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+        env.svm.add_program(matcher_program, &matcher_bytes);
+        let attacker = Keypair::new();
+        let lp = Keypair::new();
+        let attacker_account = env.create_portfolio(&attacker);
+        let lp_account = env.create_portfolio(&lp);
+        env.deposit(&attacker, attacker_account, DEPOSIT);
+        env.deposit(&lp, lp_account, DEPOSIT);
+
+        // The LP authorizes its matcher before the attacker creates asset 1. The matcher request
+        // binds asset/size/price, but carries no fee field for the LP to inspect or reject.
+        let (ctx, delegate, _) =
+            env.init_auth_matcher_context(matcher_program, &lp, lp_account);
+        let attacker_key = attacker.pubkey();
+        env.svm.warp_to_slot(1);
+        env.activate_permissionless_asset_with_fee(
+            &attacker,
+            1,
+            1,
+            100,
+            attacker_key,
+            attacker_key,
+            attacker_key,
+            attacker_key,
+            1,
+        );
+
+        for size_q in [SIZE_Q, -SIZE_Q] {
+            env.svm.expire_blockhash();
+            let fill = if batch {
+                env.send(
+                    ProgInstruction::BatchTradeCpi {
+                        legs: vec![BatchTradeCpiLeg {
+                            asset_index: 1,
+                            size_q,
+                            fee_bps: CALLER_FEE_BPS,
+                            limit_price: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(attacker.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(attacker_account, false),
+                        AccountMeta::new(lp_account, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(ctx, false),
+                        AccountMeta::new_readonly(delegate, false),
+                    ],
+                    &[&attacker],
+                )
+            } else {
+                env.send(
+                    ProgInstruction::TradeCpi {
+                        asset_index: 1,
+                        size_q,
+                        fee_bps: CALLER_FEE_BPS,
+                        limit_price: 0,
+                    },
+                    vec![
+                        AccountMeta::new(attacker.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(attacker_account, false),
+                        AccountMeta::new(lp_account, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(ctx, false),
+                        AccountMeta::new_readonly(delegate, false),
+                    ],
+                    &[&attacker],
+                )
+            };
+            assert!(
+                fill.is_ok(),
+                "{} CPI round-trip leg remains a valid fill: {fill:?}",
+                if batch { "batch" } else { "single" }
+            );
+        }
+
+        let attacker_after = env.portfolio_state(attacker_account);
+        let lp_after = env.portfolio_state(lp_account);
+        let (_, group_after) = env.market_state();
+        let asset1_budget = group_after.insurance_domain_budget[2]
+            + group_after.insurance_domain_budget[3];
+        println!(
+            "{} caller-fee round trip: attacker_capital={}, lp_capital={}, asset1_budget={asset1_budget}",
+            if batch { "batch" } else { "single" },
+            attacker_after.capital.get(),
+            lp_after.capital.get(),
+        );
+        assert_eq!(group_after.assets[1].oi_eff_long_q, 0);
+        assert_eq!(group_after.assets[1].oi_eff_short_q, 0);
+        let attacker_dest = env.token_account(attacker.pubkey(), 0);
+        env.svm.expire_blockhash();
+        let siphon = env.send(
+            ProgInstruction::WithdrawInsuranceAsset {
+                asset_index: 1,
+                amount: asset1_budget.max(1),
+            },
+            vec![
+                AccountMeta::new(attacker.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&attacker],
+        );
+        if siphon.is_ok() {
+            assert_eq!(env.token_amount(attacker_dest), asset1_budget as u64);
+            assert_eq!(
+                attacker_after.capital.get() + asset1_budget,
+                DEPOSIT + (DEPOSIT - lp_after.capital.get()),
+                "the creator realizes profit equal to the unsigned LP's fee loss"
+            );
+        }
+        assert!(
+            siphon.is_err(),
+            "{} caller fee must not become withdrawable by the permissionless asset creator",
+            if batch { "batch" } else { "single" }
+        );
+        assert_eq!(
+            attacker_after.capital.get(),
+            DEPOSIT,
+            "CPI caller fee must not charge the taker above the market-derived fee"
+        );
+        assert_eq!(
+            lp_after.capital.get(),
+            DEPOSIT,
+            "CPI caller fee must not charge an unsigned LP"
+        );
+        assert_eq!(
+            asset1_budget, 0,
+            "caller-selected fee must not create a creator-withdrawable insurance budget"
+        );
+    }
+}
+
 // BatchTradeCpi 14-leg fan-out through one batched matcher CPI, under the tx CU budget.
 #[test]
 fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {


### PR DESCRIPTION
## Security impact

`TradeCpi` and `BatchTradeCpi` let the taker choose `fee_bps`, but the LP owner does not sign either fill and the matcher ABI does not attest to that fee. A permissionless asset creator could therefore submit a 10,000 bps open-and-close round trip against an LP's existing matcher authorization, route the two-sided fees into creator-controlled insurance domains, withdraw them, and retain the LP's half as profit.

The public LiteSVM exploit exercises both CPI routes without protocol-state injection. Starting from 1,000,000 atoms each, the attacker and LP both fell to 980,000 while the attacker-controlled asset budget gained 40,000. The attacker then withdrew all 40,000, ending 20,000 atoms ahead exactly equal to the LP's loss.

## Fix

- Continue validating malformed caller fees against the configured maximum before invoking the matcher.
- Derive the fee actually charged by CPI fills from the market's configured base fee, not the unsigned taker's requested fee.
- Preserve deterministic hybrid/EWMA externality fees in the shared trade path.
- Leave `TradeNoCpi` caller-selected because both account owners sign that bilateral instruction.

## TDD evidence

- `ccc952a9` is the public red exploit for single and batch CPI.
- `e186d3af` fixes only CPI fee derivation.
- The regression proves both routes still execute and round-trip, no attacker-controlled fee reaches the LP, custody remains exact, and direct bilateral fee semantics remain unchanged.

## Validation

- `cargo build-sbf --no-default-features`
- authenticated and hostile matcher fixture SBF builds
- `cargo test --all-targets`: 5 unit tests and 564 LiteSVM/SBF tests passed, including all CU guards
- `cargo fmt --all -- --check`
- `git diff --check`

The full `cargo kani --tests` sweep is still running through the repository's pre-existing symbolic instruction-decoder harness; no affected runtime or CU test is pending.
