### PR TITLE
[BLOCKER DoS] Keep exact-OI ADL survivors exit-live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=28a7338bd8c0dff7134ea0aa06404795bbb8557b#28a7338bd8c0dff7134ea0aa06404795bbb8557b"
+source = "git+https://github.com/aeyakovenko/percolator?rev=619f3fec9a2f6c0cf2462414c47a65eeefdde81c#619f3fec9a2f6c0cf2462414c47a65eeefdde81c"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "28a7338bd8c0dff7134ea0aa06404795bbb8557b" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "619f3fec9a2f6c0cf2462414c47a65eeefdde81c" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "28a7338bd8c0dff7134ea0aa06404795bbb8557b" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "619f3fec9a2f6c0cf2462414c47a65eeefdde81c" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9930,6 +9930,191 @@ fn v16_attack_crossed_trade_cannot_turn_partial_liquidation_survivors_same_side(
 }
 
 #[test]
+fn v16_attack_exact_effective_oi_cross_must_not_strand_adl_survivor() {
+    const PRICE: u64 = 1;
+    const OPEN_Q: i128 = 13_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        h_max: 6_480_000,
+        initial_price: PRICE,
+        maintenance_margin_bps: 500,
+        initial_margin_bps: 500,
+        min_nonzero_mm_req: 599,
+        min_nonzero_im_req: 600,
+        max_price_move_bps_per_slot: 24,
+        max_accrual_dt_slots: 20,
+        max_abs_funding_e9_per_slot: 0,
+        min_funding_lifetime_slots: 10_000_000,
+        liquidation_fee_bps: 0,
+        maintenance_fee_per_slot: 27,
+        ..V16CuMarketParams::default()
+    });
+    let owner_a = Keypair::new();
+    let owner_b = Keypair::new();
+    let account_a = env.create_portfolio(&owner_a);
+    let account_b = env.create_portfolio(&owner_b);
+    env.deposit(&owner_a, account_a, 1_000);
+    env.deposit(&owner_b, account_b, 1_189);
+
+    env.svm.warp_to_slot(8);
+    env.try_trade_asset_with_cu(
+        0, &owner_a, account_a, &owner_b, account_b, OPEN_Q, PRICE, 0,
+    )
+    .expect("open trade");
+    env.svm.warp_to_slot(27);
+    env.crank(
+        account_a,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 27,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(35);
+    env.sync_maintenance_fee_with_cu(account_b, None, 35);
+    env.crank_steps(
+        account_b,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 35,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+
+    let before = env.market_state().1;
+    let surviving_effective_q = before.assets[0].oi_eff_long_q;
+    let survivor_basis_q = active_leg_for_asset(&env.portfolio_state(account_a), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    assert_eq!(surviving_effective_q, before.assets[0].oi_eff_short_q);
+    assert!(surviving_effective_q > 0 && survivor_basis_q > surviving_effective_q);
+
+    env.svm.expire_blockhash();
+    env.try_trade_asset_with_cu(
+        0,
+        &owner_b,
+        account_b,
+        &owner_a,
+        account_a,
+        surviving_effective_q as i128,
+        PRICE,
+        0,
+    )
+    .expect("exact-effective-OI crossed close");
+
+    let after_cross = env.market_state().1;
+    let survivor_after_cross = env.portfolio_state(account_a);
+    let residual_q = active_leg_for_asset(&survivor_after_cross, 0)
+        .basis_pos_q
+        .unsigned_abs();
+    println!(
+        "after exact cross: oi=({},{}) mode=({:?},{:?}) residual={residual_q}",
+        after_cross.assets[0].oi_eff_long_q,
+        after_cross.assets[0].oi_eff_short_q,
+        after_cross.assets[0].mode_long,
+        after_cross.assets[0].mode_short,
+    );
+    assert_eq!(after_cross.assets[0].oi_eff_long_q, 0);
+    assert_eq!(after_cross.assets[0].oi_eff_short_q, 0);
+    assert!(residual_q > 0);
+    assert!(
+        survivor_after_cross.capital.get() > 0,
+        "the stranded owner must retain real deposited capital"
+    );
+
+    env.svm.expire_blockhash();
+    let rebalance = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: 0,
+            reduce_q: residual_q,
+        },
+        vec![
+            AccountMeta::new(owner_a.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(account_a, false),
+        ],
+        &[&owner_a],
+    );
+    println!("owner rebalance after exact cross: {rebalance:?}");
+    assert!(
+        rebalance.is_err(),
+        "the vulnerable engine is expected to reject direct owner reduction"
+    );
+
+    env.svm.expire_blockhash();
+    let market_before_exit = env.svm.get_account(&env.market).unwrap();
+    let survivor_before_exit = env.svm.get_account(&account_a).unwrap();
+    let counterparty_before_exit = env.svm.get_account(&account_b).unwrap();
+    let trade_exit = env.try_trade_asset_with_cu(
+        0,
+        &owner_b,
+        account_b,
+        &owner_a,
+        account_a,
+        residual_q as i128,
+        PRICE,
+        0,
+    );
+    assert!(
+        trade_exit.is_err(),
+        "a fresh willing counterparty cannot fund a reduction from zero preexisting OI"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_exit);
+    assert_eq!(env.svm.get_account(&account_a).unwrap(), survivor_before_exit);
+    assert_eq!(
+        env.svm.get_account(&account_b).unwrap(),
+        counterparty_before_exit
+    );
+
+    let market_before_cranks = env.svm.get_account(&env.market).unwrap();
+    let survivor_before_cranks = env.svm.get_account(&account_a).unwrap();
+    let mut crank_results = Vec::new();
+    for _ in 0..10 {
+        env.svm.expire_blockhash();
+        crank_results.push(env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 35,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(account_a, false),
+            ],
+            &[],
+        ));
+    }
+    let after_cranks = env.market_state().1;
+    let survivor_after_cranks = env.portfolio_state(account_a);
+    println!(
+        "permissionless cranks={crank_results:?} oi=({},{}) mode=({:?},{:?}) active={}",
+        after_cranks.assets[0].oi_eff_long_q,
+        after_cranks.assets[0].oi_eff_short_q,
+        after_cranks.assets[0].mode_long,
+        after_cranks.assets[0].mode_short,
+        has_active_leg_for_asset(&survivor_after_cranks, 0),
+    );
+    assert!(
+        crank_results.iter().all(Result::is_ok),
+        "the selector currently misclassifies the stranded state as successful NoAction"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_cranks,
+        "successful no-op cranks make no market progress"
+    );
+    assert_eq!(
+        env.svm.get_account(&account_a).unwrap(),
+        survivor_before_cranks,
+        "successful no-op cranks make no survivor progress"
+    );
+
+    assert!(
+        rebalance.is_ok() || !has_active_leg_for_asset(&survivor_after_cranks, 0),
+        "ten successful public cranks must not be no-op witnesses for a permanently stuck ADL residue"
+    );
+}
+
+#[test]
 fn v16_attack_stale_resolve_matured_no_observation_liquidation_rejects() {
     let mut env = V16CuEnv::new();
     env.configure_permissionless_resolve_with_cu(5, 5);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10015,6 +10015,11 @@ fn v16_attack_exact_effective_oi_cross_must_not_strand_adl_survivor() {
     );
     assert_eq!(after_cross.assets[0].oi_eff_long_q, 0);
     assert_eq!(after_cross.assets[0].oi_eff_short_q, 0);
+    assert_eq!(
+        after_cross.assets[0].mode_long,
+        SideModeV16::ResetPending,
+        "zero effective OI with surviving ADL basis must enter a permissionlessly clearable reset"
+    );
     assert!(residual_q > 0);
     assert!(
         survivor_after_cross.capital.get() > 0,
@@ -10034,10 +10039,9 @@ fn v16_attack_exact_effective_oi_cross_must_not_strand_adl_survivor() {
         ],
         &[&owner_a],
     );
-    println!("owner rebalance after exact cross: {rebalance:?}");
     assert!(
         rebalance.is_err(),
-        "the vulnerable engine is expected to reject direct owner reduction"
+        "direct reduction is excluded once the reset route owns residue cleanup"
     );
 
     env.svm.expire_blockhash();
@@ -10058,19 +10062,22 @@ fn v16_attack_exact_effective_oi_cross_must_not_strand_adl_survivor() {
         trade_exit.is_err(),
         "a fresh willing counterparty cannot fund a reduction from zero preexisting OI"
     );
-    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_exit);
-    assert_eq!(env.svm.get_account(&account_a).unwrap(), survivor_before_exit);
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_exit
+    );
+    assert_eq!(
+        env.svm.get_account(&account_a).unwrap(),
+        survivor_before_exit
+    );
     assert_eq!(
         env.svm.get_account(&account_b).unwrap(),
         counterparty_before_exit
     );
 
