### PR TITLE
Block backing escape after committed mark

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4438,7 +4438,7 @@ pub mod processor {
         if asset_local_loss_stale_view(group, asset_index) {
             return Err(PercolatorError::EngineLockActive.into());
         }
-        reject_exposed_target_effective_lag_view(group, asset_index)?;
+        reject_exposed_target_effective_lag_view(cfg, group, asset_index)?;
         Ok(false)
     }
 
@@ -4460,6 +4460,7 @@ pub mod processor {
     }
 
     fn asset_has_exposed_target_effective_lag_view(
+        cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
     ) -> Result<bool, ProgramError> {
@@ -4469,14 +4470,30 @@ pub mod processor {
             .ok_or(PercolatorError::InvalidInstruction)?;
         let asset = &slot.engine.asset;
         let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-        Ok(exposed && asset.raw_oracle_target_price.get() != asset.effective_price.get())
+        if !exposed {
+            return Ok(false);
+        }
+        let effective_price = asset.effective_price.get();
+        if asset.raw_oracle_target_price.get() != effective_price {
+            return Ok(true);
+        }
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+        if !oracle_v16::profile_is_price_managed(&profile) {
+            return Ok(false);
+        }
+        Ok(
+            (profile.mark_ewma_e6 != 0 && profile.mark_ewma_e6 != effective_price)
+                || (profile.oracle_target_price_e6 != 0
+                    && profile.oracle_target_price_e6 != effective_price),
+        )
     }
 
     fn reject_exposed_target_effective_lag_view(
+        cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
     ) -> ProgramResult {
-        if asset_has_exposed_target_effective_lag_view(group, asset_index)? {
+        if asset_has_exposed_target_effective_lag_view(cfg, group, asset_index)? {
             return Err(PercolatorError::EngineLockActive.into());
         }
         Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59471,3 +59471,115 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+// A committed AuthMark or EWMA mark creates an economically exposed target/effective-price lag
+// before the first crank publishes that target into the engine. Backing principal is the
+// loss-absorption layer for counterparty claims, so its authority must not be able to escape during
+// that interval. The old withdrawal gate inspected only the engine's still-old raw target and
+// allowed the full bucket out; subsequent public cranks then left part of the winner's claim
+// unbacked.
+#[test]
+fn v16_attack_price_managed_mark_cannot_be_front_run_by_backing_withdraw_before_crank() {
+    const INITIAL_MARK: u64 = 1_000_000;
+    const ADVERSE_MARK: u64 = 1;
+    const BACKING: u128 = 1_000_000;
+
+    for use_ewma in [false, true] {
+        let mode = if use_ewma { "EWMA" } else { "AuthMark" };
+        let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+        env.svm.warp_to_slot(1);
+        if use_ewma {
+            env.configure_ewma_mark_with_cu(1, INITIAL_MARK, 1, 0);
+        } else {
+            env.configure_auth_mark_with_cu(1, INITIAL_MARK);
+        }
+        env.top_up_backing_bucket(0, BACKING, 1_000);
+
+        let long_owner = Keypair::new();
+        let short_owner = Keypair::new();
+        let long = env.create_portfolio(&long_owner);
+        let short = env.create_portfolio(&short_owner);
+        env.deposit(&long_owner, long, 100_000);
+        env.deposit(&short_owner, short, 2_000_000);
+        env.trade_with_cu(
+            &long_owner,
+            long,
+            &short_owner,
+            short,
+            POS_SCALE as i128,
+            INITIAL_MARK,
+            0,
+        );
+
+        env.svm.warp_to_slot(2);
+        if use_ewma {
+            env.push_ewma_mark_with_cu(2, ADVERSE_MARK);
+        } else {
+            env.push_auth_mark_with_cu(2, ADVERSE_MARK);
+        }
+        let (cfg_after_push, group_after_push) = env.market_state();
+        assert!(
+            cfg_after_push.oracle_target_price_e6 < INITIAL_MARK,
+            "{mode} committed an adverse target"
+        );
+        assert_eq!(
+            group_after_push.assets[0].effective_price, INITIAL_MARK,
+            "the committed {mode} target has not yet reached the bounded effective price"
+        );
+
+        let backing_authority = env.admin.insecure_clone();
+        let destination = env.token_account(backing_authority.pubkey(), 0);
+        env.svm.expire_blockhash();
+        let withdrawal = env.send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain: 0,
+                amount: BACKING,
+            },
+            vec![
+                AccountMeta::new(backing_authority.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(destination, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&backing_authority],
+        );
+
+        // Drive only public bounded progress. The losing trader contributes 100,000 of principal, but
+        // the adverse move creates a larger winning claim, so the pre-funded backing is material.
+        for slot in [21, 41, 61] {
+            env.svm.warp_to_slot(slot);
+            for portfolio in [long, short] {
+                env.crank(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: slot,
+                        observations: crank_observations(0),
+                    },
+                );
+            }
+        }
+        let group_after = env.market_state().1;
+        let claim_num = group_after.source_credit[0].positive_claim_bound_num;
+        let reserved_num = group_after.source_credit[0].fresh_reserved_backing_num;
+        assert!(
+            claim_num > 100_000 * BOUND_SCALE,
+            "the {mode} winner's claim must exceed the loser's contributed principal"
+        );
+        assert!(
+        withdrawal.is_err(),
+        "backing escaped after the adverse {mode} mark was committed; the public lifecycle left {} claim atoms unbacked",
+        claim_num.saturating_sub(reserved_num) / BOUND_SCALE
+    );
+        assert_eq!(
+            env.token_amount(destination),
+            0,
+            "the rejected race must pay no backing principal"
+        );
+        assert!(
+            reserved_num >= claim_num,
+            "retained backing must fully cover the {mode} winner's accrued claim"
+        );
+    }
+}


### PR DESCRIPTION
## Impact

After an AuthMark or EWMA authority committed an adverse mark, the backing authority could withdraw the entire live backing bucket before the first crank published that target into the engine. Public cranks then realized a winner claim that exceeded the losing trader's principal, leaving the claim underbacked.

The public LiteSVM regression demonstrates the old behavior with both price-managed market types: 1,000,000 backing escaped, then bounded public cranks produced a 137,161 claim against 100,000 of losing principal.

## Root cause

The live backing-withdrawal gate checked only the engine's `raw_oracle_target_price` against its effective price. `PushAuthMark` and `PushEwmaMark` first commit the target in the wrapper oracle profile, so there is a public pre-crank interval where the economically committed target is absent from that engine-only check.

## Fix

For exposed price-managed assets, include the wrapper profile's committed mark and oracle target in the existing target/effective lag gate. This keeps the reserve in place until bounded accrual catches up. It does not publish a new engine raw target during mark submission, which would invalidate account certificates and force an extra crank between EWMA-moving trades.

## Verification

- Regression failed against the parent program and passes with the fix for AuthMark and EWMA.
- `cargo build-sbf --no-default-features`
- `cargo test --lib` (5/5)
- `cargo test --test v16_cu` (564/564, including CU assertions)
- `cargo test --all-targets`
- SBF fixture builds for `auth_matcher` and `hostile_matcher`
- `cargo fmt --check`

Full Kani was also started; the payload-truncation proof passed and the unrelated high-cost decoder proof was still progressing when this PR was published.
