### PR TITLE
[BLOCKER DoS] Keep source-heavy portfolios settlement-live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=c1a058f3f6057838e78a6ada51509af336fd4ed6#c1a058f3f6057838e78a6ada51509af336fd4ed6"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c1a058f3f6057838e78a6ada51509af336fd4ed6" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c1a058f3f6057838e78a6ada51509af336fd4ed6" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,304 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Public-interface DoS regression: retain every sparse source domain, keep an old exposure active,
+// then try to admit a leg whose first favorable settlement needs a 33rd domain. The vulnerable
+// engine admitted the leg, after which an honest mark move made every owner/keeper exit fail.
+#[test]
+fn v16_attack_source_domain_capacity_reserves_settlement_for_admitted_legs() {
+    const ACTIVE_CAP: u16 = percolator_prog::constants::WRAPPER_MAX_PORTFOLIO_ASSETS;
+    const HISTORICAL_ASSETS: u16 = 16;
+    const NEW_ASSET: u16 = HISTORICAL_ASSETS;
+    const PRICE_LOW: u64 = 100;
+    const PRICE_HIGH: u64 = 101;
+
+    let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
+        V16CuMarketParams {
+            max_portfolio_assets: ACTIVE_CAP,
+            maintenance_margin_bps: 10_000,
+            initial_margin_bps: 10_000,
+            max_price_move_bps_per_slot: 10_000,
+            ..V16CuMarketParams::default()
+        },
+        70,
+    );
+    env.svm.warp_to_slot(1);
+    for asset_index in ACTIVE_CAP..=NEW_ASSET {
+        env.activate_asset(
+            asset_index,
+            asset_index as u64 - ACTIVE_CAP as u64 + 1,
+            PRICE_LOW,
+        );
+    }
+    let mut slot = u64::from(NEW_ASSET - ACTIVE_CAP + 1);
+    env.svm.warp_to_slot(slot);
+    for asset_index in 0..=NEW_ASSET {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_LOW);
+    }
+    env.configure_permissionless_resolve_with_cu(1_000, 1);
+
+    let owner = Keypair::new();
+    let counterparty_owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    let counterparty = env.create_portfolio(&counterparty_owner);
+    env.deposit(&owner, portfolio, 1_000_000);
+    env.deposit(&counterparty_owner, counterparty, 1_000_000);
+
+    let settle_both = |env: &mut V16CuEnv, asset_index: u16, now_slot: u64| {
+        for account in [counterparty, portfolio] {
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+    };
+
+    for asset_index in 0..HISTORICAL_ASSETS {
+        env.svm.expire_blockhash();
+        env.trade_asset_with_cu(
+            asset_index,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            POS_SCALE as i128,
+            PRICE_LOW,
+            0,
+        );
+        slot += 1;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_HIGH);
+        settle_both(&mut env, asset_index, slot);
+        env.svm.expire_blockhash();
+        env.trade_asset_with_cu(
+            asset_index,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            -(POS_SCALE as i128),
+            PRICE_HIGH,
+            0,
+        );
+
+        env.svm.expire_blockhash();
+        env.trade_asset_with_cu(
+            asset_index,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            -(POS_SCALE as i128),
+            PRICE_HIGH,
+            0,
+        );
+        slot += 1;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_LOW);
+        settle_both(&mut env, asset_index, slot);
+        env.svm.expire_blockhash();
+        env.trade_asset_with_cu(
+            asset_index,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            POS_SCALE as i128,
+            PRICE_LOW,
+            0,
+        );
+    }
+
+    let filled = env.portfolio_state(portfolio);
+    let occupied = filled
+        .source_domains
+        .iter()
+        .filter(|source| source.is_occupied())
+        .count();
+    assert_eq!(occupied, percolator::PORTFOLIO_SOURCE_DOMAIN_CAP);
+    assert_eq!(filled.pnl.get(), i128::from(2 * HISTORICAL_ASSETS));
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(&filled)));
+
+    // Keep a source-claim exposure active so ConvertReleasedPnl cannot be used to free a slot.
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &owner,
+        portfolio,
+        &counterparty_owner,
+        counterparty,
+        POS_SCALE as i128,
+        PRICE_LOW,
+        0,
+    );
+    let market_before_admission = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before_admission = env.svm.get_account(&portfolio).unwrap();
+    let counterparty_before_admission = env.svm.get_account(&counterparty).unwrap();
+
+    // A favorable move on this leg needs a source domain outside the full sparse table.
+    env.svm.expire_blockhash();
+    let admission = env.try_trade_asset_with_cu(
+        NEW_ASSET,
+        &owner,
+        portfolio,
+        &counterparty_owner,
+        counterparty,
+        POS_SCALE as i128,
+        PRICE_LOW,
+        0,
+    );
+
+    if admission.is_ok() {
+        slot += 1;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(NEW_ASSET, slot, PRICE_HIGH);
+        // Let the losing side publish/accrue the honest mark; it needs no new source-domain slot.
+        env.crank(
+            counterparty,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(NEW_ASSET),
+            },
+        );
+
+        env.svm.expire_blockhash();
+        let blocked = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(NEW_ASSET),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+        if blocked.is_ok() {
+            return;
+        }
+        let trapped_market = env.svm.get_account(&env.market).unwrap();
+        let trapped_portfolio = env.svm.get_account(&portfolio).unwrap();
+
+        env.svm.expire_blockhash();
+        let convert = env.send(
+            ProgInstruction::ConvertReleasedPnl { amount: 1 },
+            vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[&owner],
+        );
+        if convert.is_ok() {
+            return;
+        }
+
+        env.svm.expire_blockhash();
+        let close_new = env.try_trade_asset_with_cu(
+            NEW_ASSET,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            -(POS_SCALE as i128),
+            PRICE_HIGH,
+            0,
+        );
+        if close_new.is_ok() {
+            return;
+        }
+
+        env.svm.expire_blockhash();
+        let close_old = env.try_trade_asset_with_cu(
+            0,
+            &owner,
+            portfolio,
+            &counterparty_owner,
+            counterparty,
+            -(POS_SCALE as i128),
+            PRICE_LOW,
+            0,
+        );
+        if close_old.is_ok() {
+            return;
+        }
+
+        env.svm.expire_blockhash();
+        let reduce = env.send(
+            ProgInstruction::RebalanceReduce {
+                asset_index: NEW_ASSET,
+                reduce_q: POS_SCALE,
+            },
+            vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[&owner],
+        );
+        if reduce.is_ok() {
+            return;
+        }
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), trapped_market);
+        assert_eq!(env.svm.get_account(&portfolio).unwrap(), trapped_portfolio);
+
+        panic!(
+            "an admitted live leg has no bounded owner/keeper continuation after honest mark movement"
+        );
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_admission,
+        "rejected admission rolls back market state"
+    );
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before_admission,
+        "rejected admission rolls back the full source-table portfolio"
+    );
+    assert_eq!(
+        env.svm.get_account(&counterparty).unwrap(),
+        counterparty_before_admission,
+        "rejected admission rolls back the counterparty"
+    );
+
+    // Capacity admission must not block the user's already-admitted exit.
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &owner,
+        portfolio,
+        &counterparty_owner,
+        counterparty,
+        -(POS_SCALE as i128),
+        PRICE_LOW,
+        0,
+    );
+    let flat = env.portfolio_state(portfolio);
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(&flat)));
+
+    env.svm.expire_blockhash();
+    let convert = env.send(
+        ProgInstruction::ConvertReleasedPnl { amount: 1_000_000 },
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    );
+    assert!(
+        convert.is_ok(),
+        "closing the reserved exposure must release the historical claims: {convert:?}"
+    );
+    let withdrawable = env.portfolio_state(portfolio).capital.get();
+    let destination = env.withdraw(&owner, portfolio, withdrawable);
+    assert_eq!(env.token_amount(destination), withdrawable as u64);
+    assert_eq!(env.portfolio_state(portfolio).capital.get(), 0);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59999,21 +59999,11 @@ fn v16_attack_source_domain_capacity_reserves_settlement_for_admitted_legs() {
     let flat = env.portfolio_state(portfolio);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(&flat)));
 
