### PR TITLE
[REAL LoF] Prove ADL split-transfer backing drain is closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=54d21977695d24351be5b2ed919ff83fc33a78c5#54d21977695d24351be5b2ed919ff83fc33a78c5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "54d21977695d24351be5b2ed919ff83fc33a78c5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "54d21977695d24351be5b2ed919ff83fc33a78c5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9930,6 +9930,162 @@ fn v16_attack_crossed_trade_cannot_turn_partial_liquidation_survivors_same_side(
 }
 
 #[test]
+fn v16_adl_split_transfer_rejects_without_value_reissue_and_owner_exit_remains_live() {
+    const PRICE: u64 = 100;
+    const OPEN_Q: i128 = 13_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        h_max: 6_480_000,
+        initial_price: PRICE,
+        maintenance_margin_bps: 500,
+        initial_margin_bps: 500,
+        min_nonzero_mm_req: 59_900,
+        min_nonzero_im_req: 60_000,
+        max_price_move_bps_per_slot: 24,
+        max_accrual_dt_slots: 20,
+        max_abs_funding_e9_per_slot: 0,
+        min_funding_lifetime_slots: 10_000_000,
+        liquidation_fee_bps: 0,
+        maintenance_fee_per_slot: 2_700,
+        ..V16CuMarketParams::default()
+    });
+    env.top_up_backing_bucket(1, 100_000, 10_000);
+    let survivor_owner = Keypair::new();
+    let liquidated_owner = Keypair::new();
+    let successor_owner = Keypair::new();
+    let survivor = env.create_portfolio(&survivor_owner);
+    let liquidated = env.create_portfolio(&liquidated_owner);
+    let successor = env.create_portfolio(&successor_owner);
+    env.deposit(&survivor_owner, survivor, 100_000);
+    env.deposit(&liquidated_owner, liquidated, 118_900);
+    env.deposit(&successor_owner, successor, 100_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, PRICE);
+
+    env.svm.warp_to_slot(8);
+    env.trade_with_cu(
+        &survivor_owner,
+        survivor,
+        &liquidated_owner,
+        liquidated,
+        OPEN_Q,
+        PRICE,
+        0,
+    );
+    env.svm.warp_to_slot(27);
+    env.crank(
+        survivor,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 27,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(35);
+    env.sync_maintenance_fee_with_cu(liquidated, None, 35);
+    env.crank_steps(
+        liquidated,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 35,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+
+    let (_, after_liquidation) = env.market_state();
+    let effective_q = after_liquidation.assets[0].oi_eff_long_q;
+    let raw_q = active_leg_for_asset(&env.portfolio_state(survivor), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    assert_eq!(raw_q, OPEN_Q.unsigned_abs());
+    assert!(effective_q < raw_q);
+    assert!(after_liquidation.assets[0].a_long < percolator::ADL_ONE);
+
+    env.svm.expire_blockhash();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let survivor_before = env.svm.get_account(&survivor).unwrap();
+    let successor_before = env.svm.get_account(&successor).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let rejected = env
+        .try_trade_asset_with_cu(
+            0,
+            &survivor_owner,
+            survivor,
+            &successor_owner,
+            successor,
+            -((raw_q / 2) as i128),
+            PRICE,
+            0,
+        )
+        .expect_err("post-ADL raw basis must not be reissued to a fresh portfolio");
+    assert!(
+        rejected.contains("Custom(21)") || rejected.contains("custom program error: 0x15"),
+        "post-ADL risk increase must fail as LockActive, got {rejected}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&survivor).unwrap(), survivor_before);
+    assert_eq!(env.svm.get_account(&successor).unwrap(), successor_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+
+    let account_value = |account: &percolator::PortfolioAccountV16Account| {
+        account.capital.get() as i128 + account.pnl.get()
+    };
+    let survivor_value_before = account_value(&env.portfolio_state(survivor));
+    let liquidated_value_before = account_value(&env.portfolio_state(liquidated));
+    let vault_amount_before_mark = env.token_amount(env.vault);
+
+    env.svm.warp_to_slot(40);
+    env.push_auth_mark_with_cu(40, PRICE + 1);
+    env.crank(
+        survivor,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            observations: crank_observations(0),
+        },
+    );
+    env.crank(
+        liquidated,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            observations: crank_observations(0),
+        },
+    );
+
+    let survivor_value_after = account_value(&env.portfolio_state(survivor));
+    let liquidated_value_after = account_value(&env.portfolio_state(liquidated));
+    let net_value_delta = (survivor_value_after - survivor_value_before)
+        + (liquidated_value_after - liquidated_value_before);
+    assert!(
+        (-1..=0).contains(&net_value_delta),
+        "post-ADL mark settlement must be neutral or conservatively rounded by at most one atom, \
+         got {net_value_delta}"
+    );
+    assert_eq!(env.token_amount(env.vault), vault_amount_before_mark);
+
+    env.svm.expire_blockhash();
+    let survivor_q_before = active_leg_for_asset(&env.portfolio_state(survivor), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    let (_, market_before_exit) = env.market_state();
+    let exit_cu = env.rebalance_reduce_with_cu(&survivor_owner, survivor, 0, POS_SCALE);
+    assert_cu_within("post-ADL owner exit", exit_cu, CUSTODY_CU_LIMIT);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(survivor), 0)
+            .basis_pos_q
+            .unsigned_abs(),
+        survivor_q_before - POS_SCALE
+    );
+    let (_, market_after_exit) = env.market_state();
+    assert_eq!(
+        market_after_exit.assets[0].oi_eff_long_q,
+        market_before_exit.assets[0].oi_eff_long_q - POS_SCALE
+    );
+    assert_eq!(
+        market_after_exit.assets[0].oi_eff_short_q,
+        market_before_exit.assets[0].oi_eff_short_q - POS_SCALE
+    );
+}
+
+#[test]
 fn v16_attack_stale_resolve_matured_no_observation_liquidation_rejects() {
     let mut env = V16CuEnv::new();
     env.configure_permissionless_resolve_with_cu(5, 5);


### PR DESCRIPTION
## Impact

A public quantity-ADL split trade could copy already-haircut raw basis into a fresh portfolio. On the vulnerable engine pin, the end-to-end LiteSVM sequence converted 13,585 atoms against 12,441 atoms of counterparty loss, creating a 1,144-atom claim on honest backing.

The reproduction uses only public instructions: deposits, a normal trade, maintenance-driven permissionless liquidation, `TradeNoCpi`, an authority-mark update, permissionless cranks, and owner conversion. It does not inject or mutate account state.

## Change

- Pin engine commit `54d21977695d24351be5b2ed919ff83fc33a78c5` from engine PR aeyakovenko/percolator#134.
- Add a public LiteSVM regression proving post-ADL basis cannot be reissued through a split transfer.
- Prove the rejected trade propagates `LockActive` and SVM rollback leaves market, both portfolios, and vault byte-for-byte unchanged.
- Prove subsequent mark settlement is zero-sum within one atom of conservative rounding and does not move vault custody.
- Prove the existing owner can still reduce the position within the custody CU guardrail.

## Validation

- `cargo test --all-targets`: 6 unit tests and 566 LiteSVM tests passed, including all CU tests.
- Engine `cargo test --all-targets`: 131 passed.
- Engine `cargo test --features fuzz`: 160 passed.
- Wrapper Kani: 39/40 harnesses passed with checked unwind bounds. The unchanged `configure_hybrid_oracle` ABI harness still expands the monolithic decoder past 18 GB at its exact 97-step bound; no semantic counterexample was produced.
- `cargo fmt --all -- --check`
- `git diff --check`

Engine issue: aeyakovenko/percolator#131
Engine fix: aeyakovenko/percolator#134
