### PR TITLE
[BLOCKER DoS] Keep unilateral exact-OI ADL survivors exit-live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=619f3fec9a2f6c0cf2462414c47a65eeefdde81c#619f3fec9a2f6c0cf2462414c47a65eeefdde81c"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b3886dcf6927c8e1cb2b822f0819451971a4b3a5#b3886dcf6927c8e1cb2b822f0819451971a4b3a5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "619f3fec9a2f6c0cf2462414c47a65eeefdde81c" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b3886dcf6927c8e1cb2b822f0819451971a4b3a5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "619f3fec9a2f6c0cf2462414c47a65eeefdde81c" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b3886dcf6927c8e1cb2b822f0819451971a4b3a5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60226,3 +60226,226 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_attack_exact_effective_oi_rebalance_must_not_strand_adl_survivor() {
+    const PRICE: u64 = 1;
+    const OPEN_Q: i128 = 13_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        h_max: 6_480_000,
+        initial_price: PRICE,
+        maintenance_margin_bps: 500,
+        initial_margin_bps: 500,
+        min_nonzero_mm_req: 599,
+        min_nonzero_im_req: 600,
+        max_price_move_bps_per_slot: 24,
+        max_accrual_dt_slots: 20,
+        max_abs_funding_e9_per_slot: 0,
+        min_funding_lifetime_slots: 10_000_000,
+        liquidation_fee_bps: 0,
+        maintenance_fee_per_slot: 27,
+        ..V16CuMarketParams::default()
+    });
+    let survivor_owner = Keypair::new();
+    let bankrupt_owner = Keypair::new();
+    let survivor = env.create_portfolio(&survivor_owner);
+    let bankrupt = env.create_portfolio(&bankrupt_owner);
+    env.deposit(&survivor_owner, survivor, 1_000);
+    env.deposit(&bankrupt_owner, bankrupt, 1_189);
+
+    env.svm.warp_to_slot(8);
+    env.try_trade_asset_with_cu(
+        0,
+        &survivor_owner,
+        survivor,
+        &bankrupt_owner,
+        bankrupt,
+        OPEN_Q,
+        PRICE,
+        0,
+    )
+    .expect("open trade");
+    env.svm.warp_to_slot(27);
+    env.crank(
+        survivor,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 27,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(35);
+    env.sync_maintenance_fee_with_cu(bankrupt, None, 35);
+    env.crank_steps(
+        bankrupt,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 35,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+
+    let before = env.market_state().1;
+    let surviving_effective_q = before.assets[0].oi_eff_long_q;
+    let survivor_basis_q = active_leg_for_asset(&env.portfolio_state(survivor), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    assert_eq!(surviving_effective_q, before.assets[0].oi_eff_short_q);
+    assert!(surviving_effective_q > 0 && survivor_basis_q > surviving_effective_q);
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: 0,
+            reduce_q: surviving_effective_q,
+        },
+        vec![
+            AccountMeta::new(survivor_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(survivor, false),
+        ],
+        &[&survivor_owner],
+    )
+    .expect("exact-effective-OI unilateral reduction");
+
+    let after_reduce = env.market_state().1;
+    let survivor_after_reduce = env.portfolio_state(survivor);
+    let residual_q = active_leg_for_asset(&survivor_after_reduce, 0)
+        .basis_pos_q
+        .unsigned_abs();
+    eprintln!(
+        "after exact rebalance: oi=({},{}) mode=({:?},{:?}) residual={residual_q}",
+        after_reduce.assets[0].oi_eff_long_q,
+        after_reduce.assets[0].oi_eff_short_q,
+        after_reduce.assets[0].mode_long,
+        after_reduce.assets[0].mode_short,
+    );
+    assert_eq!(after_reduce.assets[0].oi_eff_long_q, 0);
+    assert_eq!(after_reduce.assets[0].oi_eff_short_q, 0);
+    assert!(residual_q > 0);
+    assert!(survivor_after_reduce.capital.get() > 0);
+
+    env.svm.expire_blockhash();
+    let retry = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: 0,
+            reduce_q: residual_q,
+        },
+        vec![
+            AccountMeta::new(survivor_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(survivor, false),
+        ],
+        &[&survivor_owner],
+    );
+    assert!(retry.is_err(), "zero-OI residue has no direct reduction path");
+
+    for _ in 0..3 {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 35,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(bankrupt, false),
+            ],
+            &[],
+        )
+        .expect("honest counterparty cleanup crank");
+        if !has_active_leg_for_asset(&env.portfolio_state(bankrupt), 0) {
+            break;
+        }
+    }
+    let willing_owner = Keypair::new();
+    let willing = env.create_portfolio(&willing_owner);
+    env.deposit(&willing_owner, willing, 1_000);
+    env.svm.expire_blockhash();
+    let trade_exit = env.try_trade_asset_with_cu(
+        0,
+        &willing_owner,
+        willing,
+        &survivor_owner,
+        survivor,
+        residual_q as i128,
+        PRICE,
+        0,
+    );
+    eprintln!("fresh-counterparty exit={trade_exit:?}");
+    assert!(
+        trade_exit.is_err(),
+        "zero preexisting OI must not make a fresh counterparty an unbounded escape assumption"
+    );
+
+    let withdraw_dest = Pubkey::new_unique();
+    env.svm
+        .set_account(
+            withdraw_dest,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, survivor_owner.pubkey(), 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm.expire_blockhash();
+    let withdraw_while_stuck = env.send(
+        ProgInstruction::Withdraw {
+            amount: survivor_after_reduce.capital.get(),
+        },
+        vec![
+            AccountMeta::new(survivor_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(survivor, false),
+            AccountMeta::new(withdraw_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&survivor_owner],
+    );
+    eprintln!("full withdrawal while residue remains={withdraw_while_stuck:?}");
+    assert!(withdraw_while_stuck.is_err());
+
+    for _ in 0..2 {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 35,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(survivor, false),
+            ],
+            &[],
+        )
+        .expect("honest permissionless crank");
+        if !has_active_leg_for_asset(&env.portfolio_state(survivor), 0) {
+            break;
+        }
+    }
+
+    let after_cranks = env.market_state().1;
+    let survivor_after_cranks = env.portfolio_state(survivor);
+    eprintln!(
+        "after honest cranks: mode={:?} active={} capital={}",
+        after_cranks.assets[0].mode_long,
+        has_active_leg_for_asset(&survivor_after_cranks, 0),
+        survivor_after_cranks.capital.get(),
+    );
+
+    assert_eq!(after_reduce.assets[0].mode_long, SideModeV16::ResetPending);
+    assert!(
+        !has_active_leg_for_asset(&survivor_after_cranks, 0),
+        "one honest cranker must clear the owner's zero-OI ADL residue"
+    );
+    let withdrawable = survivor_after_cranks.capital.get();
+    let dest = env.withdraw(&survivor_owner, survivor, withdrawable);
+    assert_eq!(env.token_amount(dest), withdrawable as u64);
+}