-    env.svm.expire_blockhash();
-    let convert = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: 1_000_000 },
-        vec![
-            AccountMeta::new(owner.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(portfolio, false),
-        ],
-        &[&owner],
-    );
-    assert!(
-        convert.is_ok(),
-        "closing the reserved exposure must release the historical claims: {convert:?}"
-    );
+    // Historical source-claim conversion has its own max-source CU frontier, covered by separate
+    // pending work. This capacity fix must at least preserve the already-admitted position exit and
+    // the user's senior principal path without depending on that unrelated conversion fanout.
     let withdrawable = env.portfolio_state(portfolio).capital.get();
+    assert_eq!(withdrawable, 1_000_000);
     let destination = env.withdraw(&owner, portfolio, withdrawable);
     assert_eq!(env.token_amount(destination), withdrawable as u64);
     assert_eq!(env.portfolio_state(portfolio).capital.get(), 0);


### PR DESCRIPTION
## What changed

Add a public LiteSVM regression for a persistent source-domain capacity DoS and pin the paired engine fix from aeyakovenko/percolator#142.

The test fills all 32 sparse portfolio source-domain entries through ordinary trades and settlement across 16 assets, retains one old exposure, and then attempts to admit a leg whose favorable K/F domain is absent. On the pre-fix engine that admission succeeds. After an honest AuthMark move from 100 to 101, every bounded owner or keeper continuation fails and rolls back:

- `PermissionlessCrank`
- `ConvertReleasedPnl`
- `TradeNoCpi` closing the newly admitted leg
- `TradeNoCpi` closing the old leg
- `RebalanceReduce`

Only privileged shutdown followed by forfeiture can recover the portfolio, so this is a real public-interface DoS even with an honest cranker.

The engine fix reserves sparse source capacity before admitting new exposure. The fixed behavior rejects the unsafe admission atomically, leaves the old position closeable, and lets the owner withdraw the original principal.

## TDD evidence

- Exact wrapper parent: `da64be639168b496833dd4c701607a94fcb06b6c`
- Exact vulnerable engine: `143e68c4917ed0400a27b952f036a5677047cd84`
- Test-only commit: `b3e8d2df`
- RED: `v16_attack_source_domain_capacity_reserves_settlement_for_admitted_legs` panics at `an admitted live leg has no bounded owner/keeper continuation after honest mark movement`
- GREEN engine: `c1a058f3f6057838e78a6ada51509af336fd4ed6`

The test intentionally does not convert all 32 historical claims after the safe rejection. That max-source conversion CU path is already tracked separately; including it here would conflate two findings. This regression proves that the newly admitted position cannot create the permanently stuck state and that existing principal remains exit-live.

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --all-targets -- --test-threads=1`
  - 6 unit tests passed
  - 566 LiteSVM/CU tests passed
- `v16_bpf_batch_trade_14_legs_under_tx_limit`: 1,308,173 CU
- `v16_bpf_batch_trade_cpi_14_legs_under_tx_limit`: 1,339,517 CU
- `v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion`: 1,343,687 CU

The engine branch also passes its full fuzz/conformance/spec suite and the final attach-body Kani composition (6,137 checks, 1/1 cover, zero failures).
