### PR TITLE
[BLOCKER LoF] Settle zero-move funding before trades

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5828,6 +5828,11 @@ pub mod processor {
             } else {
                 size_q.unsigned_abs()
             };
+            accrue_zero_move_funding_before_trade_view(
+                &oracle_profile,
+                &mut group,
+                asset_index as usize,
+            )?;
             // F-TRADENOCPI-FEE / F-NOCPI-MARK-FEE: request.exec_price is used by the engine only as
             // fee notional. In price-managed EWMA/stale-hybrid modes, the caller's reported print is
             // also the mark-discovery input, so first normalize it to the same per-asset dt price
@@ -6083,6 +6088,11 @@ pub mod processor {
                     return Err(PercolatorError::InvalidInstruction.into());
                 }
                 let abs_size = leg.size_q.unsigned_abs();
+                accrue_zero_move_funding_before_trade_view(
+                    &oracle_profile,
+                    &mut group,
+                    asset_index,
+                )?;
                 let fee_basis_price = accepted_reported_trade_price_view(
                     &oracle_profile,
                     &group,
@@ -6554,6 +6564,8 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
 
+        accrue_zero_move_funding_before_matcher_view(market_ai, &[asset_index])?;
+
         let (cfg_pre, mode_pre, current_slot_pre, oracle_price, max_trading_fee_bps) =
             state::read_market_trade_preflight(
                 &market_ai.try_borrow_data()?,
@@ -6867,6 +6879,7 @@ pub mod processor {
             }
             asset_indices.push(leg.asset_index);
         }
+        accrue_zero_move_funding_before_matcher_view(market_ai, &asset_indices)?;
         // One header/config parse for mode + slot + every leg's oracle price (avoids O(N^2)
         // re-parsing the market once per leg).
         let (
@@ -11567,6 +11580,70 @@ pub mod processor {
             group.header.config.max_price_move_bps_per_slot.get(),
             dt_slots,
         ))
+    }
+
+    fn accrue_zero_move_funding_before_trade_view(
+        profile: &state::AssetOracleProfileV16,
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> ProgramResult {
+        if !oracle_v16::profile_is_price_managed(profile)
+            || profile.mark_ewma_e6 == 0
+            || asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Ok(());
+        }
+        let now_slot = authenticated_market_slot_or_fallback_view(group);
+        let dt_slots = asset_segment_dt_view(group, asset_index, now_slot)?;
+        if dt_slots == 0 {
+            return Ok(());
+        }
+        let asset = group.markets[asset_index].engine.asset;
+        let effective_price = asset.effective_price.get();
+        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+        let bounded_price = oracle_v16::effective_price_from_target(
+            effective_price,
+            profile.mark_ewma_e6,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt_slots,
+            exposed,
+        );
+        // Pending nonzero price movement is handled by the full mark-accrual path. This helper
+        // closes the otherwise invisible case where integer price clamping is a no-op but signed
+        // premium funding for the same elapsed segment is not.
+        if bounded_price != effective_price {
+            return Ok(());
+        }
+        let funding_rate_e9 =
+            permissionless_funding_rate_e9_view(profile, group, asset_index, effective_price)?;
+        if funding_rate_e9 == 0 {
+            return Ok(());
+        }
+        group
+            .accrue_asset_to_not_atomic(
+                asset_index,
+                now_slot,
+                effective_price,
+                funding_rate_e9,
+                true,
+            )
+            .map_err(map_v16_error)?;
+        Ok(())
+    }
+
+    fn accrue_zero_move_funding_before_matcher_view(
+        market_ai: &AccountInfo<'_>,
+        asset_indices: &[u16],
+    ) -> ProgramResult {
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
+        for &asset_index in asset_indices {
+            let asset_index = asset_index as usize;
+            let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
+            accrue_zero_move_funding_before_trade_view(&profile, &mut group, asset_index)?;
+        }
+        group.validate_shape().map_err(map_v16_error)
     }
 
     fn hybrid_trade_fee_quote_view(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7636,6 +7636,204 @@ fn v16_bpf_permissionless_crank_computes_funding_from_internal_mark_premium() {
 }
 
 #[test]
+fn v16_attack_tradecpi_close_cannot_erase_elapsed_premium_funding() {
+    const PRICE: u64 = 2;
+    const TARGET: u64 = 1;
+    const Q: i128 = 100 * POS_SCALE as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let run = |close_before_crank: bool, batch: bool| -> (u128, u128, i128, i128) {
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            initial_price: PRICE,
+            max_price_move_bps_per_slot: 24,
+            max_accrual_dt_slots: 1,
+            max_abs_funding_e9_per_slot: 1_000,
+            min_funding_lifetime_slots: 1,
+            ..V16CuMarketParams::default()
+        });
+        env.configure_auth_mark_with_cu(0, PRICE);
+
+        let matcher_program = Pubkey::new_unique();
+        let matcher_bytes =
+            std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+        env.svm.add_program(matcher_program, &matcher_bytes);
+
+        let attacker_owner = Keypair::new();
+        let lp_owner = Keypair::new();
+        let attacker = env.create_portfolio(&attacker_owner);
+        let lp = env.create_portfolio(&lp_owner);
+        env.deposit(&attacker_owner, attacker, DEPOSIT);
+        env.deposit(&lp_owner, lp, DEPOSIT);
+        let (matcher_ctx, matcher_delegate, _) =
+            env.init_auth_matcher_context_via_system_create(matcher_program, &lp_owner, lp);
+
+        // The attacker is short and the independently authorized permissionless LP is long.
+        let open = if batch {
+            env.send(
+                ProgInstruction::BatchTradeCpi {
+                    legs: vec![BatchTradeCpiLeg {
+                        asset_index: 0,
+                        size_q: -Q,
+                        fee_bps: 0,
+                        limit_price: 0,
+                    }],
+                },
+                vec![
+                    AccountMeta::new(attacker_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(attacker, false),
+                    AccountMeta::new(lp, false),
+                    AccountMeta::new_readonly(matcher_program, false),
+                    AccountMeta::new(matcher_ctx, false),
+                    AccountMeta::new_readonly(matcher_delegate, false),
+                ],
+                &[&attacker_owner],
+            )
+        } else {
+            env.try_trade_cpi_with_cu_on_asset(
+                &attacker_owner,
+                attacker,
+                &lp_owner,
+                lp,
+                matcher_program,
+                matcher_ctx,
+                matcher_delegate,
+                0,
+                -Q,
+                0,
+            )
+        };
+        open.expect("permissionless matcher open");
+
+        // Honest mark update. At this tiny price the configured 24-bps movement cap rounds to
+        // zero, so the effective execution price remains exactly PRICE in both branches. The
+        // first crank publishes the target but correctly does not charge it retroactively.
+        env.svm.warp_to_slot(1);
+        env.push_auth_mark_with_cu(1, TARGET);
+        for portfolio in [attacker, lp] {
+            env.svm.expire_blockhash();
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        let group_at_one = env.market_state().1;
+        assert_eq!(group_at_one.assets[0].effective_price, PRICE);
+        assert_eq!(group_at_one.assets[0].f_long_num, 0);
+        assert_eq!(group_at_one.assets[0].f_short_num, 0);
+
+        env.svm.warp_to_slot(2);
+        if !close_before_crank {
+            for portfolio in [attacker, lp] {
+                env.svm.expire_blockhash();
+                env.crank(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: 2,
+                        observations: crank_observations(0),
+                    },
+                );
+            }
+        }
+
+        // Only the attacker signs. A fair, pre-authorized matcher closes both sides at the unchanged
+        // engine price; landing order relative to the crank must not erase the LP's earned funding.
+        env.svm.expire_blockhash();
+        let close = if batch {
+            env.send(
+                ProgInstruction::BatchTradeCpi {
+                    legs: vec![BatchTradeCpiLeg {
+                        asset_index: 0,
+                        size_q: Q,
+                        fee_bps: 0,
+                        limit_price: 0,
+                    }],
+                },
+                vec![
+                    AccountMeta::new(attacker_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(attacker, false),
+                    AccountMeta::new(lp, false),
+                    AccountMeta::new_readonly(matcher_program, false),
+                    AccountMeta::new(matcher_ctx, false),
+                    AccountMeta::new_readonly(matcher_delegate, false),
+                ],
+                &[&attacker_owner],
+            )
+        } else {
+            env.try_trade_cpi_with_cu_on_asset(
+                &attacker_owner,
+                attacker,
+                &lp_owner,
+                lp,
+                matcher_program,
+                matcher_ctx,
+                matcher_delegate,
+                0,
+                Q,
+                0,
+            )
+        };
+        close.expect("permissionless matcher close");
+
+        if close_before_crank {
+            for portfolio in [attacker, lp] {
+                env.svm.expire_blockhash();
+                env.crank(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: 2,
+                        observations: crank_observations(0),
+                    },
+                );
+            }
+        }
+
+        let group = env.market_state().1;
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &env.portfolio_state(attacker)
+        )));
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &env.portfolio_state(lp)
+        )));
+
+        for (owner, portfolio) in [(&attacker_owner, attacker), (&lp_owner, lp)] {
+            let pnl = env.portfolio_state(portfolio).pnl.get();
+            if pnl > 0 {
+                env.convert_released_pnl_with_cu(owner, portfolio, pnl as u128);
+            }
+        }
+        let attacker_capital = env.portfolio_state(attacker).capital.get();
+        let lp_capital = env.portfolio_state(lp).capital.get();
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, attacker_capital);
+        let lp_dest = env.withdraw(&lp_owner, lp, lp_capital);
+        (
+            env.token_amount(attacker_dest) as u128,
+            env.token_amount(lp_dest) as u128,
+            group.assets[0].f_long_num,
+            group.assets[0].f_short_num,
+        )
+    };
+
+    for batch in [false, true] {
+        let control = run(false, batch);
+        let attack = run(true, batch);
+        assert_eq!(control.0 + control.1, 2 * DEPOSIT);
+        assert_eq!(attack.0 + attack.1, 2 * DEPOSIT);
+        assert_ne!(control.2, 0, "the control interval must accrue funding");
+        assert_eq!(control.2, -control.3);
+        assert_eq!(attack.2, -attack.3);
+        assert_eq!(
+            attack, control,
+            "batch={batch}: ordering must not erase funding owed to the independent LP"
+        );
+    }
+}
+
+#[test]
 fn v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides() {
     const INITIAL_PRICE: u64 = 1_000_000;
     const FUNDING_RATE_E9: i128 = 1_000;


### PR DESCRIPTION
## Impact

A short could close through a pre-authorized permissionless CPI LP immediately before the honest crank and erase an already-deterministic premium-funding interval. The edge is reachable when the bounded price step rounds to zero but signed premium funding does not.

The exact-parent LiteSVM reproduction uses an honest AuthMark target of `1` against effective price `2`, a 24-bps per-slot cap, a fair authenticated matcher, and normal public instructions. Only the attacker signs the close; the independent LP had previously authorized its matcher.

On `da64be639168b496833dd4c701607a94fcb06b6c` with engine `143e68c4917ed0400a27b952f036a5677047cd84`:

```text
crank first: attacker=999900  LP=1000100  F=(1000000000000000,-1000000000000000)
close first: attacker=1000000 LP=1000000  F=(0,0)
```

The attacker retains 100 collateral atoms and the independent LP loses the same 100 atoms. Effective price remains exactly `2` in both paths, so this is not pending-price PnL, dishonest-oracle behavior, cadence rounding, or an omitted-observation crank.

## Root cause

Trade mutated balanced OI before committing the elapsed funding segment implied by the stored authenticated mark. Once both positions were flat, the later honest crank correctly found no balanced exposure and accrued zero funding.

## Fix

- Before matcher invocation and before every direct position delta, detect a managed-price interval where the engine-bounded price is unchanged but premium funding is nonzero.
- Commit exactly one normal `max_accrual_dt_slots`-bounded engine accrual segment at the unchanged effective price.
- Let the existing engine trade settlement apply the new F index before changing OI.
- Cover single and batch CPI paths; direct paths share the same pre-execution helpers.

The fix does not require an oracle account, reject the trade, grant a synthetic time step, or retroactively settle more than the engine's normal bounded segment. Nonzero pending price movement remains separately scoped to #260.

## TDD

- `e145af9d`: exact-parent public red test, covering both `TradeCpi` and one-leg `BatchTradeCpi` with an unsigned independent LP.
- `f52b7fbc`: production fix; close-first and crank-first balances and funding indexes are identical.
- Conservation is asserted through final SPL withdrawals in both orderings.

## Verification

- `cargo build-sbf --tools-version v1.52 --no-default-features`
- auth and hostile matcher SBF fixtures built
- `cargo test --all-targets -- --test-threads=1`: 6 host + 566 LiteSVM/CU tests passed
- existing 14-leg direct and CPI batch CU tests passed
- three focused funding/mark Kani harnesses passed with all covers reached
- full `cargo kani --tests` was stopped on the unchanged main-branch `kani_v16_unknown_or_truncated_tags_reject` CBMC blowup; this PR does not claim that pre-existing all-harness gate
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --no-deps` passed with existing warnings only
- `git diff --check`
