### PR TITLE
[REAL LoF] Settle adverse marks before unilateral reduction

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4555,6 +4555,72 @@ pub mod processor {
         Ok(())
     }
 
+    fn reject_rebalance_reduce_with_adverse_pending_mark_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+    ) -> Result<(), V16Error> {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(V16Error::InvalidConfig);
+        }
+        let leg =
+            active_leg_for_asset_view(portfolio, asset_index).map_err(|_| V16Error::InvalidLeg)?;
+        let asset = group.markets[asset_index].engine.asset;
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)
+            .map_err(|_| V16Error::InvalidConfig)?;
+        if !oracle_v16::profile_is_price_managed(&profile) {
+            return Ok(());
+        }
+
+        let now_slot = authenticated_market_slot_or_fallback_view(group);
+        let slot_last = asset.slot_last.get();
+        if now_slot < slot_last {
+            return Err(V16Error::Stale);
+        }
+        let dt = core::cmp::min(
+            now_slot - slot_last,
+            group.header.config.max_accrual_dt_slots.get(),
+        );
+        if dt == 0 {
+            return Ok(());
+        }
+
+        // Auth/EWMA profiles own their queued target. During normal Hybrid operation the
+        // committed engine target is the latest authenticated external observation; after the
+        // soft-stale boundary the profile EWMA becomes the target used by the crank instead.
+        let target = if oracle_v16::profile_is_auth_mark(&profile)
+            || oracle_v16::profile_is_ewma_mark(&profile)
+            || (oracle_v16::profile_is_hybrid(&profile)
+                && oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot))
+        {
+            profile.mark_ewma_e6
+        } else {
+            asset.raw_oracle_target_price.get()
+        };
+        if target == 0 {
+            return Err(V16Error::InvalidConfig);
+        }
+        let current = asset.effective_price.get();
+        let next = oracle_v16::effective_price_from_target(
+            current,
+            target,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt,
+            true,
+        );
+        let adverse = match leg.side {
+            SideV16::Long => next < current,
+            SideV16::Short => next > current,
+        };
+        if adverse {
+            return Err(V16Error::Stale);
+        }
+        Ok(())
+    }
+
     fn read_oracle_profile_for_asset(
         market_data: &[u8],
         cfg: &WrapperConfigV16,
@@ -8497,6 +8563,12 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
+            reject_rebalance_reduce_with_adverse_pending_mark_view(
+                cfg,
+                group,
+                portfolio,
+                asset_index as usize,
+            )?;
             group
                 .rebalance_reduce_position_not_atomic(
                     portfolio,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59788,17 +59788,42 @@ fn v16_probe_rebalance_reduce_cannot_omit_pending_adverse_mark() {
                     observations: crank_observations(0),
                 },
             );
-        }
-        env.rebalance_reduce_with_cu(
-            &market_admin,
-            attacker_short,
-            0,
-            SIZE_Q.unsigned_abs(),
-        );
-        let attacker_capital = env.portfolio_state(attacker_short).capital.get();
-        let attacker_dest = env.withdraw(&market_admin, attacker_short, attacker_capital);
-
-        if !crank_before_reduce {
+        } else {
+            let market_before = env.svm.get_account(&env.market).unwrap().data;
+            let attacker_before = env.svm.get_account(&attacker_short).unwrap().data;
+            let victim_before = env.svm.get_account(&victim_long).unwrap().data;
+            env.svm.expire_blockhash();
+            let stale_reduce = env.send(
+                ProgInstruction::RebalanceReduce {
+                    asset_index: 0,
+                    reduce_q: SIZE_Q.unsigned_abs(),
+                },
+                vec![
+                    AccountMeta::new(market_admin.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(attacker_short, false),
+                ],
+                &[&market_admin],
+            );
+            assert!(
+                stale_reduce.is_err(),
+                "unilateral reduction must not omit an adverse authenticated mark"
+            );
+            assert_eq!(
+                env.svm.get_account(&env.market).unwrap().data,
+                market_before,
+                "rejected reduction rolls back the market"
+            );
+            assert_eq!(
+                env.svm.get_account(&attacker_short).unwrap().data,
+                attacker_before,
+                "rejected reduction rolls back the attacker portfolio"
+            );
+            assert_eq!(
+                env.svm.get_account(&victim_long).unwrap().data,
+                victim_before,
+                "rejected reduction does not mutate the counterparty"
+            );
             env.crank(
                 victim_long,
                 ProgInstruction::PermissionlessCrank {
@@ -59807,6 +59832,10 @@ fn v16_probe_rebalance_reduce_cannot_omit_pending_adverse_mark() {
                 },
             );
         }
+        env.rebalance_reduce_with_cu(&market_admin, attacker_short, 0, SIZE_Q.unsigned_abs());
+        let attacker_capital = env.portfolio_state(attacker_short).capital.get();
+        let attacker_dest = env.withdraw(&market_admin, attacker_short, attacker_capital);
+
         let effective_price = env.market_state().1.assets[0].effective_price;
         env.resolve();
         let victim_dest = env.close_resolved(&honest_oracle, victim_long);
@@ -59823,4 +59852,56 @@ fn v16_probe_rebalance_reduce_cannot_omit_pending_adverse_mark() {
     assert_eq!(attack.effective_price, control.effective_price);
     assert_eq!(attack.attacker_withdrawal, control.attacker_withdrawal);
     assert_eq!(attack.victim_payout, control.victim_payout);
+}
+
+#[test]
+fn v16_rebalance_reduce_allows_pending_favorable_mark() {
+    const PRICE: u64 = 1_000_000;
+    const MARK: u64 = 2_000_000;
+    const SIZE_Q: i128 = 100 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(0, PRICE);
+    let market_admin = env.admin.insecure_clone();
+    let honest_oracle = Keypair::new();
+    env.try_update_per_asset_authority_with_cu(
+        &market_admin,
+        Some(&honest_oracle),
+        0,
+        processor::ASSET_AUTH_ORACLE,
+        honest_oracle.pubkey().to_bytes(),
+    )
+    .expect("separate honest oracle authority");
+
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 100_000_000);
+    env.deposit(&short_owner, short, 100_000_000);
+    env.trade_asset_with_cu(0, &long_owner, long, &short_owner, short, SIZE_Q, PRICE, 0);
+
+    env.svm.warp_to_slot(2);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: MARK,
+        },
+        vec![
+            AccountMeta::new(honest_oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&honest_oracle],
+    )
+    .expect("honest favorable mark");
+
+    env.rebalance_reduce_with_cu(&long_owner, long, 0, SIZE_Q.unsigned_abs());
+    assert_eq!(
+        env.portfolio_state(long).legs[0].basis_pos_q.get(),
+        0,
+        "a queued favorable mark must not block voluntary risk reduction"
+    );
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,110 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Probe: owner-only RebalanceReduce is unilateral. It must not let the losing side flatten and
+// withdraw against the old engine cursor after a separately authenticated mark is queued.
+#[test]
+fn v16_probe_rebalance_reduce_cannot_omit_pending_adverse_mark() {
+    #[derive(Debug)]
+    struct Outcome {
+        effective_price: u64,
+        attacker_withdrawal: u64,
+        victim_payout: u64,
+    }
+
+    fn run(crank_before_reduce: bool) -> Outcome {
+        const PRICE: u64 = 1_000_000;
+        const MARK: u64 = 2_000_000;
+        const DEPOSIT: u128 = 100_000_000;
+        const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+        let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+        env.svm.warp_to_slot(1);
+        env.configure_auth_mark_with_cu(0, PRICE);
+        let market_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &market_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate honest oracle authority");
+
+        let victim_long = env.create_portfolio(&honest_oracle);
+        let attacker_short = env.create_portfolio(&market_admin);
+        env.deposit(&honest_oracle, victim_long, DEPOSIT);
+        env.deposit(&market_admin, attacker_short, DEPOSIT);
+        env.trade_asset_with_cu(
+            0,
+            &honest_oracle,
+            victim_long,
+            &market_admin,
+            attacker_short,
+            SIZE_Q,
+            PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(2);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PushAuthMark {
+                asset_index: 0,
+                now_slot: 2,
+                mark_e6: MARK,
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest adverse mark");
+
+        if crank_before_reduce {
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.rebalance_reduce_with_cu(
+            &market_admin,
+            attacker_short,
+            0,
+            SIZE_Q.unsigned_abs(),
+        );
+        let attacker_capital = env.portfolio_state(attacker_short).capital.get();
+        let attacker_dest = env.withdraw(&market_admin, attacker_short, attacker_capital);
+
+        if !crank_before_reduce {
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        let effective_price = env.market_state().1.assets[0].effective_price;
+        env.resolve();
+        let victim_dest = env.close_resolved(&honest_oracle, victim_long);
+        Outcome {
+            effective_price,
+            attacker_withdrawal: env.token_amount(attacker_dest),
+            victim_payout: env.token_amount(victim_dest),
+        }
+    }
+
+    let control = run(true);
+    let attack = run(false);
+    eprintln!("pending-mark rebalance control={control:?} attack={attack:?}");
+    assert_eq!(attack.effective_price, control.effective_price);
+    assert_eq!(attack.attacker_withdrawal, control.attacker_withdrawal);
+    assert_eq!(attack.victim_payout, control.victim_payout);
+}


### PR DESCRIPTION
## Finding

`RebalanceReduce` is an owner-callable unilateral exit at the engine's current effective price. The wrapper did not bind that operation to an authenticated AuthMark/EWMA target queued in the wrapper profile. A losing side could therefore reduce to flat and withdraw before the bounded mark step was committed, permanently removing the open interest that should have received the corresponding PnL transfer.

The exact-parent LiteSVM reproduction at `da64be63` uses a separately authorized honest oracle and only public instructions. With a 1,000,000 -> 2,000,000 authenticated mark:

- crank first: effective price 1,002,400, short withdraws 97,600,000, long receives 102,400,000
- reduce first: short withdrew 100,000,000, then the same honest mark could no longer transfer PnL; long received 100,000,000

This moved 2,400,000 from an independent victim to the reducing attacker. Commit `e9d34a54` is the exact-parent red test.

## Fix

Before unilateral `RebalanceReduce`, derive the next engine-admissible bounded price from the authenticated wrapper target (or the committed Hybrid target). Reject only when that currently available step is adverse to the reducing leg. The owner can permissionlessly crank once and retry; bilateral trade exits and favorable unilateral reductions remain available.

The regression asserts rejected-call rollback byte-for-byte, then takes the bounded crank continuation and proves payouts equal the crank-first control. A separate positive test proves that a long can still reduce immediately against a queued favorable upward mark.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --test v16_cu`: 567 passed
- `cargo test --lib --examples`: 6 passed, examples passed
- Existing `RebalanceReduce` custody CU budget test passes
