### PR TITLE
[BLOCKER LoF] Keep EWMA movement fees non-reclaimable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=43c654b635956584e730fe14219dd9db83cd4c0d#43c654b635956584e730fe14219dd9db83cd4c0d"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "43c654b635956584e730fe14219dd9db83cd4c0d" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "43c654b635956584e730fe14219dd9db83cd4c0d" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5050,6 +5050,74 @@ pub mod processor {
         credit_fee_to_domain_budget_view(cfg, group, asset_index * 2 + 1, fee_short)
     }
 
+    fn credit_trade_fees_with_mark_externality_view(
+        cfg: &WrapperConfigV16,
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        fee_long: u128,
+        fee_short: u128,
+        quote: HybridTradeFeeQuote,
+    ) -> ProgramResult {
+        let total_fee = fee_long
+            .checked_add(fee_short)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        let mark_externality_fee = if quote.mark_externality_notional == 0 {
+            0
+        } else {
+            total_fee.saturating_sub(quote.base_fee_paid)
+        };
+        if mark_externality_fee == 0 {
+            return credit_trade_fees_to_market_budgets_view(
+                cfg,
+                group,
+                asset_index,
+                fee_long,
+                fee_short,
+            );
+        }
+
+        // A permissionless asset operator must not recover the fee that paid for its mark move.
+        // Keep only that collected externality fee in base insurance; ordinary fees remain local.
+        let mut mark_long = mark_externality_fee / 2;
+        let mut mark_short = mark_externality_fee
+            .checked_sub(mark_long)
+            .ok_or(PercolatorError::EngineCounterUnderflow)?;
+        if mark_long > fee_long {
+            let overflow = mark_long
+                .checked_sub(fee_long)
+                .ok_or(PercolatorError::EngineCounterUnderflow)?;
+            mark_long = fee_long;
+            mark_short = mark_short
+                .checked_add(overflow)
+                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        }
+        if mark_short > fee_short {
+            let overflow = mark_short
+                .checked_sub(fee_short)
+                .ok_or(PercolatorError::EngineCounterUnderflow)?;
+            mark_short = fee_short;
+            mark_long = mark_long
+                .checked_add(overflow)
+                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        }
+        if mark_long > fee_long || mark_short > fee_short {
+            return Err(PercolatorError::EngineCounterUnderflow.into());
+        }
+
+        credit_trade_fees_to_market_budgets_view(
+            cfg,
+            group,
+            asset_index,
+            fee_long
+                .checked_sub(mark_long)
+                .ok_or(PercolatorError::EngineCounterUnderflow)?,
+            fee_short
+                .checked_sub(mark_short)
+                .ok_or(PercolatorError::EngineCounterUnderflow)?,
+        )?;
+        credit_market_insurance_budget_view(group, 0, mark_externality_fee)
+    }
+
     fn credit_market_fee_split_across_domains_view(
         cfg: &WrapperConfigV16,
         group: &mut state::MarketViewMutV16<'_>,
@@ -5903,12 +5971,13 @@ pub mod processor {
                     backing_before_b.as_ref(),
                 )?;
             }
