### PR TITLE
[BLOCKER LoF] Publish EWMA oracle targets before exposure changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=2af64e487f3dec88b18aac634071115e588d2af1#2af64e487f3dec88b18aac634071115e588d2af1"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2af64e487f3dec88b18aac634071115e588d2af1" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "2af64e487f3dec88b18aac634071115e588d2af1" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10211,6 +10211,9 @@ pub mod processor {
             profile.oracle_target_price_e6 = next_mark;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
+            group
+                .set_asset_raw_oracle_target_not_atomic(asset_index_usize, next_mark)
+                .map_err(map_v16_error)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59794,6 +59794,11 @@ fn v16_probe_pending_ewma_oracle_target_cannot_be_migrated_to_thin_account() {
             TARGET,
             "one-slot, one-slot-halflife EWMA reaches the expected target"
         );
+        assert_eq!(
+            env.market_state().1.assets[0].raw_oracle_target_price,
+            TARGET,
+            "authenticated EWMA target is immediately visible to engine risk checks"
+        );
 
         let mut funded_live_withdrawal = 0u128;
         let mut migration_landed = false;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,157 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// An authenticated EWMA update is committed oracle state, even though the effective price reaches it
+// through the bounded crank. The engine must see that target before any later exposure migration, or
+// a losing trader can move a funded short into a thin account and withdraw the backing that the
+// independent winner should receive as the EWMA converges.
+#[test]
+fn v16_probe_pending_ewma_oracle_target_cannot_be_migrated_to_thin_account() {
+    #[derive(Debug)]
+    struct Outcome {
+        effective_price: u64,
+        attacker_recovery: u128,
+        victim_payout: u128,
+        migration_landed: bool,
+    }
+
+    fn run(migrate_after_mark: bool) -> Outcome {
+        const PRICE: u64 = 1_000_000;
+        const PUSH_PRICE: u64 = 1_200_000;
+        const TARGET: u64 = 1_100_000;
+        const FUNDED_CAPITAL: u128 = 1_100_000_000;
+        const THIN_CAPITAL: u128 = 60_000_000;
+        const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+        let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+        env.svm.warp_to_slot(1);
+        env.configure_ewma_mark_with_cu(1, PRICE, 1, 0);
+        let market_admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &market_admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate honest oracle authority");
+
+        let victim_owner = Keypair::new();
+        let victim_long = env.create_portfolio(&victim_owner);
+        let funded_owner = Keypair::new();
+        let funded_short = env.create_portfolio(&funded_owner);
+        let thin_owner = Keypair::new();
+        let thin_short = env.create_portfolio(&thin_owner);
+        env.deposit(&victim_owner, victim_long, FUNDED_CAPITAL);
+        env.deposit(&funded_owner, funded_short, FUNDED_CAPITAL);
+        env.deposit(&thin_owner, thin_short, THIN_CAPITAL);
+        env.trade_asset_with_cu(
+            0,
+            &victim_owner,
+            victim_long,
+            &funded_owner,
+            funded_short,
+            SIZE_Q,
+            PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(2);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PushEwmaMark {
+                asset_index: 0,
+                now_slot: 2,
+                mark_e6: PUSH_PRICE,
+            },
+            vec![
+                AccountMeta::new(honest_oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&honest_oracle],
+        )
+        .expect("honest EWMA oracle update");
+        assert_eq!(
+            env.market_state().0.mark_ewma_e6,
+            TARGET,
+            "one-slot, one-slot-halflife EWMA reaches the expected target"
+        );
+
+        let mut funded_live_withdrawal = 0u128;
+        let mut migration_landed = false;
+        if migrate_after_mark {
+            let migration = env.try_trade_asset_with_cu(
+                0,
+                &funded_owner,
+                funded_short,
+                &thin_owner,
+                thin_short,
+                SIZE_Q,
+                PRICE,
+                0,
+            );
+            migration_landed = migration.is_ok();
+            if migration_landed {
+                let dest = env.withdraw(&funded_owner, funded_short, FUNDED_CAPITAL);
+                funded_live_withdrawal = env.token_amount(dest) as u128;
+            }
+        }
+
+        for slot in 2..=100u64 {
+            env.svm.warp_to_slot(slot);
+            env.crank(
+                victim_long,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        let effective_price = env.market_state().1.assets[0].effective_price;
+        assert_eq!(
+            effective_price, TARGET,
+            "honest EWMA target fully converged"
+        );
+
+        env.resolve();
+        let funded_dest = env.close_resolved(&funded_owner, funded_short);
+        let thin_dest = env.close_resolved(&thin_owner, thin_short);
+        let thin_retry_dest = env.close_resolved(&thin_owner, thin_short);
+        let mut victim_payout = 0u128;
+        for _ in 0..5_000 {
+            let dest = env.close_resolved(&victim_owner, victim_long);
+            victim_payout += env.token_amount(dest) as u128;
+            let state = env.portfolio_state(victim_long);
+            let receipt = resolved_receipt(&state);
+            if state.capital.get() == 0
+                && state.pnl.get() == 0
+                && !has_active_leg_for_asset(&state, 0)
+                && (!receipt.present || receipt.finalized)
+            {
+                break;
+            }
+        }
+        Outcome {
+            effective_price,
+            attacker_recovery: funded_live_withdrawal
+                + env.token_amount(funded_dest) as u128
+                + env.token_amount(thin_dest) as u128
+                + env.token_amount(thin_retry_dest) as u128,
+            victim_payout,
+            migration_landed,
+        }
+    }
+
+    let control = run(false);
+    let attack = run(true);
+    eprintln!("pending EWMA migration control={control:?} attack={attack:?}");
+    assert_eq!(attack.effective_price, control.effective_price);
+    assert!(
+        !attack.migration_landed,
+        "exposure migration must price the committed EWMA target"
+    );
+    assert_eq!(attack.attacker_recovery, control.attacker_recovery);
+    assert_eq!(attack.victim_payout, control.victim_payout);
+}


### PR DESCRIPTION
## Impact

`PushEwmaMark` authenticated and smoothed a new oracle mark into the wrapper profile but did not publish that committed target to the engine. Before the first crank, a losing trader could migrate its exposure from a funded portfolio into a thin sacrificial portfolio at the stale engine target, withdraw the funded portfolio, and leave an independent winner underpaid.

On exact parent `da64be639168b496833dd4c701607a94fcb06b6c`, the public LiteSVM reproducer uses a separately authorized honest oracle and produces:

| path | attacker recovery | independent victim payout |
| --- | ---: | ---: |
| no migration | 1,060,038,000 | 1,199,962,000 |
| migrate after EWMA push | 1,100,000,000 | 1,160,000,000 |

That is an exact 39,962,000-atom transfer from the victim to the attacker. The test uses only public portfolio, deposit, trade, oracle push, withdrawal, crank, resolve, and payout instructions with normal account construction.

## Fix

Publish the smoothed EWMA mark through `set_asset_raw_oracle_target_not_atomic` in the same successful `PushEwmaMark` transition. This invalidates stale certificates and makes the engine's target-lag margin account for the committed move before later exposure changes.

The wrapper pins engine commit `2af64e487f3dec88b18aac634071115e588d2af1` from percolator PR #138 so adequately collateralized trades remain live while target and effective price converge; the lag is priced at final margin instead of blanket-blocking trades.

This is the `PushEwmaMark` sibling of wrapper PR #264. PR #264 changes only `PushAuthMark`; it does not cover this public entrypoint.

## TDD history

- `5d1b37d2`: exact-parent public red reproduction
- `1dafd7de`: target publication fix and engine dependency; regression green

## Verification

- `cargo build-sbf --tools-version v1.52`
- auth matcher and hostile matcher SBF fixture builds
- focused control/attack regression: green, recoveries and payouts identical
- `cargo test --all-targets -- --test-threads=1`: 6 host + 566 LiteSVM/CU tests green
- `cargo fmt --all -- --check`
- `git diff --check`