-    let market_before_cranks = env.svm.get_account(&env.market).unwrap();
-    let survivor_before_cranks = env.svm.get_account(&account_a).unwrap();
-    let mut crank_results = Vec::new();
-    for _ in 0..10 {
-        env.svm.expire_blockhash();
-        crank_results.push(env.send(
+    env.svm.expire_blockhash();
+    let crank_cu = env
+        .send(
             ProgInstruction::PermissionlessCrank {
                 now_slot: 35,
                 observations: vec![],
@@ -10081,36 +10088,31 @@ fn v16_attack_exact_effective_oi_cross_must_not_strand_adl_survivor() {
                 AccountMeta::new(account_a, false),
             ],
             &[],
-        ));
-    }
+        )
+        .expect("one permissionless crank clears the prior-reset residue");
+    assert_cu_within("exact-OI ADL residue cleanup", crank_cu, CRANK_CU_LIMIT);
     let after_cranks = env.market_state().1;
     let survivor_after_cranks = env.portfolio_state(account_a);
     println!(
-        "permissionless cranks={crank_results:?} oi=({},{}) mode=({:?},{:?}) active={}",
+        "permissionless cleanup_cu={crank_cu} oi=({},{}) mode=({:?},{:?}) active={}",
         after_cranks.assets[0].oi_eff_long_q,
         after_cranks.assets[0].oi_eff_short_q,
         after_cranks.assets[0].mode_long,
         after_cranks.assets[0].mode_short,
         has_active_leg_for_asset(&survivor_after_cranks, 0),
     );
-    assert!(
-        crank_results.iter().all(Result::is_ok),
-        "the selector currently misclassifies the stranded state as successful NoAction"
-    );
-    assert_eq!(
-        env.svm.get_account(&env.market).unwrap(),
-        market_before_cranks,
-        "successful no-op cranks make no market progress"
-    );
-    assert_eq!(
-        env.svm.get_account(&account_a).unwrap(),
-        survivor_before_cranks,
-        "successful no-op cranks make no survivor progress"
-    );
 
     assert!(
-        rebalance.is_ok() || !has_active_leg_for_asset(&survivor_after_cranks, 0),
-        "ten successful public cranks must not be no-op witnesses for a permanently stuck ADL residue"
+        !has_active_leg_for_asset(&survivor_after_cranks, 0),
+        "the public crank must not return a no-op witness for a permanently stuck ADL residue"
+    );
+    let withdrawable = survivor_after_cranks.capital.get();
+    assert!(withdrawable > 0);
+    let dest = env.withdraw(&owner_a, account_a, withdrawable);
+    assert_eq!(
+        env.token_amount(dest),
+        withdrawable as u64,
+        "the formerly stranded owner can recover all remaining principal"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add an exact-parent public LiteSVM reproduction for the equality boundary left by engine #109's preexisting-OI gate.
- Pin the isolated fix from engine PR #139, stacked on the generic reset cleanup from engine PR #99 / wrapper #201.
- Prove one bounded permissionless crank removes the residual leg and the owner withdraws all remaining principal.

## Public exploit

The test uses only ordinary public instructions and valid initialized accounts:

1. Two users deposit SPL collateral and open opposing positions.
2. Public maintenance and crank calls partially liquidate one side, leaving survivor basis larger than effective OI.
3. A crossed trade reduces effective OI by exactly the remaining amount.
4. Both OI counters become zero, but the survivor retains `1_000_000` basis units and deposited capital in an active leg.
5. Owner reduction returns `CounterUnderflow`, a fresh counterparty cannot fund an exit from zero preexisting OI, and ten honest permissionless cranks return success without changing state.

This is persistent user DoS, not a malformed-state probe, initialization footgun, stale caller hint, or transient failure. It contradicts the selector claim directly: `NoAction` was a successful no-op witness for an account whose funds had no bounded public exit.

## Exact-parent TDD

- Historical exact `main` parent: wrapper `da64be639168b496833dd4c701607a94fcb06b6c`, engine `143e68c4917ed0400a27b952f036a5677047cd84`
- Rebased red commit: `bc790f69`
- Red dependency: engine #99 at `28a7338bd8c0dff7134ea0aa06404795bbb8557b`, before the equality fix
- Red result: OI `(0,0)`, modes `(Normal,Normal)`, residual basis `1_000_000`; owner exit `Custom(25)`; 10/10 cranks return `Ok(58_771)` with identical state
- Fixed commit: `2fe02df1`
- Fixed engine: `619f3fec9a2f6c0cf2462414c47a65eeefdde81c`
- Fixed result: side enters `ResetPending`; one public crank clears the leg at 100,151 CU; owner withdraws all remaining principal

## Scope and dependencies

- Engine fix: https://github.com/aeyakovenko/percolator/pull/139
- Base wrapper: #201, providing engine #99's generic prior-reset cleanup
- Engine #118 / wrapper #219 are not duplicates: they cover bilateral zero-OI after unilateral bankruptcy close; this PR covers the distinct crossed-trade equality route

## Validation

- exact rebased red/fixed public LiteSVM TDD: fail/pass as described above
- engine `cargo test --all-targets --features fuzz`: 161 passed
- focused engine Kani guard and cleanup obligations: passed
- wrapper aggregate: 6 unit + 568 serialized LiteSVM/CU tests passed
- existing issue-103 liquidation crank remains below its 325,000-CU guard
- all full-14-leg and 10 MiB CU tests pass
- `cargo fmt --all -- --check`
- `git diff --check`
