### PR TITLE
[HARDENING DoS] Reject expired Hybrid terminal snapshots

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8687,10 +8687,16 @@ pub mod processor {
             return Ok(());
         }
 
-        let external_fresh = profile.oracle_target_publish_time > 0
-            && now_unix_ts >= profile.oracle_target_publish_time
-            && (now_unix_ts - profile.oracle_target_publish_time) as u64
-                <= profile.max_staleness_secs;
+        let oracle_leg_count = profile.oracle_leg_count as usize;
+        let external_fresh = oracle_leg_count != 0
+            && oracle_leg_count <= constants::ORACLE_LEG_CAP
+            && profile.oracle_leg_publish_times[..oracle_leg_count]
+                .iter()
+                .all(|publish_time| {
+                    *publish_time > 0
+                        && now_unix_ts >= *publish_time
+                        && (now_unix_ts - *publish_time) as u64 <= profile.max_staleness_secs
+                });
         let fee_backed_after_hours_mark_current =
             oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot)
                 && profile.mark_ewma_last_slot == now_slot;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8661,6 +8661,46 @@ pub mod processor {
         Ok(())
     }
 
+    fn require_hybrid_resolution_price_current_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        now_slot: u64,
+        now_unix_ts: i64,
+    ) -> ProgramResult {
+        let configured_slots = group.header.config.max_market_slots.get() as usize;
+        if configured_slots > group.markets.len() {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        for asset_index in 0..configured_slots {
+            let asset = &group.markets[asset_index].engine.asset;
+            let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+            if !exposed
+                || !matches!(
+                    asset.lifecycle,
+                    ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY
+                )
+            {
+                continue;
+            }
+            let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+            if !oracle_v16::profile_is_hybrid(&profile) {
+                continue;
+            }
+
+            let external_fresh = profile.oracle_target_publish_time > 0
+                && now_unix_ts >= profile.oracle_target_publish_time
+                && (now_unix_ts - profile.oracle_target_publish_time) as u64
+                    <= profile.max_staleness_secs;
+            let fee_backed_after_hours_mark_current =
+                oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot)
+                    && profile.mark_ewma_last_slot == now_slot;
+            if !external_fresh && !fee_backed_after_hours_mark_current {
+                return Err(PercolatorError::OracleStale.into());
+            }
+        }
+        Ok(())
+    }
+
     #[inline(never)]
     fn handle_resolve_market<'a>(
         program_id: &Pubkey,
@@ -8677,12 +8717,13 @@ pub mod processor {
             return Err(PercolatorError::EngineLockActive.into());
         }
         expect_live_authority(&cfg.marketauth, admin.key)?;
-        let slot = Clock::get()
-            .map(|c| c.slot)
-            .unwrap_or(group.header.current_slot.get());
+        let (slot, unix_timestamp) = Clock::get()
+            .map(|c| (c.slot, c.unix_timestamp))
+            .unwrap_or((group.header.current_slot.get(), 0));
         if slot < group.header.current_slot.get() {
             return Err(PercolatorError::EngineStale.into());
         }
+        require_hybrid_resolution_price_current_view(&cfg, &group, slot, unix_timestamp)?;
         group
             .resolve_market_not_atomic(slot)
             .map_err(map_v16_error)?;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8661,7 +8661,46 @@ pub mod processor {
         Ok(())
     }
 
