### PR TITLE
[HARDENING LoF] Prevent live fee hikes from taxing user capital

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9657,21 +9657,22 @@ pub mod processor {
         expect_signer(authority)?;
         expect_writable(market_ai)?;
         expect_owner(market_ai, program_id)?;
-        let (mut cfg, asset0_insurance_authority, max_trading_fee_bps) = {
-            let market_data = market_ai.try_borrow_data()?;
-            let (cfg, _, _, _, max_trading_fee_bps) =
-                state::read_market_trade_preflight(&market_data, 0)?;
-            let profile0 = read_oracle_profile_for_asset(&market_data, &cfg, 0)?;
-            (cfg, profile0.insurance_authority, max_trading_fee_bps)
-        };
-        expect_live_authority(&asset0_insurance_authority, authority.key)?;
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (mut cfg, group) = state::market_view_mut(&mut market_data)?;
+        let profile0 = read_oracle_profile_from_view(&group, &cfg, 0)?;
+        expect_live_authority(&profile0.insurance_authority, authority.key)?;
+        let max_trading_fee_bps = group.header.config.max_trading_fee_bps.get();
         if trade_fee_base_bps > max_trading_fee_bps
             || trade_fee_base_bps > constants::MAX_DYNAMIC_TRADE_FEE_BPS
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        if trade_fee_base_bps > cfg.trade_fee_base_bps && group.header.c_tot.get() != 0 {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         cfg.trade_fee_base_bps = trade_fee_base_bps;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        drop(group);
+        state::write_wrapper_config(&mut market_data, &cfg)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,76 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// REAL LoF: the asset-0 insurance authority controls the live mandatory base fee and defaults to
+// marketauth. It must not raise that fee after independent users already carry positions, force
+// both sides to surrender principal merely to flatten, then withdraw those forced fees as the live
+// insurance operator. Fee reductions remain safe while users are exposed.
+#[test]
+fn v16_attack_live_trade_fee_hike_cannot_rug_existing_positions() {
+    const PRICE: u64 = 100;
+    const DEPOSIT: u128 = 10_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, DEPOSIT);
+    env.deposit(&short_owner, short, DEPOSIT);
+    env.trade_with_cu(&long_owner, long, &short_owner, short, SIZE_Q, PRICE, 0);
+
+    let market_before_hike = env.svm.get_account(&env.market).unwrap();
+    env.svm.expire_blockhash();
+    let hike = env.send(
+        ProgInstruction::UpdateTradeFeePolicy {
+            trade_fee_base_bps: 10_000,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    let hike_landed = hike.is_ok();
+    if !hike_landed {
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_hike,
+            "rejected live fee hike is atomic"
+        );
+    }
+
+    env.svm.expire_blockhash();
+    env.trade_with_cu(&long_owner, long, &short_owner, short, -SIZE_Q, PRICE, 0);
+    let (_, after_close) = env.market_state();
+    let extracted = after_close.insurance;
+    let attacker_received = if extracted == 0 {
+        0
+    } else {
+        let (attacker_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&admin, 0, extracted)
+            .expect("the default admin/operator extracts the forced exit fees");
+        env.token_amount(attacker_dest) as u128
+    };
+    assert!(
+        !hike_landed,
+        "the fee authority raised mandatory fees under existing positions and extracted \
+         {attacker_received} atoms from two independent users"
+    );
+    assert_eq!(
+        attacker_received, 0,
+        "no pre-existing principal is extractable"
+    );
+    assert_eq!(env.portfolio_state(long).capital.get(), DEPOSIT);
+    assert_eq!(env.portfolio_state(short).capital.get(), DEPOSIT);
+
+    env.update_trade_fee_policy_with_cu(500);
+    assert_eq!(
+        env.market_state().0.trade_fee_base_bps,
+        500,
+        "the same increase remains available once all positions are flat"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59719,9 +59719,9 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 // REAL LoF: the asset-0 insurance authority controls the live mandatory base fee and defaults to
-// marketauth. It must not raise that fee after independent users already carry positions, force
-// both sides to surrender principal merely to flatten, then withdraw those forced fees as the live
-// insurance operator. Fee reductions remain safe while users are exposed.
+// marketauth. It must not worsen that fee while independent users have capital entrusted to the
+// market, force both sides to surrender principal merely to flatten, then withdraw those forced
+// fees as the live insurance operator. Fee reductions remain safe while users are exposed.
 #[test]
 fn v16_attack_live_trade_fee_hike_cannot_rug_existing_positions() {
     const PRICE: u64 = 100;
@@ -59783,10 +59783,55 @@ fn v16_attack_live_trade_fee_hike_cannot_rug_existing_positions() {
     assert_eq!(env.portfolio_state(long).capital.get(), DEPOSIT);
     assert_eq!(env.portfolio_state(short).capital.get(), DEPOSIT);
 
+    env.svm.expire_blockhash();
+    let still_funded = env.send(
+        ProgInstruction::UpdateTradeFeePolicy {
+            trade_fee_base_bps: 500,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        still_funded.is_err(),
+        "fee increases remain blocked while flat users still have capital deposited"
+    );
+    assert_eq!(
+        env.market_state().0.trade_fee_base_bps,
+        0,
+        "fee terms stay fixed until all entrusted capital is withdrawn"
+    );
+
+    env.withdraw_with_cu(&long_owner, long, DEPOSIT);
+    env.withdraw_with_cu(&short_owner, short, DEPOSIT);
+    env.svm.expire_blockhash();
     env.update_trade_fee_policy_with_cu(500);
     assert_eq!(
         env.market_state().0.trade_fee_base_bps,
         500,
-        "the same increase remains available once all positions are flat"
+        "the same increase remains available once all entrusted capital is withdrawn"
     );
+
+    env.deposit(&long_owner, long, 1);
+    env.update_trade_fee_policy_with_cu(100);
+    assert_eq!(
+        env.market_state().0.trade_fee_base_bps,
+        100,
+        "fee reductions remain available while user capital is deposited"
+    );
+}
+
+#[test]
+fn v16_bpf_flat_10m_market_trade_fee_increase_stays_bounded() {
+    const N: usize = 5_834;
+
+    let mut env = V16CuEnv::new();
+    grow_market_to_10m_with_high_active_asset(&mut env, N, N - 1, 100);
+
+    let cu = env.update_trade_fee_policy_with_cu(500);
+    println!("v16 flat 10MiB UpdateTradeFeePolicy CU: {cu}");
+    assert_cu_within("flat 10MiB UpdateTradeFeePolicy", cu, CUSTODY_CU_LIMIT);
+    assert_eq!(env.market_state().0.trade_fee_base_bps, 500);
 }


### PR DESCRIPTION
## Finding

`UpdateTradeFeePolicy` allowed the asset-0 insurance authority, which defaults to `marketauth`, to raise the mandatory base fee while unrelated users already had capital and open positions in a live market. A compromised non-oracle admin could set the fee to 10,000 bps, force both users to surrender principal merely to flatten, and withdraw those fees through the public live insurance interface.

The exact-parent LiteSVM repro on `da64be639168b496833dd4c701607a94fcb06b6c` opens a balanced position between two independently owned portfolios, raises the live fee from 0 to 10,000 bps, closes the position, and extracts 2,000 collateral atoms as the configured operator.

## Fix

- Reject base-fee increases while `c_tot != 0`, keeping the terms no worse for as long as any user capital is entrusted to the market.
- Continue to permit fee reductions while capital is deposited.
- Permit increases again after all capital is withdrawn.
- Use the engine-maintained constant-time `c_tot` aggregate instead of scanning assets.

## Verification

- Exact-parent public LiteSVM test fails with a 2,000-atom extraction.
- Fixed public LiteSVM test passes and verifies atomic rejection, unchanged user principal, live fee reductions, and post-withdraw reconfiguration.
- Maximal 5,834-asset / near-10 MiB market update consumes 2,005 CU.
- `cargo build-sbf --no-default-features`
- `cargo test --all-targets`: 567/567 LiteSVM tests plus all host/example targets pass after building the authenticated and hostile matcher fixtures.

No engine change is required.
