### PR TITLE
Keep unrelated epochs from blocking large exits

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10891,6 +10891,76 @@ pub mod processor {
         Ok(0)
     }
 
+    fn portfolio_active_legs_are_settlement_current_view(
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+    ) -> Result<bool, ProgramError> {
+        let active_bitmap = portfolio
+            .header
+            .active_bitmap
+            .map(percolator::V16PodU64::get);
+        let configured_assets = group.header.config.max_market_slots.get() as usize;
+        let mut slot = 0usize;
+        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            let bit = percolator::active_bitmap_get(active_bitmap, slot);
+            if bit != leg.active {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            if !leg.active {
+                slot += 1;
+                continue;
+            }
+            let asset_index = leg.asset_index as usize;
+            if asset_index >= configured_assets || asset_index >= group.markets.len() {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            let asset = group.markets[asset_index]
+                .engine
+                .asset
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            if leg.market_id != asset.market_id
+                || !matches!(
+                    asset.lifecycle,
+                    percolator::AssetLifecycleV16::Active
+                        | percolator::AssetLifecycleV16::DrainOnly
+                        | percolator::AssetLifecycleV16::Recovery
+                )
+            {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            let (side_epoch, k_target, f_target, b_target) = match leg.side {
+                SideV16::Long => (
+                    asset.epoch_long,
+                    asset.k_long,
+                    asset.f_long_num,
+                    asset.b_long_num,
+                ),
+                SideV16::Short => (
+                    asset.epoch_short,
+                    asset.k_short,
+                    asset.f_short_num,
+                    asset.b_short_num,
+                ),
+            };
+            if leg.stale
+                || leg.b_stale
+                || leg.epoch_snap != side_epoch
+                || leg.b_epoch_snap != side_epoch
+                || leg.k_snap != k_target
+                || leg.f_snap != f_target
+                || leg.b_snap != b_target
+            {
+                return Ok(false);
+            }
+            slot += 1;
+        }
+        Ok(true)
+    }
+
     fn ensure_trade_portfolio_current_for_requests_view(
         group: &state::MarketViewMutV16<'_>,
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
@@ -10937,12 +11007,15 @@ pub mod processor {
         if portfolio.header.stale_state != 0 {
             return Err(PercolatorError::EngineStale.into());
         }
-        if !cert.valid
-            || cert.cert_oracle_epoch != group.header.oracle_epoch.get()
-            || cert.cert_funding_epoch != group.header.funding_epoch.get()
-            || cert.cert_risk_epoch != group.header.risk_epoch.get()
-            || cert.cert_asset_set_epoch != group.header.asset_set_epoch.get()
-            || cert.active_bitmap_at_cert != active_bitmap
+        if !cert.valid || cert.active_bitmap_at_cert != active_bitmap {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        let cert_epochs_current = cert.cert_oracle_epoch == group.header.oracle_epoch.get()
+            && cert.cert_funding_epoch == group.header.funding_epoch.get()
+            && cert.cert_risk_epoch == group.header.risk_epoch.get()
+            && cert.cert_asset_set_epoch == group.header.asset_set_epoch.get();
+        if !cert_epochs_current
+            && !portfolio_active_legs_are_settlement_current_view(group, portfolio)?
         {
             return Err(PercolatorError::EngineStale.into());
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7926,6 +7926,165 @@ fn v16_attack_target_only_lag_invalidates_unrelated_single_trade_cert() {
     assert_eq!(short_cert.certified_maintenance_req, 1_100);
 }
 
+// A permissionless asset authority can advance the market-wide oracle epoch without changing any
+// asset held by another portfolio. That global invalidation must not force an otherwise current
+// large user through a pre-crank race when the engine can recertify and reduce one leg in-budget.
+#[test]
+fn v16_attack_unrelated_permissionless_epoch_cannot_block_eight_leg_exit() {
+    const VICTIM_LEGS: usize = 8;
+    const PRICE: u64 = 100;
+    const ATTACK_PRICE: u64 = 105;
+
+    let mut env =
+        V16CuEnv::new_with_market_params_and_price_move(VICTIM_LEGS as u16, 1_000, 1_000, 500);
+    env.update_market_init_fee_policy_with_cu(1);
+    env.svm.warp_to_slot(1);
+
+    let attacker = Keypair::new();
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        VICTIM_LEGS as u16,
+        1,
+        PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(VICTIM_LEGS as u16, &attacker, 1, PRICE);
+
+    let attacker_counterparty = Keypair::new();
+    let attacker_account = env.create_portfolio(&attacker);
+    let attacker_counterparty_account = env.create_portfolio(&attacker_counterparty);
+    env.deposit(&attacker, attacker_account, 1_000_000);
+    env.deposit(
+        &attacker_counterparty,
+        attacker_counterparty_account,
+        1_000_000,
+    );
+    env.trade_asset_with_cu(
+        VICTIM_LEGS as u16,
+        &attacker,
+        attacker_account,
+        &attacker_counterparty,
+        attacker_counterparty_account,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    let victim_long_owner = Keypair::new();
+    let victim_short_owner = Keypair::new();
+    let victim_long = env.create_portfolio(&victim_long_owner);
+    let victim_short = env.create_portfolio(&victim_short_owner);
+    env.deposit(&victim_long_owner, victim_long, 100_000_000);
+    env.deposit(&victim_short_owner, victim_short, 100_000_000);
+    let open_legs: Vec<BatchTradeLeg> = (0..VICTIM_LEGS as u16)
+        .map(|asset_index| BatchTradeLeg {
+            asset_index,
+            size_q: POS_SCALE as i128,
+            exec_price: PRICE,
+            fee_bps: 0,
+        })
+        .collect();
+    env.send(
+        ProgInstruction::BatchTradeNoCpi { legs: open_legs },
+        vec![
+            AccountMeta::new(victim_long_owner.pubkey(), true),
+            AccountMeta::new(victim_short_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_long, false),
+            AccountMeta::new(victim_short, false),
+        ],
+        &[&victim_long_owner, &victim_short_owner],
+    )
+    .expect("public setup opens the victim's eight current legs");
+
+    let (_, group_before_attack) = env.market_state();
+    for victim in [victim_long, victim_short] {
+        let account = env.portfolio_state(victim);
+        assert_eq!(
+            percolator::active_bitmap_count_ones(active_bitmap(&account)),
+            VICTIM_LEGS as u32,
+        );
+        let cert = health_cert(&account);
+        assert!(cert.valid);
+        assert_eq!(cert.cert_oracle_epoch, group_before_attack.oracle_epoch);
+        assert_eq!(account.stale_state, 0);
+        assert_eq!(account.b_stale_state, 0);
+    }
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_with_authority(VICTIM_LEGS as u16, &attacker, 2, ATTACK_PRICE);
+    env.crank(
+        attacker_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(VICTIM_LEGS as u16),
+        },
+    );
+
+    let (_, group_after_attack) = env.market_state();
+    assert!(
+        group_after_attack.oracle_epoch > group_before_attack.oracle_epoch,
+        "the attacker-controlled asset advances the global oracle epoch",
+    );
+    for asset_index in 0..VICTIM_LEGS {
+        assert_eq!(
+            group_after_attack.assets[asset_index].effective_price,
+            group_before_attack.assets[asset_index].effective_price,
+            "the attacker did not move victim-held asset {asset_index}",
+        );
+        assert_eq!(
+            group_after_attack.assets[asset_index].slot_last,
+            group_before_attack.assets[asset_index].slot_last,
+            "the attacker did not accrue victim-held asset {asset_index}",
+        );
+    }
+    for victim in [victim_long, victim_short] {
+        let account = env.portfolio_state(victim);
+        let cert = health_cert(&account);
+        assert!(cert.valid);
+        assert!(cert.cert_oracle_epoch < group_after_attack.oracle_epoch);
+        assert_eq!(cert.cert_funding_epoch, group_after_attack.funding_epoch);
+        assert!(cert.cert_risk_epoch < group_after_attack.risk_epoch);
+        assert_eq!(
+            cert.cert_asset_set_epoch,
+            group_after_attack.asset_set_epoch
+        );
+        assert_eq!(account.stale_state, 0);
+        assert_eq!(account.b_stale_state, 0);
+    }
+
+    env.svm.expire_blockhash();
+    let exit_cu = env
+        .try_trade_asset_with_cu(
+            0,
+            &victim_long_owner,
+            victim_long,
+            &victim_short_owner,
+            victim_short,
+            -(POS_SCALE as i128),
+            PRICE,
+            0,
+        )
+        .expect("an unrelated epoch bump must not block the current eight-leg exit");
+    println!("v16 unrelated epoch eight-leg exit CU: {exit_cu}");
+    assert!(
+        exit_cu < 1_400_000,
+        "eight-leg exit exceeded tx CU: {exit_cu}"
+    );
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(victim_long),
+        0,
+    ));
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(victim_short),
+        0,
+    ));
+}
+
 #[test]
 fn v16_bpf_trade_refreshes_stale_related_portfolio_leg_on_demand() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(4, 1_000, 1_000, 500);


### PR DESCRIPTION
## Finding

A permissionless asset authority can move its own exposed AuthMark asset and advance the market-wide oracle and risk epochs. On current main, that invalidates otherwise valid certificates for unrelated portfolios. For portfolios with eight or more active legs, the wrapper rejects a valid risk-reducing trade with `EngineStale` before the engine can recertify it.

This is a public partial-DoS / ordering-grief vector, not a total permanent freeze: a separate pre-crank can recover, but an attacker-controlled unrelated asset can invalidate the certificate between the pre-crank and the user's trade.

The TDD test uses only public wrapper instructions and normal account construction. No market or portfolio state is injected. On unmodified main it fails with `Custom(19)` after roughly 102k CU.

## Fix

When a large portfolio has a valid certificate bound to its current active bitmap but only its global epochs are stale, scan the fixed-size active-leg set before rejecting. The wrapper lets the engine recertify inline only when every active leg is already settlement-current for its market generation, lifecycle, side epoch, and K/F/B snapshots.

Actual local settlement staleness still returns `EngineStale` and retains the public pre-crank path, preserving the existing protection against the 2N stale-settlement CU cliff.

The repaired public eight-leg exit consumes 559,365 CU.

## Validation

- `cargo build-sbf --no-default-features`
- `cargo test`: 5 unit tests and 564 LiteSVM tests passed
- `v16_bpf_stale_full_14_leg_tradenocpi_rejects_before_cu_cliff`
- `v16_bpf_current_full_14_leg_tradenocpi_is_under_tx_limit`
- `v16_bpf_full_14_leg_refresh_crank_is_under_tx_limit`

`cargo clippy --all-targets -- -D warnings` remains blocked by 19 pre-existing warnings outside this change.