### PR TITLE
[BLOCKER LoF] Prevent signed intent replay across market generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
 - **Per-asset admin keys, isolated — uniform across all assets including asset 0** — one asset's admin
   can never be used against another asset. **✅** Every asset (0..N) carries its own `asset_admin`
   (`AssetOracleProfileV16`): assets 1..N bootstrap it to the activator, **asset 0 bootstraps it to the
-  market admin at `InitMarket`**. `UpdateAssetAuthority { asset_index, kind, new_pubkey }` is scoped to
-  that asset's profile only and now operates on **asset 0 too** (the old `asset_index == 0` rejection is
-  gone). Asset 0 is **not** special for authorities — its only special properties are **fee capture**
+  market admin at `InitMarket`**.
+  `UpdateAssetAuthority { asset_index, market_id, kind, new_pubkey }` is scoped to that asset's
+  current generation and profile only and now operates on **asset 0 too** (the old
+  `asset_index == 0` rejection is gone). Asset 0 is **not** special for authorities — its only
+  special properties are **fee capture**
   (it's the insurance-redirect target) and that it **cannot be permissionlessly created** (it's created
   at `InitMarket`, not via `UpdateAssetLifecycle`).
 - **Each asset (0..N) has a cold-storage admin** that can **rotate that asset's other keys**