-            credit_trade_fees_to_market_budgets_view(
+            credit_trade_fees_with_mark_externality_view(
                 &cfg,
                 &mut group,
                 asset_index as usize,
                 outcome.fee_a,
                 outcome.fee_b,
+                fee_quote,
             )?;
             let collected_post_trade_mark = collected_fee_supported_mark_view(
                 &oracle_profile,
@@ -6149,12 +6218,13 @@ pub mod processor {
                 remaining_fee_b = remaining_fee_b
                     .checked_sub(fee_b)
                     .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-                credit_trade_fees_to_market_budgets_view(
+                credit_trade_fees_with_mark_externality_view(
                     &cfg,
                     &mut group,
                     *asset_index,
                     fee_a,
                     fee_b,
+                    *fee_quote,
                 )?;
                 let collected_post_trade_mark =
                     collected_fee_supported_mark_view(oracle_profile, *fee_quote, fee_a, fee_b)?;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5077,7 +5077,8 @@ pub mod processor {
         }
 
         // A permissionless asset operator must not recover the fee that paid for its mark move.
-        // Keep only that collected externality fee in base insurance; ordinary fees remain local.
+        // Leave only that collected externality fee outside every withdrawable domain budget;
+        // ordinary fees remain local. CloseSlab burns the unbudgeted surplus after all claims exit.
         let mut mark_long = mark_externality_fee / 2;
         let mut mark_short = mark_externality_fee
             .checked_sub(mark_long)
@@ -5115,7 +5116,7 @@ pub mod processor {
                 .checked_sub(mark_short)
                 .ok_or(PercolatorError::EngineCounterUnderflow)?,
         )?;
-        credit_market_insurance_budget_view(group, 0, mark_externality_fee)
+        Ok(())
     }
 
     fn credit_market_fee_split_across_domains_view(
@@ -8324,21 +8325,28 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         verify_token_program(token_program)?;
 
-        let cfg_pre = {
+        let (cfg_pre, retired_unbudgeted_insurance) = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
-            let (cfg, group) = state::market_view_mut(&mut market_data)?;
+            let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
             expect_live_authority(&cfg.marketauth, admin_dest.key)?;
             if group.header.mode != 1 {
                 return Err(PercolatorError::EngineLockActive.into());
             }
-            if group.header.vault.get() != 0
-                || group.header.insurance.get() != 0
-                || group.header.c_tot.get() != 0
-                || group.header.materialized_portfolio_count.get() != 0
+            if group.header.c_tot.get() != 0 || group.header.materialized_portfolio_count.get() != 0
             {
                 return Err(PercolatorError::EngineLockActive.into());
             }
-            cfg
+            let retired = if group.header.insurance.get() == 0 {
+                0
+            } else {
+                group
+                    .retire_terminal_unbudgeted_insurance_not_atomic()
+                    .map_err(map_v16_error)?
+            };
+            if group.header.vault.get() != 0 || group.header.insurance.get() != 0 {
+                return Err(PercolatorError::EngineLockActive.into());
+            }
+            (cfg, retired)
         };
 
         let (vault_authority, bump) = derive_vault_authority(program_id, market_ai.key);
@@ -8347,6 +8355,11 @@ pub mod processor {
         verify_vault_token_account(vault_token, &vault_authority, &primary_mint)?;
         let vault_account = unpack_token_account(vault_token)?;
         verify_user_token_account(dest_token, admin_dest.key, &primary_mint)?;
+        let retired_u64 = amount_to_u64(retired_unbudgeted_insurance)?;
+        let primary_sweep_amount = vault_account
+            .amount
+            .checked_sub(retired_u64)
+            .ok_or(PercolatorError::InvalidTokenAccount)?;
         let bump_arr = [bump];
         let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
         let secondary_close = if cfg_pre.secondary_collateral_mint != [0u8; 32] {
@@ -8372,13 +8385,28 @@ pub mod processor {
             None
         };
 
-        if vault_account.amount > 0 {
+        if retired_u64 != 0 {
+            let primary_mint_index = if secondary_close.is_some() { 8 } else { 6 };
+            let primary_mint_ai = account(accounts, primary_mint_index)?;
+            expect_writable(primary_mint_ai)?;
+            expect_key(primary_mint_ai, &primary_mint)?;
+            verify_mint(primary_mint_ai)?;
+            burn_tokens_signed(
+                token_program,
+                vault_token,
+                primary_mint_ai,
+                vault_authority_ai,
+                retired_u64,
+                signer_seeds,
+            )?;
+        }
+        if primary_sweep_amount > 0 {
             transfer_tokens_signed(
                 token_program,
                 vault_token,
                 dest_token,
                 vault_authority_ai,
-                vault_account.amount,
+                primary_sweep_amount,
                 signer_seeds,
             )?;
         }
@@ -12243,6 +12271,37 @@ pub mod processor {
             &[
                 source.clone(),
                 dest.clone(),
+                authority.clone(),
+                token_program.clone(),
+            ],
+            signer_seeds,
+        )
+    }
+
+    fn burn_tokens_signed<'a>(
+        token_program: &AccountInfo<'a>,
+        source: &AccountInfo<'a>,
+        mint: &AccountInfo<'a>,
+        authority: &AccountInfo<'a>,
+        amount: u64,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<(), ProgramError> {
+        if amount == 0 {
+            return Ok(());
+        }
+        let ix = spl_token::instruction::burn(
+            token_program.key,
+            source.key,
+            mint.key,
+            authority.key,
+            &[],
+            amount,
+        )?;
+        invoke_signed(
+            &ix,
+            &[
+                source.clone(),
+                mint.clone(),
                 authority.clone(),
                 token_program.clone(),
             ],

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1235,6 +1235,14 @@ impl V16CuEnv {
         self.svm.set_account(token, account).unwrap();
     }
 
+    fn set_mint_supply(&mut self, mint_key: Pubkey, supply: u64) {
+        let mut account = self.svm.get_account(&mint_key).expect("mint account");
+        let mut mint = Mint::unpack(&account.data).expect("valid mint");
+        mint.supply = supply;
+        Mint::pack(mint, &mut account.data).expect("pack mint");
+        self.svm.set_account(mint_key, account).unwrap();
+    }
+
     fn market_state(&self) -> (state::WrapperConfigV16, MarketGroupV16) {
         let account = self.svm.get_account(&self.market).expect("market account");
         state::read_market(&account.data).unwrap()
@@ -2266,6 +2274,7 @@ impl V16CuEnv {
                 AccountMeta::new_readonly(self.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(self.mint, false),
             ],
             &[&self.admin],
         )
@@ -3354,6 +3363,11 @@ impl V16CuEnv {
     fn token_amount(&self, key: Pubkey) -> u64 {
         let account = self.svm.get_account(&key).expect("token account");
         TokenAccount::unpack(&account.data).unwrap().amount
+    }
+
+    fn mint_supply(&self, key: Pubkey) -> u64 {
+        let account = self.svm.get_account(&key).expect("mint account");
+        Mint::unpack(&account.data).unwrap().supply
     }
 
     fn convert_released_pnl_with_cu(
@@ -59742,6 +59756,9 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         min_funding_lifetime_slots: 20,
         ..V16CuMarketParams::default()
     });
+    // LiteSVM fixtures construct funded token accounts directly. Give the external SPL mint a
+    // realistic supply before the exploit so the terminal burn exercises the real token program.
+    env.set_mint_supply(env.mint, u64::MAX);
     env.update_market_init_fee_policy_with_cu(INIT_FEE);
     let compromised_marketauth = env.admin.insecure_clone();
 
@@ -59921,15 +59938,23 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         0,
         "all user capital exits before the delayed canonical-fee reclaim"
     );
-    let base_reclaimed = match env.try_withdraw_insurance_asset_with_authority(
-        &compromised_marketauth,
-        0,
-        fee_paid,
-    ) {
-        Ok((dest, _)) => env.token_amount(dest) as u128,
-        Err(_) => 0,
-    };
+    let base_reclaimed =
+        match env.try_withdraw_insurance_asset_with_authority(&compromised_marketauth, 0, fee_paid)
+        {
+            Ok((dest, _)) => env.token_amount(dest) as u128,
+            Err(_) => 0,
+        };
+    assert_eq!(
+        base_reclaimed, 0,
+        "the compromised market authority must not reclaim the mark-movement fee"
+    );
+    let (init_fee_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&compromised_marketauth, 0, INIT_FEE)
+        .expect("the unrelated permissionless-init fee remains normally withdrawable");
+    let init_fee_reclaimed = env.token_amount(init_fee_dest) as u128;
+    assert_eq!(init_fee_reclaimed, INIT_FEE);
     attacker_payout += base_reclaimed;
+    attacker_payout += init_fee_reclaimed;
     let attacker_committed = DEPOSIT * 3 + INIT_FEE;
     let victim_loss = DEPOSIT.saturating_sub(victim_payout);
     let attacker_gain = attacker_payout.saturating_sub(attacker_committed);
@@ -59946,6 +59971,57 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         attacker_payout <= attacker_committed,
         "reclaiming the mark fee made the attacker profitable by {attacker_gain} against an \
          independent LP loss of {victim_loss}"
+    );
+
+    for (owner, portfolio) in [
+        (&attacker, attacker_position),
+        (&self_long_owner, self_long),
+        (&self_short_owner, self_short),
+        (&victim, victim_lp),
+    ] {
+        env.close_portfolio_with_cu(owner, portfolio);
+    }
+    env.resolve();
+    let terminal = env.market_state().1;
+    assert_eq!(terminal.insurance, fee_paid);
+    assert_eq!(terminal.insurance_domain_budget_remaining_total, 0);
+    assert_eq!(terminal.vault, fee_paid);
+    assert_eq!(env.token_amount(env.vault) as u128, fee_paid);
+
+    let supply_before = env.mint_supply(env.mint);
+    let terminal_dest = env.token_account(compromised_marketauth.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let close = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(compromised_marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(terminal_dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(env.mint, false),
+        ],
+        &[&compromised_marketauth],
+    );
+    assert!(
+        close.is_ok(),
+        "terminal mark-fee burn must remain closable: {close:?}"
+    );
+    assert_cu_within(
+        "terminal mark-fee burn CloseSlab",
+        close.unwrap(),
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.token_amount(terminal_dest),
+        0,
+        "CloseSlab burns the fee instead of sweeping it to compromised marketauth"
+    );
+    assert_eq!(
+        env.mint_supply(env.mint),
+        supply_before - fee_paid as u64,
+        "the canonical mint supply falls by exactly the non-reclaimable movement fee"
     );
 }
 
@@ -60108,6 +60184,14 @@ fn assert_permissionless_ewma_mark_fee_not_reclaimable(route: PermissionlessMark
     .unwrap();
     let after_trade = env.market_state().1;
     let fee_paid = after_trade.insurance - before.insurance;
+    let unbudgeted_before = before
+        .insurance
+        .checked_sub(before.insurance_domain_budget_remaining_total)
+        .unwrap();
+    let unbudgeted_after = after_trade
+        .insurance
+        .checked_sub(after_trade.insurance_domain_budget_remaining_total)
+        .unwrap();
     let asset_budget_delta = after_trade.insurance_domain_budget[2]
         + after_trade.insurance_domain_budget[3]
         - asset_budget_before;
@@ -60139,8 +60223,13 @@ fn assert_permissionless_ewma_mark_fee_not_reclaimable(route: PermissionlessMark
         "{route:?}: mark fee must not land in creator-operated domains"
     );
     assert_eq!(
-        base_budget_delta, fee_paid,
-        "{route:?}: mark fee must remain in base insurance"
+        base_budget_delta, 0,
+        "{route:?}: mark fee must not become withdrawable by marketauth"
+    );
+    assert_eq!(
+        unbudgeted_after - unbudgeted_before,
+        fee_paid,
+        "{route:?}: the full movement fee stays in claim-free engine insurance"
     );
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,427 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A permissionless asset operator must remain economically negative for moving its EWMA against
+// pre-existing independent OI. Reclaiming the externality fee turns the mark move into a public
+// extraction: the attacker opens against a passive LP, self-trades to move the mark, reclaims the
+// fee, then closes against the same LP at the moved effective price.
+#[test]
+fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
+    const ASSET_INDEX: u16 = 1;
+    const MARK: u64 = 1_000_000;
+    const LOW_PRINT: u64 = 1;
+    const POSITION_Q: i128 = 1_000 * POS_SCALE as i128;
+    const DEPOSIT: u128 = 2_000_000_000;
+    const INIT_FEE: u128 = 1;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        max_portfolio_assets: 1,
+        initial_price: MARK,
+        h_max: 20,
+        max_trading_fee_bps: 100,
+        max_price_move_bps_per_slot: 100,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.update_market_init_fee_policy_with_cu(INIT_FEE);
+
+    let attacker = Keypair::new();
+    env.ensure_signer_account(attacker.pubkey());
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        ASSET_INDEX,
+        1,
+        MARK,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        INIT_FEE,
+    );
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: ASSET_INDEX,
+            now_slot: 1,
+            initial_mark_e6: MARK,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&attacker],
+    )
+    .expect("configure permissionless EWMA asset");
+
+    let attacker_position = env.create_portfolio(&attacker);
+    let self_long_owner = Keypair::new();
+    let self_long = env.create_portfolio(&self_long_owner);
+    let self_short_owner = Keypair::new();
+    let self_short = env.create_portfolio(&self_short_owner);
+    let victim = Keypair::new();
+    let victim_lp = env.create_portfolio(&victim);
+    for (owner, portfolio) in [
+        (&attacker, attacker_position),
+        (&self_long_owner, self_long),
+        (&self_short_owner, self_short),
+        (&victim, victim_lp),
+    ] {
+        env.deposit(owner, portfolio, DEPOSIT);
+    }
+
+    let matcher_program = Pubkey::new_unique();
+    env.svm.add_program(
+        matcher_program,
+        &std::fs::read(matcher_program_path()).expect("read matcher BPF"),
+    );
+    let (matcher_ctx, matcher_delegate, _) =
+        env.init_matcher_context_authorized(matcher_program, &victim, victim_lp);
+
+    // The passive LP is independently owned and authorizes normal fills at the current engine mark.
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_position,
+        &victim,
+        victim_lp,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        ASSET_INDEX,
+        -POSITION_Q,
+        0,
+    );
+
+    // The attacker-controlled pair pays the full two-sided externality fee to move the EWMA down.
+    env.svm.warp_to_slot(2);
+    let insurance_before = env.market_state().1.insurance;
+    env.try_trade_asset_with_cu(
+        ASSET_INDEX,
+        &self_long_owner,
+        self_long,
+        &self_short_owner,
+        self_short,
+        POSITION_Q,
+        LOW_PRINT,
+        0,
+    )
+    .expect("attacker self-trade moves the EWMA");
+    // Flatten the self-trade before the queued mark reaches the engine. Same-slot EWMA dt is zero,
+    // so this removes the attacker's temporary OI without reversing the paid pending move.
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        ASSET_INDEX,
+        &self_long_owner,
+        self_long,
+        &self_short_owner,
+        self_short,
+        -POSITION_Q,
+        LOW_PRINT,
+        0,
+    );
+    let group_after_move = env.market_state().1;
+    let fee_paid = group_after_move.insurance - insurance_before;
+    assert!(fee_paid > 0, "mark movement must charge a real fee");
+    assert!(
+        state::read_asset_oracle_profile(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ASSET_INDEX as usize,
+        )
+        .unwrap()
+        .mark_ewma_e6
+            < MARK,
+        "self-trade must queue a downward EWMA move"
+    );
+
+    let reclaimed =
+        match env.try_withdraw_insurance_asset_with_authority(&attacker, ASSET_INDEX, fee_paid) {
+            Ok((dest, _)) => env.token_amount(dest) as u128,
+            Err(_) => 0,
+        };
+
+    // Apply the already-paid mark and settle every participant before closing at the new mark.
+    for portfolio in [attacker_position, victim_lp] {
+        env.svm.expire_blockhash();
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(ASSET_INDEX),
+            },
+        );
+    }
+    let effective = env.market_state().1.assets[ASSET_INDEX as usize].effective_price;
+    assert!(effective < MARK, "the paid EWMA move must reach the engine");
+
+    env.svm.expire_blockhash();
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_position,
+        &victim,
+        victim_lp,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        ASSET_INDEX,
+        POSITION_Q,
+        0,
+    );
+    for portfolio in [attacker_position, victim_lp] {
+        env.svm.expire_blockhash();
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: vec![],
+            },
+        );
+    }
+
+    let withdraw_all = |env: &mut V16CuEnv, owner: &Keypair, portfolio: Pubkey| -> u128 {
+        let before = env.portfolio_state(portfolio);
+        let positive_pnl = before.pnl.get().max(0) as u128;
+        if positive_pnl != 0 {
+            env.convert_released_pnl_with_cu(owner, portfolio, positive_pnl);
+        }
+        let capital = env.portfolio_state(portfolio).capital.get();
+        if capital == 0 {
+            0
+        } else {
+            let dest = env.withdraw(owner, portfolio, capital);
+            env.token_amount(dest) as u128
+        }
+    };
+    let attacker_payout = withdraw_all(&mut env, &attacker, attacker_position)
+        + withdraw_all(&mut env, &self_long_owner, self_long)
+        + withdraw_all(&mut env, &self_short_owner, self_short)
+        + reclaimed;
+    let victim_payout = withdraw_all(&mut env, &victim, victim_lp);
+    let attacker_committed = DEPOSIT * 3 + INIT_FEE;
+    let victim_loss = DEPOSIT.saturating_sub(victim_payout);
+    let attacker_gain = attacker_payout.saturating_sub(attacker_committed);
+
+    eprintln!(
+        "EWMA reclaim extraction: fee={fee_paid} reclaimed={reclaimed} effective={effective} \
+         attacker_gain={attacker_gain} victim_loss={victim_loss}"
+    );
+    assert!(
+        victim_loss > 0,
+        "control must impose a real independent LP loss"
+    );
+    assert!(
+        attacker_payout <= attacker_committed,
+        "reclaiming the mark fee made the attacker profitable by {attacker_gain} against an \
+         independent LP loss of {victim_loss}"
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PermissionlessMarkFeeRoute {
+    NoCpiSingle,
+    NoCpiBatch,
+    CpiSingle,
+    CpiBatch,
+}
+
+fn assert_permissionless_ewma_mark_fee_not_reclaimable(route: PermissionlessMarkFeeRoute) {
+    const ASSET_INDEX: u16 = 1;
+    const MARK: u64 = 1_000_000;
+    const CAP_BPS: u64 = 50;
+    const MAX_FEE_BPS: u64 = 37;
+    const SIZE_Q: i128 = (1000u128 * POS_SCALE) as i128;
+    const HIGH_PRINT: u64 = MARK * 19 / 10;
+    const SPREAD_BPS: u32 = 9_000;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        max_portfolio_assets: 1,
+        initial_price: MARK,
+        h_max: 20,
+        max_trading_fee_bps: MAX_FEE_BPS,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.update_market_init_fee_policy_with_cu(1);
+
+    let creator = Keypair::new();
+    env.ensure_signer_account(creator.pubkey());
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        ASSET_INDEX,
+        1,
+        MARK,
+        creator.pubkey(),
+        creator.pubkey(),
+        creator.pubkey(),
+        creator.pubkey(),
+        1,
+    );
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: ASSET_INDEX,
+            now_slot: 1,
+            initial_mark_e6: MARK,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+        },
+        vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&creator],
+    )
+    .expect("permissionless creator configures its EWMA oracle");
+
+    env.svm.warp_to_slot(5);
+    let (owner_a, account_a, owner_b, account_b) =
+        funded_no_cpi_reported_price_pair(&mut env, 4_000_000_000);
+    let before = env.market_state().1;
+    let asset_budget_before = before.insurance_domain_budget[2] + before.insurance_domain_budget[3];
+    let base_budget_before = before.insurance_domain_budget[0] + before.insurance_domain_budget[1];
+
+    env.svm.expire_blockhash();
+    let trade = match route {
+        PermissionlessMarkFeeRoute::NoCpiSingle => env.try_trade_asset_with_cu(
+            ASSET_INDEX,
+            &owner_a,
+            account_a,
+            &owner_b,
+            account_b,
+            SIZE_Q,
+            HIGH_PRINT,
+            0,
+        ),
+        PermissionlessMarkFeeRoute::NoCpiBatch => env.send(
+            ProgInstruction::BatchTradeNoCpi {
+                legs: vec![BatchTradeLeg {
+                    asset_index: ASSET_INDEX,
+                    size_q: SIZE_Q,
+                    exec_price: HIGH_PRINT,
+                    fee_bps: 0,
+                }],
+            },
+            vec![
+                AccountMeta::new(owner_a.pubkey(), true),
+                AccountMeta::new(owner_b.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(account_a, false),
+                AccountMeta::new(account_b, false),
+            ],
+            &[&owner_a, &owner_b],
+        ),
+        PermissionlessMarkFeeRoute::CpiSingle | PermissionlessMarkFeeRoute::CpiBatch => {
+            let matcher_program = Pubkey::new_unique();
+            env.svm.add_program(
+                matcher_program,
+                &std::fs::read(matcher_program_path()).expect("read matcher BPF"),
+            );
+            let (ctx, delegate, _) = env.init_matcher_context_with_passive_spread_authorized(
+                matcher_program,
+                &owner_b,
+                account_b,
+                SPREAD_BPS,
+                SPREAD_BPS,
+            );
+            match route {
+                PermissionlessMarkFeeRoute::CpiSingle => env.try_trade_cpi_with_cu_on_asset(
+                    &owner_a,
+                    account_a,
+                    &owner_b,
+                    account_b,
+                    matcher_program,
+                    ctx,
+                    delegate,
+                    ASSET_INDEX,
+                    SIZE_Q,
+                    0,
+                ),
+                PermissionlessMarkFeeRoute::CpiBatch => env.send(
+                    ProgInstruction::BatchTradeCpi {
+                        legs: vec![BatchTradeCpiLeg {
+                            asset_index: ASSET_INDEX,
+                            size_q: SIZE_Q,
+                            fee_bps: 0,
+                            limit_price: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(owner_a.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(account_a, false),
+                        AccountMeta::new(account_b, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(ctx, false),
+                        AccountMeta::new_readonly(delegate, false),
+                    ],
+                    &[&owner_a],
+                ),
+                _ => unreachable!(),
+            }
+        }
+    };
+    assert!(
+        trade.is_ok(),
+        "{route:?}: permissionless-asset EWMA trade must remain live: {trade:?}"
+    );
+
+    let profile = state::read_asset_oracle_profile(
+        &env.svm.get_account(&env.market).unwrap().data,
+        ASSET_INDEX as usize,
+    )
+    .unwrap();
+    let after_trade = env.market_state().1;
+    let fee_paid = after_trade.insurance - before.insurance;
+    let asset_budget_delta = after_trade.insurance_domain_budget[2]
+        + after_trade.insurance_domain_budget[3]
+        - asset_budget_before;
+    let base_budget_delta = after_trade.insurance_domain_budget[0]
+        + after_trade.insurance_domain_budget[1]
+        - base_budget_before;
+    assert!(fee_paid > 0, "{route:?}: trade must pay a real mark fee");
+    assert!(
+        profile.mark_ewma_e6 > MARK,
+        "{route:?}: trade must move the EWMA mark"
+    );
+    assert_eq!(
+        after_trade.assets[ASSET_INDEX as usize].oi_eff_long_q,
+        SIZE_Q as u128
+    );
+    assert_eq!(
+        after_trade.assets[ASSET_INDEX as usize].oi_eff_short_q,
+        SIZE_Q as u128
+    );
+
+    env.svm.expire_blockhash();
+    let reclaim = env.try_withdraw_insurance_asset_with_authority(&creator, ASSET_INDEX, 1);
+    assert!(
+        reclaim.is_err(),
+        "{route:?}: creator/operator reclaimed the fee that paid for its EWMA mark move"
+    );
+    assert_eq!(
+        asset_budget_delta, 0,
+        "{route:?}: mark fee must not land in creator-operated domains"
+    );
+    assert_eq!(
+        base_budget_delta, fee_paid,
+        "{route:?}: mark fee must remain in base insurance"
+    );
+}
+
+#[test]
+fn v16_attack_permissionless_trade_driven_mark_fee_is_not_reclaimable() {
+    for route in [
+        PermissionlessMarkFeeRoute::NoCpiSingle,
+        PermissionlessMarkFeeRoute::NoCpiBatch,
+        PermissionlessMarkFeeRoute::CpiSingle,
+        PermissionlessMarkFeeRoute::CpiBatch,
+    ] {
+        assert_permissionless_ewma_mark_fee_not_reclaimable(route);
+    }
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59719,9 +59719,10 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 // A permissionless asset operator must remain economically negative for moving its EWMA against
-// pre-existing independent OI. Reclaiming the externality fee turns the mark move into a public
-// extraction: the attacker opens against a passive LP, self-trades to move the mark, reclaims the
-// fee, then closes against the same LP at the moved effective price.
+// pre-existing independent OI, even when the market authority is compromised. Moving the fee from
+// the creator's domains to asset-0 insurance is insufficient if marketauth can reclaim it after all
+// users exit. The coalition opens against a passive LP, self-trades to move the mark, closes every
+// portfolio, then reclaims the fee from the canonical insurance domain.
 #[test]
 fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
     const ASSET_INDEX: u16 = 1;
@@ -59742,6 +59743,7 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         ..V16CuMarketParams::default()
     });
     env.update_market_init_fee_policy_with_cu(INIT_FEE);
+    let compromised_marketauth = env.admin.insecure_clone();
 
     let attacker = Keypair::new();
     env.ensure_signer_account(attacker.pubkey());
@@ -59790,13 +59792,8 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         env.deposit(owner, portfolio, DEPOSIT);
     }
 
-    let matcher_program = Pubkey::new_unique();
-    env.svm.add_program(
-        matcher_program,
-        &std::fs::read(matcher_program_path()).expect("read matcher BPF"),
-    );
-    let (matcher_ctx, matcher_delegate, _) =
-        env.init_matcher_context_authorized(matcher_program, &victim, victim_lp);
+    let (matcher_program, matcher_ctx, matcher_delegate) =
+        auth_matcher_for_lp_via_system_create(&mut env, &victim, victim_lp);
 
     // The passive LP is independently owned and authorizes normal fills at the current engine mark.
     env.trade_cpi_with_cu_on_asset(
@@ -59853,11 +59850,15 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
         "self-trade must queue a downward EWMA move"
     );
 
-    let reclaimed =
+    let locally_reclaimed =
         match env.try_withdraw_insurance_asset_with_authority(&attacker, ASSET_INDEX, fee_paid) {
             Ok((dest, _)) => env.token_amount(dest) as u128,
             Err(_) => 0,
         };
+    assert_eq!(
+        locally_reclaimed, 0,
+        "movement fee must already be unavailable to the permissionless asset operator"
+    );
 
     // Apply the already-paid mark and settle every participant before closing at the new mark.
     for portfolio in [attacker_position, victim_lp] {
@@ -59911,17 +59912,30 @@ fn v16_attack_reclaimable_ewma_fee_cannot_fund_lp_extraction() {
             env.token_amount(dest) as u128
         }
     };
-    let attacker_payout = withdraw_all(&mut env, &attacker, attacker_position)
+    let mut attacker_payout = withdraw_all(&mut env, &attacker, attacker_position)
         + withdraw_all(&mut env, &self_long_owner, self_long)
-        + withdraw_all(&mut env, &self_short_owner, self_short)
-        + reclaimed;
+        + withdraw_all(&mut env, &self_short_owner, self_short);
     let victim_payout = withdraw_all(&mut env, &victim, victim_lp);
+    assert_eq!(
+        env.market_state().1.c_tot,
+        0,
+        "all user capital exits before the delayed canonical-fee reclaim"
+    );
+    let base_reclaimed = match env.try_withdraw_insurance_asset_with_authority(
+        &compromised_marketauth,
+        0,
+        fee_paid,
+    ) {
+        Ok((dest, _)) => env.token_amount(dest) as u128,
+        Err(_) => 0,
+    };
+    attacker_payout += base_reclaimed;
     let attacker_committed = DEPOSIT * 3 + INIT_FEE;
     let victim_loss = DEPOSIT.saturating_sub(victim_payout);
     let attacker_gain = attacker_payout.saturating_sub(attacker_committed);
 
     eprintln!(
-        "EWMA reclaim extraction: fee={fee_paid} reclaimed={reclaimed} effective={effective} \
+        "EWMA reclaim extraction: fee={fee_paid} base_reclaimed={base_reclaimed} effective={effective} \
          attacker_gain={attacker_gain} victim_loss={victim_loss}"
     );
     assert!(


### PR DESCRIPTION
## What changed

- add an exact-parent public LiteSVM attack against an independently owned passive LP
- cover `TradeNoCpi`, `BatchTradeNoCpi`, `TradeCpi`, and `BatchTradeCpi` fee routing
- leave only the collected EWMA movement fee outside every authority-withdrawable insurance domain
- retire and burn that claim-free surplus only when `CloseSlab` proves the resolved market has no remaining users or claims
- preserve ordinary trade fees in their local domains

Engine support: aeyakovenko/percolator#146

## Public exploit

A permissionless asset creator also controls that asset's insurance operator. Before this patch, an attacker could:

1. Open a directional position against an independently owned passive LP.
2. Self-trade to pay for and queue an adverse EWMA move.
3. Flatten the temporary self-trade in the same slot without reversing the queued move.
4. Withdraw the movement fee from the attacker-controlled insurance domain.
5. Crank the paid mark and close the directional position against the LP.

On exact `main` parent `da64be63`, the public LiteSVM attack reclaims `10,098,000` atoms, leaves the attacker `4,999,999` atoms net positive, and transfers `5,000,000` atoms from the independent LP. It uses normal public initialization and instructions, with no state injection, dishonest oracle, absent keeper, or rollback assumption violation.

The first fix (`d95f5a0a`) moved the fee to base insurance. The delayed exact-parent regression (`7c8321a5`) proved that was still reclaimable: after every user exited, compromised market authority could withdraw the same fee from the base domain and realize the same profit. The final fix leaves movement fees in engine insurance without assigning them to any authority budget. Once the market is resolved and every claimant is gone, `CloseSlab` atomically retires the accounting amount and burns exactly that many canonical SPL tokens instead of sweeping them to market authority.

Trade availability and mark-clamp behavior are unchanged. Failed terminal burns roll the engine transition back at the instruction boundary.

## TDD evidence

- initial exact-main red: `c30d9b85`
- incomplete base-domain fix: `d95f5a0a`
- delayed base-domain red: `7c8321a5`
- final fix: `2da0413a`
- pre-fix result: fee reclaimed `10,098,000`; attacker gain `4,999,999`; independent LP loss `5,000,000`
- fixed result: authority reclaim `0`; attacker gain `0`; movement fee remains claim-free until terminal SPL burn
- four-route matrix proves the movement fee enters neither creator-controlled nor base-authority budgets

## Validation

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1`: 567 passed
- exact public economic regression passes and terminal `CloseSlab` remains under the 300k custody CU guardrail
- Kani fee-direction contract: 30/30 checks, 3/3 covers
- Kani collected-base-fee isolation contract: 40/40 checks, 2/2 covers
- engine `cargo test --all-targets --features fuzz`: 159 passed
- engine terminal-retirement Kani contract: 132 checks, 3/3 covers

The broad wrapper Kani decoder roster was not rerun here; its eight known wide-decoder timeout harnesses are unchanged because this patch does not alter instruction decoding.