### PR TITLE
[PRIVILEGED LoF] Freeze funded hard-stale deadlines

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9733,18 +9733,25 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, mode, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (mut cfg, group) = state::market_view_mut(&mut market_data)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
-        if mode != MarketModeV16::Live {
+        if group.header.mode != 0 {
             return Err(PercolatorError::EngineLockActive.into());
         }
         if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
             return Err(PercolatorError::OracleStale.into());
         }
+        if cfg.permissionless_resolve_stale_slots != 0
+            && stale_slots > cfg.permissionless_resolve_stale_slots
+            && group.header.c_tot.get() != 0
+        {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        drop(group);
+        state::write_wrapper_config(&mut market_data, &cfg)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,179 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Bounded-admin attack: users entered under a five-slot hard oracle-stale deadline and the LP
+// authorized a matcher that fills at the wrapper-supplied oracle mark. A compromised non-oracle
+// market authority must not extend that live deadline immediately before maturity, reopen stale
+// price-taking against the passive LP, and extract the subsequent honest-oracle catch-up PnL.
+#[test]
+fn v16_attack_live_stale_policy_cannot_expose_passive_lp_after_deadline() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const PROFIT: u128 = 1_000;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    let oracle = Keypair::new();
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&oracle),
+        0,
+        processor::ASSET_AUTH_ORACLE,
+        oracle.pubkey().to_bytes(),
+    )
+    .expect("separate honest oracle authority accepts its role");
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_with_authority(0, &oracle, 1, 100);
+
+    let attacker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.deposit(&lp_owner, lp, DEPOSIT);
+    let (matcher_program, matcher_ctx, matcher_delegate) =
+        auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp);
+
+    env.svm.warp_to_slot(5);
+    let market_before_extension = env.svm.get_account(&env.market).unwrap();
+    env.svm.expire_blockhash();
+    let extension = env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: percolator_prog::constants::MAX_PERMISSIONLESS_RESOLVE_STALE_SLOTS,
+            force_close_delay_slots: 5,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    );
+    let extension_landed = extension.is_ok();
+    if !extension_landed {
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_extension,
+            "rejected live stale-deadline extension is atomic"
+        );
+    }
+
+    env.svm.warp_to_slot(6);
+    let market_before_fill = env.svm.get_account(&env.market).unwrap();
+    let attacker_before_fill = env.svm.get_account(&attacker).unwrap();
+    let lp_before_fill = env.svm.get_account(&lp).unwrap();
+    let matcher_before_fill = env.svm.get_account(&matcher_ctx).unwrap();
+    env.svm.expire_blockhash();
+    let stale_fill = env.try_trade_cpi_with_cu_on_asset(
+        &attacker_owner,
+        attacker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_ctx,
+        matcher_delegate,
+        0,
+        SIZE_Q,
+        0,
+    );
+
+    if extension_landed {
+        stale_fill
+            .as_ref()
+            .expect("source: extension reopens price-taking after the original deadline");
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(attacker), 0).basis_pos_q,
+            SIZE_Q
+        );
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(lp), 0).basis_pos_q,
+            -SIZE_Q,
+            "the independent LP owner did not sign the stale fill"
+        );
+
+        env.svm.warp_to_slot(7);
+        env.push_auth_mark_for_asset_with_authority(0, &oracle, 7, 200);
+        env.crank(
+            attacker,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 7,
+                observations: crank_observations(0),
+            },
+        );
+        env.crank(
+            lp,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 7,
+                observations: Vec::new(),
+            },
+        );
+        env.crank(
+            attacker,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 7,
+                observations: Vec::new(),
+            },
+        );
+        assert_eq!(env.portfolio_state(attacker).pnl.get(), PROFIT as i128);
+        assert_eq!(env.portfolio_state(lp).capital.get(), DEPOSIT - PROFIT);
+
+        env.svm.expire_blockhash();
+        env.trade_cpi_with_cu(
+            &attacker_owner,
+            attacker,
+            &lp_owner,
+            lp,
+            matcher_program,
+            matcher_ctx,
+            matcher_delegate,
+            -SIZE_Q,
+            0,
+        );
+        assert!(!has_active_leg_for_asset(&env.portfolio_state(attacker), 0));
+        assert!(!has_active_leg_for_asset(&env.portfolio_state(lp), 0));
+        env.convert_released_pnl_with_cu(&attacker_owner, attacker, PROFIT);
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT + PROFIT);
+        let lp_dest = env.withdraw(&lp_owner, lp, DEPOSIT - PROFIT);
+        assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT + PROFIT);
+        assert_eq!(env.token_amount(lp_dest) as u128, DEPOSIT - PROFIT);
+        assert!(
+            !extension_landed,
+            "non-oracle admin extended the live stale deadline and extracted {PROFIT} atoms from a passive LP"
+        );
+    }
+
+    assert!(
+        extension.is_err(),
+        "live stale-deadline increase must reject"
+    );
+    assert!(
+        stale_fill.is_err(),
+        "the original hard-stale deadline remains binding"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_fill
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker).unwrap(),
+        attacker_before_fill
+    );
+    assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before_fill);
+    assert_eq!(
+        env.svm.get_account(&matcher_ctx).unwrap(),
+        matcher_before_fill
+    );
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    )
+    .expect("honest permissionless resolution remains live at the original deadline");
+    let attacker_dest = env.close_resolved(&attacker_owner, attacker);
+    let lp_dest = env.close_resolved(&lp_owner, lp);
+    assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
+    assert_eq!(env.token_amount(lp_dest) as u128, DEPOSIT);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9932,7 +9932,7 @@ fn v16_attack_crossed_trade_cannot_turn_partial_liquidation_survivors_same_side(
 #[test]
 fn v16_attack_stale_resolve_matured_no_observation_liquidation_rejects() {
     let mut env = V16CuEnv::new();
-    env.configure_permissionless_resolve_with_cu(5, 5);
+    env.configure_permissionless_resolve_with_cu(6, 5);
     env.top_up_insurance(1_000_000);
     env.svm.warp_to_slot(1);
     env.configure_auth_mark_with_cu(1, 100);
@@ -59751,6 +59751,12 @@ fn v16_attack_live_stale_policy_cannot_expose_passive_lp_after_deadline() {
     env.deposit(&lp_owner, lp, DEPOSIT);
     let (matcher_program, matcher_ctx, matcher_delegate) =
         auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp);
+    env.configure_permissionless_resolve_with_cu(5, 5);
+    assert_eq!(
+        env.market_state().0.permissionless_resolve_stale_slots,
+        5,
+        "a shorter hard-stale deadline remains configurable while capital is live"
+    );
 
     env.svm.warp_to_slot(5);
     let market_before_extension = env.svm.get_account(&env.market).unwrap();
@@ -59888,8 +59894,16 @@ fn v16_attack_live_stale_policy_cannot_expose_passive_lp_after_deadline() {
         &[],
     )
     .expect("honest permissionless resolution remains live at the original deadline");
+    env.svm.warp_to_slot(11);
     let attacker_dest = env.close_resolved(&attacker_owner, attacker);
     let lp_dest = env.close_resolved(&lp_owner, lp);
     assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
     assert_eq!(env.token_amount(lp_dest) as u128, DEPOSIT);
+
+    let mut empty = V16CuEnv::new();
+    empty.configure_permissionless_resolve_with_cu(5, 5);
+    empty.configure_permissionless_resolve_with_cu(6, 6);
+    let cfg = empty.market_state().0;
+    assert_eq!(cfg.permissionless_resolve_stale_slots, 6);
+    assert_eq!(cfg.force_close_delay_slots, 6);
 }


### PR DESCRIPTION
## Impact

A compromised non-oracle market authority could raise `permissionless_resolve_stale_slots` immediately before the configured hard-stale boundary and keep stale price-taking live for up to 6,480,000 slots.

The exact-parent LiteSVM reproduction uses only public instructions and distinct roles:

- users deposit under a five-slot hard-stale policy;
- an independent LP owner authorizes a matcher that fills at the wrapper-supplied oracle mark;
- the separate honest oracle stops updating after price 100;
- at slot 5, the non-oracle admin raises the hard-stale policy to its maximum;
- at the original slot-6 deadline, an attacker opens an unsigned `TradeCpi` long against the passive LP at stale price 100;
- the honest oracle resumes at 200, the attacker flattens, converts the PnL, and withdraws 1,001,000 atoms while the LP can withdraw only 999,000.

Without the live extension, the same fill rejects atomically at slot 6 and `ResolveStalePermissionless` pays both users their original deposits.

## Fix

Once a nonzero hard-stale policy exists, reject deadline increases while `c_tot != 0`. First configuration, shorter deadlines while capital is live, idempotent writes, and longer deadlines on an empty live market remain supported.

The guard reads the constant-time market aggregate and does not scan assets or block trading/crank progress.

Deadline shortening is intentionally not claimed as a separate finding here. Its earlier payout divergence depended on the pending-mark omission already owned by PR #255; composing #255 with this PR leaves shortening enabled, forces stale resolution to reject at the old price, and permits one bounded public catch-up crank before resolution.

## TDD evidence

- exact-parent public LiteSVM RED: `7aad0c9d` completes the 1,000-atom passive-LP extraction
- fixed head: `191efc10`
- current focused recheck: exploit regression and stale non-base/global-resolution regression green against the real SBF
- patch-equivalent full verification: 6 wrapper unit tests and 566 serialized LiteSVM/CU tests green
- `cargo fmt --all -- --check` and `git diff --check` green