@@ -164,9 +166,10 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   any asset including asset 0** (`ASSET_ACTION_SHUTDOWN` → RECOVERY with the `force_close_delay_slots`
   exit window so traders can exit), **resolve/close the market** (`ResolveMarket`/`CloseSlab`),
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
-  `UpdateAuthority { new_pubkey }` (current `marketauth` signs and the non-zero replacement co-signs;
-  burn-to-zero is rejected). Everything else — restart, insurance/operator/backing/oracle on
-  **every** asset including 0 — is per-asset (`asset_admin` + `UpdateAssetAuthority`), never a separate
+  `UpdateAuthority { market_id, new_pubkey }` (current `marketauth` signs, the non-zero replacement
+  co-signs, and `market_id` must match the current base-asset generation; burn-to-zero is rejected).
+  Everything else — restart, insurance/operator/backing/oracle on **every** asset including 0 — is
+  per-asset (`asset_admin` + generation-bound `UpdateAssetAuthority`), never a separate
   marketauth-only path. `marketauth` can restart an asset only while it is also that asset's
   `asset_admin` (the asset-0 bootstrap state).
 - **Each other asset key can rotate itself; only `asset_admin` can be set to 0.** **✅** (a domain
@@ -301,7 +304,7 @@ Percolator enforces three layers with distinct responsibilities:
 - **Layout**: header + wrapper config + `MarketGroupV16Account`
 - Holds market-level totals, insurance, oracle/asset state, source-domain credit state, and asset lifecycle state.
 
-The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
+The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, co-signed authority rotations, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
 
 ### Market generation account
 - **Owner**: Percolator program id
@@ -385,10 +388,12 @@ This section describes intent and operational ordering, not argument-by-argument
   - binds the collateral mint, initializes asset 0 from the persistent generation counter, and sets
     `marketauth` to the init signer
 - **UpdateAuthority** (tag 32) — single-purpose: rotate the one market-level `marketauth` key
-  - `UpdateAuthority { new_pubkey }`: current `marketauth` signs; a non-zero replacement co-signs
+  - `UpdateAuthority { market_id, new_pubkey }`: current `marketauth` signs; a non-zero replacement
+    co-signs; `market_id` must match the current base-asset generation
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
   - per-asset authorities (insurance/operator/backing/oracle, incl. asset 0) are rotated via
-    `UpdateAssetAuthority`, not this instruction
+    `UpdateAssetAuthority { asset_index, market_id, kind, new_pubkey }`, which requires the target
+    asset's current generation, not this instruction
 - **UpdateAssetLifecycle** (tag 40)
   - appends/reactivates/retires assets 1..N, including permissionless create/reuse when the configured
     create fee is nonzero
@@ -741,8 +746,10 @@ At minimum, monitor:
 - liquidation frequency spikes
 
 ### Governance / authority handling
-- `UpdateAuthority` rotates `marketauth`; the current authority and the new key must both sign.
-- `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the new key.
+- `UpdateAuthority` rotates `marketauth`; the current authority and the new key must both sign, and
+  the payload must carry asset 0's current `market_id`.
+- `UpdateAssetAuthority` rotates per-asset authorities; the payload must carry the target asset's
+  current `market_id`, and non-admin self-rotation also requires the new key.
 - Burning is limited to `asset_admin`. Required market/domain authorities cannot be set to zero.
 
 ---
@@ -838,26 +845,26 @@ mark/insurance/operator) are reachable until asset-0's `asset_admin` is rotated 
 
 These are governance powers, not bugs:
 
-1. `UpdateAuthority { new_pubkey }`
+1. `UpdateAuthority { market_id, new_pubkey }`
    - rotate `marketauth` to an attacker key.
    - impact: governance capture.
 2. Policy updates / `UpdateMarketInitFeePolicy` / `UpdateBaseUnitMints` / asset create+retire+force-shutdown
    - change funding/cap policy knobs (within validation bounds), the create fee, the base-unit mint, and the asset set — all now under the one `marketauth` key.
    - force-shutdown any asset including asset 0. Restart is not a separate marketauth power: it requires the target asset's `asset_admin`; marketauth can restart asset 0 only while it still holds the asset-0 admin role.
    - impact: economics/market shape can become unfavorable to users (force-shutdown still honors the trader exit window).
-3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
+3. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
 4. `ResolveMarket`
    - transition market to resolved mode using stored authority price.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
-5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)
+5. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can withdraw resolved-market insurance.
    - impact: resolved insurance extraction capability is delegated.
 6. `WithdrawInsurance` (post-resolution, after positions are closed)
    - withdraw insurance buffer to admin ATA.
    - impact: no insurance backstop remains.
-7. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE_OPERATOR }` (while marketauth holds asset-0's `asset_admin`)
+7. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_INSURANCE_OPERATOR }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can call bounded live insurance withdrawal.
    - impact: bounded live insurance extraction capability is delegated.
 8. `CloseSlab` (when market is fully empty)
@@ -866,7 +873,8 @@ These are governance powers, not bugs:
     - impact: market is permanently closed.
 
 > **Authority model (items 3, 5, 7).** Asset-0's insurance/operator/oracle(mark)/backing authorities now
-> use the **same per-asset `asset_admin` model as assets 1..N** (`UpdateAssetAuthority { asset_index = 0 }`).
+> use the **same per-asset `asset_admin` model as assets 1..N**
+> (`UpdateAssetAuthority { asset_index = 0, market_id, .. }`).
 > Asset 0's `asset_admin` is bootstrapped to the **market admin** at `InitMarket`, so a malicious admin
 > **can** rotate the shared insurance operator/authority and the mark pusher (items 3/5/7) —
 > exactly the powers the asset_admin has over any asset. To make those delegations sticky, burn

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Percolator enforces three layers with distinct responsibilities:
 - **Layout**: header + wrapper config + `MarketGroupV16Account`
 - Holds market-level totals, insurance, oracle/asset state, source-domain credit state, and asset lifecycle state.
 
-The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused. Portfolio legs and close-progress ledgers carry that id, so stale state from an old shutdown market cannot bind to a reused slot.
+The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused. Trade instructions, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
 
 ### Portfolio account
 - **Owner**: Percolator program id
@@ -422,13 +422,16 @@ This section describes intent and operational ordering, not argument-by-argument
 
 ### Trading
 - **TradeNoCpi**
-  - trade without external matcher (used for testing / deterministic scenarios)
+  - trade without external matcher (used for testing / deterministic scenarios). The signed
+    `market_id` must match the current generation of `asset_index`.
 - **TradeCpi**
   - trade via LP-chosen matcher CPI with strict binding + validation. The LP portfolio must already
-    store an enabled matcher config for the passed matcher program/context/delegate tuple.
+    store an enabled matcher config for the passed matcher program/context/delegate tuple. The
+    signed `market_id` is checked before matcher CPI.
 - **BatchTradeNoCpi** (tag 66)
   - atomic multi-leg batch (up to the portfolio asset cap) against one taker/LP pair; each leg's
-    **signed** `size_q` sets its direction, so a single batch can carry a mixed long/short spread.
+    `market_id` binds the reusable asset generation and **signed** `size_q` sets its direction, so a
+    single batch can carry a mixed long/short spread.
     The engine settles both accounts once, applies every leg, then runs a **single end-state
     initial-margin check** — interim legs need not be individually margin-feasible. Current v1 batch
     execution rejects if any backing-domain trade-fee policy is configured, so those fees are not
@@ -436,8 +439,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - **BatchTradeCpi** (tag 67)
   - same atomic multi-leg batch routed through an external matcher: **one** batched matcher CPI
     (matcher tag 3) fills every leg against a single LP, each return is validated under the same
-    anti-spoof binding as `TradeCpi`, then all fills apply through the batch path. Bounded to 16
-    legs (the matcher's return-data cap).
+    anti-spoof binding as `TradeCpi`, and every signed `market_id` is checked before CPI, then all
+    fills apply through the batch path. Bounded to 16 legs (the matcher's return-data cap).
 - **SetMatcherConfig** (tag 68)
   - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
     on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,20 @@ Percolator enforces three layers with distinct responsibilities:
 - **Layout**: header + wrapper config + `MarketGroupV16Account`
 - Holds market-level totals, insurance, oracle/asset state, source-domain credit state, and asset lifecycle state.
 
-The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused. Trade instructions, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
+The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
+
+### Market generation account
+- **Owner**: Percolator program id
+- **PDA seeds**: `["market-generation", market_group_pubkey]`
+- **Layout**: header + market key + next `market_id` (56 bytes total)
+- Persists after `CloseSlab`. `InitMarket` reserves the next initial asset-ID range, while
+  `CloseSlab` checkpoints the live engine counter before deleting the market slab. This is the only
+  state duplicated across closure, and it exists solely because the engine account no longer exists
+  after close. A pre-funded system-owned PDA is allocated and assigned rather than treated as a
+  permanent initialization failure. A market address whose slab was already deleted before this
+  mechanism was deployed has no recoverable generation history and must not be reused; use a fresh
+  market address. Live pre-deployment markets are migrated when `CloseSlab` checkpoints their engine
+  counter.
 
 ### Portfolio account
 - **Owner**: Percolator program id
@@ -369,7 +382,8 @@ This section describes intent and operational ordering, not argument-by-argument
 ### Market lifecycle
 - **InitMarket**
   - initializes slab header/config + calls `RiskEngine::init_in_place(risk_params, clock.slot, init_price)`
-  - binds the collateral mint, initializes asset 0, and sets `marketauth` to the init signer
+  - binds the collateral mint, initializes asset 0 from the persistent generation counter, and sets
+    `marketauth` to the init signer
 - **UpdateAuthority** (tag 32) — single-purpose: rotate the one market-level `marketauth` key
   - `UpdateAuthority { new_pubkey }`: current `marketauth` signs; a non-zero replacement co-signs
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
@@ -743,12 +757,18 @@ Create:
 2) **Vault SPL token account**
    - mint: collateral mint
    - owner: vault authority PDA derived from `["vault", slab_pubkey]`
+3) **Market generation PDA**
+   - owner: Percolator program id
+   - seeds: `["market-generation", slab_pubkey]`
+   - retained across slab close/recreation so signed asset generations cannot repeat
 
 ### Step 1: InitMarket
 Call `InitMarket` with:
 - `marketauth` signer
 - slab (writable)
 - collateral mint
+- market generation PDA (writable)
+- System Program
 - risk params (margins, fees, liquidation knobs, price/funding caps, maintenance fee, etc.)
 
 ### Step 2: Onboard LPs and users
@@ -841,7 +861,8 @@ These are governance powers, not bugs:
    - choose who can call bounded live insurance withdrawal.
    - impact: bounded live insurance extraction capability is delegated.
 8. `CloseSlab` (when market is fully empty)
-    - decommission market account and recover slab lamports.
+    - checkpoint the engine's next asset generation, decommission the market account, and recover
+      slab lamports. The small generation PDA remains.
     - impact: market is permanently closed.
 
 > **Authority model (items 3, 5, 7).** Asset-0's insurance/operator/oracle(mark)/backing authorities now

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -124,6 +124,7 @@ pub mod error {
         OracleStale,
         OracleConfTooWide,
         InvalidOracleKey,
+        AssetGenerationMismatch,
     }
 
     impl From<PercolatorError> for ProgramError {
@@ -2158,7 +2159,7 @@ pub mod state {
     pub fn read_market_trade_preflight(
         data: &[u8],
         asset_index: usize,
-    ) -> Result<(WrapperConfigV16, MarketModeV16, u64, u64, u64), ProgramError> {
+    ) -> Result<(WrapperConfigV16, MarketModeV16, u64, u64, u64, u64), ProgramError> {
         if data.len() < MIN_MARKET_ACCOUNT_LEN {
             return Err(PercolatorError::InvalidAccountLen.into());
         }
@@ -2177,6 +2178,7 @@ pub mod state {
             config,
             decode_market_mode(wire.mode)?,
             wire.current_slot.get(),
+            slot.asset.market_id.get(),
             slot.asset.effective_price.get(),
             engine_config.max_trading_fee_bps,
         ))
@@ -2195,6 +2197,7 @@ pub mod state {
             u64,
             u64,
             usize,
+            alloc::vec::Vec<u64>,
             alloc::vec::Vec<u64>,
         ),
         ProgramError,
@@ -2215,6 +2218,7 @@ pub mod state {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let mut prices = alloc::vec::Vec::with_capacity(asset_indices.len());
+        let mut market_ids = alloc::vec::Vec::with_capacity(asset_indices.len());
         let mut seen_low_assets = 0u128;
         let mut seen_high_assets = [0u16; 16];
         let mut seen_high_len = 0usize;
@@ -2243,6 +2247,7 @@ pub mod state {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             let slot = asset_slot_wire(data, asset_index as usize)?;
+            market_ids.push(slot.asset.market_id.get());
             prices.push(slot.asset.effective_price.get());
         }
         Ok((
@@ -2252,6 +2257,7 @@ pub mod state {
             engine_config.max_trading_fee_bps,
             engine_config.max_market_slots as usize,
             prices,
+            market_ids,
         ))
     }
 
@@ -2387,6 +2393,8 @@ pub mod ix {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct BatchTradeLeg {
         pub asset_index: u16,
+        /// Asset generation expected by the signers. Asset indices are reusable after retirement.
+        pub market_id: u64,
         pub size_q: i128,
         pub exec_price: u64,
         pub fee_bps: u64,
@@ -2398,6 +2406,8 @@ pub mod ix {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct BatchTradeCpiLeg {
         pub asset_index: u16,
+        /// Asset generation expected by the taker. Asset indices are reusable after retirement.
+        pub market_id: u64,
         pub size_q: i128,
         pub fee_bps: u64,
         pub limit_price: u64,
@@ -2450,12 +2460,14 @@ pub mod ix {
         },
         TradeNoCpi {
             asset_index: u16,
+            market_id: u64,
             size_q: i128,
             exec_price: u64,
             fee_bps: u64,
         },
         TradeCpi {
             asset_index: u16,
+            market_id: u64,
             size_q: i128,
             fee_bps: u64,
             limit_price: u64,
@@ -2695,12 +2707,14 @@ pub mod ix {
                 }
                 6 => Self::TradeNoCpi {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     exec_price: read_u64(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                 },
                 10 => Self::TradeCpi {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                     limit_price: read_u64(&mut rest)?,
@@ -2714,6 +2728,7 @@ pub mod ix {
                     for _ in 0..n {
                         legs.push(BatchTradeLeg {
                             asset_index: read_u16(&mut rest)?,
+                            market_id: read_u64(&mut rest)?,
                             size_q: read_i128(&mut rest)?,
                             exec_price: read_u64(&mut rest)?,
                             fee_bps: read_u64(&mut rest)?,
@@ -2730,6 +2745,7 @@ pub mod ix {
                     for _ in 0..n {
                         legs.push(BatchTradeCpiLeg {
                             asset_index: read_u16(&mut rest)?,
+                            market_id: read_u64(&mut rest)?,
                             size_q: read_i128(&mut rest)?,
                             fee_bps: read_u64(&mut rest)?,
                             limit_price: read_u64(&mut rest)?,
@@ -2984,24 +3000,28 @@ pub mod ix {
                 }
                 Self::TradeNoCpi {
                     asset_index,
+                    market_id,
                     size_q,
                     exec_price,
                     fee_bps,
                 } => {
                     out.push(6);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, exec_price);
                     push_u64(&mut out, fee_bps);
                 }
                 Self::TradeCpi {
                     asset_index,
+                    market_id,
                     size_q,
                     fee_bps,
                     limit_price,
                 } => {
                     out.push(10);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, fee_bps);
                     push_u64(&mut out, limit_price);
@@ -3011,6 +3031,7 @@ pub mod ix {
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
+                        push_u64(&mut out, leg.market_id);
                         push_i128(&mut out, leg.size_q);
                         push_u64(&mut out, leg.exec_price);
                         push_u64(&mut out, leg.fee_bps);
@@ -3021,6 +3042,7 @@ pub mod ix {
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
+                        push_u64(&mut out, leg.market_id);
                         push_i128(&mut out, leg.size_q);
                         push_u64(&mut out, leg.fee_bps);
                         push_u64(&mut out, leg.limit_price);
@@ -5152,6 +5174,7 @@ pub mod processor {
             } => handle_permissionless_crank(program_id, accounts, now_slot, observations),
             Instruction::TradeNoCpi {
                 asset_index,
+                market_id,
                 size_q,
                 exec_price,
                 fee_bps,
@@ -5159,12 +5182,14 @@ pub mod processor {
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 size_q,
                 exec_price,
                 fee_bps,
             ),
             Instruction::TradeCpi {
                 asset_index,
+                market_id,
                 size_q,
                 fee_bps,
                 limit_price,
@@ -5172,6 +5197,7 @@ pub mod processor {
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 size_q,
                 fee_bps,
                 limit_price,
@@ -5716,6 +5742,7 @@ pub mod processor {
         account_a_ai: &AccountInfo<'a>,
         account_b_ai: &AccountInfo<'a>,
         asset_index: u16,
+        expected_market_id: u64,
         size_q: i128,
         exec_price: u64,
         fee_bps: u64,
@@ -5727,8 +5754,19 @@ pub mod processor {
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut market_data)?;
+            let asset_index_usize = asset_index as usize;
+            if asset_index_usize >= group.markets.len()
+                || group.markets[asset_index_usize]
+                    .engine
+                    .asset
+                    .market_id
+                    .get()
+                    != expected_market_id
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
+            }
             let mut oracle_profile =
-                read_oracle_profile_from_view(&group, &cfg, asset_index as usize)?;
+                read_oracle_profile_from_view(&group, &cfg, asset_index_usize)?;
             reject_permissionless_resolve_matured_live_for_profile_view(
                 &cfg,
                 &oracle_profile,
@@ -5988,6 +6026,11 @@ pub mod processor {
                 if requests.iter().any(|r| r.asset_index == asset_index) {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
+                if asset_index >= group.markets.len()
+                    || group.markets[asset_index].engine.asset.market_id.get() != leg.market_id
+                {
+                    return Err(PercolatorError::AssetGenerationMismatch.into());
+                }
                 let oracle_profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
                 reject_permissionless_resolve_matured_live_for_profile_view(
                     &cfg,
@@ -6115,6 +6158,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        market_id: u64,
         size_q: i128,
         exec_price: u64,
         fee_bps: u64,
@@ -6149,6 +6193,7 @@ pub mod processor {
             account_a_ai,
             account_b_ai,
             asset_index,
+            market_id,
             size_q,
             exec_price,
             fee_bps,
@@ -6436,6 +6481,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         size_q: i128,
         fee_bps: u64,
         limit_price: u64,
@@ -6466,11 +6512,14 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
 
-        let (cfg_pre, mode_pre, current_slot_pre, oracle_price, max_trading_fee_bps) =
+        let (cfg_pre, mode_pre, current_slot_pre, market_id, oracle_price, max_trading_fee_bps) =
             state::read_market_trade_preflight(
                 &market_ai.try_borrow_data()?,
                 asset_index as usize,
             )?;
+        if market_id != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
         let (account_a_header, account_a_owner) =
             state::read_portfolio_owner_preflight(&account_a_ai.try_borrow_data()?)?;
         let (account_b_header, account_b_owner) =
@@ -6611,6 +6660,7 @@ pub mod processor {
             account_a_ai,
             account_b_ai,
             asset_index,
+            expected_market_id,
             ret.exec_size,
             ret.exec_price_e6,
             fee_bps,
@@ -6798,7 +6848,15 @@ pub mod processor {
                 max_trading_fee_bps,
                 max_market_slots,
                 oracle_prices,
+                market_ids,
             ) = state::read_asset_effective_prices(&market_data, &asset_indices)?;
+            if legs
+                .iter()
+                .zip(market_ids.iter())
+                .any(|(leg, market_id)| leg.market_id != *market_id)
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
+            }
             let authenticated_slot = authenticated_slot_or_fallback(current_slot_pre);
             let mut stale_matured = false;
             for &asset_index in &asset_indices {
@@ -6968,6 +7026,7 @@ pub mod processor {
             }
             exec_legs.push(ix::BatchTradeLeg {
                 asset_index: leg.asset_index,
+                market_id: leg.market_id,
                 size_q: ret.exec_size,
                 exec_price: ret.exec_price_e6,
                 fee_bps: leg.fee_bps,
@@ -9469,7 +9528,7 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         let domain = domain as usize;
         let asset_index = domain / 2;
-        let (mut cfg, mode, _, _, max_trading_fee_bps) =
+        let (mut cfg, mode, _, _, _, max_trading_fee_bps) =
             state::read_market_trade_preflight(&market_ai.try_borrow_data()?, asset_index)?;
         if mode != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
@@ -9571,7 +9630,7 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         let (mut cfg, asset0_insurance_authority, max_trading_fee_bps) = {
             let market_data = market_ai.try_borrow_data()?;
-            let (cfg, _, _, _, max_trading_fee_bps) =
+            let (cfg, _, _, _, _, max_trading_fee_bps) =
                 state::read_market_trade_preflight(&market_data, 0)?;
             let profile0 = read_oracle_profile_for_asset(&market_data, &cfg, 0)?;
             (cfg, profile0.insurance_authority, max_trading_fee_bps)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -26,6 +26,8 @@ use solana_program::{
     program_error::ProgramError,
     program_pack::Pack,
     pubkey::Pubkey,
+    rent::Rent,
+    system_instruction, system_program,
     sysvar::Sysvar,
 };
 
@@ -44,6 +46,7 @@ pub mod constants {
     pub const KIND_PORTFOLIO: u8 = 2;
     pub const KIND_BACKING_DOMAIN_LEDGER: u8 = 3;
     pub const KIND_INSURANCE_LEDGER: u8 = 4;
+    pub const KIND_MARKET_GENERATION: u8 = 5;
 
     pub const HEADER_LEN: usize = 16;
     pub const WRAPPER_CONFIG_LEN: usize = 448;
@@ -156,9 +159,9 @@ pub mod state {
     use crate::{
         constants::{
             ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
+            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_MARKET_GENERATION,
+            KIND_PORTFOLIO, MAGIC, MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN,
+            ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
             ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
             PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_MATCHER_CONFIG_LEN,
             PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN, VERSION, WRAPPER_CONFIG_LEN,
@@ -651,6 +654,13 @@ pub mod state {
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+    pub struct MarketGenerationAccountV16 {
+        pub market_group: [u8; 32],
+        pub next_market_id: V16PodU64,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct PortfolioMatcherConfigV16 {
         pub matcher_program: [u8; 32],
         pub matcher_context: [u8; 32],
@@ -728,6 +738,66 @@ pub mod state {
 
     pub const fn insurance_ledger_account_len() -> usize {
         HEADER_LEN + core::mem::size_of::<InsuranceLedgerAccountV16>()
+    }
+
+    pub const fn market_generation_account_len() -> usize {
+        HEADER_LEN + core::mem::size_of::<MarketGenerationAccountV16>()
+    }
+
+    #[inline]
+    fn validate_market_generation(
+        generation: &MarketGenerationAccountV16,
+    ) -> Result<(), ProgramError> {
+        if generation.market_group == [0u8; 32] || generation.next_market_id.get() == 0 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn read_market_generation(data: &[u8]) -> Result<MarketGenerationAccountV16, ProgramError> {
+        if data.len() != market_generation_account_len() {
+            return Err(PercolatorError::InvalidAccountLen.into());
+        }
+        check_header(data, KIND_MARKET_GENERATION)?;
+        let bytes = data
+            .get(HEADER_LEN..market_generation_account_len())
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let generation = bytemuck::pod_read_unaligned(bytes);
+        validate_market_generation(&generation)?;
+        Ok(generation)
+    }
+
+    #[inline]
+    pub fn write_market_generation(
+        data: &mut [u8],
+        generation: &MarketGenerationAccountV16,
+    ) -> Result<(), ProgramError> {
+        if data.len() != market_generation_account_len() {
+            return Err(PercolatorError::InvalidAccountLen.into());
+        }
+        check_header(data, KIND_MARKET_GENERATION)?;
+        validate_market_generation(generation)?;
+        data.get_mut(HEADER_LEN..market_generation_account_len())
+            .ok_or(PercolatorError::InvalidAccountLen)?
+            .copy_from_slice(bytemuck::bytes_of(generation));
+        Ok(())
+    }
+
+    #[inline]
+    pub fn init_market_generation(
+        data: &mut [u8],
+        generation: &MarketGenerationAccountV16,
+    ) -> Result<(), ProgramError> {
+        if data.len() != market_generation_account_len() {
+            return Err(PercolatorError::InvalidAccountLen.into());
+        }
+        if is_initialized(data) {
+            return Err(PercolatorError::AlreadyInitialized.into());
+        }
+        data.fill(0);
+        write_header(data, KIND_MARKET_GENERATION)?;
+        write_market_generation(data, generation)
     }
 
     #[inline]
@@ -2048,6 +2118,7 @@ pub mod state {
         config: &WrapperConfigV16,
         engine_config: V16Config,
         market_group_id: [u8; 32],
+        first_market_id: u64,
         initial_price: u64,
         init_slot: u64,
     ) -> Result<(), ProgramError> {
@@ -2079,16 +2150,19 @@ pub mod state {
         if configured == 0 || configured > capacity {
             return Err(ProgramError::InvalidAccountData);
         }
-        let next_market_id = (configured as u64)
-            .checked_add(1)
+        if first_market_id == 0 {
+            return Err(PercolatorError::EngineInvalidConfig.into());
+        }
+        let next_market_id = first_market_id
+            .checked_add(configured as u64)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
         header.next_market_id = V16PodU64::new(next_market_id);
         *market_header_mut(data)? = header;
 
         let mut i = 0usize;
         while i < configured {
-            let market_id = (i as u64)
-                .checked_add(1)
+            let market_id = first_market_id
+                .checked_add(i as u64)
                 .ok_or(PercolatorError::EngineArithmeticOverflow)?;
             let mut asset = AssetStateV16::default();
             asset.market_id = market_id;
@@ -5464,7 +5538,10 @@ pub mod processor {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
         let mint_ai = account(accounts, 2)?;
+        let generation_ai = account(accounts, 3)?;
+        let system_program_ai = account(accounts, 4)?;
         expect_signer(admin)?;
+        expect_writable(admin)?;
         expect_writable(market_ai)?;
         expect_owner(market_ai, program_id)?;
         verify_mint(mint_ai)?;
@@ -5496,6 +5573,14 @@ pub mod processor {
         if initial_price == 0 || initial_price > percolator::MAX_ORACLE_PRICE {
             return Err(PercolatorError::EngineInvalidConfig.into());
         }
+        let first_market_id = reserve_market_id_range(
+            program_id,
+            admin,
+            market_ai,
+            generation_ai,
+            system_program_ai,
+            max_portfolio_assets,
+        )?;
         let init_slot = Clock::get().map(|c| c.slot).unwrap_or(0);
         let wrapper = WrapperConfigV16 {
             marketauth: admin.key.to_bytes(),
@@ -5547,6 +5632,7 @@ pub mod processor {
             &wrapper,
             cfg,
             market_ai.key.to_bytes(),
+            first_market_id,
             initial_price,
             init_slot,
         )
@@ -8225,7 +8311,7 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         verify_token_program(token_program)?;
 
-        let cfg_pre = {
+        let (cfg_pre, next_market_id) = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, group) = state::market_view_mut(&mut market_data)?;
             expect_live_authority(&cfg.marketauth, admin_dest.key)?;
@@ -8239,7 +8325,7 @@ pub mod processor {
             {
                 return Err(PercolatorError::EngineLockActive.into());
             }
-            cfg
+            (cfg, group.header.next_market_id.get())
         };
 
         let (vault_authority, bump) = derive_vault_authority(program_id, market_ai.key);
@@ -8272,6 +8358,18 @@ pub mod processor {
         } else {
             None
         };
+
+        let generation_index = if secondary_close.is_some() { 8 } else { 6 };
+        let generation_ai = account(accounts, generation_index)?;
+        let system_program_ai = account(accounts, generation_index + 1)?;
+        checkpoint_market_generation(
+            program_id,
+            admin_dest,
+            market_ai,
+            generation_ai,
+            system_program_ai,
+            next_market_id,
+        )?;
 
         if vault_account.amount > 0 {
             transfer_tokens_signed(
@@ -11877,6 +11975,138 @@ pub mod processor {
         u64::try_from(amount).map_err(|_| PercolatorError::InvalidInstruction.into())
     }
 
+    fn derive_market_generation(program_id: &Pubkey, market_key: &Pubkey) -> (Pubkey, u8) {
+        Pubkey::find_program_address(&[b"market-generation", market_key.as_ref()], program_id)
+    }
+
+    fn load_or_create_market_generation<'a>(
+        program_id: &Pubkey,
+        payer: &AccountInfo<'a>,
+        market_ai: &AccountInfo<'a>,
+        generation_ai: &AccountInfo<'a>,
+        system_program_ai: &AccountInfo<'a>,
+    ) -> Result<state::MarketGenerationAccountV16, ProgramError> {
+        expect_signer(payer)?;
+        expect_writable(payer)?;
+        expect_writable(generation_ai)?;
+        expect_key(system_program_ai, &system_program::ID)?;
+        let (generation_key, bump) = derive_market_generation(program_id, market_ai.key);
+        expect_key(generation_ai, &generation_key)?;
+
+        if generation_ai.owner == &system_program::ID {
+            if generation_ai.data_len() != 0 {
+                return Err(PercolatorError::InvalidAccountLen.into());
+            }
+            let data_len = state::market_generation_account_len();
+            let minimum_balance = Rent::get()?.minimum_balance(data_len);
+            let bump_seed = [bump];
+            let signer_seeds: &[&[u8]] =
+                &[b"market-generation", market_ai.key.as_ref(), &bump_seed];
+            if generation_ai.lamports() == 0 {
+                let ix = system_instruction::create_account(
+                    payer.key,
+                    generation_ai.key,
+                    minimum_balance,
+                    data_len as u64,
+                    program_id,
+                );
+                invoke_signed(
+                    &ix,
+                    &[
+                        payer.clone(),
+                        generation_ai.clone(),
+                        system_program_ai.clone(),
+                    ],
+                    &[signer_seeds],
+                )?;
+            } else {
+                let shortfall = minimum_balance.saturating_sub(generation_ai.lamports());
+                if shortfall != 0 {
+                    let ix = system_instruction::transfer(payer.key, generation_ai.key, shortfall);
+                    invoke(
+                        &ix,
+                        &[
+                            payer.clone(),
+                            generation_ai.clone(),
+                            system_program_ai.clone(),
+                        ],
+                    )?;
+                }
+                let allocate_ix = system_instruction::allocate(generation_ai.key, data_len as u64);
+                invoke_signed(
+                    &allocate_ix,
+                    &[generation_ai.clone(), system_program_ai.clone()],
+                    &[signer_seeds],
+                )?;
+                let assign_ix = system_instruction::assign(generation_ai.key, program_id);
+                invoke_signed(
+                    &assign_ix,
+                    &[generation_ai.clone(), system_program_ai.clone()],
+                    &[signer_seeds],
+                )?;
+            }
+            let initial = state::MarketGenerationAccountV16 {
+                market_group: market_ai.key.to_bytes(),
+                next_market_id: percolator::V16PodU64::new(1),
+            };
+            state::init_market_generation(&mut generation_ai.try_borrow_mut_data()?, &initial)?;
+        } else {
+            expect_owner(generation_ai, program_id)?;
+        }
+
+        let generation = state::read_market_generation(&generation_ai.try_borrow_data()?)?;
+        if generation.market_group != market_ai.key.to_bytes() {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        Ok(generation)
+    }
+
+    fn reserve_market_id_range<'a>(
+        program_id: &Pubkey,
+        payer: &AccountInfo<'a>,
+        market_ai: &AccountInfo<'a>,
+        generation_ai: &AccountInfo<'a>,
+        system_program_ai: &AccountInfo<'a>,
+        count: u16,
+    ) -> Result<u64, ProgramError> {
+        let mut generation = load_or_create_market_generation(
+            program_id,
+            payer,
+            market_ai,
+            generation_ai,
+            system_program_ai,
+        )?;
+        let first_market_id = generation.next_market_id.get();
+        let next_market_id = first_market_id
+            .checked_add(count as u64)
+            .ok_or(PercolatorError::EngineCounterOverflow)?;
+        generation.next_market_id = percolator::V16PodU64::new(next_market_id);
+        state::write_market_generation(&mut generation_ai.try_borrow_mut_data()?, &generation)?;
+        Ok(first_market_id)
+    }
+
+    fn checkpoint_market_generation<'a>(
+        program_id: &Pubkey,
+        payer: &AccountInfo<'a>,
+        market_ai: &AccountInfo<'a>,
+        generation_ai: &AccountInfo<'a>,
+        system_program_ai: &AccountInfo<'a>,
+        next_market_id: u64,
+    ) -> ProgramResult {
+        let mut generation = load_or_create_market_generation(
+            program_id,
+            payer,
+            market_ai,
+            generation_ai,
+            system_program_ai,
+        )?;
+        if next_market_id > generation.next_market_id.get() {
+            generation.next_market_id = percolator::V16PodU64::new(next_market_id);
+            state::write_market_generation(&mut generation_ai.try_borrow_mut_data()?, &generation)?;
+        }
+        Ok(())
+    }
+
     fn derive_vault_authority(program_id: &Pubkey, market_key: &Pubkey) -> (Pubkey, u8) {
         Pubkey::find_program_address(&[b"vault", market_key.as_ref()], program_id)
     }
@@ -12196,6 +12426,7 @@ pub mod processor {
                 &cfg,
                 test_engine_config(),
                 [9u8; 32],
+                1,
                 100,
                 0,
             )

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2585,15 +2585,18 @@ pub mod ix {
             fee_rate_per_slot: u128,
         },
         /// Rotate the single market-level authority (`marketauth`). The current `marketauth` must sign;
-        /// the non-zero replacement must co-sign. Burning `marketauth` to zero is rejected.
+        /// the non-zero replacement must co-sign. `market_id` binds the signed capability to the
+        /// current base-asset generation. Burning `marketauth` to zero is rejected.
         UpdateAuthority {
+            market_id: u64,
             new_pubkey: [u8; 32],
         },
         /// Rotate one of an asset's per-asset authorities. Gated by the asset's own `asset_admin`
         /// (rotates any; only the admin authority itself is burnable) or the current holder of that
-        /// authority (self-rotation). Isolated to the given asset_index.
+        /// authority (self-rotation). Isolated to the given asset_index and `market_id` generation.
         UpdateAssetAuthority {
             asset_index: u16,
+            market_id: u64,
             kind: u8,
             new_pubkey: [u8; 32],
         },
@@ -2856,10 +2859,12 @@ pub mod ix {
                     fee_rate_per_slot: read_u128(&mut rest)?,
                 },
                 32 => Self::UpdateAuthority {
+                    market_id: read_u64(&mut rest)?,
                     new_pubkey: read_bytes32(&mut rest)?,
                 },
                 65 => Self::UpdateAssetAuthority {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     kind: read_u8(&mut rest)?,
                     new_pubkey: read_bytes32(&mut rest)?,
                 },
@@ -3161,17 +3166,23 @@ pub mod ix {
                     out.push(30);
                     push_u128(&mut out, fee_rate_per_slot);
                 }
-                Self::UpdateAuthority { new_pubkey } => {
+                Self::UpdateAuthority {
+                    market_id,
+                    new_pubkey,
+                } => {
                     out.push(32);
+                    push_u64(&mut out, market_id);
                     out.extend_from_slice(&new_pubkey);
                 }
                 Self::UpdateAssetAuthority {
                     asset_index,
+                    market_id,
                     kind,
                     new_pubkey,
                 } => {
                     out.push(65);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     out.push(kind);
                     out.extend_from_slice(&new_pubkey);
                 }
@@ -5308,14 +5319,23 @@ pub mod processor {
             Instruction::CloseResolved { fee_rate_per_slot } => {
                 handle_close_resolved(program_id, accounts, fee_rate_per_slot)
             }
-            Instruction::UpdateAuthority { new_pubkey } => {
-                handle_update_authority(program_id, accounts, new_pubkey)
-            }
+            Instruction::UpdateAuthority {
+                market_id,
+                new_pubkey,
+            } => handle_update_authority(program_id, accounts, market_id, new_pubkey),
             Instruction::UpdateAssetAuthority {
                 asset_index,
+                market_id,
                 kind,
                 new_pubkey,
-            } => handle_update_asset_authority(program_id, accounts, asset_index, kind, new_pubkey),
+            } => handle_update_asset_authority(
+                program_id,
+                accounts,
+                asset_index,
+                market_id,
+                kind,
+                new_pubkey,
+            ),
             Instruction::UpdateLiquidationFeePolicy { cranker_share_bps } => {
                 handle_update_liquidation_fee_policy(program_id, accounts, cranker_share_bps)
             }
@@ -8762,6 +8782,7 @@ pub mod processor {
     fn handle_update_authority<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
         new_pubkey: [u8; 32],
     ) -> ProgramResult {
         let current = account(accounts, 0)?;
@@ -8783,6 +8804,11 @@ pub mod processor {
         let mut data = market_ai.try_borrow_mut_data()?;
         let cfg_after = {
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
+            if group.markets.is_empty()
+                || group.markets[0].engine.asset.market_id.get() != expected_market_id
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
+            }
             expect_live_authority(&cfg.marketauth, current.key)?;
             let old_marketauth = cfg.marketauth;
             let mut profile = read_oracle_profile_from_view(&group, &cfg, 0)?;
@@ -8813,6 +8839,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         kind: u8,
         new_pubkey: [u8; 32],
     ) -> ProgramResult {
@@ -8839,6 +8866,9 @@ pub mod processor {
         let (cfg, mut group) = state::market_view_mut(&mut data)?;
         if asset_index >= group.header.config.max_market_slots.get() as usize {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if group.markets[asset_index].engine.asset.market_id.get() != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
         }
         let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -5784,6 +5784,94 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     );
 }
 
+// A signed trade identifies only the reusable asset index. If the slot is retired and reused while
+// the transaction remains valid, it must not execute against the replacement market generation.
+#[test]
+fn v16_attack_signed_trade_cannot_replay_across_asset_slot_reuse() {
+    const ASSET: u16 = 1;
+    const OLD_PRICE: u64 = 100;
+    const NEW_PRICE: u64 = 250;
+
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(1);
+    env.svm.warp_to_slot(1);
+    env.activate_asset(ASSET, 1, OLD_PRICE);
+
+    let trader_a = Keypair::new();
+    let trader_b = Keypair::new();
+    let account_a = env.create_portfolio(&trader_a);
+    let account_b = env.create_portfolio(&trader_b);
+    env.deposit(&trader_a, account_a, 1_000_000);
+    env.deposit(&trader_b, account_b, 1_000_000);
+
+    let old_market_id = env.market_state().1.assets[ASSET as usize].market_id;
+    let stale_trade_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(trader_a.pubkey(), true),
+            AccountMeta::new(trader_b.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+            AccountMeta::new(account_b, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: ASSET,
+            size_q: POS_SCALE as i128,
+            exec_price: OLD_PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let stale_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_trade_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &trader_a, &trader_b],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(3);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        ASSET,
+        3,
+        0,
+    );
+    let replacement_authority = Keypair::new();
+    env.svm.warp_to_slot(4);
+    env.activate_permissionless_asset_with_fee(
+        &replacement_authority,
+        ASSET,
+        4,
+        NEW_PRICE,
+        replacement_authority.pubkey(),
+        replacement_authority.pubkey(),
+        replacement_authority.pubkey(),
+        replacement_authority.pubkey(),
+        1,
+    );
+    let new_market_id = env.market_state().1.assets[ASSET as usize].market_id;
+    assert_ne!(
+        new_market_id, old_market_id,
+        "slot reuse creates a new market generation"
+    );
+
+    let replay = env.svm.send_transaction(stale_trade);
+    if replay.is_ok() {
+        let account_a_after = env.portfolio_state(account_a);
+        let account_b_after = env.portfolio_state(account_b);
+        let leg_a = active_leg_for_asset(&account_a_after, ASSET as usize);
+        let leg_b = active_leg_for_asset(&account_b_after, ASSET as usize);
+        assert_eq!(leg_a.market_id, new_market_id);
+        assert_eq!(leg_b.market_id, new_market_id);
+        assert_eq!(leg_a.basis_pos_q, POS_SCALE as i128);
+        assert_eq!(leg_b.basis_pos_q, -(POS_SCALE as i128));
+    }
+    assert!(
+        replay.is_err(),
+        "a transaction signed for market generation {old_market_id} must not open positions in replacement generation {new_market_id}"
+    );
+}
+
 #[test]
 fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -33,6 +34,10 @@ const CUSTODY_CU_LIMIT: u64 = 300_000;
 const TRADE_CU_LIMIT: u64 = 345_000;
 const MULTI_ASSET_OPEN_TRADE_CU_LIMIT: u64 = 750_000;
 const MATCHER_CONTEXT_LEN: usize = 320;
+
+const fn first_generation_market_id(asset_index: u16) -> u64 {
+    asset_index as u64 + 1
+}
 
 fn crank_observations(asset_index: u16) -> Vec<CrankObservationHint> {
     vec![CrankObservationHint {
@@ -1240,6 +1245,10 @@ impl V16CuEnv {
         state::read_market(&account.data).unwrap()
     }
 
+    fn asset_market_id(&self, asset_index: u16) -> u64 {
+        self.market_state().1.assets[asset_index as usize].market_id
+    }
+
     fn portfolio_state(&self, portfolio: Pubkey) -> PortfolioAccountV16 {
         let account = self.svm.get_account(&portfolio).expect("portfolio account");
         state::read_portfolio(&account.data).unwrap()
@@ -1475,9 +1484,17 @@ impl V16CuEnv {
         exec_price: u64,
         fee_bps: u64,
     ) -> Result<u64, String> {
+        let market_id = self
+            .market_state()
+            .1
+            .assets
+            .get(asset_index as usize)
+            .map(|asset| asset.market_id)
+            .unwrap_or(0);
         self.send(
             ProgInstruction::TradeNoCpi {
                 asset_index,
+                market_id,
                 size_q,
                 exec_price,
                 fee_bps,
@@ -2145,6 +2162,7 @@ impl V16CuEnv {
         size_q: i128,
         fee_bps: u64,
     ) -> Result<u64, String> {
+        let market_id = self.asset_market_id(asset_index);
         let metas = vec![
             AccountMeta::new(owner_a.pubkey(), true),
             AccountMeta::new(self.market, false),
@@ -2157,6 +2175,7 @@ impl V16CuEnv {
         self.send(
             ProgInstruction::TradeCpi {
                 asset_index,
+                market_id,
                 size_q,
                 fee_bps,
                 limit_price: 0,
@@ -5784,79 +5803,214 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     );
 }
 
-// A signed trade identifies only the reusable asset index. If the slot is retired and reused while
-// the transaction remains valid, it must not execute against the replacement market generation.
+#[derive(Clone, Copy, Debug)]
+enum AssetGenerationTradePath {
+    TradeNoCpi,
+    BatchTradeNoCpi,
+    TradeCpi,
+    BatchTradeCpi,
+}
+
+// A transaction signed for one asset generation (for example, with a durable nonce) must not
+// execute after public retirement and permissionless slot reuse. Every route rejects before
+// mutation; the replacement generation then accepts the same trade when its current market_id is
+// signed, so the guard does not block trading.
 #[test]
 fn v16_attack_signed_trade_cannot_replay_across_asset_slot_reuse() {
     const ASSET: u16 = 1;
     const OLD_PRICE: u64 = 100;
     const NEW_PRICE: u64 = 250;
 
-    let mut env = V16CuEnv::new();
-    env.update_market_init_fee_policy_with_cu(1);
-    env.svm.warp_to_slot(1);
-    env.activate_asset(ASSET, 1, OLD_PRICE);
+    for path in [
+        AssetGenerationTradePath::TradeNoCpi,
+        AssetGenerationTradePath::BatchTradeNoCpi,
+        AssetGenerationTradePath::TradeCpi,
+        AssetGenerationTradePath::BatchTradeCpi,
+    ] {
+        let mut env = V16CuEnv::new();
+        env.update_market_init_fee_policy_with_cu(1);
+        env.svm.warp_to_slot(1);
+        env.activate_asset(ASSET, 1, OLD_PRICE);
 
-    let trader_a = Keypair::new();
-    let trader_b = Keypair::new();
-    let account_a = env.create_portfolio(&trader_a);
-    let account_b = env.create_portfolio(&trader_b);
-    env.deposit(&trader_a, account_a, 1_000_000);
-    env.deposit(&trader_b, account_b, 1_000_000);
+        let trader_a = Keypair::new();
+        let trader_b = Keypair::new();
+        let account_a = env.create_portfolio(&trader_a);
+        let account_b = env.create_portfolio(&trader_b);
+        env.deposit(&trader_a, account_a, 1_000_000);
+        env.deposit(&trader_b, account_b, 1_000_000);
+        let (matcher_program, matcher_ctx, matcher_delegate) =
+            auth_matcher_for_lp_via_system_create(&mut env, &trader_b, account_b);
 
-    let old_market_id = env.market_state().1.assets[ASSET as usize].market_id;
-    let stale_trade_ix = Instruction {
-        program_id: env.program_id,
-        accounts: vec![
-            AccountMeta::new(trader_a.pubkey(), true),
-            AccountMeta::new(trader_b.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(account_a, false),
-            AccountMeta::new(account_b, false),
-        ],
-        data: ProgInstruction::TradeNoCpi {
-            asset_index: ASSET,
-            size_q: POS_SCALE as i128,
-            exec_price: OLD_PRICE,
-            fee_bps: 0,
-        }
-        .encode(),
-    };
-    let stale_trade = Transaction::new_signed_with_payer(
-        &[heap_ix(), cu_ix(), stale_trade_ix],
-        Some(&env.payer.pubkey()),
-        &[&env.payer, &trader_a, &trader_b],
-        env.svm.latest_blockhash(),
-    );
+        let old_market_id = env.asset_market_id(ASSET);
+        let stale_instruction = match path {
+            AssetGenerationTradePath::TradeNoCpi => ProgInstruction::TradeNoCpi {
+                asset_index: ASSET,
+                market_id: old_market_id,
+                size_q: POS_SCALE as i128,
+                exec_price: OLD_PRICE,
+                fee_bps: 0,
+            },
+            AssetGenerationTradePath::BatchTradeNoCpi => ProgInstruction::BatchTradeNoCpi {
+                legs: vec![BatchTradeLeg {
+                    asset_index: ASSET,
+                    market_id: old_market_id,
+                    size_q: POS_SCALE as i128,
+                    exec_price: OLD_PRICE,
+                    fee_bps: 0,
+                }],
+            },
+            AssetGenerationTradePath::TradeCpi => ProgInstruction::TradeCpi {
+                asset_index: ASSET,
+                market_id: old_market_id,
+                size_q: POS_SCALE as i128,
+                fee_bps: 0,
+                limit_price: 0,
+            },
+            AssetGenerationTradePath::BatchTradeCpi => ProgInstruction::BatchTradeCpi {
+                legs: vec![BatchTradeCpiLeg {
+                    asset_index: ASSET,
+                    market_id: old_market_id,
+                    size_q: POS_SCALE as i128,
+                    fee_bps: 0,
+                    limit_price: 0,
+                }],
+            },
+        };
+        let cpi = matches!(
+            path,
+            AssetGenerationTradePath::TradeCpi | AssetGenerationTradePath::BatchTradeCpi
+        );
+        let stale_accounts = if cpi {
+            vec![
+                AccountMeta::new(trader_a.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(account_a, false),
+                AccountMeta::new(account_b, false),
+                AccountMeta::new_readonly(matcher_program, false),
+                AccountMeta::new(matcher_ctx, false),
+                AccountMeta::new_readonly(matcher_delegate, false),
+            ]
+        } else {
+            vec![
+                AccountMeta::new(trader_a.pubkey(), true),
+                AccountMeta::new(trader_b.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(account_a, false),
+                AccountMeta::new(account_b, false),
+            ]
+        };
+        let stale_trade_ix = Instruction {
+            program_id: env.program_id,
+            accounts: stale_accounts.clone(),
+            data: stale_instruction.encode(),
+        };
+        let stale_trade = if cpi {
+            Transaction::new_signed_with_payer(
+                &[heap_ix(), cu_ix(), stale_trade_ix],
+                Some(&env.payer.pubkey()),
+                &[&env.payer, &trader_a],
+                env.svm.latest_blockhash(),
+            )
+        } else {
+            Transaction::new_signed_with_payer(
+                &[heap_ix(), cu_ix(), stale_trade_ix],
+                Some(&env.payer.pubkey()),
+                &[&env.payer, &trader_a, &trader_b],
+                env.svm.latest_blockhash(),
+            )
+        };
 
-    env.svm.warp_to_slot(3);
-    env.update_asset_lifecycle_as_admin_with_cu(
-        percolator_prog::processor::ASSET_ACTION_RETIRE,
-        ASSET,
-        3,
-        0,
-    );
-    let replacement_authority = Keypair::new();
-    env.svm.warp_to_slot(4);
-    env.activate_permissionless_asset_with_fee(
-        &replacement_authority,
-        ASSET,
-        4,
-        NEW_PRICE,
-        replacement_authority.pubkey(),
-        replacement_authority.pubkey(),
-        replacement_authority.pubkey(),
-        replacement_authority.pubkey(),
-        1,
-    );
-    let new_market_id = env.market_state().1.assets[ASSET as usize].market_id;
-    assert_ne!(
-        new_market_id, old_market_id,
-        "slot reuse creates a new market generation"
-    );
+        env.svm.warp_to_slot(3);
+        env.update_asset_lifecycle_as_admin_with_cu(
+            percolator_prog::processor::ASSET_ACTION_RETIRE,
+            ASSET,
+            3,
+            0,
+        );
+        let replacement_authority = Keypair::new();
+        env.svm.warp_to_slot(4);
+        env.activate_permissionless_asset_with_fee(
+            &replacement_authority,
+            ASSET,
+            4,
+            NEW_PRICE,
+            replacement_authority.pubkey(),
+            replacement_authority.pubkey(),
+            replacement_authority.pubkey(),
+            replacement_authority.pubkey(),
+            1,
+        );
+        let new_market_id = env.asset_market_id(ASSET);
+        assert_ne!(
+            new_market_id, old_market_id,
+            "{path:?}: slot reuse creates a new market generation"
+        );
 
-    let replay = env.svm.send_transaction(stale_trade);
-    if replay.is_ok() {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let account_a_before = env.svm.get_account(&account_a).unwrap();
+        let account_b_before = env.svm.get_account(&account_b).unwrap();
+        let matcher_before = env.svm.get_account(&matcher_ctx).unwrap();
+        let replay_error = env
+            .svm
+            .send_transaction(stale_trade)
+            .expect_err("old generation must reject");
+        let replay_error = format!("{replay_error:?}");
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::AssetGenerationMismatch as u32
+        );
+        assert!(
+            replay_error.contains(&expected_error),
+            "{path:?}: stale generation must fail with {expected_error}, got {replay_error}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&account_a).unwrap(), account_a_before);
+        assert_eq!(env.svm.get_account(&account_b).unwrap(), account_b_before);
+        assert_eq!(env.svm.get_account(&matcher_ctx).unwrap(), matcher_before);
+
+        let current_instruction = match path {
+            AssetGenerationTradePath::TradeNoCpi => ProgInstruction::TradeNoCpi {
+                asset_index: ASSET,
+                market_id: new_market_id,
+                size_q: POS_SCALE as i128,
+                exec_price: NEW_PRICE,
+                fee_bps: 0,
+            },
+            AssetGenerationTradePath::BatchTradeNoCpi => ProgInstruction::BatchTradeNoCpi {
+                legs: vec![BatchTradeLeg {
+                    asset_index: ASSET,
+                    market_id: new_market_id,
+                    size_q: POS_SCALE as i128,
+                    exec_price: NEW_PRICE,
+                    fee_bps: 0,
+                }],
+            },
+            AssetGenerationTradePath::TradeCpi => ProgInstruction::TradeCpi {
+                asset_index: ASSET,
+                market_id: new_market_id,
+                size_q: POS_SCALE as i128,
+                fee_bps: 0,
+                limit_price: 0,
+            },
+            AssetGenerationTradePath::BatchTradeCpi => ProgInstruction::BatchTradeCpi {
+                legs: vec![BatchTradeCpiLeg {
+                    asset_index: ASSET,
+                    market_id: new_market_id,
+                    size_q: POS_SCALE as i128,
+                    fee_bps: 0,
+                    limit_price: 0,
+                }],
+            },
+        };
+        let current_trade = if cpi {
+            env.send(current_instruction, stale_accounts, &[&trader_a])
+        } else {
+            env.send(current_instruction, stale_accounts, &[&trader_a, &trader_b])
+        };
+        assert!(
+            current_trade.is_ok(),
+            "{path:?}: the replacement generation remains tradeable: {current_trade:?}"
+        );
         let account_a_after = env.portfolio_state(account_a);
         let account_b_after = env.portfolio_state(account_b);
         let leg_a = active_leg_for_asset(&account_a_after, ASSET as usize);
@@ -5866,10 +6020,6 @@ fn v16_attack_signed_trade_cannot_replay_across_asset_slot_reuse() {
         assert_eq!(leg_a.basis_pos_q, POS_SCALE as i128);
         assert_eq!(leg_b.basis_pos_q, -(POS_SCALE as i128));
     }
-    assert!(
-        replay.is_err(),
-        "a transaction signed for market generation {old_market_id} must not open positions in replacement generation {new_market_id}"
-    );
 }
 
 #[test]
@@ -13500,6 +13650,7 @@ fn execute_account_residual_counter_trade_path(
                 ProgInstruction::BatchTradeNoCpi {
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q,
                         exec_price,
                         fee_bps: 0,
@@ -13522,6 +13673,7 @@ fn execute_account_residual_counter_trade_path(
                 ProgInstruction::BatchTradeCpi {
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q,
                         fee_bps: 0,
                         limit_price: 0,
@@ -13668,12 +13820,14 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
                     legs: vec![
                         BatchTradeCpiLeg {
                             asset_index: 0,
+                            market_id: first_generation_market_id((0) as u16),
                             size_q: POS_SCALE as i128,
                             fee_bps: 0,
                             limit_price: 0,
                         },
                         BatchTradeCpiLeg {
                             asset_index: 1,
+                            market_id: first_generation_market_id((1) as u16),
                             size_q: -(POS_SCALE as i128),
                             fee_bps: 0,
                             limit_price: 0,
@@ -13698,12 +13852,14 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
                     legs: vec![
                         BatchTradeLeg {
                             asset_index: 0,
+                            market_id: first_generation_market_id((0) as u16),
                             size_q: POS_SCALE as i128,
                             exec_price: PRICE,
                             fee_bps: 0,
                         },
                         BatchTradeLeg {
                             asset_index: 1,
+                            market_id: first_generation_market_id((1) as u16),
                             size_q: -(POS_SCALE as i128),
                             exec_price: PRICE,
                             fee_bps: 0,
@@ -13842,6 +13998,7 @@ fn execute_backing_residual_counter_trade_path(
                 ProgInstruction::BatchTradeNoCpi {
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q,
                         exec_price,
                         fee_bps: 0,
@@ -13863,6 +14020,7 @@ fn execute_backing_residual_counter_trade_path(
                 ProgInstruction::BatchTradeCpi {
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q,
                         fee_bps: 0,
                         limit_price: 0,
@@ -16028,6 +16186,7 @@ fn v16_attack_account_type_confusion_rejected() {
     let r2 = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -19331,6 +19490,7 @@ fn v16_attack_batch_subatom_fee_reconstruction_uses_ceil_notional() {
         ProgInstruction::BatchTradeNoCpi {
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sub_atom_size,
                 exec_price: 100,
                 fee_bps: 1,
@@ -20432,6 +20592,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     let single = env.send(
         ProgInstruction::TradeCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -20461,6 +20622,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -20699,6 +20861,7 @@ fn v16_attack_tradecpi_matcher_config_arguments_must_match_account_bytes() {
         env.send(
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -20818,12 +20981,14 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 0,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: -sz,
                     fee_bps: 100,
                     limit_price: 0,
@@ -20857,6 +21022,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 100,
                 limit_price: 0,
@@ -21082,6 +21248,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
         env.send(
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -21115,6 +21282,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -21427,6 +21595,7 @@ fn v16_attack_permissionless_lp_cpi_rejects_wrong_delegate_owner_or_account_bind
     let batch_ix = ProgInstruction::BatchTradeCpi {
         legs: vec![BatchTradeCpiLeg {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
@@ -21497,6 +21666,7 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
     let single = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (10 * POS_SCALE) as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -21520,12 +21690,14 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: (5 * POS_SCALE) as i128,
                     exec_price: 100,
                     fee_bps: 0,
                 },
                 BatchTradeLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: -(5 * POS_SCALE as i128),
                     exec_price: 100,
                     fee_bps: 0,
@@ -21580,6 +21752,7 @@ fn v16_attack_tradecpi_limit_price_enforced() {
         env.send(
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: (10 * POS_SCALE) as i128,
                 fee_bps: 100,
                 limit_price: limit,
@@ -21708,6 +21881,7 @@ fn v16_attack_tradecpi_self_trade_rejected() {
     let r = env.send(
         ProgInstruction::TradeCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (10 * POS_SCALE) as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -22340,6 +22514,7 @@ fn v16_attack_non_owner_cannot_withdraw_or_trade() {
     let r_tr = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -26909,6 +27084,7 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -27201,6 +27377,7 @@ fn v16_attack_non_base_trade_rejects_after_base_resolve_matured() {
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 101,
             fee_bps: 0,
@@ -27355,6 +27532,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
         .send(
             ProgInstruction::TradeCpi {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -27383,6 +27561,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
         .send(
             ProgInstruction::TradeCpi {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -28550,6 +28729,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -28707,6 +28887,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         &env.payer,
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -30321,6 +30502,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             "TradeNoCpi",
             ProgInstruction::TradeNoCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: POS_SCALE as i128,
                 exec_price: 100,
                 fee_bps: 100,
@@ -30339,6 +30521,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             ProgInstruction::BatchTradeNoCpi {
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: POS_SCALE as i128,
                     exec_price: 100,
                     fee_bps: 100,
@@ -30357,6 +30540,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             "TradeCpi",
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -30377,6 +30561,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             ProgInstruction::BatchTradeCpi {
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: POS_SCALE as i128,
                     fee_bps: 100,
                     limit_price: 0,
@@ -30418,6 +30603,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 100,
@@ -30518,6 +30704,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -31201,6 +31388,7 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
         &env.payer,
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -36862,6 +37050,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::TradeNoCpi {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -37307,6 +37496,7 @@ fn try_no_cpi_reported_price_trade_with_cu(
             ProgInstruction::BatchTradeNoCpi {
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q,
                     exec_price,
                     fee_bps,
@@ -40769,6 +40959,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_carry_protocol_state() {
     };
     let ix = |asset_index, size_q| ProgInstruction::TradeCpi {
         asset_index,
+        market_id: first_generation_market_id((asset_index) as u16),
         size_q,
         fee_bps: 100,
         limit_price: 0,
@@ -40901,6 +41092,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     let rejected = env.send(
         ProgInstruction::TradeCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -40991,12 +41183,14 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_carry_protocol_state() {
         legs: vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 100,
                 limit_price: 0,
             },
             BatchTradeCpiLeg {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 size_q: -sz,
                 fee_bps: 100,
                 limit_price: 0,
@@ -41148,12 +41342,14 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     let legs = vec![
         BatchTradeCpiLeg {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
             limit_price: 0,
         },
         BatchTradeCpiLeg {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: -(5 * POS_SCALE as i128),
             fee_bps: 100,
             limit_price: 0,
@@ -42704,6 +42900,7 @@ fn v16_attack_tradenocpi_self_trade_rejected() {
     let r = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 100,
@@ -42753,6 +42950,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
     env.deposit(&owner, p, 1_000_000);
     let batch_leg = BatchTradeLeg {
         asset_index: 0,
+        market_id: first_generation_market_id((0) as u16),
         size_q: POS_SCALE as i128,
         exec_price: 100,
         fee_bps: 100,
@@ -42798,6 +42996,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
                 limit_price: 0,
@@ -48437,12 +48636,14 @@ fn v16_bpf_batch_trade_executes_mixed_direction_spread() {
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q: sz,
                         exec_price: 100,
                         fee_bps: 0,
                     },
                     BatchTradeLeg {
                         asset_index: 1,
+                        market_id: first_generation_market_id((1) as u16),
                         size_q: -sz,
                         exec_price: 100,
                         fee_bps: 0,
@@ -48495,12 +48696,14 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 100,
                 },
                 BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: -sz,
                     exec_price: 100,
                     fee_bps: 100,
@@ -48556,12 +48759,14 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 0,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: -sz,
                     fee_bps: 100,
                     limit_price: 0,
@@ -48615,12 +48820,14 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 0,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: -sz,
                     fee_bps: 100,
                     limit_price: 0,
@@ -48745,12 +48952,14 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
         vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 100,
                 limit_price: 0,
             },
             BatchTradeCpiLeg {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 size_q: -sz,
                 fee_bps: 100,
                 limit_price: 0,
@@ -48775,12 +48984,14 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
         vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 100,
                 limit_price: 0,
             },
             BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: -sz,
                 fee_bps: 100,
                 limit_price: 0,
@@ -48894,6 +49105,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
             "TradeCpi",
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 0,
                 limit_price: 0,
@@ -48904,6 +49116,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
             ProgInstruction::BatchTradeCpi {
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: POS_SCALE as i128,
                     fee_bps: 0,
                     limit_price: 0,
@@ -48981,12 +49194,14 @@ fn v16_bpf_batch_trade_checks_margin_on_final_portfolio_only() {
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 1,
+                        market_id: first_generation_market_id((1) as u16),
                         size_q: sz,
                         exec_price: 100,
                         fee_bps: 0,
                     },
                     BatchTradeLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q: sz,
                         exec_price: 100,
                         fee_bps: 0,
@@ -49032,6 +49247,7 @@ fn v16_bpf_batch_trade_14_legs_under_tx_limit() {
     let legs: Vec<BatchTradeLeg> = (0..14u16)
         .map(|a| BatchTradeLeg {
             asset_index: a,
+            market_id: first_generation_market_id((a) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 100,
@@ -49094,6 +49310,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         (0..count)
             .map(|asset_index| BatchTradeLeg {
                 asset_index,
+                market_id: first_generation_market_id((asset_index) as u16),
                 size_q: POS_SCALE as i128,
                 exec_price: 100,
                 fee_bps: 0,
@@ -49104,6 +49321,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         (0..count)
             .map(|asset_index| BatchTradeCpiLeg {
                 asset_index,
+                market_id: first_generation_market_id((asset_index) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 0,
                 limit_price: 0,
@@ -49321,6 +49539,7 @@ fn v16_attack_batch_tradecpi_configured_leg_cap_rejects_before_hostile_matcher_c
         let legs: Vec<BatchTradeCpiLeg> = (0..count)
             .map(|asset_index| BatchTradeCpiLeg {
                 asset_index,
+                market_id: first_generation_market_id((asset_index) as u16),
                 size_q: POS_SCALE as i128,
                 fee_bps: 0,
                 limit_price: 0,
@@ -49406,6 +49625,7 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
     let no_cpi_legs: Vec<BatchTradeLeg> = (0..u16::from(u8::MAX))
         .map(|asset_index| BatchTradeLeg {
             asset_index,
+            market_id: first_generation_market_id((asset_index) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
@@ -49440,6 +49660,7 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
     let cpi_legs: Vec<BatchTradeCpiLeg> = (0..u16::from(u8::MAX))
         .map(|asset_index| BatchTradeCpiLeg {
             asset_index,
+            market_id: first_generation_market_id((asset_index) as u16),
             size_q: POS_SCALE as i128,
             fee_bps: 0,
             limit_price: 0,
@@ -49492,12 +49713,14 @@ fn v16_bpf_batch_trade_cpi_executes_mixed_spread_through_matcher() {
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q: sz,
                         fee_bps: 100,
                         limit_price: 0,
                     },
                     BatchTradeCpiLeg {
                         asset_index: 1,
+                        market_id: first_generation_market_id((1) as u16),
                         size_q: -sz,
                         fee_bps: 100,
                         limit_price: 0,
@@ -49560,6 +49783,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
         ProgInstruction::BatchTradeNoCpi {
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 exec_price: 100,
                 fee_bps: 0,
@@ -49598,6 +49822,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
         ProgInstruction::BatchTradeCpi {
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 0,
                 limit_price: 0,
@@ -49686,6 +49911,7 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
             ProgInstruction::BatchTradeNoCpi {
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 0,
@@ -49731,6 +49957,7 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
         ProgInstruction::BatchTradeNoCpi {
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 exec_price: 100,
                 fee_bps: 0,
@@ -49846,6 +50073,7 @@ fn v16_attack_non_active_asset_cannot_enable_backing_fee_batch_gate() {
             ProgInstruction::BatchTradeNoCpi {
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 0,
@@ -49991,6 +50219,7 @@ fn v16_attack_retired_reused_asset_backing_fee_policy_cannot_stick_batch_gate() 
         ProgInstruction::BatchTradeNoCpi {
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 exec_price: 100,
                 fee_bps: 0,
@@ -50116,6 +50345,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
             .send(
                 ProgInstruction::TradeCpi {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: POS_SCALE as i128,
                     fee_bps: 0,
                     limit_price: 0,
@@ -50183,6 +50413,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
                     ProgInstruction::BatchTradeCpi {
                         legs: vec![BatchTradeCpiLeg {
                             asset_index: 1,
+                            market_id: first_generation_market_id((1) as u16),
                             size_q: POS_SCALE as i128,
                             fee_bps: 0,
                             limit_price: 0,
@@ -50195,6 +50426,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
                 env.send(
                     ProgInstruction::TradeCpi {
                         asset_index: 1,
+                        market_id: first_generation_market_id((1) as u16),
                         size_q: POS_SCALE as i128,
                         fee_bps: 0,
                         limit_price: 0,
@@ -50249,6 +50481,7 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
             ProgInstruction::BatchTradeCpi {
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: (5 * POS_SCALE) as i128,
                     fee_bps,
                     limit_price: 0,
@@ -50339,6 +50572,7 @@ fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {
     let legs: Vec<BatchTradeCpiLeg> = (0..14u16)
         .map(|a| BatchTradeCpiLeg {
             asset_index: a,
+            market_id: first_generation_market_id((a) as u16),
             size_q: POS_SCALE as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -50487,6 +50721,7 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     let seed_legs: Vec<BatchTradeLeg> = (FIRST_TAIL_ASSET..N)
         .map(|asset_index| BatchTradeLeg {
             asset_index: asset_index as u16,
+            market_id: first_generation_market_id((asset_index as u16) as u16),
             size_q: POS_SCALE as i128,
             exec_price: PRICE,
             fee_bps: 100,
@@ -50519,6 +50754,7 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     let legs: Vec<BatchTradeCpiLeg> = (FIRST_TAIL_ASSET..N)
         .map(|asset_index| BatchTradeCpiLeg {
             asset_index: asset_index as u16,
+            market_id: first_generation_market_id((asset_index as u16) as u16),
             size_q: POS_SCALE as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -50618,12 +50854,14 @@ fn v16_attack_batch_fees_isolated_to_each_asset_domain() {
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 100,
                 },
                 BatchTradeLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 500,
@@ -50674,12 +50912,14 @@ fn v16_attack_batch_cannot_force_counterparty_underwater() {
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 0,
                 },
                 BatchTradeLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: sz,
                     exec_price: 100,
                     fee_bps: 0,
@@ -50817,12 +51057,14 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 1_000_000,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 100,
@@ -50848,12 +51090,14 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 1_000_000,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 1_000_000,
@@ -50903,12 +51147,14 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
     let legs = vec![
         BatchTradeCpiLeg {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
         },
         BatchTradeCpiLeg {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
@@ -51015,12 +51261,14 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
     let legs = vec![
         BatchTradeCpiLeg {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
         },
         BatchTradeCpiLeg {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: -sz,
             fee_bps: 100,
             limit_price: 0,
@@ -51168,12 +51416,14 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     let legs = vec![
         BatchTradeCpiLeg {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
         },
         BatchTradeCpiLeg {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             size_q: sz,
             fee_bps: 100,
             limit_price: 0,
@@ -51356,6 +51606,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
             .send(
                 ProgInstruction::TradeCpi {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
                     limit_price: 0,
@@ -51388,6 +51639,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
             .send(
                 ProgInstruction::TradeCpi {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
                     limit_price: 0,
@@ -51483,12 +51735,14 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         let legs = vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: -(POS_SCALE as i128),
                 fee_bps: 0,
                 limit_price: 0,
             },
             BatchTradeCpiLeg {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 size_q: -(POS_SCALE as i128),
                 fee_bps: 0,
                 limit_price: 0,
@@ -51635,6 +51889,7 @@ fn v16_attack_batch_tradecpi_fee_bps_rejects_before_hostile_matcher_cpi() {
             ProgInstruction::BatchTradeCpi {
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: (5 * POS_SCALE) as i128,
                     fee_bps,
                     limit_price: 0,
@@ -51769,6 +52024,7 @@ fn v16_attack_batch_tradecpi_backing_fee_policy_rejects_before_hostile_matcher_c
             ProgInstruction::BatchTradeCpi {
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: (5 * POS_SCALE) as i128,
                     fee_bps: 0,
                     limit_price: 0,
@@ -51876,6 +52132,7 @@ fn v16_attack_batch_nocpi_stale_reject_rolls_back_legacy_realloc() {
             ProgInstruction::BatchTradeNoCpi {
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q,
                     exec_price: 100,
                     fee_bps: 100,
@@ -52140,12 +52397,14 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
+                        market_id: first_generation_market_id((0) as u16),
                         size_q: sz,
                         fee_bps: 100,
                         limit_price: 0,
                     },
                     BatchTradeCpiLeg {
                         asset_index: 1,
+                        market_id: first_generation_market_id((1) as u16),
                         size_q: sz,
                         fee_bps: 100,
                         limit_price: 0,
@@ -52289,6 +52548,7 @@ fn v16_attack_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
     let r = env.send(
         ProgInstruction::TradeCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
             limit_price: 0,
@@ -52386,12 +52646,14 @@ fn v16_attack_batch_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q: sz,
                     fee_bps: 100,
                     limit_price: 0,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: -sz,
                     fee_bps: 100,
                     limit_price: 0,
@@ -53403,6 +53665,7 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
         let result = env.send(
             ProgInstruction::TradeCpi {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 size_q: sz,
                 fee_bps: 100,
                 limit_price: 0,
@@ -53545,12 +53808,14 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
+                    market_id: first_generation_market_id((0) as u16),
                     size_q,
                     fee_bps: 100,
                     limit_price: 0,
                 },
                 BatchTradeCpiLeg {
                     asset_index: 1,
+                    market_id: first_generation_market_id((1) as u16),
                     size_q: -size_q,
                     fee_bps: 100,
                     limit_price: 0,
@@ -53659,6 +53924,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
         ],
         data: ProgInstruction::TradeCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q,
             fee_bps: 100,
             limit_price: 0,
@@ -55154,6 +55420,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     program_pack::Pack,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
-    system_instruction,
+    system_instruction, system_program,
     transaction::Transaction,
 };
 use spl_token::state::{Account as TokenAccount, AccountState, Mint};
@@ -357,6 +357,10 @@ fn canonical_vault_ata(vault_authority: Pubkey, mint: Pubkey) -> Pubkey {
     .0
 }
 
+fn market_generation_pda(program_id: Pubkey, market: Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"market-generation", market.as_ref()], &program_id).0
+}
+
 fn make_token_data(mint: Pubkey, owner: Pubkey, amount: u64) -> Vec<u8> {
     let mut data = vec![0u8; TokenAccount::LEN];
     TokenAccount::pack(
@@ -505,6 +509,7 @@ struct V16CuEnv {
     payer: Keypair,
     admin: Keypair,
     market: Pubkey,
+    market_generation: Pubkey,
     mint: Pubkey,
     vault: Pubkey,
     vault_authority: Pubkey,
@@ -608,6 +613,7 @@ fn init_host_market_data_for_serializer_probe() -> Vec<u8> {
         &wrapper,
         engine_config,
         [9u8; 32],
+        1,
         params.initial_price,
         0,
     )
@@ -697,6 +703,7 @@ impl V16CuEnv {
         let payer = Keypair::new();
         let admin = Keypair::new();
         let market = Pubkey::new_unique();
+        let market_generation = market_generation_pda(program_id, market);
         let mint = Pubkey::new_unique();
         let vault_authority =
             Pubkey::find_program_address(&[b"vault", market.as_ref()], &program_id).0;
@@ -770,6 +777,8 @@ impl V16CuEnv {
                 AccountMeta::new(admin.pubkey(), true),
                 AccountMeta::new(market, false),
                 AccountMeta::new_readonly(mint, false),
+                AccountMeta::new(market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -780,6 +789,7 @@ impl V16CuEnv {
             payer,
             admin,
             market,
+            market_generation,
             mint,
             vault,
             vault_authority,
@@ -2280,6 +2290,8 @@ impl V16CuEnv {
                 AccountMeta::new_readonly(self.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(self.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&self.admin],
         )
@@ -3853,6 +3865,8 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
             AccountMeta::new_readonly(mint.pubkey(), false),
+            AccountMeta::new(market_generation_pda(program_id, market.pubkey()), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -4162,6 +4176,8 @@ fn init_independent_market_same_mint(
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -6020,6 +6036,301 @@ fn v16_attack_signed_trade_cannot_replay_across_asset_slot_reuse() {
         assert_eq!(leg_a.basis_pos_q, POS_SCALE as i128);
         assert_eq!(leg_b.basis_pos_q, -(POS_SCALE as i128));
     }
+}
+
+// Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
+// address reset every asset market_id to its first-generation value. Keep the original, fully
+// signed transaction object across that public lifecycle: rebuilding the instruction after reinit
+// would not prove an authorization replay. If accepted, the stale trade can reopen risk in newly
+// funded portfolios and an adverse mark transfers value from a signer who believed the old market
+// was gone.
+#[test]
+fn v16_attack_signed_trade_cannot_replay_across_market_reinit() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 50;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let params = V16CuMarketParams::default();
+    let mut env = V16CuEnv::new_with_init_params(params);
+    let initial_market_id = env.asset_market_id(0);
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("empty asset shuts down before generation rotation");
+    env.svm.warp_to_slot(3);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 3, PRICE)
+        .expect("empty asset restarts with a fresh engine generation");
+    env.configure_auth_mark_with_cu(3, PRICE);
+
+    let victim = Keypair::new();
+    let attacker = Keypair::new();
+    let victim_account = env.create_portfolio(&victim);
+    let attacker_account = env.create_portfolio(&attacker);
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&attacker, attacker_account, DEPOSIT);
+
+    let old_market_id = env.asset_market_id(0);
+    assert_ne!(old_market_id, initial_market_id);
+    assert_eq!(
+        state::read_market_generation(
+            &env.svm
+                .get_account(&env.market_generation)
+                .unwrap()
+                .data,
+        )
+        .unwrap()
+        .next_market_id
+        .get(),
+        old_market_id,
+        "the persistent counter is intentionally one generation behind until CloseSlab checkpoints the live engine"
+    );
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_account, false),
+            AccountMeta::new(attacker_account, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            market_id: old_market_id,
+            size_q: SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let stale_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim, &attacker],
+        env.svm.latest_blockhash(),
+    );
+
+    env.withdraw(&victim, victim_account, DEPOSIT);
+    env.withdraw(&attacker, attacker_account, DEPOSIT);
+    env.close_portfolio_with_cu(&victim, victim_account);
+    env.close_portfolio_with_cu(&attacker, attacker_account);
+    env.resolve();
+    env.close_slab_with_cu();
+    assert_eq!(env.svm.get_account(&env.market).unwrap().lamports, 0);
+    assert_eq!(
+        state::read_market_generation(&env.svm.get_account(&env.market_generation).unwrap().data,)
+            .unwrap()
+            .next_market_id
+            .get(),
+        old_market_id + 1,
+        "CloseSlab checkpoints all engine-side generation advances before deleting the slab"
+    );
+
+    let reinit_slot = 11;
+    env.svm.warp_to_slot(reinit_slot);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    env.send(
+        init_market_instruction(&reinit_params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("same market address is publicly reinitialized");
+    env.configure_auth_mark_with_cu(reinit_slot, PRICE);
+    assert_ne!(
+        env.asset_market_id(0),
+        old_market_id,
+        "a full-market reinit must consume the persisted next generation"
+    );
+
+    for (owner, portfolio) in [(&victim, victim_account), (&attacker, attacker_account)] {
+        env.svm
+            .set_account(
+                portfolio,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: vec![0u8; env.portfolio_account_len],
+                    owner: env.program_id,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let init_portfolio = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            data: ProgInstruction::InitPortfolio.encode(),
+        };
+        send_raw_ixs(
+            &mut env.svm,
+            &env.payer,
+            vec![
+                heap_ix(),
+                cu_ix(),
+                ComputeBudgetInstruction::set_compute_unit_price(1),
+                init_portfolio,
+            ],
+            &[owner],
+        )
+        .expect("same portfolio address is publicly reinitialized");
+    }
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&attacker, attacker_account, DEPOSIT);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_account).unwrap();
+    let attacker_before = env.svm.get_account(&attacker_account).unwrap();
+    let replay = env.svm.send_transaction(stale_trade);
+    if replay.is_ok() {
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(victim_account), 0).basis_pos_q,
+            SIZE_Q,
+            "the old signed intent reopened victim risk in the new market"
+        );
+        env.svm.warp_to_slot(reinit_slot + 1);
+        env.push_auth_mark_with_cu(reinit_slot + 1, ADVERSE_PRICE);
+        env.crank(
+            victim_account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: reinit_slot + 1,
+                observations: crank_observations(0),
+            },
+        );
+        let victim_after = env.portfolio_state(victim_account);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        assert!(
+            victim_equity < DEPOSIT as i128,
+            "the replayed position must expose newly deposited value to an adverse mark"
+        );
+        panic!(
+            "an old signed trade executed in a new market incarnation and reduced victim equity from {DEPOSIT} to {victim_equity}"
+        );
+    }
+
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale market-incarnation intent must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&victim_account).unwrap(), victim_before);
+    assert_eq!(
+        env.svm.get_account(&attacker_account).unwrap(),
+        attacker_before
+    );
+}
+
+#[test]
+fn v16_attack_prefunded_market_generation_pda_cannot_block_init() {
+    let mut env = V16CuEnv::new();
+    let params = V16CuMarketParams::default();
+    let market = Keypair::new();
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &market,
+        state::market_account_len_for_capacity(params.max_portfolio_assets as usize).unwrap(),
+        env.program_id,
+    );
+    let generation = market_generation_pda(env.program_id, market.pubkey());
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &generation, 1),
+        &[],
+    )
+    .expect("attacker can pre-fund the uninitialized generation PDA");
+    let prefunded = env.svm.get_account(&generation).unwrap();
+    assert_eq!(prefunded.owner, system_program::ID);
+    assert!(prefunded.data.is_empty());
+
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        init_market_instruction(&params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(market.pubkey(), false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("prefunded generation PDA is allocated and assigned during InitMarket");
+
+    let generation_account = env.svm.get_account(&generation).unwrap();
+    assert_eq!(generation_account.owner, env.program_id);
+    assert_eq!(
+        generation_account.data.len(),
+        state::market_generation_account_len()
+    );
+    assert_eq!(
+        state::read_market_generation(&generation_account.data)
+            .unwrap()
+            .next_market_id
+            .get(),
+        2
+    );
+    assert_eq!(
+        state::read_market(&env.svm.get_account(&market.pubkey()).unwrap().data)
+            .unwrap()
+            .1
+            .assets[0]
+            .market_id,
+        1
+    );
 }
 
 #[test]
@@ -8585,6 +8896,8 @@ fn v16_attack_sync_maintenance_rejects_cross_market_cranker_reward() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -22237,6 +22550,8 @@ fn v16_attack_cure_rejects_cross_market_portfolio_before_transfer() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -23076,6 +23391,8 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -23437,6 +23754,8 @@ fn v16_attack_insurance_ledger_market_binding_enforced() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -23681,6 +24000,8 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -23990,6 +24311,8 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -27644,6 +27967,8 @@ fn v16_attack_close_slab_requires_full_winddown() {
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&env.admin],
         )
@@ -27704,6 +28029,8 @@ fn v16_attack_close_slab_bad_primary_dest_is_atomic() {
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -27821,6 +28148,8 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
             AccountMeta::new_readonly(env.vault_authority, false),
             AccountMeta::new(stale_dest, false),
             AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&old_admin],
     );
@@ -27858,6 +28187,8 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
             AccountMeta::new_readonly(env.vault_authority, false),
             AccountMeta::new(new_dest, false),
             AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&new_admin],
     );
@@ -27973,6 +28304,8 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(market_generation_pda(program_id, market.pubkey()), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -28038,6 +28371,8 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
             AccountMeta::new_readonly(vault_authority, false),
             AccountMeta::new(dest, false),
             AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(market_generation_pda(program_id, market.pubkey()), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&market],
     );
@@ -28131,6 +28466,8 @@ fn v16_attack_close_slab_rejects_delegated_or_closable_primary_vault() {
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         );
@@ -28166,6 +28503,8 @@ fn v16_attack_close_slab_rejects_delegated_or_closable_primary_vault() {
             AccountMeta::new_readonly(env.vault_authority, false),
             AccountMeta::new(dest, false),
             AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );
@@ -28252,6 +28591,8 @@ fn v16_attack_close_slab_rejects_foreign_primary_vault() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -28275,6 +28616,8 @@ fn v16_attack_close_slab_rejects_foreign_primary_vault() {
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -30198,6 +30541,8 @@ fn v16_attack_cross_market_portfolio_cannot_drain_foreign_vault() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -30801,6 +31146,8 @@ fn v16_attack_close_resolved_rejects_cross_market_portfolio_payout() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -31056,6 +31403,8 @@ fn v16_attack_claim_resolved_topup_rejects_cross_market_portfolio_payout() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -31309,6 +31658,8 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -36192,6 +36543,8 @@ fn v16_attack_swap_secondary_rejects_foreign_market_vault() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -36380,6 +36733,8 @@ fn v16_attack_close_slab_requires_secondary_vault_recovery() {
             AccountMeta::new_readonly(spl_token::ID, false),
             AccountMeta::new(secondary_vault, false),
             AccountMeta::new(wrong_secondary_dest, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );
@@ -36427,6 +36782,8 @@ fn v16_attack_close_slab_requires_secondary_vault_recovery() {
             AccountMeta::new_readonly(spl_token::ID, false),
             AccountMeta::new(secondary_vault, false),
             AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );
@@ -36530,6 +36887,8 @@ fn v16_attack_close_slab_rejects_foreign_secondary_vault() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     )
@@ -36591,6 +36950,8 @@ fn v16_attack_close_slab_rejects_foreign_secondary_vault() {
                     AccountMeta::new_readonly(spl_token::ID, false),
                     AccountMeta::new(secondary_vault, false),
                     AccountMeta::new(secondary_dest, false),
+                    AccountMeta::new(env.market_generation, false),
+                    AccountMeta::new_readonly(system_program::ID, false),
                 ],
                 &[&admin],
             )
@@ -39876,6 +40237,8 @@ fn v16_attack_liquidation_rejects_cross_market_cranker_reward() {
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(market_generation_pda(env.program_id, market_b), false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&env.admin],
     )
@@ -47375,6 +47738,8 @@ fn v16_attack_scheduled_close_cannot_strand_funds_then_reclaims() {
                 AccountMeta::new_readonly(vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -52843,6 +53208,11 @@ fn v16_attack_init_market_rejects_grief_config_without_burning_market_account() 
                 AccountMeta::new(admin.pubkey(), true),
                 AccountMeta::new(market.pubkey(), false),
                 AccountMeta::new_readonly(env.mint, false),
+                AccountMeta::new(
+                    market_generation_pda(env.program_id, market.pubkey()),
+                    false,
+                ),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         );
@@ -52868,6 +53238,11 @@ fn v16_attack_init_market_rejects_grief_config_without_burning_market_account() 
                 AccountMeta::new(admin.pubkey(), true),
                 AccountMeta::new(market.pubkey(), false),
                 AccountMeta::new_readonly(env.mint, false),
+                AccountMeta::new(
+                    market_generation_pda(env.program_id, market.pubkey()),
+                    false,
+                ),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -52971,6 +53346,8 @@ fn v16_attack_init_market_cannot_reinitialize_funded_market() {
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
             AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );
@@ -53039,6 +53416,8 @@ fn v16_attack_init_market_cannot_reinitialize_empty_market_or_seize_authority() 
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new(env.market, false),
             AccountMeta::new_readonly(attacker_mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&attacker],
     );
@@ -53345,6 +53724,8 @@ fn v16_attack_abandoned_empty_portfolio_cannot_block_slab_close() {
                 AccountMeta::new_readonly(env.vault_authority, false),
                 AccountMeta::new(dest, false),
                 AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
             ],
             &[&admin],
         )
@@ -59023,6 +59404,8 @@ fn v16_attack_close_slab_rejects_closable_secondary_vault_before_reclaim() {
             AccountMeta::new_readonly(spl_token::ID, false),
             AccountMeta::new(secondary_vault, false),
             AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );
@@ -59078,6 +59461,8 @@ fn v16_attack_close_slab_rejects_closable_secondary_vault_before_reclaim() {
             AccountMeta::new_readonly(spl_token::ID, false),
             AccountMeta::new(secondary_vault, false),
             AccountMeta::new(secondary_dest, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         &[&admin],
     );

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1054,11 +1054,13 @@ impl V16CuEnv {
 
     fn update_asset_authority_with_cu(&mut self, new_authority: &Keypair) -> u64 {
         self.ensure_signer_account(new_authority.pubkey());
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::UpdateAuthority {
+                market_id,
                 new_pubkey: new_authority.pubkey().to_bytes(),
             },
             vec![
@@ -1088,9 +1090,11 @@ impl V16CuEnv {
         } else {
             self.payer.pubkey()
         };
+        let market_id = self.asset_market_id(asset_index);
         self.send(
             ProgInstruction::UpdateAssetAuthority {
                 asset_index,
+                market_id,
                 kind,
                 new_pubkey,
             },
@@ -6038,6 +6042,140 @@ fn v16_attack_signed_trade_cannot_replay_across_asset_slot_reuse() {
     }
 }
 
+// UpdateAssetAuthority has the same attacker-held signature shape as UpdateAuthority: the incoming
+// non-zero authority co-signs. Retiring and restarting an asset must invalidate an old rotation, or
+// the incoming oracle authority can take control of a replacement generation and move value against
+// positions that did not exist when the transaction was signed.
+#[test]
+fn v16_attack_signed_asset_authority_rotation_cannot_replay_after_restart() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 50;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let attacker = Keypair::new();
+    env.ensure_signer_account(attacker.pubkey());
+    let old_market_id = env.asset_market_id(0);
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::UpdateAssetAuthority {
+            asset_index: 0,
+            market_id: old_market_id,
+            kind: processor::ASSET_AUTH_ORACLE,
+            new_pubkey: attacker.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let stale_rotation = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin, &attacker],
+        env.svm.latest_blockhash(),
+    );
+
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(1);
+    env.try_shutdown_asset_with_authority(&admin, 0, 1)
+        .expect("empty asset shuts down");
+    env.svm.warp_to_slot(2);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 2, PRICE)
+        .expect("asset restarts");
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+    env.configure_auth_mark_with_cu(2, PRICE);
+
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let attacker_portfolio = env.create_portfolio(&attacker);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &attacker,
+        attacker_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let attacker_before = env.svm.get_account(&attacker_portfolio).unwrap();
+
+    let replay = env.svm.send_transaction(stale_rotation);
+    if replay.is_ok() {
+        assert_eq!(
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+                .unwrap()
+                .oracle_authority,
+            attacker.pubkey().to_bytes(),
+            "the retained rotation seized the replacement generation's oracle"
+        );
+        env.svm.warp_to_slot(3);
+        env.push_auth_mark_for_asset_with_authority(0, &attacker, 3, ADVERSE_PRICE);
+        env.crank(
+            victim_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(0),
+            },
+        );
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        assert!(
+            victim_equity < DEPOSIT as i128,
+            "the seized oracle must move value against fresh exposure"
+        );
+        panic!(
+            "an attacker replayed an old asset-authority rotation and reduced victim equity from {DEPOSIT} to {victim_equity}"
+        );
+    }
+
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale asset-authority intent must fail with {expected_error}, got {replay_error}"
+    );
+
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_portfolio).unwrap(),
+        attacker_before
+    );
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: 0,
+            market_id: new_market_id,
+            kind: processor::ASSET_AUTH_ORACLE,
+            new_pubkey: attacker.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin, &attacker],
+    )
+    .expect("the same rotation remains live when signed for the current asset generation");
+}
+
 // Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
 // address reset every asset market_id to its first-generation value. Keep the original, fully
 // signed transaction object across that public lifecycle: rebuilding the instruction after reinit
@@ -6265,6 +6403,156 @@ fn v16_attack_signed_trade_cannot_replay_across_market_reinit() {
         env.svm.get_account(&attacker_account).unwrap(),
         attacker_before
     );
+}
+
+// The incoming market authority co-signs UpdateAuthority and therefore necessarily possesses the
+// complete transaction. A full market close/reinit must invalidate that old capability just as it
+// invalidates an old signed trade. Otherwise the incoming authority can seize and resolve a newly
+// funded incarnation at the same address.
+#[test]
+fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
+    let params = V16CuMarketParams::default();
+    let mut env = V16CuEnv::new_with_init_params(params);
+    let admin = env.admin.insecure_clone();
+    let attacker = Keypair::new();
+    env.ensure_signer_account(attacker.pubkey());
+
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::UpdateAuthority {
+            market_id: env.asset_market_id(0),
+            new_pubkey: attacker.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let stale_rotation = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin, &attacker],
+        env.svm.latest_blockhash(),
+    );
+
+    env.resolve();
+    env.close_slab_with_cu();
+    assert_eq!(env.svm.get_account(&env.market).unwrap().lamports, 0);
+
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    env.send(
+        init_market_instruction(&reinit_params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("same market address is publicly reinitialized");
+
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    env.deposit(&victim, victim_portfolio, 1_000_000);
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+
+    let replay = env.svm.send_transaction(stale_rotation);
+    if replay.is_ok() {
+        assert_eq!(
+            env.market_state().0.marketauth,
+            attacker.pubkey().to_bytes(),
+            "the retained old rotation seized the fresh market"
+        );
+        let forced_resolve = send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::ResolveMarket,
+            vec![
+                AccountMeta::new(attacker.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&attacker],
+        );
+        assert!(
+            forced_resolve.is_ok(),
+            "the replayed authority must be operational: {forced_resolve:?}"
+        );
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+        panic!("an attacker replayed an old co-signed rotation and resolved a newly funded market");
+    }
+
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale market-authority intent must fail with {expected_error}, got {replay_error}"
+    );
+
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+    let current_market_id = env.asset_market_id(0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAuthority {
+            market_id: current_market_id,
+            new_pubkey: attacker.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin, &attacker],
+    )
+    .expect("the same rotation remains live when signed for the current market generation");
 }
 
 #[test]
@@ -26119,6 +26407,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: victim.pubkey().to_bytes(),
         },
         vec![
@@ -26147,6 +26436,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: new_asset.pubkey().to_bytes(),
         },
         vec![
@@ -26179,6 +26469,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: env.admin.pubkey().to_bytes(),
         },
         vec![
@@ -26212,6 +26503,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         &env.payer,
         ProgInstruction::UpdateAssetAuthority {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: victim.pubkey().to_bytes(),
         },
@@ -26241,6 +26533,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         &env.payer,
         ProgInstruction::UpdateAssetAuthority {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: new_ins.pubkey().to_bytes(),
         },
@@ -28317,6 +28610,7 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
         program_id,
         &payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: market.pubkey().to_bytes(),
         },
         vec![
@@ -43989,6 +44283,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: mallory.pubkey().to_bytes(),
         },
         vec![
@@ -44017,6 +44312,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         &env.payer,
         ProgInstruction::UpdateAssetAuthority {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: mallory.pubkey().to_bytes(),
         },
@@ -44053,6 +44349,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: new_admin.pubkey().to_bytes(),
         },
         vec![
@@ -44091,6 +44388,7 @@ fn v16_attack_marketauth_renounce_rejected_even_with_fallback() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: [0u8; 32],
         },
         vec![
@@ -44120,6 +44418,7 @@ fn v16_attack_marketauth_renounce_rejected_even_with_fallback() {
         env.program_id,
         &env.payer,
         ProgInstruction::UpdateAuthority {
+            market_id: first_generation_market_id(0),
             new_pubkey: [0u8; 32],
         },
         vec![
@@ -45380,6 +45679,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         if let Some(k) = co {
             signers.push(k);
         }
+        let market_id = env.asset_market_id(ai);
         env.svm.expire_blockhash();
         send_tx(
             &mut env.svm,
@@ -45387,6 +45687,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
             &env.payer,
             ProgInstruction::UpdateAssetAuthority {
                 asset_index: ai,
+                market_id,
                 kind,
                 new_pubkey: new,
             },
@@ -45597,6 +45898,7 @@ fn v16_attack_update_asset_authority_rejects_zero_domain_authority() {
             &env.payer,
             ProgInstruction::UpdateAssetAuthority {
                 asset_index: 0,
+                market_id: first_generation_market_id(0),
                 kind,
                 new_pubkey: [0u8; 32],
             },
@@ -58437,6 +58739,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     let rot = env.send(
         ProgInstruction::UpdateAssetAuthority {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
             new_pubkey: newauth.pubkey().to_bytes(),
         },

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -602,6 +602,7 @@ fn kani_v16_legacy_permissionless_crank_size_payload_is_rejected() {
 
 #[kani::proof]
 fn kani_v16_update_authority_decode_preserves_wire_fields() {
+    let market_id: u64 = kani::any();
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;
     while i < 32 {
@@ -609,14 +610,17 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 33];
+    let mut data = [0u8; 41];
     data[0] = 32;
-    data[1..33].copy_from_slice(&new_pubkey);
+    data[1..9].copy_from_slice(&market_id.to_le_bytes());
+    data[9..41].copy_from_slice(&new_pubkey);
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateAuthority {
+            market_id: got_market_id,
             new_pubkey: got_pubkey,
         } => {
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_pubkey, new_pubkey);
         }
         _ => unreachable!(),
@@ -626,6 +630,7 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let kind: u8 = kani::any();
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;
@@ -634,24 +639,38 @@ fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 36];
+    let mut data = [0u8; 44];
     data[0] = 65;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3] = kind;
-    data[4..36].copy_from_slice(&new_pubkey);
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11] = kind;
+    data[12..44].copy_from_slice(&new_pubkey);
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateAssetAuthority {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             kind: got_kind,
             new_pubkey: got_pubkey,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_kind, kind);
             assert_eq!(got_pubkey, new_pubkey);
         }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_authority_payloads_are_rejected() {
+    let mut legacy_market: [u8; 33] = kani::any();
+    legacy_market[0] = 32;
+    let mut legacy_asset: [u8; 36] = kani::any();
+    legacy_asset[0] = 65;
+
+    assert!(Instruction::decode(&legacy_market).is_err());
+    assert!(Instruction::decode(&legacy_asset).is_err());
 }
 
 #[kani::proof]
@@ -1216,6 +1235,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(Instruction::ResolveMarket, extra);
     assert_rejects_trailing_byte(
         Instruction::UpdateAuthority {
+            market_id: 1,
             new_pubkey: [1u8; 32],
         },
         extra,
@@ -1223,6 +1243,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::UpdateAssetAuthority {
             asset_index: 1,
+            market_id: 2,
             kind: 0,
             new_pubkey: [1u8; 32],
         },

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -385,25 +385,29 @@ fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 43];
     data[0] = 6;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&exec_price.to_le_bytes());
-    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11..27].copy_from_slice(&size_q.to_le_bytes());
+    data[27..35].copy_from_slice(&exec_price.to_le_bytes());
+    data[35..43].copy_from_slice(&fee_bps.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeNoCpi {
             asset_index: got_asset,
+            market_id: got_market_id,
             size_q: got_size,
             exec_price: got_price,
             fee_bps: got_fee,
         } => {
             assert_eq!(got_asset, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_size, size_q);
             assert_eq!(got_price, exec_price);
             assert_eq!(got_fee, fee_bps);
@@ -415,25 +419,29 @@ fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_tradecpi_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let size_q: i128 = kani::any();
     let fee_bps: u64 = kani::any();
     let limit_price: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 43];
     data[0] = 10;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&fee_bps.to_le_bytes());
-    data[27..35].copy_from_slice(&limit_price.to_le_bytes());
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11..27].copy_from_slice(&size_q.to_le_bytes());
+    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[35..43].copy_from_slice(&limit_price.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeCpi {
             asset_index: got_asset,
+            market_id: got_market_id,
             size_q: got_size,
             fee_bps: got_fee,
             limit_price: got_limit,
         } => {
             assert_eq!(got_asset, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_size, size_q);
             assert_eq!(got_fee, fee_bps);
             assert_eq!(got_limit, limit_price);
@@ -674,8 +682,9 @@ fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
-fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle() {
+fn kani_v16_batch_trade_decodes_preserve_generation_ids() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
@@ -683,6 +692,7 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
     let data = Instruction::BatchTradeNoCpi {
         legs: vec![percolator_prog::ix::BatchTradeLeg {
             asset_index,
+            market_id,
             size_q,
             exec_price,
             fee_bps,
@@ -695,12 +705,53 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
         Instruction::BatchTradeNoCpi { legs } => {
             assert_eq!(legs.len(), 1);
             assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].market_id, market_id);
             assert_eq!(legs[0].size_q, size_q);
             assert_eq!(legs[0].exec_price, exec_price);
             assert_eq!(legs[0].fee_bps, fee_bps);
         }
         _ => unreachable!(),
     }
+
+    let cpi_data = Instruction::BatchTradeCpi {
+        legs: vec![percolator_prog::ix::BatchTradeCpiLeg {
+            asset_index,
+            market_id,
+            size_q,
+            fee_bps,
+            limit_price: exec_price,
+        }],
+    }
+    .encode();
+
+    assert_eq!(cpi_data[0], 67);
+    match Instruction::decode(&cpi_data).unwrap() {
+        Instruction::BatchTradeCpi { legs } => {
+            assert_eq!(legs.len(), 1);
+            assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].market_id, market_id);
+            assert_eq!(legs[0].size_q, size_q);
+            assert_eq!(legs[0].fee_bps, fee_bps);
+            assert_eq!(legs[0].limit_price, exec_price);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_trade_payloads_are_rejected() {
+    let mut single: [u8; 35] = kani::any();
+    single[0] = 6;
+    assert!(Instruction::decode(&single).is_err());
+    single[0] = 10;
+    assert!(Instruction::decode(&single).is_err());
+
+    let mut batch: [u8; 36] = kani::any();
+    batch[0] = 66;
+    batch[1] = 1;
+    assert!(Instruction::decode(&batch).is_err());
+    batch[0] = 67;
+    assert!(Instruction::decode(&batch).is_err());
 }
 
 #[kani::proof]
@@ -870,6 +921,7 @@ fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let oracle_leg_count: u8 = kani::any();
@@ -940,7 +992,9 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
             assert_eq!(got_invert, invert);
             assert_eq!(got_unit_scale, unit_scale);
             assert_eq!(got_conf, conf_filter_bps);
-            assert_eq!(got_feeds, feeds);
+            assert_eq!(got_feeds[0], feeds[0]);
+            assert_eq!(got_feeds[1], feeds[1]);
+            assert_eq!(got_feeds[2], feeds[2]);
         }
         _ => unreachable!(),
     }
@@ -1081,6 +1135,7 @@ fn kani_v16_init_market_payload_rejects_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_custody_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1115,6 +1170,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1131,6 +1187,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::TradeNoCpi {
             asset_index: 0,
+            market_id: 1,
             size_q: 1,
             exec_price: 100,
             fee_bps: 0,
@@ -1140,6 +1197,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::TradeCpi {
             asset_index: 0,
+            market_id: 1,
             size_q: 1,
             fee_bps: 0,
             limit_price: 0,
@@ -1150,6 +1208,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1345,6 +1404,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_unknown_or_truncated_tags_reject() {
     let tag: u8 = kani::any();
     kani::assume(tag != 0);
@@ -1408,6 +1468,7 @@ fn kani_v16_zero_length_decode_rejects() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let init_market = [0u8; 80];
     assert!(Instruction::decode(&init_market).is_err());
@@ -1424,10 +1485,10 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let asset_lifecycle = [40u8; 147];
     assert!(Instruction::decode(&asset_lifecycle).is_err());
 
-    let trade = [6u8; 33];
+    let trade = [6u8; 42];
     assert!(Instruction::decode(&trade).is_err());
 
-    let trade_cpi = [10u8; 33];
+    let trade_cpi = [10u8; 42];
     assert!(Instruction::decode(&trade_cpi).is_err());
 
     let top_up = [9u8; 16];


### PR DESCRIPTION
## What changed

- Add the current asset `market_id` to the signed wire format for `TradeNoCpi`, `TradeCpi`, `BatchTradeNoCpi`, and `BatchTradeCpi`.
- Add the expected generation to the co-signed `UpdateAuthority` and `UpdateAssetAuthority` payloads.
- Reject a generation mismatch before matcher CPI, authority-profile access, or state mutation.
- Persist the next market generation in a 56-byte program-owned PDA keyed by the market address.
- Reserve initial asset IDs from that PDA during `InitMarket` and checkpoint engine-side generation advances during `CloseSlab` before the slab is deleted.
- Allocate and assign a pre-funded system-owned generation PDA so a one-lamport transfer cannot block market initialization.
- Reject legacy signed payloads that do not bind an asset generation.

## Root cause and impact

Asset indices are reusable, but signed instructions previously identified an asset only by `asset_index`, or identified a market only by its account address. A retained transaction signed for generation A could therefore execute after that slot or the full market account had been retired and recreated as generation B.

The public LiteSVM TDD probes demonstrate three concrete attacks using the exact retained transaction object:

- All four trade routes could reopen victim risk after an asset generation changed.
- After `CloseSlab` and same-address `InitMarket`, a retained co-signed `UpdateAuthority` seized `marketauth` and let the attacker resolve a newly funded live market: total market DoS.
- After asset shutdown/restart, a retained co-signed `UpdateAssetAuthority` seized the replacement oracle authority. Moving the mark reduced fresh victim equity from 1,000,000 to 750,000 atoms.
- The full-market trade replay likewise reduced fresh victim equity from 1,000,000 to 750,000 atoms.

The authority cases do not depend on a compromised RPC guessing private intent: the incoming authority is required to co-sign, so the attacker necessarily possesses the complete valid transaction and can withhold it. Every exploit instruction returns `Ok`; SVM rollback does not mitigate the issue.

Portfolio generation tags do not prevent these attacks because the engine receives an otherwise valid request for the current slot. The signed request itself must bind the generation, and the generation namespace must survive market-account deletion.

## ABI and migration

This is a trade, authority-rotation, and lifecycle ABI change:

- Trade clients must read and sign each leg's current `market_id`.
- `UpdateAuthority` must carry asset 0's current `market_id`.
- `UpdateAssetAuthority` must carry the target asset's current `market_id`.
- `InitMarket` and `CloseSlab` must pass the generation PDA plus System Program.
- Old unbound payloads fail closed.

Live markets created before this change migrate when `CloseSlab` checkpoints their current engine counter. A market address whose slab was already deleted before deployment has no recoverable generation history and must not be reused; initialize a fresh market address instead.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 5 unit tests and 568/568 LiteSVM/CU tests passed
- Both new public authority-replay TDD tests pass and verify exact `AssetGenerationMismatch`, byte-for-byte rollback, and successful current-generation rotations
- 3/3 new authority Kani harnesses passed: market-authority field preservation, asset-authority field preservation, and arbitrary legacy unbound-payload rejection
- Existing focused trade-generation Kani harnesses passed in the prior commits
- `cargo fmt --check`
- `git diff --check`

The broad pre-existing aggregate admin trailing-byte harness was also attempted, but remained in generic decoder-loop symbolic expansion until interrupted. The three narrow payload proofs above complete the changed authority ABI without relying on that aggregate harness. The repository-wide Kani command has the same existing decoder-expansion limitation documented by PR 135.

Engine pin remains `143e68c4917ed0400a27b952f036a5677047cd84`.
