### PR TITLE
[HARDENING DoS] Keep funded Recovery deadlines monotonic

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9733,18 +9733,25 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, mode, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (mut cfg, group) = state::market_view_mut(&mut market_data)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
-        if mode != MarketModeV16::Live {
+        if group.header.mode != 0 {
             return Err(PercolatorError::EngineLockActive.into());
         }
         if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
             return Err(PercolatorError::OracleStale.into());
         }
+        if cfg.force_close_delay_slots != 0
+            && force_close_delay_slots > cfg.force_close_delay_slots
+            && group.header.c_tot.get() != 0
+        {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        drop(group);
+        state::write_wrapper_config(&mut market_data, &cfg)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,178 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// PARTIAL DoS: the live resolve policy is part of the bounded Recovery exit guarantee. After an
+// honest oracle creates a winner and a separate non-oracle admin shuts the asset down, that admin
+// must not move an already-running five-slot force-close deadline out to ten million slots. At the
+// original deadline an honest cranker must still close the pair and the winner must recover its
+// crystallized claim. Forfeiting the leg releases principal but leaves that claim unconvertible, so
+// it is not a complete payout-liveness path.
+#[test]
+fn v16_attack_live_policy_cannot_extend_recovery_force_close_deadline() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: u128 = 1_000 * POS_SCALE;
+    const PROFIT: u128 = 10_000;
+    const SHUTDOWN_SLOT: u64 = 3;
+    const ORIGINAL_DEADLINE: u64 = 8;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let oracle = Keypair::new();
+    let cranker = Keypair::new();
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&oracle),
+        0,
+        processor::ASSET_AUTH_ORACLE,
+        oracle.pubkey().to_bytes(),
+    )
+    .expect("separate the honest oracle key from the non-oracle admin");
+    env.configure_auth_mark_for_asset_with_authority(0, &oracle, 1, 100);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, DEPOSIT);
+    env.deposit(&short_owner, short, DEPOSIT);
+    env.trade_with_cu(
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        SIZE_Q as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_with_authority(0, &oracle, 2, 110);
+    env.crank(
+        long,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: Vec::new(),
+        },
+    );
+    env.crank(
+        long,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: Vec::new(),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(long).pnl.get(),
+        PROFIT as i128,
+        "honest mark creates a real winner before the admin action"
+    );
+
+    env.svm.warp_to_slot(SHUTDOWN_SLOT);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        processor::ASSET_ACTION_SHUTDOWN,
+        0,
+        SHUTDOWN_SLOT,
+        0,
+    );
+    let market_before_extension = env.svm.get_account(&env.market).unwrap();
+
+    env.svm.warp_to_slot(ORIGINAL_DEADLINE - 1);
+    env.svm.expire_blockhash();
+    let extension = env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 100,
+            force_close_delay_slots: percolator_prog::constants::MAX_FORCE_CLOSE_DELAY_SLOTS,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    let extension_landed = extension.is_ok();
+    if !extension_landed {
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_extension,
+            "rejected deadline extension is atomic"
+        );
+    }
+
+    env.svm.warp_to_slot(ORIGINAL_DEADLINE);
+    let force_close = env.try_force_close_abandoned_asset_with_cu(
+        &cranker,
+        long,
+        short,
+        0,
+        ORIGINAL_DEADLINE,
+        SIZE_Q,
+    );
+
+    if extension_landed {
+        assert!(
+            force_close.is_err(),
+            "control: the live policy extension actually blocks the honest cranker"
+        );
+        env.svm.expire_blockhash();
+        let convert = env.send(
+            ProgInstruction::ConvertReleasedPnl { amount: PROFIT },
+            vec![
+                AccountMeta::new(long_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[&long_owner],
+        );
+        assert!(
+            convert.is_err(),
+            "winner cannot convert while its Recovery position remains trapped"
+        );
+        env.forfeit_recovery_leg_with_cu(&long_owner, long, 0, 1);
+        let forfeited = env.portfolio_state(long);
+        assert_eq!(forfeited.pnl.get(), PROFIT as i128);
+        env.svm.expire_blockhash();
+        let convert_after_forfeit = env.send(
+            ProgInstruction::ConvertReleasedPnl { amount: PROFIT },
+            vec![
+                AccountMeta::new(long_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[&long_owner],
+        );
+        assert!(
+            convert_after_forfeit.is_err(),
+            "forfeiting the leg must not be mistaken for payout progress"
+        );
+        let dest = env.withdraw(&long_owner, long, DEPOSIT);
+        assert_eq!(env.token_amount(dest) as u128, DEPOSIT);
+        assert_eq!(env.portfolio_state(long).pnl.get(), PROFIT as i128);
+        assert!(
+            !extension_landed,
+            "the non-oracle admin extended an in-flight Recovery deadline and stranded the winner's {PROFIT}-atom claim"
+        );
+    }
+
+    let force_close_cu = force_close.expect("original Recovery deadline remains live");
+    assert_cu_within(
+        "immutable Recovery force-close deadline",
+        force_close_cu,
+        TRADE_CU_LIMIT,
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(short), 0));
+    assert_eq!(env.portfolio_state(long).pnl.get(), PROFIT as i128);
+    env.convert_released_pnl_with_cu(&long_owner, long, PROFIT);
+    assert_eq!(env.portfolio_state(long).capital.get(), DEPOSIT + PROFIT);
+    let dest = env.withdraw(&long_owner, long, DEPOSIT + PROFIT);
+    assert_eq!(env.token_amount(dest) as u128, DEPOSIT + PROFIT);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59887,8 +59887,43 @@ fn v16_attack_live_policy_cannot_extend_recovery_force_close_deadline() {
     assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
     assert!(!has_active_leg_for_asset(&env.portfolio_state(short), 0));
     assert_eq!(env.portfolio_state(long).pnl.get(), PROFIT as i128);
+
+    env.configure_permissionless_resolve_with_cu(100, 4);
+    assert_eq!(
+        env.market_state().0.force_close_delay_slots,
+        4,
+        "a shorter exit delay remains available while capital is deposited"
+    );
+
     env.convert_released_pnl_with_cu(&long_owner, long, PROFIT);
     assert_eq!(env.portfolio_state(long).capital.get(), DEPOSIT + PROFIT);
     let dest = env.withdraw(&long_owner, long, DEPOSIT + PROFIT);
     assert_eq!(env.token_amount(dest) as u128, DEPOSIT + PROFIT);
+
+    let short_capital = env.portfolio_state(short).capital.get();
+    let short_dest = env.withdraw(&short_owner, short, short_capital);
+    assert_eq!(env.token_amount(short_dest) as u128, short_capital);
+    assert_eq!(env.market_state().1.c_tot, 0);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    assert_eq!(
+        env.market_state().0.force_close_delay_slots,
+        5,
+        "a longer delay remains configurable after all user capital exits"
+    );
+}
+
+#[test]
+fn v16_bpf_flat_10m_market_resolve_policy_update_stays_bounded() {
+    const N: usize = 5_834;
+
+    let mut env = V16CuEnv::new();
+    grow_market_to_10m_with_high_active_asset(&mut env, N, N - 1, 100);
+
+    let cu = env.configure_permissionless_resolve_with_cu(100, 5);
+    println!("v16 flat 10MiB ConfigurePermissionlessResolve CU: {cu}");
+    assert_cu_within(
+        "flat 10MiB ConfigurePermissionlessResolve",
+        cu,
+        CUSTODY_CU_LIMIT,
+    );
 }


### PR DESCRIPTION
## Impact

A non-oracle market authority could extend `force_close_delay_slots` after an asset entered Recovery and postpone an already-funded winner claim for up to 10,000,000 slots.

The exact-parent LiteSVM reproduction uses only public instructions and separate oracle/admin keys:

- honest oracle moves the mark from 100 to 110;
- two funded users open the position;
- the admin shuts the asset down under a 5-slot force-close window;
- immediately before maturity, the admin extends the live policy to the maximum;
- an honest cranker can no longer force-close, and `ConvertReleasedPnl` cannot release the winner's 10,000-atom claim.

The owner can forfeit the Recovery leg and withdraw principal, so this is a partial payout DoS rather than a total account freeze or principal LoF.

## Fix

Once a nonzero force-close policy exists, reject delay increases while `c_tot != 0`. First-time configuration, shorter windows while capital is live, and longer windows after all capital exits remain supported.

The check reads the constant-time market aggregate and does not scan assets.

## Validation

- exact-parent public LiteSVM red test, fixed green
- controls for first configuration, delay reduction, and post-exit increase
- `cargo test --all-targets`: 567/567 runtime tests plus all host/example targets
- 10 MiB / 5,834-asset `ConfigurePermissionlessResolve`: 1,940 CU
- `cargo build-sbf --no-default-features`
