### PR TITLE
[BLOCKER LoF] Prevent delayed asset-authority revival

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   gone). Asset 0 is **not** special for authorities — its only special properties are **fee capture**
   (it's the insurance-redirect target) and that it **cannot be permissionlessly created** (it's created
   at `InitMarket`, not via `UpdateAssetLifecycle`).
-- **Each asset (0..N) has a cold-storage admin** that can **rotate that asset's other keys**
-  (insurance/operator/backing/oracle), **shut down/restart that asset after the exit+empty gates**,
-  and **can be burned (set to 0)** — a credibly admin-free asset that can't be locally revived after
-  shutdown. **✅** For asset 0 this means the market admin starts as the asset-0 admin and can
-  force-replace the shared insurance operator/authority via `UpdateAssetAuthority`, while required
-  domain authorities themselves cannot be burned to zero.
+- **Each asset (0..N) has a cold-storage admin** that controls its own handoff and can
+  **restart that asset after the exit+empty gates**, and **can be burned (set to 0)** - a credibly
+  admin-free asset that cannot be locally revived after shutdown. **✅** Operational authorities
+  (insurance/operator/backing/oracle) each control their own co-signed handoff. An `asset_admin`
+  cannot replace a distinct holder or seize its funded domain; required operational authorities
+  cannot be burned to zero.
 - **One market-level key: `marketauth`.** **✅** All market-level governance collapses into a single
   `WrapperConfigV16.marketauth` key (it replaced the former separate `admin` / `asset_authority` /
   `base_unit_authority`). `marketauth` is the only key that can: **create market 0** (`InitMarket`),
@@ -174,13 +174,17 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
   `UpdateAuthority { new_pubkey }` (current `marketauth` signs and the non-zero replacement co-signs;
   burn-to-zero is rejected). Everything else — restart, insurance/operator/backing/oracle on
-  **every** asset including 0 — is per-asset (`asset_admin` + `UpdateAssetAuthority`), never a separate
-  marketauth-only path. `marketauth` can restart an asset only while it is also that asset's
+  **every** asset including 0 - is per-asset (`UpdateAssetAuthority`), holder-controlled, and never a
+  separate marketauth-only path. `marketauth` can restart an asset only while it is also that asset's
   `asset_admin` (the asset-0 bootstrap state).
 - **Each other asset key can rotate itself; only `asset_admin` can be set to 0.** **✅** (a domain
   authority self-rotates even after the asset admin is burned; required domain authorities cannot be
   burned). All verified by
-  `v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable`.
+  `v16_attack_per_asset_authority_handoffs_are_isolated_and_admin_burnable` and
+  `v16_attack_asset_admin_cannot_rekey_and_steal_provider_backing`. Holder-controlled handoffs also
+  invalidate a delayed admin-signed assignment after a newer holder-signed correction, preventing
+  the stale assignment from reviving a displaced withdrawal key
+  (`v16_attack_delayed_asset_admin_handoff_cannot_revive_displaced_insurance_operator`).
 - **Market admin can run a scheduled market close** — fully shut the market down and **reclaim the
   account id** — with **safe delays that cannot steal user funds** but **eventually drain an
   abandoned market to zero**. **✅** `v16_attack_scheduled_close_cannot_strand_funds_then_reclaims`
@@ -324,7 +328,7 @@ The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-
 
 Authority fields are split by scope:
 - **`WrapperConfigV16.marketauth`**: one market-level governance key for market policies, asset lifecycle, resolution/close, and base-unit controls
-- **`AssetOracleProfileV16.asset_admin`**: per-asset cold key that rotates that asset's scoped authorities
+- **`AssetOracleProfileV16.asset_admin`**: per-asset cold key for its own handoff and restart
 - **`AssetOracleProfileV16.insurance_authority` / `insurance_operator` / `backing_bucket_authority` / `oracle_authority`**: per-asset operational authorities
 
 Matcher requests do not use a persisted market nonce. The wrapper invokes the matcher and requires the response to echo the request id, LP identity, asset index, oracle price, and requested size/sign constraints.
@@ -705,7 +709,7 @@ The LiteSVM integration tests exercise the economic behavior through SBF paths, 
 ### Who runs what?
 - **Users / LPs**: init + deposits + trades
 - **Keepers (permissionless)**: call `PermissionlessCrank` regularly
