### PR TITLE
[BLOCKER DoS] Prevent permissionless micro-price crank pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a8b8877e784e34fbef7bfd16ce7228130219904b#a8b8877e784e34fbef7bfd16ce7228130219904b"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a8b8877e784e34fbef7bfd16ce7228130219904b" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a8b8877e784e34fbef7bfd16ce7228130219904b" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10504,6 +10504,7 @@ pub mod processor {
                             AutoCrankWorkV16 {
                                 now_slot: authenticated_now_slot,
                                 observations: &[],
+                                observations_preaccrued: false,
                                 resolved_close_fee_rate_per_slot: 0,
                             },
                         )
@@ -10660,29 +10661,36 @@ pub mod processor {
             let summary = group
                 .build_actionable_summary(&portfolio.as_view())
                 .map_err(map_v16_error)?;
-            if let Some(asset_index) =
-                auto_crank_selected_asset_that_accrues_view(&portfolio, &summary)?
-            {
-                reject_missing_pending_selected_observation_view(
-                    &cfg,
-                    &group,
-                    asset_index,
-                    authenticated_now_slot,
-                    observations.as_slice(),
-                )?;
+            if observations.is_empty() {
+                if let Some(asset_index) =
+                    auto_crank_selected_asset_that_accrues_view(&portfolio, &summary)?
+                {
+                    reject_missing_pending_selected_observation_view(
+                        &cfg,
+                        &group,
+                        asset_index,
+                        authenticated_now_slot,
+                        observations.as_slice(),
+                    )?;
+                }
             }
-            let result = match group.permissionless_auto_crank_not_atomic(
-                &mut portfolio,
-                AutoCrankWorkV16 {
-                    now_slot: authenticated_now_slot,
-                    observations: observations.as_slice(),
-                    resolved_close_fee_rate_per_slot: 0,
-                },
-            ) {
-                Ok(result) => Some(result),
-                Err(V16Error::NonProgress) if !observations.is_empty() => None,
-                Err(err) => return Err(map_v16_error(err)),
-            };
+            // Supplied observations were authenticated and accrued above. Tell the engine to
+            // dispatch the selected current-state account action without replaying a second market
+            // segment. Every engine error propagates so SVM rollback covers all not-atomic
+            // mutations; no error may be converted into a successful partial commit.
+            let result = Some(
+                group
+                    .permissionless_auto_crank_not_atomic(
+                        &mut portfolio,
+                        AutoCrankWorkV16 {
+                            now_slot: authenticated_now_slot,
+                            observations: observations.as_slice(),
+                            observations_preaccrued: !observations.is_empty(),
+                            resolved_close_fee_rate_per_slot: 0,
+                        },
+                    )
+                    .map_err(map_v16_error)?,
+            );
 
             let selected_fee_asset = match result.as_ref().map(|r| &r.selected) {
                 Some(AutoCrankPlanV16::RefreshAccount {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -47522,13 +47522,15 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
     );
     assert_cu_within("10MiB PushEwmaMark", push_cu, CUSTODY_CU_LIMIT);
 
+    // Pre-accrual can first expose account settlement work, followed by certificate refresh and
+    // liquidation. Each auto-crank dispatches one bounded highest-priority step.
     let liquidation_cu = env.crank_steps(
         short,
         ProgInstruction::PermissionlessCrank {
             now_slot: LIQUIDATION_SLOT,
             observations: crank_observations(HIGH_ASSET as u16),
         },
-        2,
+        3,
     );
     println!(
         "v16 10MiB PermissionlessCrank Liquidate: assets={N}, account_len={account_len}, \
@@ -59716,4 +59718,123 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     ] {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
+}
+
+// A percentage price cap can round a one-slot move below one price atom. Permissionless callers
+// must not consume those zero-delta slots and reset the elapsed interval forever: failed calls
+// preserve state until enough time has accumulated for a representable target-directed move.
+#[test]
+fn v16_attack_permissionless_micro_price_cranks_cannot_pin_oracle_progress() {
+    const PRICE: u64 = 100;
+    const TARGET: u64 = 200;
+    const CAP_BPS: u64 = 24;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(0);
+    env.configure_auth_mark_with_cu(0, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, TARGET);
+    let crank_once = |env: &mut V16CuEnv, slot: u64| {
+        env.svm.warp_to_slot(slot);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+    };
+
+    for slot in 1..5u64 {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let crank = crank_once(&mut env, slot);
+        assert!(
+            matches!(&crank, Err(err) if err.contains("Custom(22)")),
+            "slot {slot} zero-delta crank must return engine NonProgress: {crank:?}"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before,
+            "slot {slot} rejected crank is byte-stable under SVM rollback"
+        );
+        let asset = env.market_state().1.assets[0];
+        assert_eq!(asset.slot_last, 0, "slot {slot} was not consumed");
+        assert_eq!(
+            asset.effective_price, PRICE,
+            "zero-delta rejection preserves the effective price"
+        );
+        assert_eq!(
+            asset.raw_oracle_target_price, PRICE,
+            "the engine target copy rolls back with the rejected crank"
+        );
+        assert_eq!(
+            env.market_state().0.oracle_target_price_e6,
+            TARGET,
+            "the separately committed authenticated wrapper target remains pending"
+        );
+    }
+
+    let first_cu = crank_once(&mut env, 5).expect("five accumulated slots move one price atom");
+    assert!(
+        first_cu <= CRANK_CU_LIMIT,
+        "representable progress stays within crank CU budget: {first_cu}"
+    );
+    let first = env.market_state().1.assets[0];
+    assert_eq!(first.slot_last, 5);
+    assert_eq!(first.effective_price, PRICE + 1);
+    assert_eq!(first.raw_oracle_target_price, TARGET);
+
+    for slot in 6..10u64 {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let crank = crank_once(&mut env, slot);
+        assert!(
+            matches!(&crank, Err(err) if err.contains("Custom(22)")),
+            "slot {slot} zero-delta crank must return engine NonProgress: {crank:?}"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before,
+            "slot {slot} rejected crank is byte-stable under SVM rollback"
+        );
+    }
+
+    let second_cu = crank_once(&mut env, 10).expect("next five-slot interval also progresses");
+    assert!(
+        second_cu <= CRANK_CU_LIMIT,
+        "repeated representable progress stays within crank CU budget: {second_cu}"
+    );
+    let second = env.market_state().1.assets[0];
+    assert_eq!(second.slot_last, 10);
+    assert_eq!(second.effective_price, PRICE + 2);
+    assert_eq!(second.raw_oracle_target_price, TARGET);
 }


### PR DESCRIPTION
## Impact

A permissionless caller could indefinitely pin a live exposed market away from its authenticated oracle target when the percentage movement cap rounded a short interval below one price atom.

At price 100 with a 24 bps/slot cap and target 200, one public `PermissionlessCrank` per slot previously succeeded and advanced engine `slot_last` while leaving `effective_price` at 100. Repeating this erased the elapsed interval needed for a representable move, freezing price-dependent PnL, liquidation, and funding progress despite real long and short OI.

The fail-first LiteSVM probe used only public instructions on a normally initialized AuthMark market. Against engine `143e68c4917ed0400a27b952f036a5677047cd84`, the first attacker crank incorrectly succeeded at 69,481 CU instead of returning `NonProgress`.

## Fix

- Pin engine `a8b8877e784e34fbef7bfd16ce7228130219904b` from [percolator#128](https://github.com/aeyakovenko/percolator/pull/128). The engine rejects exposed, lagged, positive-time accrual segments whose capped effective price does not change, before any mutation.
- Mark observations as `observations_preaccrued` after the wrapper authenticates and applies them, so auto-crank dispatches the selected account action without replaying a second market segment.
- Propagate every auto-crank engine error to the instruction boundary. No `NonProgress` result is converted into a successful partial commit; SVM rollback preserves the elapsed interval.
- Keep the 10 MiB/highest-asset liquidation liveness check exact: the bounded price/refresh/liquidation sequence completes in three calls, with peak liquidation work at 245,179 CU.

## Coverage

`v16_attack_permissionless_micro_price_cranks_cannot_pin_oracle_progress` creates opposing positions through the public trade API, commits target 200, and submits attacker cranks at every slot. Slots 1-4 and 6-9 must return engine `NonProgress` with byte-identical market state; slots 5 and 10 must move one atom toward the target within the crank CU budget.

This is net-new coverage of target-distance liveness under integer cap quantization. Existing liveness tests treated successful `slot_last` advancement as progress and did not exercise a successful zero-price-delta state transition.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets` (6 unit + 565 LiteSVM tests)
- `cargo test --test v16_cu v16_attack_permissionless_micro_price_cranks_cannot_pin_oracle_progress -- --exact --nocapture`
- `cargo test --test v16_cu v16_bpf_permissionless_liquidation_is_bounded -- --exact --nocapture` (242,236 CU)
- `cargo test --test v16_cu v16_bpf_10m_market_liquidation_high_asset_stays_bounded -- --exact --nocapture` (245,179 CU)
- `cargo kani --tests --harness kani_v16_permissionless_crank_decode_preserves_wire_fields`
- Engine Kani: `proof_v16_lagged_target_zero_delta_cannot_consume_accrual_segment` (0/3,329 failed; cover satisfied)
- `cargo fmt --all -- --check`
- `git diff --check`
