### PR TITLE
[BLOCKER LoF] Require committed accrual before market resolve

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8683,6 +8683,12 @@ pub mod processor {
         {
             return Ok(None);
         }
+        // With an active mark equal to the engine price, the clamped next price is unchanged and
+        // premium funding is exactly zero. Avoid two wide divisions per exposed asset; resolution
+        // must remain bounded for dense, normally constructed markets.
+        if profile.mark_ewma_e6 == asset.effective_price.get() {
+            return Ok(None);
+        }
         let next_price =
             committed_effective_price_for_accrual_view(profile, group, asset_index, resolved_slot)?;
         let funding_rate_e9 =

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8661,6 +8661,39 @@ pub mod processor {
         Ok(())
     }
 
+    fn committed_market_resolve_accrual_for_profile_view(
+        profile: &state::AssetOracleProfileV16,
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        resolved_slot: u64,
+    ) -> Result<Option<(u64, i128)>, ProgramError> {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let asset = group.markets[asset_index].engine.asset;
+        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+        // A mark newer than the asset cursor remains prospective. Resolution and its catch-up
+        // crank must agree on this boundary so a stale caller cannot activate a fresh report.
+        if !exposed
+            || asset.slot_last.get() >= resolved_slot
+            || !oracle_v16::profile_is_price_managed(profile)
+            || profile.mark_ewma_last_slot > asset.slot_last.get()
+        {
+            return Ok(None);
+        }
+        let next_price =
+            committed_effective_price_for_accrual_view(profile, group, asset_index, resolved_slot)?;
+        let funding_rate_e9 =
+            permissionless_funding_rate_e9_view(profile, group, asset_index, next_price)?;
+        let balanced = asset.oi_eff_long_q.get() != 0 && asset.oi_eff_short_q.get() != 0;
+        if next_price == asset.effective_price.get() && (!balanced || funding_rate_e9 == 0) {
+            return Ok(None);
+        }
+        Ok(Some((next_price, funding_rate_e9)))
+    }
+
     #[inline(never)]
     fn reject_market_resolve_before_committed_accrual_view(
         cfg: &WrapperConfigV16,
@@ -8674,30 +8707,15 @@ pub mod processor {
             let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
             if exposed && asset.slot_last.get() < resolved_slot {
                 let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
-                // A mark newer than the asset cursor is still prospective. Existing resolution
-                // semantics intentionally ignore it until a crank activates that checkpoint.
-                if oracle_v16::profile_is_price_managed(&profile)
-                    && profile.mark_ewma_last_slot <= asset.slot_last.get()
+                if committed_market_resolve_accrual_for_profile_view(
+                    &profile,
+                    group,
+                    asset_index,
+                    resolved_slot,
+                )?
+                .is_some()
                 {
-                    let next_price = committed_effective_price_for_accrual_view(
-                        &profile,
-                        group,
-                        asset_index,
-                        resolved_slot,
-                    )?;
-                    let funding_rate_e9 = permissionless_funding_rate_e9_view(
-                        &profile,
-                        group,
-                        asset_index,
-                        next_price,
-                    )?;
-                    let balanced =
-                        asset.oi_eff_long_q.get() != 0 && asset.oi_eff_short_q.get() != 0;
-                    if next_price != asset.effective_price.get()
-                        || (balanced && funding_rate_e9 != 0)
-                    {
-                        return Err(PercolatorError::EngineStale.into());
-                    }
+                    return Err(PercolatorError::EngineStale.into());
                 }
             }
             asset_index += 1;
@@ -10565,6 +10583,7 @@ pub mod processor {
             if summary.liquidatable
                 && !summary.b_stale
                 && permissionless_resolve_matured_now_view(&cfg, &group)
+                && observation_hints.is_empty()
             {
                 return Err(PercolatorError::OracleStale.into());
             }
@@ -10598,6 +10617,7 @@ pub mod processor {
             let insurance_before = group.header.insurance.get();
             let mut observations: Vec<AutoCrankObservationV16> =
                 Vec::with_capacity(percolator::V16_MAX_PORTFOLIO_ASSETS_N);
+            let mut settlement_only_after_maturity = None;
             let clock_unix_ts = Clock::get().ok().map(|c| c.unix_timestamp);
             for hint in observation_hints.iter() {
                 let asset_index = hint.asset_index as usize;
@@ -10608,7 +10628,24 @@ pub mod processor {
                 }
                 let oracle_account_count = hint.oracle_accounts as usize;
                 let mut oracle_profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
-                if oracle_account_count != oracle_profile.oracle_leg_count as usize {
+                let resolve_matured = global_or_profile_resolve_matured_at_slot(
+                    &cfg,
+                    &oracle_profile,
+                    authenticated_now_slot,
+                );
+                if let Some(expected) = settlement_only_after_maturity {
+                    if expected != resolve_matured {
+                        return Err(PercolatorError::InvalidInstruction.into());
+                    }
+                } else {
+                    settlement_only_after_maturity = Some(resolve_matured);
+                }
+                if resolve_matured && oracle_account_count != 0 {
+                    return Err(PercolatorError::OracleStale.into());
+                }
+                if !resolve_matured
+                    && oracle_account_count != oracle_profile.oracle_leg_count as usize
+                {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
                 if oracle_tail.len() < oracle_account_count {
@@ -10623,31 +10660,42 @@ pub mod processor {
                         .oracle_target_publish_time
                         .saturating_add(i64::try_from(elapsed_slots).unwrap_or(i64::MAX))
                 });
-                reject_non_base_oracle_update_after_global_resolve_matured(
-                    &cfg,
-                    asset_index,
-                    authenticated_now_slot,
-                )?;
-                reject_permissionless_resolve_matured_live_for_profile_view(
-                    &cfg,
-                    &oracle_profile,
-                    &group,
-                )?;
-                let crank_price = hybrid_effective_price_for_crank_view(
-                    &cfg,
-                    &mut oracle_profile,
-                    &group,
-                    asset_index,
-                    authenticated_now_slot,
-                    now_unix_ts,
-                    observation_tail,
-                )?;
-                let computed_funding_rate_e9 = permissionless_funding_rate_e9_view(
-                    &oracle_profile,
-                    &group,
-                    asset_index,
-                    crank_price,
-                )?;
+                let (crank_price, computed_funding_rate_e9) = if resolve_matured {
+                    committed_market_resolve_accrual_for_profile_view(
+                        &oracle_profile,
+                        &group,
+                        asset_index,
+                        authenticated_now_slot,
+                    )?
+                    .ok_or(PercolatorError::EngineNonProgress)?
+                } else {
+                    reject_non_base_oracle_update_after_global_resolve_matured(
+                        &cfg,
+                        asset_index,
+                        authenticated_now_slot,
+                    )?;
+                    reject_permissionless_resolve_matured_live_for_profile_view(
+                        &cfg,
+                        &oracle_profile,
+                        &group,
+                    )?;
+                    let crank_price = hybrid_effective_price_for_crank_view(
+                        &cfg,
+                        &mut oracle_profile,
+                        &group,
+                        asset_index,
+                        authenticated_now_slot,
+                        now_unix_ts,
+                        observation_tail,
+                    )?;
+                    let funding_rate_e9 = permissionless_funding_rate_e9_view(
+                        &oracle_profile,
+                        &group,
+                        asset_index,
+                        crank_price,
+                    )?;
+                    (crank_price, funding_rate_e9)
+                };
                 group
                     .set_asset_raw_oracle_target_not_atomic(
                         asset_index,
@@ -10697,6 +10745,14 @@ pub mod processor {
             }
             if !oracle_tail.is_empty() {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+
+            if settlement_only_after_maturity.unwrap_or(false) {
+                group.validate_shape().map_err(map_v16_error)?;
+                drop(group);
+                drop(market_data);
+                state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)?;
+                return Ok(());
             }
 
             let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8662,6 +8662,50 @@ pub mod processor {
     }
 
     #[inline(never)]
+    fn reject_market_resolve_before_committed_accrual_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        resolved_slot: u64,
+    ) -> ProgramResult {
+        let configured_slots = group.header.config.max_market_slots.get() as usize;
+        let mut asset_index = 0usize;
+        while asset_index < configured_slots {
+            let asset = group.markets[asset_index].engine.asset;
+            let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+            if exposed && asset.slot_last.get() < resolved_slot {
+                let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+                // A mark newer than the asset cursor is still prospective. Existing resolution
+                // semantics intentionally ignore it until a crank activates that checkpoint.
+                if oracle_v16::profile_is_price_managed(&profile)
+                    && profile.mark_ewma_last_slot <= asset.slot_last.get()
+                {
+                    let next_price = committed_effective_price_for_accrual_view(
+                        &profile,
+                        group,
+                        asset_index,
+                        resolved_slot,
+                    )?;
+                    let funding_rate_e9 = permissionless_funding_rate_e9_view(
+                        &profile,
+                        group,
+                        asset_index,
+                        next_price,
+                    )?;
+                    let balanced =
+                        asset.oi_eff_long_q.get() != 0 && asset.oi_eff_short_q.get() != 0;
+                    if next_price != asset.effective_price.get()
+                        || (balanced && funding_rate_e9 != 0)
+                    {
+                        return Err(PercolatorError::EngineStale.into());
+                    }
+                }
+            }
+            asset_index += 1;
+        }
+        Ok(())
+    }
+
+    #[inline(never)]
     fn handle_resolve_market<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
@@ -8683,6 +8727,7 @@ pub mod processor {
         if slot < group.header.current_slot.get() {
             return Err(PercolatorError::EngineStale.into());
         }
+        reject_market_resolve_before_committed_accrual_view(&cfg, &group, slot)?;
         group
             .resolve_market_not_atomic(slot)
             .map_err(map_v16_error)?;
@@ -9768,6 +9813,7 @@ pub mod processor {
         if !oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot) {
             return Err(PercolatorError::OracleStale.into());
         }
+        reject_market_resolve_before_committed_accrual_view(&cfg, &group, authenticated_slot)?;
         group
             .resolve_market_not_atomic(authenticated_slot)
             .map_err(map_v16_error)?;
@@ -11463,6 +11509,37 @@ pub mod processor {
         Ok(core::cmp::min(
             now_slot - asset_slot_last,
             group.header.config.max_accrual_dt_slots.get(),
+        ))
+    }
+
+    fn committed_effective_price_for_accrual_view(
+        profile: &state::AssetOracleProfileV16,
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        now_slot: u64,
+    ) -> Result<u64, ProgramError> {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let asset = group.markets[asset_index].engine.asset;
+        let current = asset.effective_price.get();
+        let target = if oracle_v16::profile_is_price_managed(profile) {
+            profile.mark_ewma_e6
+        } else {
+            current
+        };
+        if target == 0 {
+            return Err(PercolatorError::OracleInvalid.into());
+        }
+        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+        Ok(oracle_v16::effective_price_from_target(
+            current,
+            target,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            asset_segment_dt_view(group, asset_index, now_slot)?,
+            exposed,
         ))
     }
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8666,6 +8666,7 @@ pub mod processor {
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
         resolved_slot: u64,
+        include_pending_mark: bool,
     ) -> Result<Option<(u64, i128)>, ProgramError> {
         if asset_index >= group.header.config.max_market_slots.get() as usize
             || asset_index >= group.markets.len()
@@ -8674,12 +8675,13 @@ pub mod processor {
         }
         let asset = group.markets[asset_index].engine.asset;
         let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-        // A mark newer than the asset cursor remains prospective. Resolution and its catch-up
-        // crank must agree on this boundary so a stale caller cannot activate a fresh report.
+        // At stale-resolution maturity, the stored price-managed mark is the last authenticated
+        // report. It remains a required bounded transition even when no keeper has yet advanced
+        // the engine cursor to its publication slot.
         if !exposed
             || asset.slot_last.get() >= resolved_slot
             || !oracle_v16::profile_is_price_managed(profile)
-            || profile.mark_ewma_last_slot > asset.slot_last.get()
+            || (!include_pending_mark && profile.mark_ewma_last_slot > asset.slot_last.get())
         {
             return Ok(None);
         }
@@ -8705,6 +8707,7 @@ pub mod processor {
         cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         resolved_slot: u64,
+        include_pending_mark: bool,
     ) -> ProgramResult {
         let configured_slots = group.header.config.max_market_slots.get() as usize;
         let mut asset_index = 0usize;
@@ -8718,6 +8721,7 @@ pub mod processor {
                     group,
                     asset_index,
                     resolved_slot,
+                    include_pending_mark,
                 )?
                 .is_some()
                 {
@@ -8751,7 +8755,7 @@ pub mod processor {
         if slot < group.header.current_slot.get() {
             return Err(PercolatorError::EngineStale.into());
         }
-        reject_market_resolve_before_committed_accrual_view(&cfg, &group, slot)?;
+        reject_market_resolve_before_committed_accrual_view(&cfg, &group, slot, false)?;
         group
             .resolve_market_not_atomic(slot)
             .map_err(map_v16_error)?;
@@ -9837,7 +9841,12 @@ pub mod processor {
         if !oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot) {
             return Err(PercolatorError::OracleStale.into());
         }
-        reject_market_resolve_before_committed_accrual_view(&cfg, &group, authenticated_slot)?;
+        reject_market_resolve_before_committed_accrual_view(
+            &cfg,
+            &group,
+            authenticated_slot,
+            true,
+        )?;
         group
             .resolve_market_not_atomic(authenticated_slot)
             .map_err(map_v16_error)?;
@@ -10672,6 +10681,7 @@ pub mod processor {
                         &group,
                         asset_index,
                         authenticated_now_slot,
+                        true,
                     )?
                     .ok_or(PercolatorError::EngineNonProgress)?
                 } else {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60145,3 +60145,133 @@ fn v16_dense_price_managed_stale_market_remains_resolvable() {
     assert!(resolve_cu < 1_400_000);
     assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
 }
+
+#[test]
+fn v16_probe_stale_resolve_cannot_discard_pending_authenticated_mark() {
+    #[derive(Debug)]
+    struct Outcome {
+        effective_price: u64,
+        long_payout: u64,
+        short_payout: u64,
+        unsafe_resolve_rejected: bool,
+    }
+
+    fn run(crank_before_maturity: bool) -> Outcome {
+        const PRICE: u64 = 1_000_000;
+        const MARK: u64 = 1_010_000;
+        const DEPOSIT: u128 = 2_000_000_000;
+        const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+        const PUSH_SLOT: u64 = 2;
+        const RESOLVE_SLOT: u64 = 5;
+
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            max_portfolio_assets: 1,
+            initial_price: PRICE,
+            h_max: 20,
+            max_trading_fee_bps: 100,
+            max_price_move_bps_per_slot: 100,
+            max_accrual_dt_slots: 20,
+            min_funding_lifetime_slots: 20,
+            ..V16CuMarketParams::default()
+        });
+        env.configure_permissionless_resolve_with_cu(3, 1);
+        env.svm.warp_to_slot(1);
+        env.configure_auth_mark_with_cu(1, PRICE);
+
+        let marketauth = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &marketauth,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate honest oracle from market authority");
+
+        let victim = Keypair::new();
+        let victim_long = env.create_portfolio(&victim);
+        let attacker = Keypair::new();
+        let attacker_short = env.create_portfolio(&attacker);
+        env.deposit(&victim, victim_long, DEPOSIT);
+        env.deposit(&attacker, attacker_short, DEPOSIT);
+        env.trade_asset_with_cu(
+            0,
+            &victim,
+            victim_long,
+            &attacker,
+            attacker_short,
+            SIZE_Q,
+            PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(PUSH_SLOT);
+        env.push_auth_mark_for_asset_with_authority(0, &honest_oracle, PUSH_SLOT, MARK);
+        assert_eq!(env.market_state().1.assets[0].effective_price, PRICE);
+
+        if crank_before_maturity {
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: PUSH_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+
+        env.svm.warp_to_slot(RESOLVE_SLOT);
+        env.svm.expire_blockhash();
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let unsafe_resolve = env.send(
+            ProgInstruction::ResolveStalePermissionless {
+                now_slot: RESOLVE_SLOT,
+            },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        );
+        let unsafe_resolve_rejected = unsafe_resolve.is_err();
+        if unsafe_resolve_rejected {
+            assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+            env.svm.expire_blockhash();
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: RESOLVE_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+            env.svm.expire_blockhash();
+            env.send(
+                ProgInstruction::ResolveStalePermissionless {
+                    now_slot: RESOLVE_SLOT,
+                },
+                vec![AccountMeta::new(env.market, false)],
+                &[],
+            )
+            .expect("resolve after stored-state catch-up");
+        }
+
+        let effective_price = env.market_state().1.assets[0].effective_price;
+        env.svm.warp_to_slot(RESOLVE_SLOT + 1);
+        let short_dest = env.close_resolved(&attacker, attacker_short);
+        let long_dest = env.close_resolved(&victim, victim_long);
+        Outcome {
+            effective_price,
+            long_payout: env.token_amount(long_dest),
+            short_payout: env.token_amount(short_dest),
+            unsafe_resolve_rejected,
+        }
+    }
+
+    let control = run(true);
+    let attack = run(false);
+    eprintln!("pending-mark stale resolve control={control:?} attack={attack:?}");
+    assert_eq!(attack.effective_price, control.effective_price);
+    assert_eq!(attack.long_payout, control.long_payout);
+    assert_eq!(attack.short_payout, control.short_payout);
+    assert!(
+        attack.unsafe_resolve_rejected,
+        "stale resolver discarded an authenticated pending mark"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -27283,9 +27283,29 @@ fn v16_attack_non_base_trade_rejects_after_base_resolve_matured() {
         &[],
     );
     assert!(
-        resolve.is_ok(),
-        "base resolve remains available after rejected non-base trade: {resolve:?}"
+        resolve.is_err(),
+        "base resolve must not discard the pending authenticated non-base mark: {resolve:?}"
     );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected resolve leaves the pending mark and market state intact"
+    );
+    env.svm.expire_blockhash();
+    env.crank(
+        taker_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 8,
+            observations: crank_observations(1),
+        },
+    );
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    )
+    .expect("base resolve remains live after bounded stored-mark catch-up");
     assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59981,3 +59981,167 @@ fn v16_attack_stale_resolve_can_finish_committed_funding_accrual() {
     assert_eq!(env.token_amount(long_dest), 100_100_000);
     assert_eq!(env.token_amount(short_dest), 99_900_000);
 }
+
+#[test]
+fn v16_dense_price_managed_stale_market_remains_resolvable() {
+    const ASSET_COUNT: u16 = 4_000;
+    const PRICE: u64 = 100;
+    // Pre-sizing is part of normal market-account construction. InitMarket still configures only
+    // the first 14 slots; every additional slot is activated below through the public API.
+    let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
+        V16CuMarketParams {
+            max_portfolio_assets: percolator_prog::constants::WRAPPER_MAX_PORTFOLIO_ASSETS,
+            ..V16CuMarketParams::default()
+        },
+        ASSET_COUNT as usize,
+    );
+
+    let admin = env.admin.insecure_clone();
+    let initial_slots = env.market_state().1.config.max_market_slots as u16;
+    for asset_index in 0..initial_slots {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, PRICE);
+    }
+    for asset_index in initial_slots..ASSET_COUNT {
+        env.svm.warp_to_slot(asset_index as u64);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::UpdateAssetLifecycle {
+                action: processor::ASSET_ACTION_ACTIVATE,
+                asset_index,
+                now_slot: asset_index as u64,
+                initial_price: PRICE,
+                insurance_authority: admin.pubkey().to_bytes(),
+                insurance_operator: admin.pubkey().to_bytes(),
+                backing_bucket_authority: admin.pubkey().to_bytes(),
+                oracle_authority: admin.pubkey().to_bytes(),
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&admin],
+        )
+        .unwrap_or_else(|err| panic!("public activation failed at asset {asset_index}: {err}"));
+        env.configure_auth_mark_for_asset_as_admin(asset_index, asset_index as u64, PRICE);
+    }
+    assert_eq!(
+        env.market_state().1.config.max_market_slots,
+        ASSET_COUNT as u32
+    );
+
+    let open_batch = |env: &mut V16CuEnv,
+                      long_owner: &Keypair,
+                      long: Pubkey,
+                      short_owner: &Keypair,
+                      short: Pubkey,
+                      start: u16,
+                      end: u16|
+     -> Result<u64, String> {
+        let legs = (start..end)
+            .map(|asset_index| BatchTradeLeg {
+                asset_index,
+                size_q: POS_SCALE as i128,
+                exec_price: PRICE,
+                fee_bps: 0,
+            })
+            .collect();
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::BatchTradeNoCpi { legs },
+            vec![
+                AccountMeta::new(long_owner.pubkey(), true),
+                AccountMeta::new(short_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+                AccountMeta::new(short, false),
+            ],
+            &[long_owner, short_owner],
+        )
+    };
+
+    let victim = Keypair::new();
+    let cooperative_lp = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let cooperative_lp_portfolio = env.create_portfolio(&cooperative_lp);
+    env.deposit(&victim, victim_portfolio, 1_000_000);
+    env.deposit(&cooperative_lp, cooperative_lp_portfolio, 1_000_000);
+    open_batch(
+        &mut env,
+        &victim,
+        victim_portfolio,
+        &cooperative_lp,
+        cooperative_lp_portfolio,
+        0,
+        14,
+    )
+    .expect("open victim positions through the public batch route");
+
+    for start in (14..ASSET_COUNT).step_by(14) {
+        let end = start.saturating_add(14).min(ASSET_COUNT);
+        let long_owner = Keypair::new();
+        let short_owner = Keypair::new();
+        let long = env.create_portfolio(&long_owner);
+        let short = env.create_portfolio(&short_owner);
+        env.deposit(&long_owner, long, 1_000_000);
+        env.deposit(&short_owner, short, 1_000_000);
+        open_batch(&mut env, &long_owner, long, &short_owner, short, start, end)
+            .unwrap_or_else(|err| panic!("public exposure failed at asset {start}: {err}"));
+    }
+    assert_eq!(
+        env.market_state().1.assets[ASSET_COUNT as usize - 1].oi_eff_long_q,
+        POS_SCALE
+    );
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 1,
+            force_close_delay_slots: 1,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    )
+    .expect("configure permissionless resolution");
+    let resolved_slot = ASSET_COUNT as u64 + 1;
+    env.svm.warp_to_slot(resolved_slot);
+
+    env.svm.expire_blockhash();
+    let stale_exit = env
+        .send(
+            ProgInstruction::TradeNoCpi {
+                asset_index: 0,
+                size_q: -(POS_SCALE as i128),
+                exec_price: PRICE,
+                fee_bps: 0,
+            },
+            vec![
+                AccountMeta::new(victim.pubkey(), true),
+                AccountMeta::new(cooperative_lp.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim_portfolio, false),
+                AccountMeta::new(cooperative_lp_portfolio, false),
+            ],
+            &[&victim, &cooperative_lp],
+        )
+        .expect_err("mature staleness must block the ordinary trade exit");
+    assert!(
+        stale_exit.contains("Custom(27)") || stale_exit.contains("custom program error: 0x1b"),
+        "ordinary exit should fail specifically as OracleStale: {stale_exit}"
+    );
+
+    env.svm.expire_blockhash();
+    let resolve_cu = env
+        .send(
+            ProgInstruction::ResolveStalePermissionless {
+                now_slot: resolved_slot,
+            },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .expect("a publicly constructed dense market must retain a bounded stale resolver");
+    assert!(resolve_cu < 1_400_000);
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -47556,6 +47556,47 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
     assert_eq!(health_cert(&short_after).certified_liq_deficit, 0);
 }
 
+#[test]
+fn v16_bpf_10m_market_resolve_accrual_preflight_stays_bounded() {
+    const N: usize = 5_834;
+    const HIGH_ASSET: usize = N - 1;
+    const PRICE: u64 = 100;
+
+    let mut env = V16CuEnv::new();
+    let account_len = grow_market_to_10m_with_high_active_asset(&mut env, N, HIGH_ASSET, PRICE);
+    env.portfolio_account_len = state::portfolio_account_len_for_market_slots(N).unwrap();
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.svm.warp_to_slot(1);
+    env.trade_asset_with_cu(
+        HIGH_ASSET as u16,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    let resolve_cu = env.resolve();
+    println!(
+        "v16 10MiB ResolveMarket accrual preflight: assets={N}, account_len={account_len}, \
+         last_exposed_asset={HIGH_ASSET}, CU={resolve_cu}"
+    );
+    assert!(
+        resolve_cu < 1_400_000,
+        "10MiB ResolveMarket accrual preflight must fit the transaction CU limit: {resolve_cu}"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
 // Scale proof — the largest current market that fits Solana's 10 MiB account cap is valid AND a
 // real BPF trade on a HIGH asset index executes with O(1)-in-N compute.
 //
@@ -59716,4 +59757,141 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     ] {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
+}
+
+// Resolve may ignore a mark that has never become an accrual checkpoint, but it must not erase a
+// deterministic funding segment after a public crank has activated that checkpoint.
+#[test]
+fn v16_attack_market_resolve_cannot_erase_committed_funding() {
+    #[derive(Debug)]
+    struct Outcome {
+        f_long_num: i128,
+        f_short_num: i128,
+        long_payout: u64,
+        short_payout: u64,
+    }
+
+    fn run(crank_before_resolve: bool) -> Outcome {
+        const PRICE: u64 = 100;
+        const MARK: u64 = 99;
+        const OPEN_SLOT: u64 = 1;
+        const PRIME_SLOT: u64 = 2;
+        const RESOLVE_SLOT: u64 = 3;
+        const DEPOSIT: u128 = 100_000_000;
+        const SIZE_Q: i128 = 100_000 * POS_SCALE as i128;
+
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            initial_price: PRICE,
+            max_price_move_bps_per_slot: 1,
+            max_accrual_dt_slots: 1,
+            max_abs_funding_e9_per_slot: 10_000,
+            min_funding_lifetime_slots: 1,
+            ..V16CuMarketParams::default()
+        });
+        env.svm.warp_to_slot(OPEN_SLOT);
+        env.configure_auth_mark_with_cu(OPEN_SLOT, PRICE);
+
+        let resolve_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &resolve_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate the honest oracle key from the resolve admin");
+
+        let victim_long = env.create_portfolio(&honest_oracle);
+        let attacker_short = env.create_portfolio(&resolve_admin);
+        env.deposit(&honest_oracle, victim_long, DEPOSIT);
+        env.deposit(&resolve_admin, attacker_short, DEPOSIT);
+        env.trade_with_cu(
+            &honest_oracle,
+            victim_long,
+            &resolve_admin,
+            attacker_short,
+            SIZE_Q,
+            PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(PRIME_SLOT);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PushAuthMark {
+                asset_index: 0,
+                now_slot: PRIME_SLOT,
+                mark_e6: MARK,
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest oracle mark");
+        env.crank(
+            victim_long,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: PRIME_SLOT,
+                observations: crank_observations(0),
+            },
+        );
+
+        env.svm.warp_to_slot(RESOLVE_SLOT);
+        if crank_before_resolve {
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: RESOLVE_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.svm.expire_blockhash();
+        let first_resolve = send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::ResolveMarket,
+            vec![
+                AccountMeta::new(resolve_admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&resolve_admin],
+        );
+        if crank_before_resolve {
+            first_resolve.expect("current committed funding permits resolve");
+        } else if first_resolve.is_err() {
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: RESOLVE_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+            env.resolve();
+        }
+        let (_, resolved) = env.market_state();
+
+        // The funding loser closes first so its realized loss is available for the winner.
+        let short_dest = env.close_resolved(&resolve_admin, attacker_short);
+        let long_dest = env.close_resolved(&honest_oracle, victim_long);
+        Outcome {
+            f_long_num: resolved.assets[0].f_long_num,
+            f_short_num: resolved.assets[0].f_short_num,
+            long_payout: env.token_amount(long_dest),
+            short_payout: env.token_amount(short_dest),
+        }
+    }
+
+    let control = run(true);
+    let attack = run(false);
+    eprintln!("resolve funding control={control:?} attack={attack:?}");
+    assert!(control.f_long_num > 0 && control.f_short_num < 0);
+    assert_eq!(attack.f_long_num, control.f_long_num);
+    assert_eq!(attack.f_short_num, control.f_short_num);
+    assert_eq!(attack.long_payout, control.long_payout);
+    assert_eq!(attack.short_payout, control.short_payout);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59895,3 +59895,89 @@ fn v16_attack_market_resolve_cannot_erase_committed_funding() {
     assert_eq!(attack.long_payout, control.long_payout);
     assert_eq!(attack.short_payout, control.short_payout);
 }
+
+// Once stale resolution matures, its accrual preflight and the public crank must not deadlock each
+// other. The crank may commit already-stored price/funding state, but must not accept a fresh oracle
+// report that could reset the stale clock and postpone resolution.
+#[test]
+fn v16_attack_stale_resolve_can_finish_committed_funding_accrual() {
+    const PRICE: u64 = 100;
+    const MARK: u64 = 99;
+    const OPEN_SLOT: u64 = 1;
+    const PRIME_SLOT: u64 = 2;
+    const RESOLVE_SLOT: u64 = 3;
+    const DEPOSIT: u128 = 100_000_000;
+    const SIZE_Q: i128 = 100_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: 1,
+        max_accrual_dt_slots: 1,
+        max_abs_funding_e9_per_slot: 10_000,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_permissionless_resolve_with_cu(1, 1);
+    env.svm.warp_to_slot(OPEN_SLOT);
+    env.configure_auth_mark_with_cu(OPEN_SLOT, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, DEPOSIT);
+    env.deposit(&short_owner, short, DEPOSIT);
+    env.trade_with_cu(&long_owner, long, &short_owner, short, SIZE_Q, PRICE, 0);
+
+    env.svm.warp_to_slot(PRIME_SLOT);
+    env.push_auth_mark_with_cu(PRIME_SLOT, MARK);
+    env.crank(
+        long,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: PRIME_SLOT,
+            observations: crank_observations(0),
+        },
+    );
+
+    env.svm.warp_to_slot(RESOLVE_SLOT);
+    env.svm.expire_blockhash();
+    let unsafe_resolve = env
+        .send(
+            ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .expect_err("stale resolve must wait for the committed funding segment");
+    assert!(
+        unsafe_resolve.contains("Custom(19)")
+            || unsafe_resolve.contains("custom program error: 0x13"),
+        "unsafe stale resolve should reject as EngineStale, got {unsafe_resolve}"
+    );
+
+    env.svm.expire_blockhash();
+    env.crank(
+        long,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: RESOLVE_SLOT,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, accrued) = env.market_state();
+    assert!(accrued.assets[0].f_long_num > 0);
+    assert!(accrued.assets[0].f_short_num < 0);
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    )
+    .expect("stale resolve succeeds after bounded public catch-up");
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+
+    env.svm.warp_to_slot(RESOLVE_SLOT + 1);
+    let short_dest = env.close_resolved(&short_owner, short);
+    let long_dest = env.close_resolved(&long_owner, long);
+    assert_eq!(env.token_amount(long_dest), 100_100_000);
+    assert_eq!(env.token_amount(short_dest), 99_900_000);
+}


### PR DESCRIPTION
## Finding

Terminal resolution could freeze value before the public accrual route committed it.

1. A compromised non-oracle market authority could call public `ResolveMarket` after an honest AuthMark checkpoint had activated but before its next deterministic funding segment accrued.
2. Any caller could invoke `ResolveStalePermissionless` while an authenticated mark target was pending, causing resolution at the old effective mark and permanently discarding the move.

Both exact-parent LiteSVM repros use independent long and short owners plus a separate honest oracle. The funding repro transferred 100,000 atoms away from the owed long. The pending-mark repro moves an AuthMark from 1,000,000 to 1,010,000: the control pays 2,010,000,000 / 1,990,000,000, while resolve-first paid 2,000,000,000 to each side, transferring 10,000,000 atoms from the victim long to the attacker short. Both attacks use only public instructions and no injected protocol state.

## Fix

- Use one shared predicate for value-bearing accrual that must precede privileged or stale permissionless resolution.
- Require stale permissionless resolution to commit a pending authenticated mark before terminalizing the asset.
- Preserve current privileged-resolution mark policy here; PR #262 owns that separate policy change.
- At stale-resolution maturity, allow only zero-oracle-account catch-up of the exact stored transition required by the predicate.
- Skip account action/liquidation dispatch on this settlement-only route, and never reset the stale clock.
- Keep the scan cheap for empty assets by filtering exposure before decoding an oracle profile.
- Short-circuit an active mark equal to the engine price: both clamped price movement and premium funding are exactly zero, so no wide arithmetic is needed.

## TDD and liveness

- On exact parent `da64be63`, stale resolution lands before committed funding and before the pending authenticated mark, proving both value transfers.
- On the initial guard-only fix, stale resolution rejects with `EngineStale` but the catch-up crank rejects with `OracleStale`; the test exposes that persistent DoS.
- At fixed head, each unsafe resolve rolls back, one public stored-state crank commits the pending transition, retry resolves, and payouts match the control.
- A public CU regression pre-sizes a normal 4,000-asset market, activates/configures every asset, and opens balanced OI through `BatchTradeNoCpi`. At stale maturity the victim exit is `OracleStale`; the sole resolver remains below the transaction limit.

## Verification

- `cargo fmt --all -- --check`
- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1`: 570/570 LiteSVM/CU tests and 6/6 host tests green
- 10MiB public resolve reaches exposed asset 5,833 in a 10,484,888-byte market at 79,692 CU