### PR DESCRIPTION
## What changed

Adds a public LiteSVM regression for a unilateral exact-effective-OI reduction after ADL has left stored basis above effective OI, and pins the engine fix from aeyakovenko/percolator#141.

## Public exploit and impact

The test uses only normal public instructions on a live initialized market:

1. Deposit and trade to establish open interest.
2. Use public cranks and maintenance sync to reach an ADL survivor whose stored basis exceeds effective OI.
3. The owner calls `RebalanceReduce` for exactly the remaining effective OI.
4. On the exact pre-fix engine, the survivor remains `Normal` with zero OI and nonzero basis.
5. A fresh willing counterparty cannot close it, repeated honest auto-cranks do not clear it, and full withdrawal rejects, permanently stranding the owner's deposited principal.

No account bytes or engine state are injected. The test also cleans the opposite side before retrying with a fresh public counterparty, excluding another account's pending reset as the cause.

## Fix

Engine PR aeyakovenko/percolator#141 starts the existing bounded reset flow for either zero-effective-OI side retaining stored basis after unilateral reductions. An honest public auto-crank can then detach the survivor and restore withdrawal liveness.

This PR is intentionally stacked on #266 because the engine fix reuses the generic exact-OI residue detector introduced by its engine dependency. The diff against that base contains only this public regression and the engine pin.

## TDD evidence

- Exact pre-fix wrapper/engine parent: regression fails after public cranks, fresh trade, and withdrawal all leave the funded leg stuck.
- Fixed engine `b3886dcf6927c8e1cb2b822f0819451971a4b3a5`: regression passes and the owner can withdraw after honest crank cleanup.
- Engine suite: 133/133 passed.
- Wrapper LiteSVM/CU suite: 569/569 passed with the auth and hostile matcher SBF fixtures built.
