### PR TITLE
[BLOCKER DoS] Keep max-shape zero-delta stale resolution live

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4583,6 +4583,45 @@ pub mod processor {
         Ok(profile)
     }
 
+    fn read_oracle_profile_for_resolve_scan_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> Result<state::AssetOracleProfileV16, ProgramError> {
+        // Public profile writes perform the full structural validation. Resolution only consumes
+        // this price summary, so re-walking every cold oracle-feed field here would make the sole
+        // terminal path exceed max-shape CU. Revalidate every field that this scan reads.
+        let market = group
+            .markets
+            .get(asset_index)
+            .ok_or(PercolatorError::InvalidInstruction)?;
+        let bytes = market
+            .wrapper
+            .get(..constants::ASSET_ORACLE_PROFILE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let profile: state::AssetOracleProfileV16 = bytemuck::pod_read_unaligned(bytes);
+        match profile.oracle_mode {
+            constants::ORACLE_MODE_MANUAL
+            | constants::ORACLE_MODE_HYBRID_AFTER_HOURS
+            | constants::ORACLE_MODE_EWMA_MARK
+            | constants::ORACLE_MODE_AUTH_MARK => {}
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+        if oracle_v16::profile_is_price_managed(&profile)
+            && (profile.mark_ewma_e6 == 0
+                || profile.mark_ewma_e6 > percolator::MAX_ORACLE_PRICE
+                || profile.oracle_target_price_e6 == 0
+                || profile.oracle_target_price_e6 > percolator::MAX_ORACLE_PRICE)
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if oracle_v16::profile_is_auth_mark(&profile)
+            && profile.mark_ewma_e6 != profile.oracle_target_price_e6
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(profile)
+    }
+
     fn write_oracle_profile_to_view_if_separate(
         group: &mut state::MarketViewMutV16<'_>,
         asset_index: usize,
@@ -8661,12 +8700,27 @@ pub mod processor {
         Ok(())
     }
 
+    fn zero_delta_anchor_price_ceiling_view(group: &state::MarketViewMutV16<'_>) -> u64 {
+        let max_delta_factor = group
+            .header
+            .config
+            .max_price_move_bps_per_slot
+            .get()
+            .saturating_mul(group.header.config.max_accrual_dt_slots.get());
+        if max_delta_factor == 0 {
+            u64::MAX
+        } else {
+            9_999 / max_delta_factor
+        }
+    }
+
     fn committed_market_resolve_accrual_for_profile_view(
         profile: &state::AssetOracleProfileV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
         resolved_slot: u64,
         include_pending_mark: bool,
+        zero_delta_anchor_price_ceiling: u64,
     ) -> Result<Option<(u64, i128)>, ProgramError> {
         if asset_index >= group.header.config.max_market_slots.get() as usize
             || asset_index >= group.markets.len()
@@ -8691,11 +8745,22 @@ pub mod processor {
         if profile.mark_ewma_e6 == asset.effective_price.get() {
             return Ok(None);
         }
+        // A different mark can still be a provable no-op when even the maximum configured dt makes
+        // the bounded price delta round to zero. The caller computes the ceiling once so this
+        // max-shape scan only needs a comparison per exposed asset.
+        let balanced = asset.oi_eff_long_q.get() != 0 && asset.oi_eff_short_q.get() != 0;
+        let price_must_remain_unchanged = profile.mark_ewma_e6 != 0
+            && asset.effective_price.get() <= zero_delta_anchor_price_ceiling;
+        let funding_must_remain_zero = !balanced
+            || group.header.config.max_abs_funding_e9_per_slot.get() == 0
+            || profile.mark_ewma_last_slot > asset.slot_last.get();
+        if price_must_remain_unchanged && funding_must_remain_zero {
+            return Ok(None);
+        }
         let next_price =
             committed_effective_price_for_accrual_view(profile, group, asset_index, resolved_slot)?;
         let funding_rate_e9 =
             permissionless_funding_rate_e9_view(profile, group, asset_index, next_price)?;
-        let balanced = asset.oi_eff_long_q.get() != 0 && asset.oi_eff_short_q.get() != 0;
         if next_price == asset.effective_price.get() && (!balanced || funding_rate_e9 == 0) {
             return Ok(None);
         }
@@ -8704,24 +8769,25 @@ pub mod processor {
 
     #[inline(never)]
     fn reject_market_resolve_before_committed_accrual_view(
-        cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         resolved_slot: u64,
         include_pending_mark: bool,
     ) -> ProgramResult {
         let configured_slots = group.header.config.max_market_slots.get() as usize;
+        let zero_delta_anchor_price_ceiling = zero_delta_anchor_price_ceiling_view(group);
         let mut asset_index = 0usize;
         while asset_index < configured_slots {
             let asset = group.markets[asset_index].engine.asset;
             let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
             if exposed && asset.slot_last.get() < resolved_slot {
-                let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+                let profile = read_oracle_profile_for_resolve_scan_view(group, asset_index)?;
                 if committed_market_resolve_accrual_for_profile_view(
                     &profile,
                     group,
                     asset_index,
                     resolved_slot,
                     include_pending_mark,
+                    zero_delta_anchor_price_ceiling,
                 )?
                 .is_some()
                 {
@@ -8755,7 +8821,7 @@ pub mod processor {
         if slot < group.header.current_slot.get() {
             return Err(PercolatorError::EngineStale.into());
         }
-        reject_market_resolve_before_committed_accrual_view(&cfg, &group, slot, false)?;
+        reject_market_resolve_before_committed_accrual_view(&group, slot, false)?;
         group
             .resolve_market_not_atomic(slot)
             .map_err(map_v16_error)?;
@@ -9841,12 +9907,7 @@ pub mod processor {
         if !oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot) {
             return Err(PercolatorError::OracleStale.into());
         }
-        reject_market_resolve_before_committed_accrual_view(
-            &cfg,
-            &group,
-            authenticated_slot,
-            true,
-        )?;
+        reject_market_resolve_before_committed_accrual_view(&group, authenticated_slot, true)?;
         group
             .resolve_market_not_atomic(authenticated_slot)
             .map_err(map_v16_error)?;
@@ -10682,6 +10743,7 @@ pub mod processor {
                         asset_index,
                         authenticated_now_slot,
                         true,
+                        zero_delta_anchor_price_ceiling_view(&group),
                     )?
                     .ok_or(PercolatorError::EngineNonProgress)?
                 } else {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60004,7 +60004,7 @@ fn v16_attack_stale_resolve_can_finish_committed_funding_accrual() {
 
 #[test]
 fn v16_dense_zero_delta_price_managed_stale_market_remains_resolvable() {
-    const ASSET_COUNT: u16 = 2_000;
+    const ASSET_COUNT: u16 = 5_834;
     const PRICE: u64 = 100;
     // Pre-sizing is part of normal market-account construction. InitMarket still configures only
     // the first 14 slots; every additional slot is activated below through the public API.
@@ -60165,7 +60165,6 @@ fn v16_dense_zero_delta_price_managed_stale_market_remains_resolvable() {
     );
 
     env.svm.expire_blockhash();
-    env.svm.expire_blockhash();
     let no_progress = env
         .send(
             ProgInstruction::PermissionlessCrank {
@@ -60181,8 +60180,7 @@ fn v16_dense_zero_delta_price_managed_stale_market_remains_resolvable() {
         )
         .expect_err("the zero-delta committed mark leaves the account crank with no action");
     assert!(
-        no_progress.contains("Custom(22)")
-            || no_progress.contains("custom program error: 0x16"),
+        no_progress.contains("Custom(22)") || no_progress.contains("custom program error: 0x16"),
         "the honest crank should fail specifically as EngineNonProgress: {no_progress}"
     );
 
@@ -60196,6 +60194,7 @@ fn v16_dense_zero_delta_price_managed_stale_market_remains_resolvable() {
             &[],
         )
         .expect("a publicly constructed dense market must retain a bounded stale resolver");
+    eprintln!("dense zero-delta stale resolve CU={resolve_cu}");
     assert!(resolve_cu < 1_400_000);
     assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60003,14 +60003,16 @@ fn v16_attack_stale_resolve_can_finish_committed_funding_accrual() {
 }
 
 #[test]
-fn v16_dense_price_managed_stale_market_remains_resolvable() {
-    const ASSET_COUNT: u16 = 4_000;
+fn v16_dense_zero_delta_price_managed_stale_market_remains_resolvable() {
+    const ASSET_COUNT: u16 = 2_000;
     const PRICE: u64 = 100;
     // Pre-sizing is part of normal market-account construction. InitMarket still configures only
     // the first 14 slots; every additional slot is activated below through the public API.
     let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
         V16CuMarketParams {
             max_portfolio_assets: percolator_prog::constants::WRAPPER_MAX_PORTFOLIO_ASSETS,
+            max_price_move_bps_per_slot: 1,
+            max_abs_funding_e9_per_slot: 0,
             ..V16CuMarketParams::default()
         },
         ASSET_COUNT as usize,
@@ -60125,7 +60127,17 @@ fn v16_dense_price_managed_stale_market_remains_resolvable() {
         &[&admin],
     )
     .expect("configure permissionless resolution");
-    let resolved_slot = ASSET_COUNT as u64 + 1;
+
+    // Every exposed asset has a different committed mark, but its configured one-slot move
+    // rounds to zero and funding is disabled. There is no accrual work to commit, so resolution
+    // must remain bounded even though each entry reaches the full preflight predicate.
+    let mark_slot = ASSET_COUNT as u64 + 1;
+    env.svm.warp_to_slot(mark_slot);
+    for asset_index in 0..ASSET_COUNT {
+        env.push_auth_mark_for_asset_as_admin(asset_index, mark_slot, PRICE - 1);
+    }
+
+    let resolved_slot = mark_slot + 2;
     env.svm.warp_to_slot(resolved_slot);
 
     env.svm.expire_blockhash();
@@ -60150,6 +60162,28 @@ fn v16_dense_price_managed_stale_market_remains_resolvable() {
     assert!(
         stale_exit.contains("Custom(27)") || stale_exit.contains("custom program error: 0x1b"),
         "ordinary exit should fail specifically as OracleStale: {stale_exit}"
+    );
+
+    env.svm.expire_blockhash();
+    env.svm.expire_blockhash();
+    let no_progress = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: resolved_slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim_portfolio, false),
+            ],
+            &[],
+        )
+        .expect_err("the zero-delta committed mark leaves the account crank with no action");
+    assert!(
+        no_progress.contains("Custom(22)")
+            || no_progress.contains("custom program error: 0x16"),
+        "the honest crank should fail specifically as EngineNonProgress: {no_progress}"
     );
 
     env.svm.expire_blockhash();


### PR DESCRIPTION
## What changed

- Add a public LiteSVM regression that fills all 5,834 supported market slots with balanced OI, stages a distinct authenticated mark on every asset, and proves stale resolution remains bounded when every configured price move rounds to zero.
- Precompute the zero-delta anchor ceiling once per resolve scan instead of evaluating wide clamp arithmetic per asset.
- Decode and fail-closed validate only the oracle-profile fields consumed by terminal accrual preflight. Full profile structure remains validated on every public profile write.

## Root cause

PR #255 added a full exposed-asset scan before stale resolution so pending committed mark/funding work cannot be discarded. Its existing 10MiB benchmark exposed only one late asset, while the public dense test stopped at 4,000 equal-mark assets and already consumed about 1.30M CU.

A normally configured low-price market can have a distinct authenticated mark while `anchor * max_price_move_bps_per_slot * max_accrual_dt_slots < 10_000`; the effective-price move is then exactly zero. With funding disabled, there is no work for the account crank, but the pre-fix resolver still fully validates and evaluates every exposed profile. At 2,000 public assets it exhausts the 1.4M transaction budget.

That is a persistent public liveness failure after stale maturity: ordinary exits are `OracleStale`, the honest permissionless crank returns `EngineNonProgress`, mature-state recovery mutations are blocked, and the sole permissionless resolver cannot complete.

## TDD evidence

- Base: exact PR #255 head `eab3c4f66e45381860541a04701e7f0438a0ffe3`
- Red: test commit `086ed2c6` reproduces `ProgramFailedToComplete` at 1,400,000 CU using only normal account construction and public wrapper instructions; no market or portfolio bytes are injected.
- Green: the fixed head resolves the fully exposed 5,834-asset market in 1,140,523 CU and enters `Resolved` mode.
- Real pending price and funding tests still force bounded public catch-up before resolution.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets -- --test-threads=1`: 570/570 LiteSVM/CU tests and 6/6 host tests pass
- `cargo test --test v16_cu v16_dense_zero_delta_price_managed_stale_market_remains_resolvable -- --nocapture`: 1/1 pass, 1,140,523 CU

This PR is intentionally stacked on #255 because the vulnerable accrual preflight does not exist on current `main`.
