### PR TITLE
[BLOCKER LoF] Bind AuthMark targets before exposure migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=2af64e487f3dec88b18aac634071115e588d2af1#2af64e487f3dec88b18aac634071115e588d2af1"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2af64e487f3dec88b18aac634071115e588d2af1" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2af64e487f3dec88b18aac634071115e588d2af1" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10275,6 +10275,9 @@ pub mod processor {
             profile.oracle_target_price_e6 = mark_e6;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
+            group
+                .set_asset_raw_oracle_target_not_atomic(asset_index_usize, mark_e6)
+                .map_err(map_v16_error)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,150 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Probe: an authenticated AuthMark target lives in the wrapper profile until the first crank copies
+// it into the engine's raw target. During that gap, a losing trader must not be able to migrate its
+// exposure from a well-capitalized account into a thin sacrificial account at the stale risk cursor,
+// withdraw the original capital, and leave the independent winner with the later insolvency.
+#[test]
+fn v16_probe_pending_authmark_cannot_be_migrated_to_thin_account() {
+    #[derive(Debug)]
+    struct Outcome {
+        effective_price: u64,
+        attacker_recovery: u128,
+        victim_payout: u128,
+    }
+
+    fn run(migrate_after_mark: bool) -> Outcome {
+        const PRICE: u64 = 1_000_000;
+        const MARK: u64 = 1_100_000;
+        const FUNDED_CAPITAL: u128 = 1_100_000_000;
+        const THIN_CAPITAL: u128 = 60_000_000;
+        const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+        let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+        env.svm.warp_to_slot(1);
+        env.configure_auth_mark_with_cu(0, PRICE);
+        let market_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &market_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate honest oracle authority");
+
+        let victim_owner = Keypair::new();
+        let victim_long = env.create_portfolio(&victim_owner);
+        let funded_owner = Keypair::new();
+        let funded_short = env.create_portfolio(&funded_owner);
+        let thin_owner = Keypair::new();
+        let thin_short = env.create_portfolio(&thin_owner);
+        env.deposit(&victim_owner, victim_long, FUNDED_CAPITAL);
+        env.deposit(&funded_owner, funded_short, FUNDED_CAPITAL);
+        env.deposit(&thin_owner, thin_short, THIN_CAPITAL);
+        env.trade_asset_with_cu(
+            0,
+            &victim_owner,
+            victim_long,
+            &funded_owner,
+            funded_short,
+            SIZE_Q,
+            PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(2);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PushAuthMark {
+                asset_index: 0,
+                now_slot: 2,
+                mark_e6: MARK,
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest adverse mark");
+
+        let mut funded_live_withdrawal = 0u128;
+        if migrate_after_mark {
+            // The funded account takes the long side of this transfer to close its short; the thin
+            // account inherits the short. Both attacker-controlled owners sign through the public API.
+            env.trade_asset_with_cu(
+                0,
+                &funded_owner,
+                funded_short,
+                &thin_owner,
+                thin_short,
+                SIZE_Q,
+                PRICE,
+                0,
+            );
+            assert!(
+                !has_active_leg_for_asset(&env.portfolio_state(funded_short), 0),
+                "funded attacker account became flat"
+            );
+            assert!(
+                has_active_leg_for_asset(&env.portfolio_state(thin_short), 0),
+                "thin account inherited the adverse short"
+            );
+            let capital = env.portfolio_state(funded_short).capital.get();
+            let dest = env.withdraw(&funded_owner, funded_short, capital);
+            funded_live_withdrawal = env.token_amount(dest) as u128;
+        }
+
+        // Production's 24 bps/slot circuit breaker reaches the 10% target in finite bounded steps.
+        for slot in 2..=100u64 {
+            env.svm.warp_to_slot(slot);
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        let effective_price = env.market_state().1.assets[0].effective_price;
+        assert_eq!(effective_price, MARK, "honest mark fully converged");
+
+        env.resolve();
+        let funded_dest = env.close_resolved(&funded_owner, funded_short);
+        let thin_dest = env.close_resolved(&thin_owner, thin_short);
+        let thin_retry_dest = env.close_resolved(&thin_owner, thin_short);
+        let mut victim_payout = 0u128;
+        for _ in 0..5_000 {
+            let dest = env.close_resolved(&victim_owner, victim_long);
+            victim_payout += env.token_amount(dest) as u128;
+            let state = env.portfolio_state(victim_long);
+            let receipt = resolved_receipt(&state);
+            if state.capital.get() == 0
+                && state.pnl.get() == 0
+                && !has_active_leg_for_asset(&state, 0)
+                && (!receipt.present || receipt.finalized)
+            {
+                break;
+            }
+        }
+        Outcome {
+            effective_price,
+            attacker_recovery: funded_live_withdrawal
+                + env.token_amount(funded_dest) as u128
+                + env.token_amount(thin_dest) as u128
+                + env.token_amount(thin_retry_dest) as u128,
+            victim_payout,
+        }
+    }
+
+    let control = run(false);
+    let attack = run(true);
+    eprintln!("pending AuthMark migration control={control:?} attack={attack:?}");
+    assert_eq!(attack.effective_price, control.effective_price);
+    assert_eq!(attack.attacker_recovery, control.attacker_recovery);
+    assert_eq!(attack.victim_payout, control.victim_payout);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59787,12 +59787,21 @@ fn v16_probe_pending_authmark_cannot_be_migrated_to_thin_account() {
             &[&honest_oracle],
         )
         .expect("honest adverse mark");
+        assert_eq!(
+            env.market_state().1.assets[0].raw_oracle_target_price,
+            MARK,
+            "authenticated target is immediately visible to engine risk checks"
+        );
 
-        let mut funded_live_withdrawal = 0u128;
+        let funded_live_withdrawal = 0u128;
         if migrate_after_mark {
             // The funded account takes the long side of this transfer to close its short; the thin
             // account inherits the short. Both attacker-controlled owners sign through the public API.
-            env.trade_asset_with_cu(
+            let market_before = env.svm.get_account(&env.market).unwrap().data;
+            let funded_before = env.svm.get_account(&funded_short).unwrap().data;
+            let thin_before = env.svm.get_account(&thin_short).unwrap().data;
+            let victim_before = env.svm.get_account(&victim_long).unwrap().data;
+            let migration = env.try_trade_asset_with_cu(
                 0,
                 &funded_owner,
                 funded_short,
@@ -59803,16 +59812,29 @@ fn v16_probe_pending_authmark_cannot_be_migrated_to_thin_account() {
                 0,
             );
             assert!(
-                !has_active_leg_for_asset(&env.portfolio_state(funded_short), 0),
-                "funded attacker account became flat"
+                migration.is_err(),
+                "thin account must not inherit exposure it cannot margin against the authenticated target"
             );
-            assert!(
-                has_active_leg_for_asset(&env.portfolio_state(thin_short), 0),
-                "thin account inherited the adverse short"
+            assert_eq!(
+                env.svm.get_account(&env.market).unwrap().data,
+                market_before,
+                "rejected migration rolls back the market"
             );
-            let capital = env.portfolio_state(funded_short).capital.get();
-            let dest = env.withdraw(&funded_owner, funded_short, capital);
-            funded_live_withdrawal = env.token_amount(dest) as u128;
+            assert_eq!(
+                env.svm.get_account(&funded_short).unwrap().data,
+                funded_before,
+                "rejected migration rolls back the funded account"
+            );
+            assert_eq!(
+                env.svm.get_account(&thin_short).unwrap().data,
+                thin_before,
+                "rejected migration rolls back the thin account"
+            );
+            assert_eq!(
+                env.svm.get_account(&victim_long).unwrap().data,
+                victim_before,
+                "rejected migration does not mutate the independent victim"
+            );
         }
 
         // Production's 24 bps/slot circuit breaker reaches the 10% target in finite bounded steps.


### PR DESCRIPTION
## Finding

An authenticated `PushAuthMark` updated only the wrapper oracle profile. Until a later crank copied that target into the engine, engine health checks still certified accounts at the old target.

A losing trader could use only public instructions to move an adverse short from a well-capitalized portfolio into a thin sacrificial portfolio after the honest mark was signed, withdraw the original portfolio's capital, and leave an independent long underpaid when the mark later converged.

On the exact pre-fix parent, the LiteSVM repro produces:

| path | attacker recovery | independent victim payout |
| --- | ---: | ---: |
| no migration | 1,060,038,000 | 1,199,962,000 |
| migrated exposure | 1,100,000,000 | 1,160,000,000 |

That is an exact 39,962,000-atom transfer from the victim to the attacker. The market uses production risk parameters, a separate honest oracle signer, public portfolio/deposit/trade/withdraw/crank/resolve/close instructions, and no state injection.

## Fix

`PushAuthMark` now publishes the authenticated mark to the engine raw target in the same instruction. The target update increments the oracle epoch, invalidates stale certificates, and makes the engine's full adverse-target margin penalty apply before any subsequent exposure change.

The migration then fails final IM and LiteSVM proves byte-exact rollback for the market, both attacker portfolios, and the independent victim. Adequately collateralized trades during target convergence remain live through the dependent engine change in [percolator#138](https://github.com/aeyakovenko/percolator/pull/138); target lag is priced by final margin rather than blanket-blocked.

## TDD history

- `a36c7530`: exact-parent red public LiteSVM repro
- `f7a64eb0`: wrapper fix plus engine dependency; regression green

## Validation

- targeted public repro: green, attack and control payouts identical
- both target-lag positive-path regressions: green
- `cargo test --test v16_cu`: 566/566 green, including all CU tests
- `cargo test --all-targets`: 572/572 green (6 host + 566 LiteSVM)
- engine dependency: 130 native/spec/fuzz tests and four directly affected Kani proofs/contracts green in percolator#138