-    fn require_hybrid_resolution_price_current_view(
+    fn require_hybrid_terminal_price_current_for_asset_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        now_slot: u64,
+        now_unix_ts: i64,
+    ) -> ProgramResult {
+        let configured_slots = group.header.config.max_market_slots.get() as usize;
+        if asset_index >= configured_slots || asset_index >= group.markets.len() {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let asset = &group.markets[asset_index].engine.asset;
+        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+        if !exposed
+            || !matches!(
+                asset.lifecycle,
+                ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY
+            )
+        {
+            return Ok(());
+        }
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+        if !oracle_v16::profile_is_hybrid(&profile) {
+            return Ok(());
+        }
+
+        let external_fresh = profile.oracle_target_publish_time > 0
+            && now_unix_ts >= profile.oracle_target_publish_time
+            && (now_unix_ts - profile.oracle_target_publish_time) as u64
+                <= profile.max_staleness_secs;
+        let fee_backed_after_hours_mark_current =
+            oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot)
+                && profile.mark_ewma_last_slot == now_slot;
+        if !external_fresh && !fee_backed_after_hours_mark_current {
+            return Err(PercolatorError::OracleStale.into());
+        }
+        Ok(())
+    }
+
+    fn require_hybrid_resolution_prices_current_view(
         cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         now_slot: u64,
@@ -8672,31 +8711,13 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         for asset_index in 0..configured_slots {
-            let asset = &group.markets[asset_index].engine.asset;
-            let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-            if !exposed
-                || !matches!(
-                    asset.lifecycle,
-                    ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY
-                )
-            {
-                continue;
-            }
-            let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
-            if !oracle_v16::profile_is_hybrid(&profile) {
-                continue;
-            }
-
-            let external_fresh = profile.oracle_target_publish_time > 0
-                && now_unix_ts >= profile.oracle_target_publish_time
-                && (now_unix_ts - profile.oracle_target_publish_time) as u64
-                    <= profile.max_staleness_secs;
-            let fee_backed_after_hours_mark_current =
-                oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot)
-                    && profile.mark_ewma_last_slot == now_slot;
-            if !external_fresh && !fee_backed_after_hours_mark_current {
-                return Err(PercolatorError::OracleStale.into());
-            }
+            require_hybrid_terminal_price_current_for_asset_view(
+                cfg,
+                group,
+                asset_index,
+                now_slot,
+                now_unix_ts,
+            )?;
         }
         Ok(())
     }
