### PR TITLE
[BLOCKER DoS] Restore terminal exit after partial Recovery forfeit (#236)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=493fcacc55e236af36e0c8c6e683923ee50a2365#493fcacc55e236af36e0c8c6e683923ee50a2365"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "493fcacc55e236af36e0c8c6e683923ee50a2365" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "493fcacc55e236af36e0c8c6e683923ee50a2365" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8673,7 +8673,10 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         let mut market_data = market_ai.try_borrow_mut_data()?;
         let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
-        if group.header.mode != 0 {
+        // mode: 0 = Live, 1 = Resolved, 2 = Recovery. Admin may resolve a Live market
+        // OR a market stuck in a permissionless global-Recovery escalation (issue #236)
+        // so it can wind down; only an already-Resolved market is rejected.
+        if group.header.mode == 1 {
             return Err(PercolatorError::EngineLockActive.into());
         }
         expect_live_authority(&cfg.marketauth, admin.key)?;
@@ -9759,7 +9762,12 @@ pub mod processor {
         let authenticated_slot = authenticated_slot_or_fallback(now_slot);
         let mut market_data = market_ai.try_borrow_mut_data()?;
         let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
-        if group.header.mode != 0 {
+        // mode: 0 = Live, 1 = Resolved, 2 = Recovery. A market stuck in a permissionless
+        // global-Recovery escalation (issue #236) must retain a bounded PUBLIC wind-down:
+        // once the oracle is stale-matured, any keeper may resolve it so CloseResolved /
+        // CloseSlab / capital exit become reachable. Only an already-Resolved market is
+        // rejected here.
+        if group.header.mode == 1 {
             return Err(PercolatorError::EngineLockActive.into());
         }
         if authenticated_slot < group.header.current_slot.get() {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,282 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+// [BLOCKER DoS] A losing owner can publicly commit one bounded Recovery-forfeit
+// chunk and then disappear. Before #236, that pending close blocks force-close,
+// the opposite owner's forfeit/reduce paths, and auto-crank. Expiry then escalates
+// the whole market to Recovery, where neither admin nor permissionless resolve
+// could reach Resolved. This fixture uses only public instructions and a normal
+// secondary-asset shutdown; no state bytes or oracle fixtures are injected.
+#[test]
+fn v16_attack_partial_recovery_forfeit_has_public_terminal_escape() {
+    const OPEN_PRICE: u64 = 100;
+    const FINAL_PRICE: u64 = 150_000_101;
+    const SIZE_Q: i128 = percolator::MAX_POSITION_ABS_Q as i128;
+    const HONEST_CAPITAL: u64 = 5_000_000_000_000_000;
+    const ATTACKER_CAPITAL: u64 = 5_000_000_000_000_000;
+    const EXPECTED_PENDING: u128 = 100_000_000;
+    const ASSET: u16 = 1;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: OPEN_PRICE,
+        max_bankrupt_close_lifetime_slots: 100,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.configure_auth_mark_with_cu(0, OPEN_PRICE);
+    env.activate_asset(ASSET, 0, OPEN_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, OPEN_PRICE);
+
+    let honest_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let honest = env.create_portfolio(&honest_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    env.deposit(&honest_owner, honest, HONEST_CAPITAL as u128);
+    env.deposit(&attacker_owner, attacker, ATTACKER_CAPITAL as u128);
+    env.trade_asset_with_cu(
+        ASSET,
+        &honest_owner,
+        honest,
+        &attacker_owner,
+        attacker,
+        SIZE_Q,
+        OPEN_PRICE,
+        0,
+    );
+
+    let mut slot = 0u64;
+    let mut mark = OPEN_PRICE;
+    while mark < FINAL_PRICE {
+        slot += 1;
+        mark = mark.saturating_mul(2).min(FINAL_PRICE);
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(ASSET, slot, mark);
+        env.crank(
+            honest,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+    assert_eq!(
+        env.market_state().1.assets[ASSET as usize].effective_price,
+        FINAL_PRICE
+    );
+
+    let shutdown_slot = slot + 1;
+    env.svm.warp_to_slot(shutdown_slot);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        processor::ASSET_ACTION_SHUTDOWN,
+        ASSET,
+        shutdown_slot,
+        0,
+    );
+    env.forfeit_recovery_leg_with_cu(&attacker_owner, attacker, ASSET, 1);
+
+    let attacker_after = env.portfolio_state(attacker);
+    let ledger = close_progress(&attacker_after);
+    assert_eq!(
+        ledger.residual_remaining, EXPECTED_PENDING,
+        "one bounded forfeit leaves an organically reachable pending residual"
+    );
+    assert!(has_active_leg_for_asset(&attacker_after, ASSET as usize));
+
+    // Every ordinary bounded continuation is blocked while the attacker is gone.
+    let blocked_slot = shutdown_slot + 1;
+    env.svm.warp_to_slot(blocked_slot);
+    let cranker = Keypair::new();
+    assert!(env
+        .try_force_close_abandoned_asset_with_cu(
+            &cranker,
+            honest,
+            attacker,
+            ASSET,
+            blocked_slot,
+            u128::MAX,
+        )
+        .is_err());
+    env.svm.expire_blockhash();
+    assert!(env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: blocked_slot,
+                observations: Vec::new(),
+            },
+            vec![
+                AccountMeta::new_readonly(env.payer.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker, false),
+            ],
+            &[],
+        )
+        .is_err());
+    env.svm.expire_blockhash();
+    assert!(env
+        .send(
+            ProgInstruction::ForfeitRecoveryLeg {
+                asset_index: ASSET,
+                b_delta_budget: u128::MAX,
+            },
+            vec![
+                AccountMeta::new(honest_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(honest, false),
+            ],
+            &[&honest_owner],
+        )
+        .is_err());
+    env.svm.expire_blockhash();
+    assert!(env
+        .send(
+            ProgInstruction::RebalanceReduce {
+                asset_index: ASSET,
+                reduce_q: u128::MAX,
+            },
+            vec![
+                AccountMeta::new(honest_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(honest, false),
+            ],
+            &[&honest_owner],
+        )
+        .is_err());
+
+    // Keep asset 0 fresh while the attacker ledger expires. This proves local
+    // asset staleness is not accidentally supplying the global terminal route.
+    env.svm.warp_to_slot(200);
+    env.push_auth_mark_with_cu(200, OPEN_PRICE);
+    env.svm.expire_blockhash();
+    assert!(env
+        .send(
+            ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .is_err());
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 200,
+            observations: Vec::new(),
+        },
+        vec![
+            AccountMeta::new_readonly(env.payer.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker, false),
+        ],
+        &[],
+    )
+    .expect("expired attacker ledger commits global Recovery");
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Recovery);
+    let honest_before_resolve = env.portfolio_state(honest);
+    assert!(
+        honest_before_resolve.capital.get() > 0
+            && has_active_leg_for_asset(&honest_before_resolve, ASSET as usize)
+    );
+
+    // RED on the exact parent: Recovery mode was rejected before reaching the
+    // engine. GREEN after #236: once Recovery freezes base updates and its stale
+    // window matures, any keeper can transition the market to Resolved.
+    env.svm.warp_to_slot(300);
+    env.svm.expire_blockhash();
+    let resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        resolve.is_ok(),
+        "permissionless Recovery wind-down must succeed: {resolve:?}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+
+    // Settle the abandoned loser permissionlessly. Each call is bounded by the
+    // configured chunk and pays no attacker-controlled key.
+    env.svm.warp_to_slot(302);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(attacker_owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker, false),
+        ],
+        &[],
+    )
+    .expect("permissionless close settles the abandoned loser");
+    assert_eq!(
+        close_progress(&env.portfolio_state(attacker)).residual_remaining,
+        0
+    );
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(attacker_owner.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker, false),
+        ],
+        &[],
+    )
+    .expect("second bounded close books and detaches the abandoned loser");
+    assert!(
+        percolator::active_bitmap_is_empty(
+            env.portfolio_state(attacker)
+                .active_bitmap
+                .map(|word| word.get())
+        ),
+        "abandoned loser reaches a terminal account state"
+    );
+
+    // The honest account was refreshed at every authenticated price step. Once
+    // the abandoned ledger is gone it can consume one configured B-loss chunk
+    // plus the small tail without surrendering already-booked positive PnL.
+    env.svm.expire_blockhash();
+    let first_winner_cu = env.forfeit_recovery_leg_with_cu(&honest_owner, honest, ASSET, u128::MAX);
+    assert_cu_within(
+        "winner terminal B chunk after Recovery",
+        first_winner_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let honest_after_first = env.portfolio_state(honest);
+    assert!(
+        has_active_leg_for_asset(&honest_after_first, ASSET as usize)
+            && active_leg_for_asset(&honest_after_first, ASSET as usize).b_stale,
+        "first bounded call consumes the full configured loss chunk and exposes the tail"
+    );
+    env.svm.expire_blockhash();
+    let second_winner_cu =
+        env.forfeit_recovery_leg_with_cu(&honest_owner, honest, ASSET, u128::MAX);
+    assert_cu_within(
+        "winner terminal B tail after Recovery",
+        second_winner_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(honest), ASSET as usize),
+        "second bounded continuation detaches the winner"
+    );
+
+    let vault_before = env.market_state().1.vault;
+    env.svm.expire_blockhash();
+    let (honest_dest, close_cu) = env.close_resolved_with_cu(&honest_owner, honest);
+    assert_cu_within(
+        "honest terminal exit after Recovery",
+        close_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let payout = env.token_amount(honest_dest);
+    assert!(
+        payout >= HONEST_CAPITAL,
+        "independent winner recovers principal through the real vault: payout={payout}"
+    );
+    let (_, after) = env.market_state();
+    assert_eq!(after.vault, vault_before - payout as u128);
+    assert!(after.vault >= after.c_tot + after.insurance);
+}


### PR DESCRIPTION
## Classification: [BLOCKER DoS]

A public losing trader can strand every user after a normal secondary-asset shutdown. The reproduction uses only program instructions and the default certified engine profile. It does not mutate account bytes, inject a close ledger, forge an oracle, or require a malicious market authority.

## Public attack

1. Two funded users open opposite positions on a secondary asset.
2. Authenticated marks advance within the configured per-slot price cap until one side is bankrupt.
3. The market authority performs the normal secondary-asset shutdown transition.
4. The losing owner calls `ForfeitRecoveryLeg` once. The default bounded bankruptcy chunk commits, leaving a real `100_000_000` residual and an active close ledger, then the owner disappears.
5. `ForceCloseAbandonedAsset`, the opposite owner's `ForfeitRecoveryLeg` and `RebalanceReduce`, and pre-expiry auto-crank all reject.
6. After `max_bankrupt_close_lifetime_slots`, public auto-crank escalates the global market to `Recovery`.
7. Before this fix, both wrapper resolve routes reject `Recovery`, while withdrawal requires `Live` and terminal close requires `Resolved`. An independent funded winner has no terminal route.

This disproves the earlier state-injection-only premise. The liquidation preflight is not the only public close-ledger producer; `ForfeitRecoveryLeg` can organically commit a partial bankruptcy ledger.

## Fix

- Pin engine commit `493fcacc55e236af36e0c8c6e683923ee50a2365`, which permits `Recovery -> Resolved`.
- Let admin `ResolveMarket` and mature `ResolveStalePermissionless` reject only an already-`Resolved` market.
- Keep stale maturity, authenticated clock, owner, and engine validation unchanged.

Once resolved, the regression proves bounded public progress through the abandoned loser, two bounded winner B-loss steps, and a real SPL-vault payout. The winner recovers at least principal; the vault falls by exactly the payout and senior conservation still holds.

## TDD evidence

Exact parent:

- wrapper `36fa587e1424a8c7fdde2c701c10938188a51876`
- engine `143e68c4917ed0400a27b952f036a5677047cd84`
- `v16_attack_partial_recovery_forfeit_has_public_terminal_escape`
- RED: mature `ResolveStalePermissionless` returns `Custom(21)` after the public sequence reaches global `Recovery`

Fixed branch:

- wrapper `631abdec`
- engine `493fcacc55e236af36e0c8c6e683923ee50a2365`
- GREEN: the same public setup reaches `Resolved`, clears both users in bounded calls, and pays the independent winner through the canonical vault

## Verification

- `cargo build-sbf --no-default-features`
- focused public RED/GREEN regression
- Recovery filter: 12/12
- resolve filter: 65/65
- full LiteSVM/CU suite: 566/566
- wrapper unit tests: 6/6
- `v16_kani` target compiles cleanly (proof harnesses are Kani-gated)

Paired engine PR: aeyakovenko/percolator#136.
