### PR TITLE
[BLOCKER DoS] Scope bankruptcy locks to affected assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=cd9f2c522199a220525b96fe15c587a437c330c7#cd9f2c522199a220525b96fe15c587a437c330c7"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "cd9f2c522199a220525b96fe15c587a437c330c7" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "cd9f2c522199a220525b96fe15c587a437c330c7" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -277,6 +277,7 @@ pub mod state {
         pub current_slot: u64,
         pub assets: Vec<AssetStateV16>,
         pub bankruptcy_hlock_active: bool,
+        pub bankruptcy_hlock_fully_attributed: bool,
         pub threshold_stress_active: bool,
         pub loss_stale_active: bool,
         pub recovery_reason: Option<PermissionlessRecoveryReasonV16>,
@@ -355,6 +356,7 @@ pub mod state {
                 current_slot: 0,
                 assets,
                 bankruptcy_hlock_active: false,
+                bankruptcy_hlock_fully_attributed: false,
                 threshold_stress_active: false,
                 loss_stale_active: false,
                 recovery_reason: None,
@@ -1766,7 +1768,15 @@ pub mod state {
             slot_last: wire.slot_last.get(),
             current_slot: wire.current_slot.get(),
             assets: Vec::with_capacity(slot_count),
-            bankruptcy_hlock_active: decode_bool(wire.bankruptcy_hlock_active)?,
+            bankruptcy_hlock_active: percolator::bankruptcy_hlock_active_from_wire(
+                wire.bankruptcy_hlock_active,
+            )
+            .map_err(map_account_wire_error)?,
+            bankruptcy_hlock_fully_attributed:
+                percolator::bankruptcy_hlock_fully_attributed_from_wire(
+                    wire.bankruptcy_hlock_active,
+                )
+                .map_err(map_account_wire_error)?,
             threshold_stress_active: decode_bool(wire.threshold_stress_active)?,
             loss_stale_active: decode_bool(wire.loss_stale_active)?,
             recovery_reason: wire
@@ -1950,7 +1960,10 @@ pub mod state {
         header.funding_epoch = percolator::V16PodU64::new(group.funding_epoch);
         header.slot_last = percolator::V16PodU64::new(group.slot_last);
         header.current_slot = percolator::V16PodU64::new(group.current_slot);
-        header.bankruptcy_hlock_active = encode_bool_for_account(group.bankruptcy_hlock_active);
+        header.bankruptcy_hlock_active = percolator::bankruptcy_hlock_to_wire(
+            group.bankruptcy_hlock_active,
+            group.bankruptcy_hlock_fully_attributed,
+        );
         header.threshold_stress_active = encode_bool_for_account(group.threshold_stress_active);
         header.loss_stale_active = encode_bool_for_account(group.loss_stale_active);
         header.recovery_reason =
@@ -4423,7 +4436,9 @@ pub mod processor {
             return Ok(true);
         }
         reject_permissionless_resolve_matured_live_view(cfg, group)?;
-        if group.header.bankruptcy_hlock_active != 0
+        let ignore_unrelated_bankruptcy_hlock =
+            bankruptcy_hlock_is_only_unrelated_to_asset_view(group, asset_index)?;
+        if (group.header.bankruptcy_hlock_active != 0 && !ignore_unrelated_bankruptcy_hlock)
             || group.header.threshold_stress_active != 0
             || group.header.loss_stale_active != 0
             || group
@@ -4440,6 +4455,27 @@ pub mod processor {
         }
         reject_exposed_target_effective_lag_view(group, asset_index)?;
         Ok(false)
+    }
+
+    fn bankruptcy_hlock_is_only_unrelated_to_asset_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> Result<bool, ProgramError> {
+        let configured_assets = group.header.config.max_market_slots.get() as usize;
+        if !percolator::bankruptcy_hlock_active_from_wire(group.header.bankruptcy_hlock_active)
+            .map_err(map_v16_error)?
+            || !percolator::bankruptcy_hlock_fully_attributed_from_wire(
+                group.header.bankruptcy_hlock_active,
+            )
+            .map_err(map_v16_error)?
+            || asset_index >= configured_assets
+            || configured_assets > group.markets.len()
+        {
+            return Ok(false);
+        }
+        percolator::bankruptcy_asset_slot_has_lock_state(&group.markets[asset_index].engine)
+            .map(|locked| !locked)
+            .map_err(map_v16_error)
     }
 
     fn asset_local_loss_stale_view(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -44569,6 +44569,10 @@ fn trigger_permissionless_asset_one_bankruptcy(
     let (_, group) = env.market_state();
     assert_eq!(group.mode, MarketModeV16::Live);
     assert!(group.bankruptcy_hlock_active);
+    assert!(
+        group.bankruptcy_hlock_fully_attributed,
+        "the public single-asset insolvency must persist asset-local attribution"
+    );
     assert_eq!(env.portfolio_state(short_account).capital.get(), 0);
     assert_eq!(group.assets[1].mode_long, SideModeV16::ResetPending);
     (long_owner, long_account)
@@ -44589,6 +44593,7 @@ fn v16_attack_permissionless_asset_bankruptcy_cannot_freeze_unrelated_insurance(
         .expect("healthy base insurance is live before the unrelated attack");
 
     let _ = trigger_permissionless_asset_one_bankruptcy(&mut env, &creator, 2);
+    env.top_up_insurance_domain_with_authority(&creator, 2, 100);
     let before = env.market_state().1;
     assert_eq!(before.insurance_domain_budget[0], 900);
     assert_eq!(before.insurance_domain_spent[0], 0);
@@ -44601,6 +44606,45 @@ fn v16_attack_permissionless_asset_bankruptcy_cannot_freeze_unrelated_insurance(
     let after = env.market_state().1;
     assert_eq!(after.insurance_domain_budget[0], 800);
     assert_eq!(after.insurance_domain_spent[0], 0);
+
+    env.svm.expire_blockhash();
+    let related_withdrawal = env.try_withdraw_insurance_asset_with_authority(&creator, 1, 1);
+    assert!(
+        related_withdrawal.is_err(),
+        "the bankrupt asset's own insurance must remain locked"
+    );
+}
+
+#[test]
+fn v16_bpf_unrelated_bankruptcy_hlock_withdraw_stays_bounded_on_10m_market() {
+    const N: usize = 5_834;
+    const HIGH_ASSET: usize = N - 1;
+    const FUNDED: u128 = 100;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    let account_len = grow_market_to_10m_with_high_active_asset(&mut env, N, HIGH_ASSET, 100);
+    env.enable_live_insurance_withdrawal();
+    let admin = env.admin.insecure_clone();
+    env.top_up_insurance_domain_with_authority(&admin, 0, FUNDED);
+    env.mutate_market(|_, group| {
+        group.bankruptcy_hlock_active = true;
+        group.bankruptcy_hlock_fully_attributed = true;
+        group.assets[HIGH_ASSET].mode_long = SideModeV16::ResetPending;
+    });
+
+    env.svm.expire_blockhash();
+    let (_, withdraw_cu) = env
+        .try_withdraw_insurance_asset_with_authority(&admin, 0, 1)
+        .expect("unrelated tail bankruptcy must not brick base insurance withdrawal");
+    println!(
+        "v16 10MiB unrelated bankruptcy hlock withdrawal: assets={N}, account_len={account_len}, CU={withdraw_cu}"
+    );
+    assert_cu_within(
+        "10MiB unrelated bankruptcy hlock withdrawal",
+        withdraw_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.market_state().1.insurance_domain_budget[0], FUNDED - 1);
 }
 
 #[test]
@@ -44666,6 +44710,13 @@ fn v16_attack_permissionless_asset_bankruptcy_cannot_freeze_unrelated_backed_pnl
 
     let (failed_asset_winner, failed_asset_winner_account) =
         trigger_permissionless_asset_one_bankruptcy(&mut env, &creator, 3);
+    env.crank(
+        pairs[1].1,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+    );
     let target_before = env.portfolio_state(pairs[1].1);
     assert_eq!(target_before.pnl.get(), PNL as i128);
     env.svm.expire_blockhash();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -44497,6 +44497,209 @@ fn v16_attack_market_exceeds_64_assets_position_holds_any_14_legs() {
 // asset 0's funded domain-insurance budget (draining funds that back asset-0 traders). Protection: domain
 // insurance budgets are per-domain (asset i -> domains 2i, 2i+1); asset-1 bad debt is bounded to asset-1's
 // own domains, so asset 0's domain-insurance bytes are unchanged. Senior conservation holds throughout.
+fn configure_permissionless_asset_one(env: &mut V16CuEnv, creator: &Keypair, start_slot: u64) {
+    let creator_key = creator.pubkey();
+    env.activate_permissionless_asset_with_fee(
+        creator,
+        1,
+        start_slot,
+        100,
+        creator_key,
+        creator_key,
+        creator_key,
+        creator_key,
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, creator, start_slot, 100);
+}
+
+fn trigger_permissionless_asset_one_bankruptcy(
+    env: &mut V16CuEnv,
+    creator: &Keypair,
+    start_slot: u64,
+) -> (Keypair, Pubkey) {
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, 1_000_000);
+    env.deposit(&short_owner, short_account, 250);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+
+    for (slot, mark) in [
+        (start_slot + 1, 200u64),
+        (start_slot + 2, 400),
+        (start_slot + 3, 800),
+    ] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_with_authority(1, creator, slot, mark);
+        for portfolio in [long_account, short_account] {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(1),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                &[],
+            );
+        }
+    }
+    env.crank_steps(
+        short_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: start_slot + 3,
+            observations: crank_observations(1),
+        },
+        4,
+    );
+    let (_, group) = env.market_state();
+    assert_eq!(group.mode, MarketModeV16::Live);
+    assert!(group.bankruptcy_hlock_active);
+    assert_eq!(env.portfolio_state(short_account).capital.get(), 0);
+    assert_eq!(group.assets[1].mode_long, SideModeV16::ResetPending);
+    (long_owner, long_account)
+}
+
+#[test]
+fn v16_attack_permissionless_asset_bankruptcy_cannot_freeze_unrelated_insurance() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+    env.update_market_init_fee_policy_with_cu(1);
+    let creator = Keypair::new();
+    configure_permissionless_asset_one(&mut env, &creator, 2);
+    env.enable_live_insurance_withdrawal();
+    let base_provider = env.admin.insecure_clone();
+    env.top_up_insurance_domain_with_authority(&base_provider, 0, 1_000);
+    env.try_withdraw_insurance_asset_with_authority(&base_provider, 0, 100)
+        .expect("healthy base insurance is live before the unrelated attack");
+
+    let _ = trigger_permissionless_asset_one_bankruptcy(&mut env, &creator, 2);
+    let before = env.market_state().1;
+    assert_eq!(before.insurance_domain_budget[0], 900);
+    assert_eq!(before.insurance_domain_spent[0], 0);
+    env.svm.expire_blockhash();
+    let withdrawal = env.try_withdraw_insurance_asset_with_authority(&base_provider, 0, 100);
+    assert!(
+        withdrawal.is_ok(),
+        "asset-1 bankruptcy must not permanently freeze untouched asset-0 insurance: {withdrawal:?}"
+    );
+    let after = env.market_state().1;
+    assert_eq!(after.insurance_domain_budget[0], 800);
+    assert_eq!(after.insurance_domain_spent[0], 0);
+}
+
+#[test]
+fn v16_attack_permissionless_asset_bankruptcy_cannot_freeze_unrelated_backed_pnl() {
+    const DEPOSIT: u128 = 1_000_000;
+    const PNL: u128 = 100;
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+    env.update_market_init_fee_policy_with_cu(1);
+    let creator = Keypair::new();
+    configure_permissionless_asset_one(&mut env, &creator, 1);
+
+    let mut pairs = Vec::new();
+    for _ in 0..2 {
+        let winner = Keypair::new();
+        let loser = Keypair::new();
+        let winner_account = env.create_portfolio(&winner);
+        let loser_account = env.create_portfolio(&loser);
+        env.deposit(&winner, winner_account, DEPOSIT);
+        env.deposit(&loser, loser_account, DEPOSIT);
+        env.trade_asset_with_cu(
+            0,
+            &winner,
+            winner_account,
+            &loser,
+            loser_account,
+            POS_SCALE as i128,
+            100,
+            0,
+        );
+        pairs.push((winner, winner_account, loser, loser_account));
+    }
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 200);
+    for (_, winner_account, _, loser_account) in &pairs {
+        for portfolio in [*loser_account, *winner_account] {
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+    }
+    for (winner, winner_account, loser, loser_account) in &pairs {
+        env.trade_asset_with_cu(
+            0,
+            winner,
+            *winner_account,
+            loser,
+            *loser_account,
+            -(POS_SCALE as i128),
+            200,
+            0,
+        );
+        assert_eq!(env.portfolio_state(*winner_account).pnl.get(), PNL as i128);
+    }
+
+    env.convert_released_pnl_with_cu(&pairs[0].0, pairs[0].1, PNL);
+    assert_eq!(env.portfolio_state(pairs[0].1).capital.get(), DEPOSIT + PNL);
+
+    let (failed_asset_winner, failed_asset_winner_account) =
+        trigger_permissionless_asset_one_bankruptcy(&mut env, &creator, 3);
+    let target_before = env.portfolio_state(pairs[1].1);
+    assert_eq!(target_before.pnl.get(), PNL as i128);
+    env.svm.expire_blockhash();
+    let unrelated_convert = env.send(
+        ProgInstruction::ConvertReleasedPnl { amount: PNL },
+        vec![
+            AccountMeta::new(pairs[1].0.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(pairs[1].1, false),
+        ],
+        &[&pairs[1].0],
+    );
+    assert!(
+        unrelated_convert.is_ok(),
+        "asset-1 bankruptcy must not freeze asset-0's fully source-backed payout: {unrelated_convert:?}"
+    );
+    assert_eq!(env.portfolio_state(pairs[1].1).capital.get(), DEPOSIT + PNL);
+
+    env.svm.expire_blockhash();
+    let related_convert = env.send(
+        ProgInstruction::ConvertReleasedPnl { amount: 1_000_000 },
+        vec![
+            AccountMeta::new(failed_asset_winner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(failed_asset_winner_account, false),
+        ],
+        &[&failed_asset_winner],
+    );
+    assert!(
+        related_convert.is_err(),
+        "the failed asset's own unresolved winner must remain locked"
+    );
+}
+
 #[test]
 fn v16_attack_asset1_insolvency_cannot_drain_asset0_domain_insurance() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 10_000, 10_000, 10_000);


### PR DESCRIPTION
## Public reproduction

A permissionless asset creator can create asset 1, open both sides through the normal trade API, move the authenticated mark, and permissionlessly crank the short into bankruptcy. Before this fix, the resulting global H-lock permanently rejected both of these unrelated asset 0 exits:

- a live insurance-domain withdrawal
- conversion of fully source-backed favorable PnL

The regressions use only public LiteSVM instructions and normal account construction. They also prove the bankrupt asset's own exits remain locked.

## Fix

- pin engine PR [#120](https://github.com/aeyakovenko/percolator/pull/120) at `cd9f2c522199a220525b96fe15c587a437c330c7`
- preserve the engine's attributed H-lock state in host account serialization
- use the engine's canonical asset-local lock predicate when gating insurance withdrawal
- keep legacy, unattributed, and same-asset bankruptcy states fail-closed
- add a 5,834-asset, near-10 MiB market regression to bound the new check

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 5 unit tests and 566 LiteSVM tests passed
- max-shape unrelated withdrawal: 32,693 CU
- engine focused Kani proof: 0/3297 checks failed; 3/3 covers passed

The aggregate wrapper Kani run is not claimed complete: its pre-existing zero-length decoder harness continued symbolic loop unwinding through 125 iterations and was stopped. The first aggregate harness passed, and the directly relevant engine contract passed.