### PR TITLE
[PRIVILEGED LoF] Lock live insurance while users remain exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ There are two different insurance withdrawal surfaces:
 - live `WithdrawInsuranceAsset`, which is a per-asset operator path bounded by that asset's funded
   long+short insurance budget
 
-Live insurance withdrawal is intentionally stricter. It is expected to be allowed only when the live market is flat or loss-current, target/effective-lag-free, stress-free, h-lock-free, and has non-negative senior residual. In other words, live insurance can be withdrawn from an empty or fully healthy market, but not while the insurance fund is still protecting unresolved loss or bankruptcy work.
+Live insurance withdrawal is intentionally stricter. It is allowed only when the target asset is empty of positions and unresolved loss state, target/effective-lag-free, stress-free, h-lock-free, and has non-negative senior residual. The market account cannot prove that every exposed portfolio has absorbed the latest oracle epoch, so insurance remains locked while users have exposure and can only be released once it is no longer protecting loss or bankruptcy work.
 
 ### Product intuition
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8063,6 +8063,13 @@ pub mod processor {
             let ledger_authority = if live_mode {
                 let shutdown_drain =
                     live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
+                // The market account cannot enumerate portfolios to prove that every account has
+                // absorbed the latest oracle epoch. Keep live insurance locked while this asset has
+                // any position or unresolved loss state; otherwise an operator can withdraw the
+                // reserve after a mark is accrued by another account but before the loser refreshes.
+                if asset_local_has_position_or_loss_state_view(&group, asset_index) {
+                    return Err(PercolatorError::EngineLockActive.into());
+                }
                 let local_authorized =
                     live_authority_matches(&authorities.insurance_operator, operator.key);
                 let admin_shutdown_authorized = asset_index != 0

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,104 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+#[test]
+fn v16_attack_live_insurance_withdraw_rejects_unsettled_stale_certificate_loss() {
+    const OPEN_PRICE: u64 = 100;
+    const INSURANCE: u128 = 500;
+
+    let mut env = V16CuEnv::new();
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, OPEN_PRICE);
+    let admin = env.admin.insecure_clone();
+    env.top_up_insurance_domain_with_authority(&admin, 0, INSURANCE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let cranker_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    let cranker = env.create_portfolio(&cranker_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 250);
+    env.trade_with_cu(
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        OPEN_PRICE,
+        0,
+    );
+
+    // A different account fully accrues the authenticated move. The asset-level
+    // stale and target-lag gates are now clear even though the losing account has
+    // not settled the new oracle epoch.
+    for (slot, mark) in [(2u64, 200u64), (3, 400), (4, 800)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, mark);
+        env.crank(
+            cranker,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+
+    let before_withdraw = env.market_state().1;
+    let stale_short = env.portfolio_state(short);
+    assert_eq!(before_withdraw.assets[0].effective_price, 800);
+    assert_eq!(before_withdraw.assets[0].raw_oracle_target_price, 800);
+    assert!(
+        health_cert(&stale_short).cert_oracle_epoch < before_withdraw.oracle_epoch,
+        "the losing account remains stale after another account accrues the mark"
+    );
+    assert_eq!(before_withdraw.assets[0].oi_eff_short_q, POS_SCALE);
+    assert!(!before_withdraw.bankruptcy_hlock_active);
+    assert!(!before_withdraw.threshold_stress_active);
+    assert!(!before_withdraw.loss_stale_active);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    env.svm.expire_blockhash();
+    let withdraw = env.try_withdraw_insurance_asset_with_authority(&admin, 0, INSURANCE);
+    assert!(
+        withdraw.is_err(),
+        "live insurance must remain locked while stale accounts can realize losses"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+
+    // The retained reserve is economically necessary: once the stale short is
+    // refreshed and liquidated, it absorbs the 450-atom capital deficit. No B
+    // social loss may be pushed onto the winning side.
+    env.svm.expire_blockhash();
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: vec![],
+        },
+    );
+    assert!(health_cert(&env.portfolio_state(short)).certified_liq_deficit > 0);
+
+    env.svm.expire_blockhash();
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: vec![],
+        },
+    );
+    let after_liquidation = env.market_state().1;
+    assert_eq!(after_liquidation.insurance, 50);
+    assert_eq!(after_liquidation.assets[0].b_long_num, 0);
+    assert_eq!(after_liquidation.assets[0].b_epoch_start_long_num, 0);
+    assert_eq!(
+        after_liquidation.assets[0].explicit_unallocated_loss_long,
+        0
+    );
+    assert_eq!(after_liquidation.vault as u64, env.token_amount(env.vault));
+    assert!(after_liquidation.vault >= after_liquidation.c_tot + after_liquidation.insurance);
+}


### PR DESCRIPTION
## Summary
- Reject live `WithdrawInsuranceAsset` while the target asset has any position or unresolved loss state.
- Add a public-only LiteSVM regression for a fully accrued adverse mark with an unrefreshed losing portfolio.
- Keep flat live withdrawal, resolved withdrawal, backing withdrawal, and empty shutdown-drain behavior unchanged.

## Exploit proof
On unpatched `main`, a separate public cranker fully applies marks `100 -> 200 -> 400 -> 800`, clearing market-level stale/lag gates while the short portfolio certificate remains on the old oracle epoch. The insurance operator then publicly withdraws all 500 atoms. Refresh and liquidation subsequently create 450 atoms of winning-side B social loss. No state injection is used.

With this change, that withdrawal rejects atomically. The same refresh/liquidation consumes 450 insurance atoms, leaves 50 insurance, and creates zero B or explicit unallocated loss.

## Validation
- `cargo build-sbf --no-default-features`
- `cargo test --all-targets --no-default-features` (564 LiteSVM + 5 unit tests pass)
- `cargo kani --tests --harness kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields` (821/821 checks pass)
- A direct full `cargo kani --tests` run completed the 823-check active-payload truncation harness, then spent more than 15 minutes expanding the pre-existing monolithic unknown/truncated-tag decoder harness past 140 unwind iterations; that unrelated full run was stopped and is not claimed green.