-- **`marketauth` / scoped authorities**: may update policies or rotate scoped authorities; only `asset_admin` can be burned
+- **`marketauth` / scoped authorities**: may update policies or rotate the authority they currently hold; only `asset_admin` can be burned
 
 ### PermissionlessCrank cadence
 Run `PermissionlessCrank` often enough to satisfy engine freshness rules:
@@ -733,7 +737,7 @@ At minimum, monitor:
 
 ### Governance / authority handling
 - `UpdateAuthority` rotates `marketauth`; the current authority and the new key must both sign.
-- `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the new key.
+- `UpdateAssetAuthority` rotates per-asset authorities; the current holder and new key must both sign.
 - Burning is limited to `asset_admin`. Required market/domain authorities cannot be set to zero.
 
 ---
@@ -816,8 +820,9 @@ governance). This section lists:
 - what that key is intentionally trusted to do (and therefore can abuse),
 - what it is **not** supposed to be able to do.
 
-Note: `marketauth` is *also* asset-0's `asset_admin` at `InitMarket`, so items 3/5/7 (asset-0's
-mark/insurance/operator) are reachable until asset-0's `asset_admin` is rotated away or burned.
+Note: `marketauth` initially holds asset-0's `asset_admin`, oracle, insurance, operator, and backing
+roles. It can hand off each role while it remains that role's current holder, but cannot retake a
+role after handing it to a distinct key.
 
 ### What a malicious marketauth can do (by design / trust boundary)
 
@@ -830,36 +835,36 @@ These are governance powers, not bugs:
    - change funding/cap policy knobs (within validation bounds), the create fee, the base-unit mint, and the asset set — all now under the one `marketauth` key.
    - force-shutdown any asset including asset 0. Restart is not a separate marketauth power: it requires the target asset's `asset_admin`; marketauth can restart asset 0 only while it still holds the asset-0 admin role.
    - impact: economics/market shape can become unfavorable to users (force-shutdown still honors the trader exit window).
-3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
+3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE }` (while marketauth remains asset-0's oracle authority)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
 4. `ResolveMarket`
    - transition market to resolved mode using stored authority price.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
-5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)
+5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE }` (while marketauth remains asset-0's insurance authority)
    - choose who can withdraw resolved-market insurance.
    - impact: resolved insurance extraction capability is delegated.
 6. `WithdrawInsurance` (post-resolution, after positions are closed)
    - withdraw insurance buffer to admin ATA.
    - impact: no insurance backstop remains.
-7. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE_OPERATOR }` (while marketauth holds asset-0's `asset_admin`)
+7. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE_OPERATOR }` (while marketauth remains asset-0's insurance operator)
    - choose who can call bounded live insurance withdrawal.
    - impact: bounded live insurance extraction capability is delegated.
 8. `CloseSlab` (when market is fully empty)
     - decommission market account and recover slab lamports.
     - impact: market is permanently closed.
 
-> **Authority model (items 3, 5, 7).** Asset-0's insurance/operator/oracle(mark)/backing authorities now
-> use the **same per-asset `asset_admin` model as assets 1..N** (`UpdateAssetAuthority { asset_index = 0 }`).
-> Asset 0's `asset_admin` is bootstrapped to the **market admin** at `InitMarket`, so a malicious admin
-> **can** rotate the shared insurance operator/authority and the mark pusher (items 3/5/7) —
-> exactly the powers the asset_admin has over any asset. To make those delegations sticky, burn
-> asset-0's **`asset_admin`** (set to 0); no key can rotate asset-0's sub-authorities again, and the
-> current holders are frozen. The market-wide `UpdateAuthority` (tag 32) rotates only `marketauth`; the per-asset
+> **Authority model (items 3, 5, 7).** Asset-0's insurance/operator/oracle(mark)/backing authorities
+> use the same holder-controlled `UpdateAssetAuthority { asset_index = 0 }` path as assets 1..N.
+> Asset 0 bootstraps every role to the market admin at `InitMarket`, so that key may perform the
+> initial handoffs. After a role is handed to a distinct key, neither `marketauth` nor `asset_admin`
+> can retake it without the current holder's signature. Burning `asset_admin` disables future admin
+> handoff/restart but does not freeze operational roles; their current holders can still self-rotate.
+> The market-wide `UpdateAuthority` (tag 32) rotates only `marketauth`; the per-asset
 > `ASSET_ADMIN`/`ORACLE`/`INSURANCE`/`INSURANCE_OPERATOR`/`BACKING` kinds are tag-65
 > `UpdateAssetAuthority`. Verified by
-> `v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable` (asset-0 `asset_admin` rotates
-> asset-0's sub-authorities and can burn itself, isolated from other assets),
+> `v16_attack_per_asset_authority_handoffs_are_isolated_and_admin_burnable`,
+> `v16_attack_asset_admin_cannot_rekey_and_steal_provider_backing`,
 > `v16_attack_update_authority_non_holder_cannot_rotate`, and
 > `v16_attack_update_authority_requires_new_authority_signature`.
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -585,9 +585,9 @@ pub mod state {
         pub oracle_leg_feeds: [[u8; 32]; ORACLE_LEG_CAP],
         pub oracle_leg_prices_e6: [u64; ORACLE_LEG_CAP],
         pub oracle_leg_publish_times: [i64; ORACLE_LEG_CAP],
-        // Per-asset cold-storage admin (assets 1..N). Can rotate THIS asset's domain authorities
-        // (insurance/operator/backing/oracle) and itself, and can be burned (set to 0). Isolated:
-        // it can never act on another asset. Set to the activator at creation.
+        // Per-asset cold-storage admin (assets 1..N). It controls its own handoff and restart, and
+        // can be burned (set to 0). Each operational authority controls its own handoff. Set to the
+        // activator at creation and isolated from every other asset.
         pub asset_admin: [u8; 32],
     }
 
@@ -2540,9 +2540,9 @@ pub mod ix {
         UpdateAuthority {
             new_pubkey: [u8; 32],
         },
-        /// Rotate one of an asset's per-asset authorities. Gated by the asset's own `asset_admin`
-        /// (rotates any; only the admin authority itself is burnable) or the current holder of that
-        /// authority (self-rotation). Isolated to the given asset_index.
+        /// Rotate one of an asset's per-asset authorities. The current holder of the selected
+        /// authority must sign and the replacement must co-sign. Only `asset_admin` is burnable.
+        /// Isolated to the given asset_index.
         UpdateAssetAuthority {
             asset_index: u16,
             kind: u8,
@@ -8773,11 +8773,9 @@ pub mod processor {
         }
         let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
 
-        // The asset's own cold-storage admin may rotate ANY of its authorities, and only the admin
-        // authority itself may be burned to 0; otherwise the current holder of THIS authority
-        // self-rotates. Scoped to this asset's profile only — it can never act on another asset.
-        let admin_signed =
-            profile.asset_admin != [0u8; 32] && profile.asset_admin == current.key.to_bytes();
+        // Every authority owns its own handoff. The asset admin may rotate or burn the admin key,
+        // but it cannot seize an independently funded backing/insurance domain or take over an
+        // oracle by replacing that authority without its consent.
         let current_value = match kind {
             ASSET_AUTH_ADMIN => profile.asset_admin,
             ASSET_AUTH_INSURANCE => profile.insurance_authority,
@@ -8792,9 +8790,7 @@ pub mod processor {
         if new_pubkey == [0u8; 32] && kind != ASSET_AUTH_ADMIN {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        if !admin_signed {
-            expect_live_authority(&current_value, current.key)?;
-        }
+        expect_live_authority(&current_value, current.key)?;
         match kind {
             ASSET_AUTH_ADMIN => profile.asset_admin = new_pubkey,
             ASSET_AUTH_INSURANCE => profile.insurance_authority = new_pubkey,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -45137,6 +45137,135 @@ fn v16_attack_update_asset_authority_rejects_zero_domain_authority() {
     env.close_slab_with_cu();
 }
 
+// A delayed asset-admin handoff must not revive a displaced insurance operator after the current
+// operator has already handed the role to a replacement. Otherwise an unprivileged relayer can
+// reorder a previously valid admin-signed assignment after an independent provider funds the
+// replacement operator's domain, restoring the stale key long enough to drain that fresh reserve.
+#[test]
+fn v16_attack_delayed_asset_admin_handoff_cannot_revive_displaced_insurance_operator() {
+    const ASSET: u16 = 1;
+    const DOMAIN: u16 = 2;
+    const AMOUNT: u128 = 50_000;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let original_operator = Keypair::new();
+    let displaced_operator = Keypair::new();
+    let replacement_operator = Keypair::new();
+    let provider = Keypair::new();
+    for key in [
+        &original_operator,
+        &displaced_operator,
+        &replacement_operator,
+        &provider,
+    ] {
+        env.ensure_signer_account(key.pubkey());
+    }
+
+    env.svm.warp_to_slot(1);
+    env.activate_asset_with_authorities(
+        ASSET,
+        1,
+        100,
+        provider.pubkey(),
+        original_operator.pubkey(),
+        provider.pubkey(),
+        provider.pubkey(),
+    );
+
+    let delayed_assignment = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(displaced_operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::UpdateAssetAuthority {
+            asset_index: ASSET,
+            kind: processor::ASSET_AUTH_INSURANCE_OPERATOR,
+            new_pubkey: displaced_operator.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let retained_handoff = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), delayed_assignment],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin, &displaced_operator],
+        env.svm.latest_blockhash(),
+    );
+
+    // The live holder lands the newer correction first. This is valid both before and after the
+    // holder-consent fix, and leaves the cold admin unchanged.
+    env.send(
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: ASSET,
+            kind: processor::ASSET_AUTH_INSURANCE_OPERATOR,
+            new_pubkey: replacement_operator.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(original_operator.pubkey(), true),
+            AccountMeta::new(replacement_operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&original_operator, &replacement_operator],
+    )
+    .expect("current operator hands the role to the replacement");
+    assert_eq!(
+        state::read_asset_oracle_profile(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ASSET as usize
+        )
+        .unwrap()
+        .insurance_operator,
+        replacement_operator.pubkey().to_bytes()
+    );
+
+    let provider_source = env.top_up_insurance_domain_with_authority(&provider, DOMAIN, AMOUNT);
+    assert_eq!(env.token_amount(provider_source), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+
+    let delayed_result = env.svm.send_transaction(retained_handoff);
+    if delayed_result.is_ok() {
+        assert_eq!(
+            state::read_asset_oracle_profile(
+                &env.svm.get_account(&env.market).unwrap().data,
+                ASSET as usize
+            )
+            .unwrap()
+            .insurance_operator,
+            displaced_operator.pubkey().to_bytes(),
+            "the delayed assignment revived the displaced operator"
+        );
+        let (stolen_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&displaced_operator, ASSET, AMOUNT)
+            .expect("revived operator drains the independent provider's fresh reserve");
+        assert_eq!(env.token_amount(stolen_dest), AMOUNT as u64);
+        panic!("a delayed asset-admin handoff revived a displaced withdrawal authority");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale handoff leaves market state byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected stale handoff leaves custody byte-identical"
+    );
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        AMOUNT,
+        "the independent provider's reserve remains available"
+    );
+    assert!(
+        env.try_withdraw_insurance_asset_with_authority(&displaced_operator, ASSET, AMOUNT)
+            .is_err(),
+        "the displaced operator remains unauthorized"
+    );
+}
+
 // Product spec — cross-asset BACKING isolation (counterpart to the domain-insurance isolation test):
 // a faulty/insolvent permissionless asset must not drain ANOTHER asset's backing bucket. Fund both
 // assets' backing, drive asset 1 insolvent + liquidate, and assert asset 0's backing buckets are

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -5958,29 +5958,29 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
     )
     .expect("asset-0 admin rotates to a cold key");
     env.try_update_per_asset_authority_with_cu(
-        &asset_admin,
+        &marketauth,
         Some(&insurance_authority),
         0,
         processor::ASSET_AUTH_INSURANCE,
         insurance_authority.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates asset-0 insurance authority");
+    .expect("current asset-0 insurance holder rotates its authority");
     env.try_update_per_asset_authority_with_cu(
-        &asset_admin,
+        &marketauth,
         Some(&insurance_operator),
         0,
         processor::ASSET_AUTH_INSURANCE_OPERATOR,
         insurance_operator.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates asset-0 insurance operator");
+    .expect("current asset-0 insurance operator rotates its authority");
     env.try_update_per_asset_authority_with_cu(
-        &asset_admin,
+        &marketauth,
         Some(&backing_bucket_authority),
         0,
         processor::ASSET_AUTH_BACKING_BUCKET,
         backing_bucket_authority.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates asset-0 backing bucket authority");
+    .expect("current asset-0 backing holder rotates its authority");
     env.top_up_insurance_domain_with_authority(&insurance_authority, 0, 500);
     let insurance_before_shutdown = env.market_state().1.insurance;
     let vault_before_shutdown = env.token_amount(env.vault);
@@ -6179,13 +6179,13 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
     assert_eq!(env.market_state().1.insurance_domain_budget[0], 500);
 
     env.try_update_per_asset_authority_with_cu(
-        &asset_admin,
+        &marketauth,
         Some(&new_oracle),
         0,
         processor::ASSET_AUTH_ORACLE,
         new_oracle.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates oracle before restart");
+    .expect("current asset-0 oracle holder rotates before restart");
     env.svm.warp_to_slot(8);
     env.svm.expire_blockhash();
     let restart_by_marketauth = send_tx(
@@ -43484,8 +43484,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         "a non-holder seizing the market authority must reject"
     );
 
-    // and rotating ASSET 0's insurance authority (now a per-asset op) by a non-holder also rejects:
-    // mallory is neither asset-0's asset_admin nor its insurance authority.
+    // Rotating ASSET 0's insurance authority (now a per-asset op) by a non-holder also rejects.
     let prof0 = |env: &V16CuEnv| {
         state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
             .unwrap()
@@ -44817,14 +44816,12 @@ fn v16_attack_spent_cleanup_cannot_erase_provider_receivable() {
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 }
 
-// Product spec — per-asset cold-storage admin keys (governance): EVERY asset (including asset 0) has
-// its OWN admin that can rotate that asset's domain authorities (insurance/operator/backing/oracle)
-// and itself, and the asset admin can be BURNED to 0; isolated — it can never act on another asset. Asset 0's
-// asset_admin is bootstrapped to the market admin at InitMarket and is rotated/burned through the same
-// UpdateAssetAuthority path as assets 1..N. Each domain authority can also self-rotate through a
-// co-signed handoff, but cannot be burned to zero after activation.
+// Product spec — per-asset authority handoffs are holder-controlled and isolated. Every asset
+// (including asset 0) has an admin key that may rotate or burn itself, while each domain authority
+// self-rotates through a co-signed handoff and cannot be burned after activation. At bootstrap the
+// asset admin is also each initial domain holder, but admin status alone grants no later takeover.
 #[test]
-fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
+fn v16_attack_per_asset_authority_handoffs_are_isolated_and_admin_burnable() {
     let mut env = V16CuEnv::new(); // 1 slot (asset 0); asset 1 is APPENDED permissionlessly below
     env.configure_auth_mark_with_cu(0, 100);
     env.activate_asset(1, 2, 100); // APPEND asset 1 -> profile.asset_admin bootstraps to the activator (admin)
@@ -44880,7 +44877,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         )
     };
 
-    // 1) the per-asset admin rotates the asset's ORACLE authority (new key co-signs).
+    // 1) the initial oracle holder rotates the asset's ORACLE authority (new key co-signs).
     let new_oracle = Keypair::new();
     assert!(
         upd(
@@ -44892,7 +44889,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
             new_oracle.pubkey().to_bytes()
         )
         .is_ok(),
-        "per-asset admin rotates the asset's oracle authority"
+        "initial oracle holder rotates the asset's oracle authority"
     );
     assert_eq!(
         prof(&env, 1).oracle_authority,
@@ -44916,8 +44913,8 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         "non-admin cannot rotate the asset's authorities"
     );
 
-    // 3) ASSET 0 uses the SAME per-asset path: its asset_admin (the market admin) rotates asset-0's
-    //    insurance authority — and this is ISOLATED, leaving asset 1's authorities byte-identical.
+    // 3) ASSET 0 uses the SAME path: its initial insurance holder rotates asset-0's insurance
+    //    authority, leaving asset 1's authorities byte-identical.
     let a0_ins = Keypair::new();
     let a1_oracle_before = prof(&env, 1).oracle_authority;
     let a1_ins_before = prof(&env, 1).insurance_authority;
@@ -44931,7 +44928,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
             a0_ins.pubkey().to_bytes()
         )
         .is_ok(),
-        "asset-0 admin rotates asset-0 insurance authority via UpdateAssetAuthority"
+        "asset-0 insurance holder rotates via UpdateAssetAuthority"
     );
     assert_eq!(
         prof(&env, 0).insurance_authority,
@@ -44949,7 +44946,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         "asset-1 insurance UNTOUCHED by asset-0 rotation"
     );
 
-    // 3b) ISOLATION the other way: the asset-1 admin cannot reach asset 0.
+    // 3b) Once asset 1's oracle has a distinct holder, its asset admin cannot retake it.
     let a0_prof_before = prof(&env, 0);
     assert!(
         upd(
@@ -44960,8 +44957,8 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
             processor::ASSET_AUTH_ORACLE,
             new_oracle.pubkey().to_bytes()
         )
-        .is_ok(),
-        "asset-1 admin rotates asset-1 oracle (re-establish a known holder)"
+        .is_err(),
+        "asset admin cannot replace a distinct oracle holder"
     );
     assert_eq!(
         prof(&env, 0).insurance_authority,
@@ -45036,6 +45033,88 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         "asset-0 admin can be burned"
     );
     assert_eq!(prof(&env, 0).asset_admin, [0u8; 32], "asset-0 admin burned");
+}
+
+// PRIVILEGED LoF: the asset admin is governance, not the owner of independently supplied backing.
+// Once a provider accepts a domain and funds it, only that current domain authority may hand the
+// domain to a replacement. Otherwise a compromised asset-admin key can rekey the funded bucket to
+// an attacker and immediately withdraw the provider's principal through public instructions.
+#[test]
+fn v16_attack_asset_admin_cannot_rekey_and_steal_provider_backing() {
+    let mut env = V16CuEnv::new();
+    let asset_admin = env.admin.insecure_clone();
+    let provider = Keypair::new();
+    let attacker = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&provider),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        provider.pubkey().to_bytes(),
+    )
+    .expect("the current backing authority hands the empty domain to the provider");
+    env.top_up_backing_bucket_with_authority(&provider, 0, 500, 100_000);
+
+    let (_, funded) = env.market_state();
+    assert_eq!(
+        funded.source_backing_buckets[0].fresh_unliened_backing_num,
+        500 * BOUND_SCALE,
+        "independent provider principal is live in the domain"
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+
+    env.svm.expire_blockhash();
+    let takeover = env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&attacker),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        attacker.pubkey().to_bytes(),
+    );
+
+    let attacker_dest = env.token_account(attacker.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let steal = env.send(
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 0,
+            amount: 500,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&attacker],
+    );
+
+    assert!(
+        steal.is_err(),
+        "attacker must not withdraw the provider's funded domain"
+    );
+    assert!(
+        takeover.is_err(),
+        "asset admin must not replace a distinct live backing authority"
+    );
+    assert_eq!(
+        env.token_amount(attacker_dest),
+        0,
+        "attacker extracts no provider principal"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected takeover and withdrawal preserve market accounting"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected takeover and withdrawal preserve custody"
+    );
 }
 
 // security.md sweep — zero required authority anti-brick (#6/#30/#48): activation rejects zero domain
@@ -57924,7 +58003,7 @@ fn v16_attack_cure_cannot_be_replayed_on_canceled_close_ledger() {
 // GRANT it to the new key. If rotation only updated state cosmetically (old key still able to push), a
 // rotated-out / compromised key could keep injecting marks to manipulate settlement (LoF); if the new key
 // could not push, the asset's oracle would be bricked (DoS). Drives the functional transfer end-to-end:
-// admin (the bootstrapped oracle authority) pushes once, the asset_admin rotates the oracle authority to a
+// admin (the bootstrapped oracle authority) pushes once, then hands the oracle authority to a
 // fresh key, then the OLD key's push rejects (Unauthorized) while the NEW key's push succeeds. The
 // existing rotation test checks state-level isolation/burnability, not the functional push transfer.
 #[test]
@@ -57953,8 +58032,8 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
         "admin (oracle authority) can push before rotation: {r0:?}"
     );
 
-    // Rotate the ORACLE authority admin -> newauth. admin signs as asset_admin; newauth co-signs (proves
-    // control of the incoming key).
+    // Rotate the ORACLE authority admin -> newauth. Admin signs as the current oracle holder;
+    // newauth co-signs to prove control of the incoming key.
     let newauth = Keypair::new();
     env.ensure_signer_account(newauth.pubkey());
     env.svm.expire_blockhash();
@@ -57973,7 +58052,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     );
     assert!(
         rot.is_ok(),
-        "asset_admin rotates the oracle authority: {rot:?}"
+        "current oracle holder rotates the oracle authority: {rot:?}"
     );
 
     env.svm.warp_to_slot(3);
@@ -59127,7 +59206,7 @@ fn v16_attack_asset0_operator_rotation_rekeys_live_insurance_withdraw() {
         processor::ASSET_AUTH_INSURANCE_OPERATOR,
         new_operator.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates the live insurance operator");
+    .expect("current asset-0 insurance operator rotates its authority");
     env.top_up_insurance_domain_with_authority(&admin, 0, 500);
 
     let (_, group_before) = env.market_state();
@@ -59236,7 +59315,7 @@ fn v16_attack_asset0_backing_rotation_rekeys_live_bucket_withdraw() {
         processor::ASSET_AUTH_BACKING_BUCKET,
         new_backing.pubkey().to_bytes(),
     )
-    .expect("asset-0 admin rotates the backing-bucket authority");
+    .expect("current asset-0 backing holder rotates its authority");
     env.top_up_backing_bucket_with_authority(&new_backing, 0, 500, 100_000);
 
     let (_, group_before) = env.market_state();


### PR DESCRIPTION
## What changed

- Require the current holder of every `UpdateAssetAuthority` role to sign its handoff.
- Keep the incoming-key co-signature and the rule that only `asset_admin` may be burned.
- Add a public LiteSVM regression for a delayed, previously valid admin-signed operator assignment that lands after a newer holder-signed correction.
- Retain coverage for the separate compromised-admin provider takeover and reconcile authority lifecycle fixtures and the README.

## Root cause and public exploit

`UpdateAssetAuthority` let an unchanged `asset_admin` replace a distinct operational authority without the current holder. A stale but honestly signed admin assignment therefore remained valid after a newer authority correction.

The exact-parent LiteSVM reproduction uses only public instructions and normally initialized accounts:

1. A cold asset admin signs an operator assignment to key B but it is delayed.
2. The current operator lands a newer co-signed handoff to key C.
3. An independent insurance provider funds 50,000 atoms after C is visible.
4. An unprivileged relayer lands the retained admin+B assignment under the same recent blockhash.
5. B is revived as operator and withdraws all 50,000 atoms of the provider's fresh reserve.

No key currently authorized at step 4 is compromised, no protocol bytes are injected, and the victim provider did not sign the harmful transition. This is `[BLOCKER LoF]` under `scripts/loop.md`'s honest-signature replay rule. The older compromised-admin takeover remains a separate `[PRIVILEGED LoF]` consequence of the same root cause.

## Fix

Every selected role now owns its own handoff: the current holder must sign and a nonzero replacement must co-sign. `asset_admin` may rotate or burn only itself. After a role is handed to another key, stale admin assignments and unilateral admin takeovers reject before mutation.

## TDD evidence

- Exact parent `36fa587e1424a8c7fdde2c701c10938188a51876` with RED test commit `be3f713b`: the retained handoff lands, B drains 50,000 atoms, and the test panics.
- Fixed head `255e56ee`: the stale handoff rejects; market and vault remain byte-identical; B remains unauthorized; the provider reserve remains intact.

## Verification

- `cargo build-sbf --tools-version v1.52`
- Built real `auth_matcher` and `hostile_matcher` SBF fixtures
- `cargo test --all-targets -- --test-threads=1`: 567/567 LiteSVM/CU + 6/6 unit tests passed
- `cargo check --all-targets`
- `cargo fmt` and `git diff --check`