@@ -8723,7 +8744,7 @@ pub mod processor {
         if slot < group.header.current_slot.get() {
             return Err(PercolatorError::EngineStale.into());
         }
-        require_hybrid_resolution_price_current_view(&cfg, &group, slot, unix_timestamp)?;
+        require_hybrid_resolution_prices_current_view(&cfg, &group, slot, unix_timestamp)?;
         group
             .resolve_market_not_atomic(slot)
             .map_err(map_v16_error)?;
@@ -9307,6 +9328,7 @@ pub mod processor {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
             let authenticated_slot = authenticated_slot_or_fallback(now_slot);
+            let authenticated_unix_ts = Clock::get().map(|c| c.unix_timestamp).unwrap_or(0);
             if oracle_v16::permissionless_stale_matured(&cfg_pre, authenticated_slot) {
                 return Err(PercolatorError::OracleStale.into());
             }
@@ -9330,6 +9352,13 @@ pub mod processor {
                 if authenticated_slot < group.header.current_slot.get() {
                     return Err(PercolatorError::EngineStale.into());
                 }
+                require_hybrid_terminal_price_current_for_asset_view(
+                    &cfg,
+                    &group,
+                    asset_index,
+                    authenticated_slot,
+                    authenticated_unix_ts,
+                )?;
                 match group.markets[asset_index].engine.asset.lifecycle {
                     ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY => {
                         let frozen_mark = group.markets[asset_index]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,202 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Public-interface TDD probe: a non-oracle market authority must not resolve a live Hybrid market
+// against an expired stored mark after the honest external feed has published a current report. The
+// control differs only by letting a permissionless keeper ingest that report before resolution.
+#[test]
+fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
+    const OPEN_PRICE_E6: u64 = 100_000;
+    const FRESH_PRICE_E6: u64 = 110_000;
+    const CAPITAL: u128 = 100_000_000;
+    const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+    const FEED: [u8; 32] = [0xacu8; 32];
+
+    fn setup() -> (V16CuEnv, Keypair, Pubkey, Keypair, Pubkey) {
+        let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+        set_test_clock(&mut env, 1, 100);
+        let initial_oracle = env.set_pyth_price(&FEED, OPEN_PRICE_E6 as i64, -6, 100);
+
+        // Separate the honest oracle authority from the adversarial market authority. The attack
+        // below uses only ResolveMarket; it never signs an oracle instruction or rewrites the feed.
+        let old_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &old_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("handoff oracle authority to an independent honest key");
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::ConfigureHybridOracle {
+                asset_index: 0,
+                now_slot: 1,
+                now_unix_ts: 100,
+                oracle_leg_count: 1,
+                oracle_leg_flags: 0,
+                max_staleness_secs: 60,
+                hybrid_soft_stale_slots: 3,
+                mark_ewma_halflife_slots: 1,
+                mark_min_fee: 0,
+                invert: 0,
+                unit_scale: 0,
+                conf_filter_bps: 500,
+                oracle_leg_feeds: [FEED, [0u8; 32], [0u8; 32]],
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new_readonly(initial_oracle, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest oracle authority configures the Hybrid market");
+        assert_eq!(
+            env.market_state().1.assets[0].effective_price,
+            OPEN_PRICE_E6
+        );
+
+        let victim = Keypair::new();
+        let victim_portfolio = env.create_portfolio(&victim);
+        let attacker = Keypair::new();
+        let attacker_portfolio = env.create_portfolio(&attacker);
+        env.deposit(&victim, victim_portfolio, CAPITAL);
+        env.deposit(&attacker, attacker_portfolio, CAPITAL);
+        env.trade_asset_with_cu(
+            0,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+            SIZE_Q,
+            OPEN_PRICE_E6,
+            0,
+        );
+        (env, victim, victim_portfolio, attacker, attacker_portfolio)
+    }
+
+    fn close_resolved_payouts(
+        env: &mut V16CuEnv,
+        victim: &Keypair,
+        victim_portfolio: Pubkey,
+        attacker: &Keypair,
+        attacker_portfolio: Pubkey,
+    ) -> (u64, u64) {
+        let attacker_dest = env.close_resolved(attacker, attacker_portfolio);
+        let victim_dest = env.close_resolved(victim, victim_portfolio);
+        (
+            env.token_amount(victim_dest),
+            env.token_amount(attacker_dest),
+        )
+    }
+
+    let (mut attacked, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
+    set_test_clock(&mut attacked, 100, 200);
+    let ignored_report = attacked.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    assert_eq!(
+        attacked.market_state().1.assets[0].effective_price,
+        OPEN_PRICE_E6,
+        "the stored report is expired and the fresh external report is not yet ingested"
+    );
+    assert!(
+        attacked.svm.get_account(&ignored_report).is_some(),
+        "the honest external report existed before adversarial resolution"
+    );
+    let market_before = attacked.svm.get_account(&attacked.market).unwrap();
+    let victim_before = attacked.svm.get_account(&victim_portfolio).unwrap();
+    let attacker_before = attacked.svm.get_account(&attacker_portfolio).unwrap();
+    let compromised_admin = attacked.admin.insecure_clone();
+    attacked.svm.expire_blockhash();
+    let stale_resolve = attacked.send(
+        ProgInstruction::ResolveMarket,
+        vec![
+            AccountMeta::new(compromised_admin.pubkey(), true),
+            AccountMeta::new(attacked.market, false),
+        ],
+        &[&compromised_admin],
+    );
+    let stale_resolve_rejected = stale_resolve.is_err();
+    let attacked_payouts = if stale_resolve_rejected {
+        assert_eq!(
+            attacked.svm.get_account(&attacked.market).unwrap(),
+            market_before
+        );
+        assert_eq!(
+            attacked.svm.get_account(&victim_portfolio).unwrap(),
+            victim_before
+        );
+        assert_eq!(
+            attacked.svm.get_account(&attacker_portfolio).unwrap(),
+            attacker_before
+        );
+        let keeper = Keypair::new();
+        let keeper_portfolio = attacked.create_portfolio(&keeper);
+        attacked.crank_with_oracle_tail(
+            keeper_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 100,
+                observations: crank_observations(0),
+            },
+            &[ignored_report],
+        );
+        attacked.resolve();
+        close_resolved_payouts(
+            &mut attacked,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+        )
+    } else {
+        close_resolved_payouts(
+            &mut attacked,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+        )
+    };
+
+    let (mut control, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
+    set_test_clock(&mut control, 100, 200);
+    let fresh_report = control.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    let keeper = Keypair::new();
+    let keeper_portfolio = control.create_portfolio(&keeper);
+    control.crank_with_oracle_tail(
+        keeper_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 100,
+            observations: crank_observations(0),
+        },
+        &[fresh_report],
+    );
+    assert_eq!(
+        control.market_state().1.assets[0].effective_price,
+        FRESH_PRICE_E6,
+        "permissionless control ingests the honest report"
+    );
+    control.resolve();
+    let control_payouts = close_resolved_payouts(
+        &mut control,
+        &victim,
+        victim_portfolio,
+        &attacker,
+        attacker_portfolio,
+    );
+    assert_eq!(control_payouts.0 + control_payouts.1, 2 * CAPITAL as u64);
+    assert_eq!(
+        attacked_payouts, control_payouts,
+        "stale admin resolution deprived the independent long victim and let the colluding short avoid its honest loss: attack={attacked_payouts:?}, control={control_payouts:?}"
+    );
+    assert!(
+        stale_resolve_rejected,
+        "ResolveMarket must reject an expired stored Hybrid report before terminal settlement"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59727,12 +59727,14 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
     const FRESH_PRICE_E6: u64 = 110_000;
     const CAPITAL: u128 = 100_000_000;
     const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
-    const FEED: [u8; 32] = [0xacu8; 32];
+    const FEED0: [u8; 32] = [0xacu8; 32];
+    const FEED1: [u8; 32] = [0xadu8; 32];
 
     fn setup() -> (V16CuEnv, Keypair, Pubkey, Keypair, Pubkey) {
         let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
-        set_test_clock(&mut env, 1, 100);
-        let initial_oracle = env.set_pyth_price(&FEED, OPEN_PRICE_E6 as i64, -6, 100);
+        set_test_clock(&mut env, 1, 160);
+        let initial_oracle0 = env.set_pyth_price(&FEED0, OPEN_PRICE_E6 as i64, -6, 160);
+        let initial_oracle1 = env.set_pyth_price(&FEED1, 1_000_000, -6, 100);
 
         // Separate the honest oracle authority from the adversarial market authority. The attack
         // below uses only ResolveMarket; it never signs an oracle instruction or rewrites the feed.
@@ -59754,8 +59756,8 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
             ProgInstruction::ConfigureHybridOracle {
                 asset_index: 0,
                 now_slot: 1,
-                now_unix_ts: 100,
-                oracle_leg_count: 1,
+                now_unix_ts: 160,
+                oracle_leg_count: 2,
                 oracle_leg_flags: 0,
                 max_staleness_secs: 60,
                 hybrid_soft_stale_slots: 3,
@@ -59764,12 +59766,13 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
                 invert: 0,
                 unit_scale: 0,
                 conf_filter_bps: 500,
-                oracle_leg_feeds: [FEED, [0u8; 32], [0u8; 32]],
+                oracle_leg_feeds: [FEED0, FEED1, [0u8; 32]],
             },
             vec![
                 AccountMeta::new(honest_oracle.pubkey(), true),
                 AccountMeta::new(env.market, false),
-                AccountMeta::new_readonly(initial_oracle, false),
+                AccountMeta::new_readonly(initial_oracle0, false),
+                AccountMeta::new_readonly(initial_oracle1, false),
             ],
             &[&honest_oracle],
         )
@@ -59814,12 +59817,13 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
     }
 
     let (mut attacked, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
-    set_test_clock(&mut attacked, 100, 200);
-    let ignored_report = attacked.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    set_test_clock(&mut attacked, 100, 220);
+    let current_leg0 = attacked.set_pyth_price(&FEED0, OPEN_PRICE_E6 as i64, -6, 160);
+    let ignored_report = attacked.set_pyth_price(&FEED1, 1_100_000, -6, 220);
     assert_eq!(
         attacked.market_state().1.assets[0].effective_price,
         OPEN_PRICE_E6,
-        "the stored report is expired and the fresh external report is not yet ingested"
+        "one stored composite leg is expired and the fresh replacement is not yet ingested"
     );
     assert!(
         attacked.svm.get_account(&ignored_report).is_some(),
@@ -59860,7 +59864,7 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
                 now_slot: 100,
                 observations: crank_observations(0),
             },
-            &[ignored_report],
+            &[current_leg0, ignored_report],
         );
         attacked.resolve();
         close_resolved_payouts(
@@ -59881,8 +59885,9 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
     };
 
     let (mut control, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
-    set_test_clock(&mut control, 100, 200);
-    let fresh_report = control.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    set_test_clock(&mut control, 100, 220);
+    let current_leg0 = control.set_pyth_price(&FEED0, OPEN_PRICE_E6 as i64, -6, 160);
+    let fresh_report = control.set_pyth_price(&FEED1, 1_100_000, -6, 220);
     let keeper = Keypair::new();
     let keeper_portfolio = control.create_portfolio(&keeper);
     control.crank_with_oracle_tail(
@@ -59891,7 +59896,7 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
             now_slot: 100,
             observations: crank_observations(0),
         },
-        &[fresh_report],
+        &[current_leg0, fresh_report],
     );
     assert_eq!(
         control.market_state().1.assets[0].effective_price,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59916,3 +59916,220 @@ fn v16_attack_resolve_market_rejects_expired_hybrid_snapshot() {
         "ResolveMarket must reject an expired stored Hybrid report before terminal settlement"
     );
 }
+
+// Public-interface TDD probe: a non-oracle market authority must not freeze an exposed Hybrid asset
+// in Recovery at an expired stored mark after the honest external feed has published a current
+// report. Both paths complete through permissionless force-close and ordinary owner withdrawals.
+#[test]
+fn v16_attack_asset_shutdown_rejects_expired_hybrid_snapshot() {
+    const OPEN_PRICE_E6: u64 = 100_000;
+    const FRESH_PRICE_E6: u64 = 110_000;
+    const CAPITAL: u128 = 100_000_000;
+    const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+    const FEED: [u8; 32] = [0xacu8; 32];
+
+    fn setup() -> (V16CuEnv, Keypair, Pubkey, Keypair, Pubkey) {
+        let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+        set_test_clock(&mut env, 1, 100);
+        let initial_oracle = env.set_pyth_price(&FEED, OPEN_PRICE_E6 as i64, -6, 100);
+
+        // Separate the honest oracle authority from the adversarial market authority. The attack
+        // below uses only UpdateAssetLifecycle; it never signs an oracle instruction or rewrites
+        // the feed.
+        let old_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &old_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("handoff oracle authority to an independent honest key");
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::ConfigureHybridOracle {
+                asset_index: 0,
+                now_slot: 1,
+                now_unix_ts: 100,
+                oracle_leg_count: 1,
+                oracle_leg_flags: 0,
+                max_staleness_secs: 60,
+                hybrid_soft_stale_slots: 3,
+                mark_ewma_halflife_slots: 1,
+                mark_min_fee: 0,
+                invert: 0,
+                unit_scale: 0,
+                conf_filter_bps: 500,
+                oracle_leg_feeds: [FEED, [0u8; 32], [0u8; 32]],
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new_readonly(initial_oracle, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest oracle authority configures the Hybrid market");
+        env.configure_permissionless_resolve_with_cu(1_000, 5);
+        assert_eq!(
+            env.market_state().1.assets[0].effective_price,
+            OPEN_PRICE_E6
+        );
+
+        let victim = Keypair::new();
+        let victim_portfolio = env.create_portfolio(&victim);
+        let attacker = Keypair::new();
+        let attacker_portfolio = env.create_portfolio(&attacker);
+        env.deposit(&victim, victim_portfolio, CAPITAL);
+        env.deposit(&attacker, attacker_portfolio, CAPITAL);
+        env.trade_asset_with_cu(
+            0,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+            SIZE_Q,
+            OPEN_PRICE_E6,
+            0,
+        );
+        (env, victim, victim_portfolio, attacker, attacker_portfolio)
+    }
+
+    fn force_close_payouts(
+        env: &mut V16CuEnv,
+        victim: &Keypair,
+        victim_portfolio: Pubkey,
+        attacker: &Keypair,
+        attacker_portfolio: Pubkey,
+    ) -> (u64, u64) {
+        set_test_clock(env, 106, 206);
+        let cranker = Keypair::new();
+        env.force_close_abandoned_asset_with_cu(
+            &cranker,
+            victim_portfolio,
+            attacker_portfolio,
+            0,
+            106,
+            SIZE_Q as u128,
+        );
+        for (owner, portfolio) in [(victim, victim_portfolio), (attacker, attacker_portfolio)] {
+            let pnl = env.portfolio_state(portfolio).pnl.get();
+            if pnl > 0 {
+                env.convert_released_pnl_with_cu(owner, portfolio, pnl as u128);
+            }
+        }
+        let victim_capital = env.portfolio_state(victim_portfolio).capital.get();
+        let attacker_capital = env.portfolio_state(attacker_portfolio).capital.get();
+        let attacker_dest = env.withdraw(attacker, attacker_portfolio, attacker_capital);
+        let victim_dest = env.withdraw(victim, victim_portfolio, victim_capital);
+        (
+            env.token_amount(victim_dest),
+            env.token_amount(attacker_dest),
+        )
+    }
+
+    let (mut attacked, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
+    set_test_clock(&mut attacked, 100, 200);
+    let ignored_report = attacked.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    assert_eq!(
+        attacked.market_state().1.assets[0].effective_price,
+        OPEN_PRICE_E6,
+        "the stored report is expired and the fresh external report is not yet ingested"
+    );
+    assert!(
+        attacked.svm.get_account(&ignored_report).is_some(),
+        "the honest external report existed before adversarial shutdown"
+    );
+    let market_before = attacked.svm.get_account(&attacked.market).unwrap();
+    let victim_before = attacked.svm.get_account(&victim_portfolio).unwrap();
+    let attacker_before = attacked.svm.get_account(&attacker_portfolio).unwrap();
+    let compromised_admin = attacked.admin.insecure_clone();
+    attacked.svm.expire_blockhash();
+    let stale_shutdown = attacked.try_shutdown_asset_with_authority(&compromised_admin, 0, 100);
+    let stale_shutdown_rejected = stale_shutdown.is_err();
+    let attacked_payouts = if stale_shutdown_rejected {
+        assert_eq!(
+            attacked.svm.get_account(&attacked.market).unwrap(),
+            market_before
+        );
+        assert_eq!(
+            attacked.svm.get_account(&victim_portfolio).unwrap(),
+            victim_before
+        );
+        assert_eq!(
+            attacked.svm.get_account(&attacker_portfolio).unwrap(),
+            attacker_before
+        );
+        let keeper = Keypair::new();
+        let keeper_portfolio = attacked.create_portfolio(&keeper);
+        attacked.crank_with_oracle_tail(
+            keeper_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 100,
+                observations: crank_observations(0),
+            },
+            &[ignored_report],
+        );
+        attacked
+            .try_shutdown_asset_with_authority(&compromised_admin, 0, 100)
+            .expect("shutdown after accepting the current report");
+        force_close_payouts(
+            &mut attacked,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+        )
+    } else {
+        force_close_payouts(
+            &mut attacked,
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+        )
+    };
+
+    let (mut control, victim, victim_portfolio, attacker, attacker_portfolio) = setup();
+    set_test_clock(&mut control, 100, 200);
+    let fresh_report = control.set_pyth_price(&FEED, FRESH_PRICE_E6 as i64, -6, 200);
+    let keeper = Keypair::new();
+    let keeper_portfolio = control.create_portfolio(&keeper);
+    control.crank_with_oracle_tail(
+        keeper_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 100,
+            observations: crank_observations(0),
+        },
+        &[fresh_report],
+    );
+    assert_eq!(
+        control.market_state().1.assets[0].effective_price,
+        FRESH_PRICE_E6,
+        "permissionless control ingests the honest report"
+    );
+    let control_admin = control.admin.insecure_clone();
+    control
+        .try_shutdown_asset_with_authority(&control_admin, 0, 100)
+        .expect("control shutdown after accepting the current report");
+    let control_payouts = force_close_payouts(
+        &mut control,
+        &victim,
+        victim_portfolio,
+        &attacker,
+        attacker_portfolio,
+    );
+    assert_eq!(control_payouts.0 + control_payouts.1, 2 * CAPITAL as u64);
+    assert_eq!(
+        attacked_payouts, control_payouts,
+        "stale admin shutdown deprived the independent long victim and let the colluding short avoid its honest loss: attack={attacked_payouts:?}, control={control_payouts:?}"
+    );
+    assert!(
+        stale_shutdown_rejected,
+        "asset shutdown must reject an expired stored Hybrid report before freezing Recovery"
+    );
+}


### PR DESCRIPTION
## What changed

- reject privileged `ResolveMarket` while any exposed Active/DrainOnly Hybrid asset has neither a current accepted external report nor a same-slot fee-backed after-hours EWMA
- apply the same asset-scoped gate before `UpdateAssetLifecycle::SHUTDOWN` freezes a Hybrid asset in Recovery
- require every configured composite-oracle leg to be current; a newer component cannot mask an expired component through the aggregate max publish time
- keep `ResolveStalePermissionless` unchanged as the configured outage escape
- add a public LiteSVM TDD regression with independent long and short portfolios and an independently controlled oracle authority

## Root cause and impact

The privileged market-resolution and asset-shutdown paths called engine terminal-snapshot transitions without enforcing the Hybrid profile's configured external-report freshness. A compromised non-oracle market authority could therefore resolve a market, or freeze an asset in Recovery, against an expired stored mark after an honest current report had been published but before a keeper ingested it.

On the exact pre-fix parent, each probe settles the victim/attacker at `(100_000_000, 100_000_000)` instead of the honest-report control `(110_000_000, 90_000_000)`, depriving the independent long of `10_000_000` units. The shutdown probe completes through delayed permissionless force-close, public PnL conversion, and ordinary owner withdrawals. The attacks use only public instructions and `marketauth`; neither signs an oracle instruction nor mutates protocol state directly.

## TDD evidence

- exact-parent resolve red: `bd39a4c0` test commit over `da64be63`; the regression fails with the payout divergence above
- post-first-fix shutdown red: `77ef3d69`; the independent shutdown regression fails with the same payout divergence
- composite-leg red: `8a75895d`; one current leg masks one expired leg and reproduces the same payout divergence against the first fix
- fixed green: `398c5cac`

## Validation

- `cargo build-sbf --tools-version v1.52`
- `cargo test --test v16_cu -- --nocapture` (`567 passed`)
- `cargo test --lib --examples` (`6 passed`)
- `cargo fmt --all -- --check`
