### PR TITLE
Pin shutdown provider recovery to its owners

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -7436,15 +7436,12 @@ pub mod processor {
         }
         let profile = read_oracle_profile_for_asset(&market_data, &cfg, asset_index)?;
         let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
-        let local_authorized = match authority_kind {
-            DOMAIN_WITHDRAW_AUTH_INSURANCE => {
-                live_authority_matches(&authorities.insurance_operator, authority.key)
-            }
-            DOMAIN_WITHDRAW_AUTH_BACKING => {
-                live_authority_matches(&authorities.backing_bucket_authority, authority.key)
-            }
+        let withdrawal_authority = match authority_kind {
+            DOMAIN_WITHDRAW_AUTH_INSURANCE => authorities.insurance_operator,
+            DOMAIN_WITHDRAW_AUTH_BACKING => authorities.backing_bucket_authority,
             _ => return Err(PercolatorError::InvalidInstruction.into()),
         };
+        let local_authorized = live_authority_matches(&withdrawal_authority, authority.key);
         if !local_authorized && !live_authority_matches(&cfg.marketauth, authority.key) {
             return Err(PercolatorError::Unauthorized.into());
         }
@@ -7452,7 +7449,7 @@ pub mod processor {
         expect_key(vault_authority_ai, &vault_authority)?;
         verify_withdrawable_token_accounts(
             dest_token,
-            authority.key,
+            &Pubkey::new_from_array(withdrawal_authority),
             vault_token,
             &vault_authority,
             &cfg,
@@ -7628,11 +7625,9 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
-            let ledger_authority = if admin_shutdown_authorized && !local_authorized {
-                cfg.marketauth
-            } else {
-                authorities.backing_bucket_authority
-            };
+            // Marketauth may drive mature shutdown cleanup, but the backing principal and its
+            // accounting remain owned by the provider authority.
+            let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {
@@ -7753,11 +7748,7 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
-            let ledger_authority = if admin_shutdown_authorized && !local_authorized {
-                cfg.marketauth
-            } else {
-                authorities.backing_bucket_authority
-            };
+            let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
             if amount > bucket.utilization_fee_earnings || amount > group.header.vault.get() {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8026,11 +8026,21 @@ pub mod processor {
             {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
+            let profile = read_oracle_profile_for_asset(&market_data, &cfg, asset_index)?;
+            let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
+            let local_operator =
+                live_authority_matches(&authorities.insurance_operator, operator.key);
+            // A marketauth fallback can submit shutdown cleanup, but cannot become its payee.
+            let destination_owner = if local_operator {
+                *operator.key
+            } else {
+                Pubkey::new_from_array(authorities.insurance_authority)
+            };
             let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
             expect_key(vault_authority_ai, &vault_authority)?;
             verify_withdrawable_token_accounts(
                 dest_token,
-                operator.key,
+                &destination_owner,
                 vault_token,
                 &vault_authority,
                 &cfg,
@@ -8062,11 +8072,7 @@ pub mod processor {
                 if !local_authorized && !admin_shutdown_authorized {
                     return Err(PercolatorError::Unauthorized.into());
                 }
-                if admin_shutdown_authorized && !local_authorized {
-                    cfg.marketauth
-                } else {
-                    authorities.insurance_authority
-                }
+                authorities.insurance_authority
             } else {
                 if group.header.materialized_portfolio_count.get() != 0
                     || group.header.c_tot.get() != 0

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -7589,18 +7589,7 @@ pub mod processor {
         }
 
         let domain_usize = domain as usize;
-        let (bump, amount_u64) = verify_domain_withdrawal_preflight(
-            program_id,
-            market_ai,
-            authority,
-            dest_token,
-            vault_token,
-            vault_authority_ai,
-            domain_usize,
-            amount,
-            false,
-            DOMAIN_WITHDRAW_AUTH_BACKING,
-        )?;
+        let escheat_to_base_insurance;
 
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
@@ -7625,8 +7614,11 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
-            // Marketauth may drive mature shutdown cleanup, but the backing principal and its
-            // accounting remain owned by the provider authority.
+            // Abandoned residual: when marketauth drives mature shutdown cleanup and the provider is
+            // not the caller, there is no live owner to pay. Escheat the freed principal to the base
+            // insurance fund (domain 0) exactly like fees, rather than paying a possibly-absent
+            // provider token account (which would strand cleanup) or the marketauth signer (the rug).
+            escheat_to_base_insurance = admin_shutdown_authorized && !local_authorized;
             let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
@@ -7654,6 +7646,12 @@ pub mod processor {
             group
                 .withdraw_fresh_counterparty_backing_not_atomic(domain_usize, amount)
                 .map_err(map_v16_error)?;
+            if escheat_to_base_insurance {
+                // Vault-neutral reattribution: the freed backing tokens are already custodied in the
+                // vault, so credit them into the base insurance fund without moving tokens. The
+                // withdraw above debited header.vault; this deposit re-credits it, netting to zero.
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_principal_atoms = ledger
                     .total_principal_atoms
@@ -7672,16 +7670,30 @@ pub mod processor {
             }
         }
 
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (bump, amount_u64) = verify_domain_withdrawal_preflight(
+                program_id,
+                market_ai,
+                authority,
+                dest_token,
+                vault_token,
+                vault_authority_ai,
+                domain_usize,
+                amount,
+                false,
+                DOMAIN_WITHDRAW_AUTH_BACKING,
+            )?;
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 
@@ -7712,18 +7724,7 @@ pub mod processor {
         }
 
         let domain_usize = domain as usize;
-        let (bump, amount_u64) = verify_domain_withdrawal_preflight(
-            program_id,
-            market_ai,
-            authority,
-            dest_token,
-            vault_token,
-            vault_authority_ai,
-            domain_usize,
-            amount,
-            false,
-            DOMAIN_WITHDRAW_AUTH_BACKING,
-        )?;
+        let escheat_to_base_insurance;
 
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
@@ -7748,6 +7749,9 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
+            // Abandoned residual: escheat the freed provider earnings to the base insurance fund
+            // (domain 0) exactly like fees when marketauth drives cleanup for an absent provider.
+            escheat_to_base_insurance = admin_shutdown_authorized && !local_authorized;
             let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
@@ -7766,6 +7770,12 @@ pub mod processor {
             group
                 .withdraw_backing_provider_earnings_not_atomic(domain_usize, amount)
                 .map_err(map_v16_error)?;
+            if escheat_to_base_insurance {
+                // Vault-neutral reattribution (see handle_withdraw_backing_bucket): the withdraw
+                // above debited header.vault; this deposit re-credits it, netting to zero, and the
+                // earnings tokens already custodied in the vault become base insurance.
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             ledger.last_observed_bucket_earnings_atoms = ledger
                 .last_observed_bucket_earnings_atoms
                 .checked_sub(amount)
@@ -7778,16 +7788,30 @@ pub mod processor {
             write_or_init_backing_domain_ledger(&mut ledger_data, &ledger, initialized)?;
         }
 
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (bump, amount_u64) = verify_domain_withdrawal_preflight(
+                program_id,
+                market_ai,
+                authority,
+                dest_token,
+                vault_token,
+                vault_authority_ai,
+                domain_usize,
+                amount,
+                false,
+                DOMAIN_WITHDRAW_AUTH_BACKING,
+            )?;
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 
@@ -8016,38 +8040,8 @@ pub mod processor {
             .checked_mul(2)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
         let amount_u64 = amount_to_u64(amount)?;
-        {
-            let market_data = market_ai.try_borrow_data()?;
-            let (cfg, mode, configured_slots, _) =
-                state::read_market_config_mode_and_capacity(&market_data)?;
-            if (mode != MarketModeV16::Live && mode != MarketModeV16::Resolved)
-                || asset_index >= configured_slots
-                || long_domain >= configured_slots.saturating_mul(2)
-            {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
-            let profile = read_oracle_profile_for_asset(&market_data, &cfg, asset_index)?;
-            let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
-            let local_operator =
-                live_authority_matches(&authorities.insurance_operator, operator.key);
-            // A marketauth fallback can submit shutdown cleanup, but cannot become its payee.
-            let destination_owner = if local_operator {
-                *operator.key
-            } else {
-                Pubkey::new_from_array(authorities.insurance_authority)
-            };
-            let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
-            expect_key(vault_authority_ai, &vault_authority)?;
-            verify_withdrawable_token_accounts(
-                dest_token,
-                &destination_owner,
-                vault_token,
-                &vault_authority,
-                &cfg,
-            )?;
-            require_token_balance(vault_token, amount_u64)?;
-        }
-        let (_, bump) = derive_vault_authority(program_id, market_ai.key);
+        let escheat_to_base_insurance;
+        let destination_owner;
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
@@ -8061,17 +8055,20 @@ pub mod processor {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             let authorities = domain_authorities_from_view(&group, &cfg, long_domain)?;
+            let local_operator =
+                live_authority_matches(&authorities.insurance_operator, operator.key);
             let ledger_authority = if live_mode {
                 let shutdown_drain =
                     live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
-                let local_authorized =
-                    live_authority_matches(&authorities.insurance_operator, operator.key);
                 let admin_shutdown_authorized = asset_index != 0
                     && shutdown_drain
                     && live_authority_matches(&cfg.marketauth, operator.key);
-                if !local_authorized && !admin_shutdown_authorized {
+                if !local_operator && !admin_shutdown_authorized {
                     return Err(PercolatorError::Unauthorized.into());
                 }
+                // Abandoned residual: escheat to the base insurance fund (domain 0) exactly like fees
+                // when marketauth drives cleanup for an absent operator.
+                escheat_to_base_insurance = admin_shutdown_authorized && !local_operator;
                 authorities.insurance_authority
             } else {
                 if group.header.materialized_portfolio_count.get() != 0
@@ -8082,7 +8079,14 @@ pub mod processor {
                 if !live_authority_matches(&authorities.insurance_authority, operator.key) {
                     return Err(PercolatorError::Unauthorized.into());
                 }
+                escheat_to_base_insurance = false;
                 authorities.insurance_authority
+            };
+            // Marketauth fallback may drive cleanup but cannot become the payee (payout path only).
+            destination_owner = if local_operator {
+                *operator.key
+            } else {
+                Pubkey::new_from_array(authorities.insurance_authority)
             };
             let available = market_insurance_withdraw_capacity_view(&group, asset_index)?;
             if amount > available
@@ -8111,6 +8115,12 @@ pub mod processor {
             // Atomic insurance/vault/budget withdraw through the engine (maintains the
             // insurance_domain_budget_remaining_total aggregate).
             debit_market_insurance_budget_view(&mut group, asset_index, amount)?;
+            if escheat_to_base_insurance {
+                // Vault-neutral reattribution: the debit above removed this asset's insurance and
+                // debited header.vault; re-credit the base insurance fund (domain 0) for the same
+                // amount so header.vault and total insurance are unchanged and no tokens move.
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_withdrawn_atoms = ledger
                     .total_withdrawn_atoms
@@ -8129,16 +8139,32 @@ pub mod processor {
                 write_or_init_insurance_ledger(data, ledger, *initialized)?;
             }
         }
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (vault_authority, bump) = derive_vault_authority(program_id, market_ai.key);
+            expect_key(vault_authority_ai, &vault_authority)?;
+            {
+                let market_data = market_ai.try_borrow_data()?;
+                let (cfg, _, _, _) = state::read_market_config_mode_and_capacity(&market_data)?;
+                verify_withdrawable_token_accounts(
+                    dest_token,
+                    &destination_owner,
+                    vault_token,
+                    &vault_authority,
+                    &cfg,
+                )?;
+            }
+            require_token_balance(vault_token, amount_u64)?;
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,121 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+// Public isolation probe: marketauth may drive an abandoned shutdown asset toward cleanup, but it
+// must not redirect that permissionless asset's provider-owned backing principal to itself.
+#[test]
+fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_backing_principal() {
+    const BACKING: u128 = 500;
+
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.update_market_init_fee_policy_with_cu(1);
+
+    let provider = Keypair::new();
+    let provider_key = provider.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &provider,
+        1,
+        1,
+        100,
+        provider_key,
+        provider_key,
+        provider_key,
+        provider_key,
+        1,
+    );
+    let ledger = env.backing_domain_ledger_account();
+    let backing_source = env.token_account(provider_key, BACKING as u64);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: 2,
+            amount: BACKING,
+            expiry_slot: 1_000,
+        },
+        vec![
+            AccountMeta::new(provider_key, true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
+        ],
+        &[&provider],
+    )
+    .expect("provider funds its backing bucket and ledger");
+
+    let marketauth = env.admin.insecure_clone();
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&marketauth, 1, 2)
+        .expect("marketauth can shut down the permissionless asset");
+    env.svm.warp_to_slot(7);
+
+    let before_market = env.svm.get_account(&env.market).unwrap();
+    let before_vault = env.svm.get_account(&env.vault).unwrap();
+    let admin_dest = env.token_account(marketauth.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let redirected = env.send(
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 2,
+            amount: BACKING,
+        },
+        vec![
+            AccountMeta::new(marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(admin_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&marketauth],
+    );
+    assert!(
+        redirected.is_err(),
+        "shutdown cleanup must not redirect provider backing to marketauth"
+    );
+    assert_eq!(env.token_amount(admin_dest), 0);
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_market);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), before_vault);
+
+    // Cleanup remains permissionless: marketauth can submit it when the payout token account is
+    // owned by the backing provider, even if the provider itself is offline.
+    let provider_dest = env.token_account(provider_key, 0);
+    env.svm.expire_blockhash();
+    let cleanup_cu = env
+        .send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain: 2,
+                amount: BACKING,
+            },
+            vec![
+                AccountMeta::new(marketauth.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger, false),
+            ],
+            &[&marketauth],
+        )
+        .expect("marketauth cleanup pays the backing provider");
+    assert_cu_within(
+        "provider-pinned shutdown backing cleanup",
+        cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.token_amount(provider_dest), BACKING as u64);
+    let ledger_after =
+        state::read_backing_domain_ledger(&env.svm.get_account(&ledger).unwrap().data)
+            .expect("provider ledger remains valid after marketauth cleanup");
+    assert_eq!(ledger_after.authority, provider_key.to_bytes());
+    assert_eq!(ledger_after.total_principal_atoms, 0);
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[2].fresh_unliened_backing_num,
+        0
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -5655,11 +5655,14 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     assert!(!has_active_leg_for_asset(&long_closed, 1));
     assert!(!has_active_leg_for_asset(&short_closed, 1));
 
-    let admin_key = env.admin.pubkey();
-    let admin_recovery = env.token_account(admin_key, 0);
+    let insurance_recovery = env.token_account(insurance_authority.pubkey(), 0);
     let provider_recovery = env.token_account(backing_authority.pubkey(), 0);
     for (domain, amount) in [(2u8, 6u128), (3u8, 4u128)] {
-        env.withdraw_insurance_domain_to_admin_token_with_cu(admin_recovery, domain.into(), amount);
+        env.withdraw_insurance_domain_to_admin_token_with_cu(
+            insurance_recovery,
+            domain.into(),
+            amount,
+        );
     }
     for (domain, amount) in [(2u8, 20u128), (3u8, 25u128)] {
         env.withdraw_backing_bucket_to_admin_token_with_cu(
@@ -5669,9 +5672,9 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
         );
     }
     assert_eq!(
-        env.token_amount(admin_recovery),
+        env.token_amount(insurance_recovery),
         10,
-        "marketauth recovers only protocol insurance during shutdown cleanup"
+        "market-driven cleanup returns domain insurance to its authority"
     );
     assert_eq!(
         env.token_amount(provider_recovery),
@@ -5679,14 +5682,6 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
         "market-driven cleanup returns backing principal to its provider"
     );
     assert_eq!(env.token_amount(env.vault), 20_025);
-
-    env.top_up_insurance_from_admin_token_with_cu(admin_recovery, 10);
-    assert_eq!(
-        env.token_amount(admin_recovery),
-        0,
-        "recovered protocol insurance is re-deposited into market 0"
-    );
-    assert_eq!(env.token_amount(env.vault), 20_035);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (_, recovered_group) = state::read_market(&market_data).unwrap();
     assert_eq!(recovered_group.insurance_domain_budget[2], 0);
@@ -5699,8 +5694,8 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
         recovered_group.source_backing_buckets[3].fresh_unliened_backing_num,
         0
     );
-    assert_eq!(recovered_group.insurance_domain_budget[0], 17);
-    assert_eq!(recovered_group.insurance_domain_budget[1], 18);
+    assert_eq!(recovered_group.insurance_domain_budget[0], 12);
+    assert_eq!(recovered_group.insurance_domain_budget[1], 13);
     assert_eq!(
         recovered_group.source_backing_buckets[0].fresh_unliened_backing_num,
         0
@@ -5760,7 +5755,7 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     );
     println!("v16 permissionless asset reuse BPF CU: {reuse_cu}");
     assert_eq!(env.token_amount(reuse_source), 0);
-    assert_eq!(env.token_amount(env.vault), 20_060);
+    assert_eq!(env.token_amount(env.vault), 20_050);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (reused_cfg, reused_group) = state::read_market(&market_data).unwrap();
     assert_eq!(reused_cfg.free_market_slot_count, 0);
@@ -59597,4 +59592,106 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_backing_principal() {
         env.market_state().1.source_backing_buckets[2].fresh_unliened_backing_num,
         0
     );
+}
+
+#[test]
+fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_insurance_principal() {
+    const INSURANCE: u128 = 300;
+
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.update_market_init_fee_policy_with_cu(1);
+
+    let creator = Keypair::new();
+    let insurance_authority = Keypair::new();
+    let insurance_operator = Keypair::new();
+    let creator_key = creator.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        1,
+        1,
+        100,
+        insurance_authority.pubkey(),
+        insurance_operator.pubkey(),
+        creator_key,
+        creator_key,
+        1,
+    );
+    let ledger = env.insurance_ledger_account();
+    env.top_up_insurance_domain_with_authority_ledger_and_cu(
+        &insurance_authority,
+        ledger,
+        2,
+        INSURANCE,
+    );
+
+    let marketauth = env.admin.insecure_clone();
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&marketauth, 1, 2)
+        .expect("marketauth can shut down the permissionless asset");
+    env.svm.warp_to_slot(7);
+
+    let before_market = env.svm.get_account(&env.market).unwrap();
+    let before_vault = env.svm.get_account(&env.vault).unwrap();
+    let admin_dest = env.token_account(marketauth.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let redirected = env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 1,
+            amount: INSURANCE,
+        },
+        vec![
+            AccountMeta::new(marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(admin_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&marketauth],
+    );
+    assert!(
+        redirected.is_err(),
+        "shutdown cleanup must not redirect insurance principal to marketauth"
+    );
+    assert_eq!(env.token_amount(admin_dest), 0);
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_market);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), before_vault);
+
+    let authority_dest = env.token_account(insurance_authority.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let cleanup_cu = env
+        .send(
+            ProgInstruction::WithdrawInsuranceAsset {
+                asset_index: 1,
+                amount: INSURANCE,
+            },
+            vec![
+                AccountMeta::new(marketauth.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(authority_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger, false),
+            ],
+            &[&marketauth],
+        )
+        .expect("marketauth cleanup pays the insurance authority");
+    assert_cu_within(
+        "provider-pinned shutdown insurance cleanup",
+        cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.token_amount(authority_dest), INSURANCE as u64);
+    let ledger_after = state::read_insurance_ledger(&env.svm.get_account(&ledger).unwrap().data)
+        .expect("insurance authority ledger remains valid after marketauth cleanup");
+    assert_eq!(
+        ledger_after.authority,
+        insurance_authority.pubkey().to_bytes()
+    );
+    assert_eq!(ledger_after.total_principal_atoms, 0);
+    assert_eq!(env.market_state().1.insurance_domain_budget[2], 0);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -5671,17 +5671,20 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
             amount,
         );
     }
+    // Abandoned residual: marketauth-driven cleanup escheats the absent provider's insurance and
+    // backing into the base insurance fund (like fees) instead of paying the authority, and does so
+    // vault-neutrally (the tokens stay in the vault).
     assert_eq!(
         env.token_amount(insurance_recovery),
-        10,
-        "market-driven cleanup returns domain insurance to its authority"
+        0,
+        "market-driven cleanup escheats domain insurance rather than paying the authority"
     );
     assert_eq!(
         env.token_amount(provider_recovery),
-        45,
-        "market-driven cleanup returns backing principal to its provider"
+        0,
+        "market-driven cleanup escheats backing principal rather than paying the provider"
     );
-    assert_eq!(env.token_amount(env.vault), 20_025);
+    assert_eq!(env.token_amount(env.vault), 20_080);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (_, recovered_group) = state::read_market(&market_data).unwrap();
     assert_eq!(recovered_group.insurance_domain_budget[2], 0);
@@ -5694,8 +5697,10 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
         recovered_group.source_backing_buckets[3].fresh_unliened_backing_num,
         0
     );
-    assert_eq!(recovered_group.insurance_domain_budget[0], 12);
-    assert_eq!(recovered_group.insurance_domain_budget[1], 13);
+    // Base insurance grew by the escheated residual: 55 atoms (10 insurance + 45 backing) split
+    // across the long/short base domains on top of the pre-existing 12/13.
+    assert_eq!(recovered_group.insurance_domain_budget[0], 39);
+    assert_eq!(recovered_group.insurance_domain_budget[1], 41);
     assert_eq!(
         recovered_group.source_backing_buckets[0].fresh_unliened_backing_num,
         0
@@ -5755,7 +5760,7 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     );
     println!("v16 permissionless asset reuse BPF CU: {reuse_cu}");
     assert_eq!(env.token_amount(reuse_source), 0);
-    assert_eq!(env.token_amount(env.vault), 20_050);
+    assert_eq!(env.token_amount(env.vault), 20_105);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (reused_cfg, reused_group) = state::read_market(&market_data).unwrap();
     assert_eq!(reused_cfg.free_market_slot_count, 0);
@@ -59479,7 +59484,7 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
 // Public isolation probe: marketauth may drive an abandoned shutdown asset toward cleanup, but it
 // must not redirect that permissionless asset's provider-owned backing principal to itself.
 #[test]
-fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_backing_principal() {
+fn v16_attack_shutdown_cleanup_escheats_abandoned_backing_to_base_insurance() {
     const BACKING: u128 = 500;
 
     let mut env = V16CuEnv::new();
@@ -59528,47 +59533,55 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_backing_principal() {
         .expect("marketauth can shut down the permissionless asset");
     env.svm.warp_to_slot(7);
 
-    let before_market = env.svm.get_account(&env.market).unwrap();
-    let before_vault = env.svm.get_account(&env.vault).unwrap();
-    let admin_dest = env.token_account(marketauth.pubkey(), 0);
+    const RECLAIM: u128 = 200;
+    const ABANDONED: u128 = BACKING - RECLAIM;
+
+    // Reclaim-first: the provider (backing authority) can still withdraw its own principal during
+    // shutdown; those funds pay the provider, not the base insurance fund.
+    let provider_dest = env.token_account(provider_key, 0);
     env.svm.expire_blockhash();
-    let redirected = env.send(
+    env.send(
         ProgInstruction::WithdrawBackingBucket {
             domain: 2,
-            amount: BACKING,
+            amount: RECLAIM,
         },
         vec![
-            AccountMeta::new(marketauth.pubkey(), true),
+            AccountMeta::new(provider_key, true),
             AccountMeta::new(env.market, false),
-            AccountMeta::new(admin_dest, false),
+            AccountMeta::new(provider_dest, false),
             AccountMeta::new(env.vault, false),
             AccountMeta::new_readonly(env.vault_authority, false),
             AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
         ],
-        &[&marketauth],
-    );
-    assert!(
-        redirected.is_err(),
-        "shutdown cleanup must not redirect provider backing to marketauth"
-    );
-    assert_eq!(env.token_amount(admin_dest), 0);
-    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_market);
-    assert_eq!(env.svm.get_account(&env.vault).unwrap(), before_vault);
+        &[&provider],
+    )
+    .expect("provider reclaims its own backing during shutdown");
+    assert_eq!(env.token_amount(provider_dest), RECLAIM as u64);
 
-    // Cleanup remains permissionless: marketauth can submit it when the payout token account is
-    // owned by the backing provider, even if the provider itself is offline.
-    let provider_dest = env.token_account(provider_key, 0);
+    // Snapshot before the abandoned-residual cleanup.
+    let base_insurance_before = {
+        let g = env.market_state().1;
+        g.insurance_domain_budget[0] + g.insurance_domain_budget[1]
+    };
+    let vault_tokens_before = env.token_amount(env.vault);
+    let header_vault_before = env.market_state().1.vault;
+
+    // Abandoned residual: marketauth drives cleanup for the absent provider. It cannot pay itself
+    // (the original rug) and must not need a provider token account (which would strand cleanup);
+    // the residual escheats to the base insurance fund exactly like fees, leaving tokens in vault.
+    let admin_dest = env.token_account(marketauth.pubkey(), 0);
     env.svm.expire_blockhash();
     let cleanup_cu = env
         .send(
             ProgInstruction::WithdrawBackingBucket {
                 domain: 2,
-                amount: BACKING,
+                amount: ABANDONED,
             },
             vec![
                 AccountMeta::new(marketauth.pubkey(), true),
                 AccountMeta::new(env.market, false),
-                AccountMeta::new(provider_dest, false),
+                AccountMeta::new(admin_dest, false),
                 AccountMeta::new(env.vault, false),
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
@@ -59576,26 +59589,37 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_backing_principal() {
             ],
             &[&marketauth],
         )
-        .expect("marketauth cleanup pays the backing provider");
+        .expect("marketauth escheats abandoned backing to base insurance");
     assert_cu_within(
-        "provider-pinned shutdown backing cleanup",
+        "abandoned backing escheat cleanup",
         cleanup_cu,
         CUSTODY_CU_LIMIT,
     );
-    assert_eq!(env.token_amount(provider_dest), BACKING as u64);
+
+    // Marketauth received nothing; the tokens stayed in the vault (vault-neutral, like fees).
+    assert_eq!(env.token_amount(admin_dest), 0);
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+    let g = env.market_state().1;
+    assert_eq!(g.vault, header_vault_before, "escheat is vault-neutral");
+    let base_insurance_after = g.insurance_domain_budget[0] + g.insurance_domain_budget[1];
+    assert_eq!(
+        base_insurance_after - base_insurance_before,
+        ABANDONED,
+        "abandoned backing escheats into the base insurance fund"
+    );
+    assert_eq!(
+        g.source_backing_buckets[2].fresh_unliened_backing_num, 0,
+        "source backing bucket fully drained"
+    );
     let ledger_after =
         state::read_backing_domain_ledger(&env.svm.get_account(&ledger).unwrap().data)
-            .expect("provider ledger remains valid after marketauth cleanup");
+            .expect("provider ledger remains valid after escheat");
     assert_eq!(ledger_after.authority, provider_key.to_bytes());
     assert_eq!(ledger_after.total_principal_atoms, 0);
-    assert_eq!(
-        env.market_state().1.source_backing_buckets[2].fresh_unliened_backing_num,
-        0
-    );
 }
 
 #[test]
-fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_insurance_principal() {
+fn v16_attack_shutdown_cleanup_escheats_abandoned_insurance_to_base_insurance() {
     const INSURANCE: u128 = 300;
 
     let mut env = V16CuEnv::new();
@@ -59633,34 +59657,18 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_insurance_principal() {
         .expect("marketauth can shut down the permissionless asset");
     env.svm.warp_to_slot(7);
 
-    let before_market = env.svm.get_account(&env.market).unwrap();
-    let before_vault = env.svm.get_account(&env.vault).unwrap();
-    let admin_dest = env.token_account(marketauth.pubkey(), 0);
-    env.svm.expire_blockhash();
-    let redirected = env.send(
-        ProgInstruction::WithdrawInsuranceAsset {
-            asset_index: 1,
-            amount: INSURANCE,
-        },
-        vec![
-            AccountMeta::new(marketauth.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(admin_dest, false),
-            AccountMeta::new(env.vault, false),
-            AccountMeta::new_readonly(env.vault_authority, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-        ],
-        &[&marketauth],
-    );
-    assert!(
-        redirected.is_err(),
-        "shutdown cleanup must not redirect insurance principal to marketauth"
-    );
-    assert_eq!(env.token_amount(admin_dest), 0);
-    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_market);
-    assert_eq!(env.svm.get_account(&env.vault).unwrap(), before_vault);
+    // Snapshot before the abandoned-residual cleanup.
+    let base_insurance_before = {
+        let g = env.market_state().1;
+        g.insurance_domain_budget[0] + g.insurance_domain_budget[1]
+    };
+    let vault_tokens_before = env.token_amount(env.vault);
+    let header_vault_before = env.market_state().1.vault;
 
-    let authority_dest = env.token_account(insurance_authority.pubkey(), 0);
+    // Abandoned residual: marketauth drives cleanup for the absent insurance operator. It cannot pay
+    // itself (the original rug) and needs no provider token account (which would strand cleanup); the
+    // reserve escheats to the base insurance fund exactly like fees, leaving the tokens in the vault.
+    let admin_dest = env.token_account(marketauth.pubkey(), 0);
     env.svm.expire_blockhash();
     let cleanup_cu = env
         .send(
@@ -59671,7 +59679,7 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_insurance_principal() {
             vec![
                 AccountMeta::new(marketauth.pubkey(), true),
                 AccountMeta::new(env.market, false),
-                AccountMeta::new(authority_dest, false),
+                AccountMeta::new(admin_dest, false),
                 AccountMeta::new(env.vault, false),
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
@@ -59679,19 +59687,33 @@ fn v16_attack_shutdown_cleanup_cannot_redirect_foreign_insurance_principal() {
             ],
             &[&marketauth],
         )
-        .expect("marketauth cleanup pays the insurance authority");
+        .expect("marketauth escheats abandoned insurance to base insurance");
     assert_cu_within(
-        "provider-pinned shutdown insurance cleanup",
+        "abandoned insurance escheat cleanup",
         cleanup_cu,
         CUSTODY_CU_LIMIT,
     );
-    assert_eq!(env.token_amount(authority_dest), INSURANCE as u64);
+
+    // Marketauth received nothing; the tokens stayed in the vault (vault-neutral, like fees).
+    assert_eq!(env.token_amount(admin_dest), 0);
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+    let g = env.market_state().1;
+    assert_eq!(g.vault, header_vault_before, "escheat is vault-neutral");
+    let base_insurance_after = g.insurance_domain_budget[0] + g.insurance_domain_budget[1];
+    assert_eq!(
+        base_insurance_after - base_insurance_before,
+        INSURANCE,
+        "abandoned insurance escheats into the base insurance fund"
+    );
+    assert_eq!(
+        g.insurance_domain_budget[2], 0,
+        "asset insurance domain fully drained"
+    );
     let ledger_after = state::read_insurance_ledger(&env.svm.get_account(&ledger).unwrap().data)
-        .expect("insurance authority ledger remains valid after marketauth cleanup");
+        .expect("insurance authority ledger remains valid after escheat");
     assert_eq!(
         ledger_after.authority,
         insurance_authority.pubkey().to_bytes()
     );
     assert_eq!(ledger_after.total_principal_atoms, 0);
-    assert_eq!(env.market_state().1.insurance_domain_budget[2], 0);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -5657,27 +5657,36 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
 
     let admin_key = env.admin.pubkey();
     let admin_recovery = env.token_account(admin_key, 0);
+    let provider_recovery = env.token_account(backing_authority.pubkey(), 0);
     for (domain, amount) in [(2u8, 6u128), (3u8, 4u128)] {
         env.withdraw_insurance_domain_to_admin_token_with_cu(admin_recovery, domain.into(), amount);
     }
     for (domain, amount) in [(2u8, 20u128), (3u8, 25u128)] {
-        env.withdraw_backing_bucket_to_admin_token_with_cu(admin_recovery, domain.into(), amount);
+        env.withdraw_backing_bucket_to_admin_token_with_cu(
+            provider_recovery,
+            domain.into(),
+            amount,
+        );
     }
     assert_eq!(
         env.token_amount(admin_recovery),
-        55,
-        "admin must recover asset-domain insurance and backing funds"
+        10,
+        "marketauth recovers only protocol insurance during shutdown cleanup"
+    );
+    assert_eq!(
+        env.token_amount(provider_recovery),
+        45,
+        "market-driven cleanup returns backing principal to its provider"
     );
     assert_eq!(env.token_amount(env.vault), 20_025);
 
     env.top_up_insurance_from_admin_token_with_cu(admin_recovery, 10);
-    env.top_up_backing_bucket_from_admin_token_with_cu(admin_recovery, 0, 45, 20);
     assert_eq!(
         env.token_amount(admin_recovery),
         0,
-        "recovered funds should be re-deposited into market-0 buckets"
+        "recovered protocol insurance is re-deposited into market 0"
     );
-    assert_eq!(env.token_amount(env.vault), 20_080);
+    assert_eq!(env.token_amount(env.vault), 20_035);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (_, recovered_group) = state::read_market(&market_data).unwrap();
     assert_eq!(recovered_group.insurance_domain_budget[2], 0);
@@ -5694,7 +5703,7 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     assert_eq!(recovered_group.insurance_domain_budget[1], 18);
     assert_eq!(
         recovered_group.source_backing_buckets[0].fresh_unliened_backing_num,
-        45 * BOUND_SCALE
+        0
     );
 
     env.update_asset_lifecycle_as_admin_with_cu(
@@ -5751,7 +5760,7 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     );
     println!("v16 permissionless asset reuse BPF CU: {reuse_cu}");
     assert_eq!(env.token_amount(reuse_source), 0);
-    assert_eq!(env.token_amount(env.vault), 20_105);
+    assert_eq!(env.token_amount(env.vault), 20_060);
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (reused_cfg, reused_group) = state::read_market(&market_data).unwrap();
     assert_eq!(reused_cfg.free_market_slot_count, 0);


### PR DESCRIPTION
## What changed

- Add public LiteSVM exploits for provider backing and funded domain insurance after permissionless-asset shutdown.
- Pin marketauth-driven cleanup destinations and optional ledgers to the configured backing/insurance authorities.
- Keep marketauth able to submit bounded cleanup while providers are offline.
- Correct the full shutdown/retire/reuse lifecycle so provider funds leave to their owners while the slot still retires and reuses.

## Root cause and impact

The mature-shutdown fallback made marketauth an authorized cleanup submitter, but token preflight also treated the transaction signer as the payout owner and rebound optional ledgers to marketauth. After forcing an empty permissionless asset into Recovery and waiting five slots, marketauth could therefore withdraw all provider backing or funded domain insurance to itself.

The TDD backing probe failed on current `main` after marketauth received all 500 atoms. The equivalent insurance route was present in the same fallback. The fixed paths reject marketauth-owned destinations atomically, then succeed under the same marketauth signature when clean destinations are owned by the configured providers. No provider signature is required, so abandoned-slot liveness is preserved.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu v16_attack_shutdown_cleanup -- --nocapture`
- `cargo test --test v16_cu shutdown -- --nocapture`
- `cargo test --all-targets` (5 unit + 565 LiteSVM tests)
- auth and hostile matcher fixtures rebuilt before the full run

No engine change.