### PR TITLE
[PRIVILEGED LoF] Bind direct trades to backing-fee consent

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2490,6 +2490,10 @@ pub mod ix {
             size_q: i128,
             exec_price: u64,
             fee_bps: u64,
+            /// Highest source-backing policy rate both owners authorize. Legacy payloads omit
+            /// this field and decode to zero, so a pre-existing signed transaction cannot be
+            /// charged a backing fee that was installed after authorization.
+            max_backing_fee_bps: u16,
         },
         TradeCpi {
             asset_index: u16,
@@ -2730,12 +2734,24 @@ pub mod ix {
                         observations,
                     }
                 }
-                6 => Self::TradeNoCpi {
-                    asset_index: read_u16(&mut rest)?,
-                    size_q: read_i128(&mut rest)?,
-                    exec_price: read_u64(&mut rest)?,
-                    fee_bps: read_u64(&mut rest)?,
-                },
+                6 => {
+                    let asset_index = read_u16(&mut rest)?;
+                    let size_q = read_i128(&mut rest)?;
+                    let exec_price = read_u64(&mut rest)?;
+                    let fee_bps = read_u64(&mut rest)?;
+                    let max_backing_fee_bps = if rest.is_empty() {
+                        0
+                    } else {
+                        read_u16(&mut rest)?
+                    };
+                    Self::TradeNoCpi {
+                        asset_index,
+                        size_q,
+                        exec_price,
+                        fee_bps,
+                        max_backing_fee_bps,
+                    }
+                }
                 10 => Self::TradeCpi {
                     asset_index: read_u16(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
@@ -3024,12 +3040,14 @@ pub mod ix {
                     size_q,
                     exec_price,
                     fee_bps,
+                    max_backing_fee_bps,
                 } => {
                     out.push(6);
                     push_u16(&mut out, asset_index);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, exec_price);
                     push_u64(&mut out, fee_bps);
+                    push_u16(&mut out, max_backing_fee_bps);
                 }
                 Self::TradeCpi {
                     asset_index,
@@ -5228,6 +5246,7 @@ pub mod processor {
                 size_q,
                 exec_price,
                 fee_bps,
+                max_backing_fee_bps,
             } => handle_trade_nocpi(
                 program_id,
                 accounts,
@@ -5235,6 +5254,7 @@ pub mod processor {
                 size_q,
                 exec_price,
                 fee_bps,
+                max_backing_fee_bps,
             ),
             Instruction::TradeCpi {
                 asset_index,
@@ -5798,6 +5818,7 @@ pub mod processor {
         size_q: i128,
         exec_price: u64,
         fee_bps: u64,
+        max_backing_fee_bps: u16,
         max_market_slots: usize,
     ) -> ProgramResult {
         ensure_portfolio_storage_for_market_slots(account_a_ai, max_market_slots)?;
@@ -5901,6 +5922,7 @@ pub mod processor {
                     backing_before_a.as_ref(),
                     &mut account_b,
                     backing_before_b.as_ref(),
+                    max_backing_fee_bps,
                 )?;
             }
             credit_trade_fees_to_market_budgets_view(
@@ -6206,6 +6228,7 @@ pub mod processor {
         size_q: i128,
         exec_price: u64,
         fee_bps: u64,
+        max_backing_fee_bps: u16,
     ) -> ProgramResult {
         let signer_a = account(accounts, 0)?;
         let signer_b = account(accounts, 1)?;
@@ -6221,6 +6244,9 @@ pub mod processor {
         expect_owner(account_a_ai, program_id)?;
         expect_owner(account_b_ai, program_id)?;
         if account_a_ai.key == account_b_ai.key {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if max_backing_fee_bps > 10_000 {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         ensure_valid_reported_trade_price(exec_price)?;
@@ -6240,6 +6266,7 @@ pub mod processor {
             size_q,
             exec_price,
             fee_bps,
+            max_backing_fee_bps,
             max_market_slots,
         )
     }
@@ -6702,6 +6729,7 @@ pub mod processor {
             ret.exec_size,
             ret.exec_price_e6,
             fee_bps,
+            10_000,
             max_market_slots,
         )
     }
@@ -11272,6 +11300,7 @@ pub mod processor {
         cfg: &WrapperConfigV16,
         account: &percolator::PortfolioV16ViewMut<'_>,
         before: &[(u32, u128)],
+        max_backing_fee_bps: u16,
         fees_by_domain: &mut DomainFeeTotals,
     ) -> Result<u128, ProgramError> {
         // Iterate only the OCCUPIED source-domain slots (after-state, <= CAP). For each, compute the
@@ -11296,6 +11325,9 @@ pub mod processor {
                 )
                 .map_err(map_v16_error)?;
                 if split.total_fee != 0 {
+                    if bps > max_backing_fee_bps {
+                        return Err(PercolatorError::Unauthorized.into());
+                    }
                     domain_fee_add(
                         fees_by_domain,
                         domain,
@@ -11348,6 +11380,7 @@ pub mod processor {
         before_a: &[(u32, u128)],
         account_b: &mut percolator::PortfolioV16ViewMut<'_>,
         before_b: &[(u32, u128)],
+        max_backing_fee_bps: u16,
     ) -> Result<u128, ProgramError> {
         let mut fees_a_by_domain: DomainFeeTotals = Vec::new();
         let fee_a = collect_backing_domain_fees_for_account_view(
@@ -11355,6 +11388,7 @@ pub mod processor {
             cfg,
             account_a,
             before_a,
+            max_backing_fee_bps,
             &mut fees_a_by_domain,
         )?;
         let mut fees_b_by_domain: DomainFeeTotals = Vec::new();
@@ -11363,6 +11397,7 @@ pub mod processor {
             cfg,
             account_b,
             before_b,
+            max_backing_fee_bps,
             &mut fees_b_by_domain,
         )?;
         if fee_a == 0 && fee_b == 0 {
@@ -12425,6 +12460,7 @@ pub mod processor {
                     before_a,
                     &mut account_b,
                     before_b,
+                    10_000,
                 )
                 .unwrap();
                 assert_eq!(charged, 10);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -41,6 +41,265 @@ fn crank_observations(asset_index: u16) -> Vec<CrankObservationHint> {
     }]
 }
 
+// LoF: a backing authority changes the fee after both TradeNoCpi owners signed. The stale
+// transaction must not silently transfer one owner's source-backed PnL to that authority.
+#[test]
+fn v16_attack_presigned_trade_nocpi_cannot_be_rugged_by_backing_fee_update() {
+    const INITIAL_PRICE: u64 = 100;
+    const LP_DEPOSIT: u128 = 3_130;
+    const TRADER_DEPOSIT: u128 = 10_000;
+    const WINNING_SIZE_Q: i128 = 200 * POS_SCALE as i128;
+    const LOSING_SIZE_Q: i128 = 100 * POS_SCALE as i128;
+    const INCREASE_Q: i128 = 20 * POS_SCALE as i128;
+    const WINNING_DOMAIN: u16 = 3;
+
+    let mut env =
+        V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(2, 1_000, 1_000, 500, 30);
+    env.update_market_init_fee_policy_with_cu(1);
+    let attacker = Keypair::new();
+    let market_trader = Keypair::new();
+    let lp = Keypair::new();
+
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, INITIAL_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, INITIAL_PRICE);
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        2,
+        0,
+    );
+    env.svm.warp_to_slot(3);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        3,
+        INITIAL_PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &attacker, 3, INITIAL_PRICE);
+
+    let attacker_account = env.create_portfolio(&attacker);
+    let market_trader_account = env.create_portfolio(&market_trader);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&attacker, attacker_account, TRADER_DEPOSIT);
+    env.deposit(&market_trader, market_trader_account, TRADER_DEPOSIT);
+    env.deposit(&lp, lp_account, LP_DEPOSIT);
+
+    let ledger = Keypair::new();
+    let payer = env.payer.insecure_clone();
+    system_create_account_for_test(
+        &mut env.svm,
+        &payer,
+        &ledger,
+        state::backing_domain_ledger_account_len(),
+        env.program_id,
+    );
+    let backing_source = env.token_account(attacker.pubkey(), 5_000);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: WINNING_DOMAIN,
+            amount: 5_000,
+            expiry_slot: 100,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger.pubkey(), false),
+        ],
+        &[&attacker],
+    )
+    .expect("attacker funds its backing domain");
+
+    env.try_trade_asset_with_cu(
+        1,
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        -WINNING_SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    )
+    .expect("initial winning TradeNoCpi leg");
+    env.try_trade_asset_with_cu(
+        0,
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        -LOSING_SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    )
+    .expect("initial losing TradeNoCpi leg");
+
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_for_asset_with_authority(1, &attacker, 4, INITIAL_PRICE);
+    env.push_auth_mark_for_asset_as_admin(0, 4, INITIAL_PRICE);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+        (lp_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 4,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    env.sync_maintenance_fee_with_cu(lp_account, None, 4);
+
+    env.svm.warp_to_slot(5);
+    env.push_auth_mark_for_asset_with_authority(1, &attacker, 5, 105);
+    env.push_auth_mark_for_asset_as_admin(0, 5, 95);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 5,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    assert_eq!(env.portfolio_state(lp_account).pnl.get(), 1_000);
+
+    let trade_data = |max_backing_fee_bps: Option<u16>| {
+        let mut data = vec![6];
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&(-INCREASE_Q).to_le_bytes());
+        data.extend_from_slice(&95u64.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        if let Some(cap) = max_backing_fee_bps {
+            data.extend_from_slice(&cap.to_le_bytes());
+        }
+        data
+    };
+
+    // Both owners authorize the legacy wire payload while the domain fee is zero. On the fixed
+    // program, an omitted cap means zero rather than consenting to an arbitrary future policy.
+    let trade_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(lp.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_account, false),
+            AccountMeta::new(lp_account, false),
+        ],
+        data: trade_data(None),
+    };
+    let presigned_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), trade_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &attacker, &lp],
+        env.svm.latest_blockhash(),
+    );
+
+    env.send(
+        ProgInstruction::UpdateBackingFeePolicy {
+            domain: WINNING_DOMAIN,
+            fee_bps: 5_000,
+            insurance_share_bps: 0,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&attacker],
+    )
+    .expect("backing authority changes the live fee after trade authorization");
+
+    let market_before_reject = env.svm.get_account(&env.market).unwrap();
+    let attacker_before_reject = env.svm.get_account(&attacker_account).unwrap();
+    let lp_before_reject = env.svm.get_account(&lp_account).unwrap();
+    let rejected = env.svm.send_transaction(presigned_trade);
+    assert!(
+        rejected.is_err(),
+        "a zero-cap pre-signed trade must reject a later backing-fee hike"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_reject
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_account).unwrap(),
+        attacker_before_reject
+    );
+    assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_before_reject);
+
+    // A freshly signed transaction can opt into the observed policy explicitly.
+    let provider_before = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings;
+    let lp_before = env.portfolio_state(lp_account).capital.get();
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(attacker.pubkey(), true),
+                AccountMeta::new(lp.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker_account, false),
+                AccountMeta::new(lp_account, false),
+            ],
+            data: trade_data(Some(5_000)),
+        },
+        &[&attacker, &lp],
+    )
+    .expect("owners can opt into the current backing-fee policy");
+    let provider_after = env.market_state().1.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings;
+    let lp_after = env.portfolio_state(lp_account).capital.get();
+    let extracted = provider_after - provider_before;
+    assert_eq!(
+        extracted, 70,
+        "the opted-in trade pays the exact backing fee"
+    );
+    assert_eq!(lp_before - lp_after, extracted);
+
+    let earnings_dest = env.token_account(attacker.pubkey(), 0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::WithdrawBackingBucketEarnings {
+            domain: WINNING_DOMAIN,
+            amount: extracted,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(ledger.pubkey(), false),
+            AccountMeta::new(earnings_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&attacker],
+    )
+    .expect("attacker withdraws the victim-funded fee");
+    assert_eq!(env.token_amount(earnings_dest) as u128, extracted);
+}
+
 fn crank_observations_with_accounts(
     asset_index: u16,
     oracle_accounts: u8,
@@ -1486,6 +1745,7 @@ impl V16CuEnv {
                 size_q,
                 exec_price,
                 fee_bps,
+                max_backing_fee_bps: 10_000,
             },
             vec![
                 AccountMeta::new(owner_a.pubkey(), true),
@@ -15948,6 +16208,7 @@ fn v16_attack_account_type_confusion_rejected() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(la.pubkey(), true),
@@ -21542,6 +21803,7 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
             size_q: (10 * POS_SCALE) as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(taker_owner.pubkey(), true),
@@ -22385,6 +22647,7 @@ fn v16_attack_non_owner_cannot_withdraw_or_trade() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -26954,6 +27217,7 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -27246,6 +27510,7 @@ fn v16_attack_non_base_trade_rejects_after_base_resolve_matured() {
             size_q: POS_SCALE as i128,
             exec_price: 101,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),
@@ -28595,6 +28860,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(local_owner.pubkey(), true),
@@ -28752,6 +29018,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(local_owner.pubkey(), true),
@@ -30366,6 +30633,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
                 size_q: POS_SCALE as i128,
                 exec_price: 100,
                 fee_bps: 100,
+                max_backing_fee_bps: 0,
             },
             vec![
                 AccountMeta::new(attacker.pubkey(), true),
@@ -30463,6 +30731,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 100,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(good_a.pubkey(), true),
@@ -31246,6 +31515,7 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(long_owner.pubkey(), true),
@@ -36907,6 +37177,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(b_long_owner.pubkey(), true),
@@ -42750,6 +43021,7 @@ fn v16_attack_tradenocpi_self_trade_rejected() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 100,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(owner.pubkey(), true),
@@ -55200,6 +55472,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
             size_q: POS_SCALE as i128,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         vec![
             AccountMeta::new(taker.pubkey(), true),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -462,11 +462,47 @@ fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
             size_q: got_size,
             exec_price: got_price,
             fee_bps: got_fee,
+            max_backing_fee_bps: got_backing_cap,
         } => {
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_size, size_q);
             assert_eq!(got_price, exec_price);
             assert_eq!(got_fee, fee_bps);
+            assert_eq!(got_backing_cap, 0);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_tradenocpi_decode_preserves_backing_fee_cap() {
+    let asset_index: u16 = kani::any();
+    let size_q: i128 = kani::any();
+    let exec_price: u64 = kani::any();
+    let fee_bps: u64 = kani::any();
+    let max_backing_fee_bps: u16 = kani::any();
+
+    let mut data = [0u8; 37];
+    data[0] = 6;
+    data[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    data[3..19].copy_from_slice(&size_q.to_le_bytes());
+    data[19..27].copy_from_slice(&exec_price.to_le_bytes());
+    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[35..37].copy_from_slice(&max_backing_fee_bps.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::TradeNoCpi {
+            asset_index: got_asset,
+            size_q: got_size,
+            exec_price: got_price,
+            fee_bps: got_fee,
+            max_backing_fee_bps: got_backing_cap,
+        } => {
+            assert_eq!(got_asset, asset_index);
+            assert_eq!(got_size, size_q);
+            assert_eq!(got_price, exec_price);
+            assert_eq!(got_fee, fee_bps);
+            assert_eq!(got_backing_cap, max_backing_fee_bps);
         }
         _ => unreachable!(),
     }
@@ -1194,6 +1230,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
             size_q: 1,
             exec_price: 100,
             fee_bps: 0,
+            max_backing_fee_bps: 0,
         },
         extra,
     );


### PR DESCRIPTION
## Impact

A permissionless backing authority could raise a live source-backing fee after both owners signed a `TradeNoCpi` transaction. Landing the unchanged transaction then charged an independent LP at the new rate, credited the attacker-controlled backing ledger, and made the victim-funded fee immediately withdrawable.

The public LiteSVM regression uses normal market, portfolio, position, policy-update, trade, and withdrawal instructions. It does not mutate account state directly. The exploit extracts exactly 70 base units from the independent LP in the test geometry.

## Root cause

`TradeNoCpi` authorized the trade fee but did not bind either signer to the mutable source-backing fee policy evaluated at execution time. This made an already-signed transaction vulnerable to an out-of-order policy update.

## Fix

- Add a signer-authorized `max_backing_fee_bps` cap to `TradeNoCpi`.
- Decode legacy 35-byte payloads with an implicit zero cap, so existing signatures cannot acquire new fee consent.
- Reject a positive source-backing charge above the signed cap while preserving zero-fee and risk-reducing progress.
- Prove both legacy and extended wire decodes with Kani.

## TDD evidence

Exact parent `da64be639168b496833dd4c701607a94fcb06b6c` fails `v16_attack_presigned_trade_nocpi_cannot_be_rugged_by_backing_fee_update` because the zero-cap pre-signed transaction succeeds after the fee hike. Commit `2b317e55` rejects that stale transaction with byte-identical rollback, accepts a newly signed capped transaction, charges exactly 70 units, and lets the attacker withdraw the fee.

## Verification

- `cargo test --lib` (6/6)
- `cargo test --test v16_cu -- --test-threads=1` (566/566)
- `cargo build --examples`
- `cargo build-sbf --tools-version v1.52`
- targeted Kani wire proofs (all green)
- `cargo fmt --check`
- `git diff --check`

`TradeCpi` has a distinct matcher-consent surface tracked separately; batch direct trading currently rejects configured backing fees.