### PR TITLE
[HARDENING DoS] Unstick fragmented recovery force-close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f7630b0dc4b1145196aaaae4c0246cb7c997b760#f7630b0dc4b1145196aaaae4c0246cb7c997b760"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f7630b0dc4b1145196aaaae4c0246cb7c997b760" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f7630b0dc4b1145196aaaae4c0246cb7c997b760" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,124 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+// Recovery liveness: aggregate opposite OI may be split across several portfolios. Once the
+// force-close delay expires, a permissionless cranker must be able to consume each matched pair
+// even when the larger account is maintenance-healthy but remains below initial margin after the
+// first partial close. Reusing the ordinary trade IM gate makes every available pair revert and
+// leaves an abandoned position with no permissionless rank-decreasing continuation.
+#[test]
+fn v16_attack_fragmented_recovery_force_close_makes_permissionless_progress() {
+    const ASSET: u16 = 1;
+    const MARK: u64 = 100;
+    const SHUTDOWN_MARK: u64 = 110;
+    const SHUTDOWN_SLOT: u64 = 10;
+    const FORCE_CLOSE_DELAY: u64 = 5;
+    const LARGE_Q: u128 = 10 * POS_SCALE;
+    const SMALL_Q: u128 = POS_SCALE;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 5_000, 10_000, 1_000);
+    env.configure_permissionless_resolve_with_cu(1_000, FORCE_CLOSE_DELAY);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 1, MARK);
+
+    let large_owner = Keypair::new();
+    let large = env.create_portfolio(&large_owner);
+    env.deposit(&large_owner, large, 1_000);
+    let mut small_owners = Vec::new();
+    let mut smalls = Vec::new();
+    for _ in 0..10 {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        env.deposit(&owner, portfolio, 100);
+        env.trade_asset_with_cu(
+            ASSET,
+            &large_owner,
+            large,
+            &owner,
+            portfolio,
+            -(SMALL_Q as i128),
+            MARK,
+            0,
+        );
+        small_owners.push(owner);
+        smalls.push(portfolio);
+    }
+
+    env.svm.warp_to_slot(SHUTDOWN_SLOT);
+    env.push_auth_mark_for_asset_as_admin(ASSET, SHUTDOWN_SLOT, SHUTDOWN_MARK);
+    for portfolio in core::iter::once(large).chain(smalls.iter().copied()) {
+        env.svm.expire_blockhash();
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: SHUTDOWN_SLOT,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+
+    let large_before_shutdown = env.portfolio_state(large);
+    let cert = health_cert(&large_before_shutdown);
+    assert_eq!(
+        active_leg_for_asset(&large_before_shutdown, ASSET as usize).basis_pos_q,
+        -(LARGE_Q as i128)
+    );
+    assert_eq!(cert.certified_liq_deficit, 0, "the large leg is not liquidatable");
+    assert!(
+        cert.certified_equity >= cert.certified_maintenance_req as i128
+            && cert.certified_equity < cert.certified_initial_req as i128,
+        "the large leg must sit strictly between maintenance and initial margin"
+    );
+
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        ASSET,
+        SHUTDOWN_SLOT,
+        0,
+    );
+    env.svm
+        .warp_to_slot(SHUTDOWN_SLOT + FORCE_CLOSE_DELAY + 1);
+    let cranker = Keypair::new();
+
+    for (index, small) in smalls.iter().copied().enumerate() {
+        env.svm.expire_blockhash();
+        let cu = env
+            .try_force_close_abandoned_asset_with_cu(
+                &cranker,
+                large,
+                small,
+                ASSET,
+                SHUTDOWN_SLOT + FORCE_CLOSE_DELAY + 1,
+                SMALL_Q,
+            )
+            .unwrap_or_else(|err| {
+                panic!(
+                    "fragment {index} must make permissionless recovery progress: {err}"
+                )
+            });
+        assert_cu_within(
+            "fragmented recovery ForceCloseAbandonedAsset",
+            cu,
+            TRADE_CU_LIMIT,
+        );
+        let expected_q = LARGE_Q - SMALL_Q * (index as u128 + 1);
+        let large_after = env.portfolio_state(large);
+        if expected_q == 0 {
+            assert!(!has_active_leg_for_asset(&large_after, ASSET as usize));
+        } else {
+            assert_eq!(
+                active_leg_for_asset(&large_after, ASSET as usize).basis_pos_q,
+                -(expected_q as i128)
+            );
+        }
+    }
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(large),
+        ASSET as usize
+    ));
+    let (_, group) = env.market_state();
+    assert_eq!(group.assets[ASSET as usize].oi_eff_long_q, 0);
+    assert_eq!(group.assets[ASSET as usize].oi_eff_short_q, 0);
+    assert!(group.vault >= group.c_tot + group.insurance);
+    assert_eq!(group.vault as u64, env.token_amount(env.vault));
+}


### PR DESCRIPTION
## What changed

- Add a public LiteSVM reproduction for fragmented permissionless recovery force-close.
- Pin engine commit `f7630b0dc4b1145196aaaae4c0246cb7c997b760` from aeyakovenko/percolator#119.
- Keep the wrapper production route unchanged; it already calls the affected engine trade path.

## Exploit and root cause

A publicly created non-base market can have one 10-unit short matched against ten independent 1-unit longs. An authenticated 10% mark move leaves the large account maintenance-healthy but below initial margin. The asset is then shut down normally and the delayed permissionless force-close window expires.

Every available opposite portfolio can reduce the large leg by only one unit. Before the fix, `ForceCloseAbandonedAsset` reused the ordinary final initial-margin gate, so the first call failed with `EngineInvalidConfig` at about 193k CU: the large account remained below IM after that partial reduction. The same was true for every available pair. Auto-liquidation was unavailable because the account had zero liquidation deficit, so an absent owner could permanently block permissionless asset wind-down despite balanced aggregate OI.

The engine now admits a matched reduction below IM only when neither absolute position increases and both post-trade accounts remain maintenance-healthy. Risk increases and liquidatable/bankrupt accounts retain the existing IM gate, so this does not create a bilateral bankruptcy escape.

## TDD evidence

- Commit `61e9d608` is the public-only red reproduction on the prior engine pin; the first force-close fails with `Custom(14)` and rolls back.
- Commit `47e85c6f` pins the engine fix; all ten one-unit force-closes succeed, reduce rank monotonically, clear both OI sides, conserve custody, and remain under the trade CU bound.

## Validation

- `cargo build-sbf --no-default-features`
- built `tests/fixtures/auth_matcher` and `tests/fixtures/hostile_matcher`
- `cargo test --all-targets`: 5 unit + 564 LiteSVM tests green
- all 10 force-close tests green, including the existing 14-leg 1.4M-CU boundary
- existing bankrupt and off-mark recycle tests remain rejecting
