### PR TITLE
[BLOCKER LoF] Settle zero-move funding before unilateral reduction

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4555,6 +4555,75 @@ pub mod processor {
         Ok(())
     }
 
+    fn accrue_zero_move_funding_before_rebalance_reduce_view(
+        cfg: &WrapperConfigV16,
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> Result<(), V16Error> {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(V16Error::InvalidConfig);
+        }
+        let profile = read_oracle_profile_from_view(group, cfg, asset_index)
+            .map_err(|_| V16Error::InvalidConfig)?;
+        if !oracle_v16::profile_is_price_managed(&profile) {
+            return Ok(());
+        }
+
+        let now_slot = authenticated_market_slot_or_fallback_view(group);
+        let asset = group.markets[asset_index].engine.asset;
+        let slot_last = asset.slot_last.get();
+        if now_slot < slot_last {
+            return Err(V16Error::Stale);
+        }
+        let dt = core::cmp::min(
+            now_slot - slot_last,
+            group.header.config.max_accrual_dt_slots.get(),
+        );
+        if dt == 0 || asset.oi_eff_long_q.get() == 0 || asset.oi_eff_short_q.get() == 0 {
+            return Ok(());
+        }
+
+        let target = if oracle_v16::profile_is_auth_mark(&profile)
+            || oracle_v16::profile_is_ewma_mark(&profile)
+            || (oracle_v16::profile_is_hybrid(&profile)
+                && oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot))
+        {
+            profile.mark_ewma_e6
+        } else {
+            asset.raw_oracle_target_price.get()
+        };
+        if target == 0 {
+            return Err(V16Error::InvalidConfig);
+        }
+        let current = asset.effective_price.get();
+        let next = oracle_v16::effective_price_from_target(
+            current,
+            target,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt,
+            true,
+        );
+        if next != current || profile.mark_ewma_last_slot > slot_last {
+            return Ok(());
+        }
+
+        let max_abs_rate = group.header.config.max_abs_funding_e9_per_slot.get();
+        if max_abs_rate == 0 {
+            return Ok(());
+        }
+        let funding_rate_e9 =
+            policy_v16::premium_funding_rate_e9(profile.mark_ewma_e6, current, max_abs_rate)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+        if funding_rate_e9 == 0 {
+            return Ok(());
+        }
+        group
+            .accrue_asset_to_not_atomic(asset_index, now_slot, current, funding_rate_e9, true)
+            .map(|_| ())
+    }
+
     fn read_oracle_profile_for_asset(
         market_data: &[u8],
         cfg: &WrapperConfigV16,
@@ -8497,6 +8566,11 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
+            accrue_zero_move_funding_before_rebalance_reduce_view(
+                cfg,
+                group,
+                asset_index as usize,
+            )?;
             group
                 .rebalance_reduce_position_not_atomic(
                     portfolio,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7695,7 +7695,12 @@ fn v16_attack_rebalance_reduce_cannot_erase_elapsed_premium_funding() {
         // In the attack branch only the short signs: it exits through the public
         // unilateral-reduction route before any keeper can settle this interval.
         env.svm.expire_blockhash();
-        env.rebalance_reduce_with_cu(&attacker_owner, attacker, 0, Q as u128);
+        let reduce_cu = env.rebalance_reduce_with_cu(&attacker_owner, attacker, 0, Q as u128);
+        assert_cu_within(
+            "zero-move funding rebalance reduce",
+            reduce_cu,
+            CUSTODY_CU_LIMIT,
+        );
 
         // Settle the independent LP's epoch snapshot permissionlessly. Its raw
         // leg remains in the normal side-reset lifecycle, but its funding claim

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7636,6 +7636,101 @@ fn v16_bpf_permissionless_crank_computes_funding_from_internal_mark_premium() {
 }
 
 #[test]
+fn v16_attack_rebalance_reduce_cannot_erase_elapsed_premium_funding() {
+    const PRICE: u64 = 2;
+    const TARGET: u64 = 1;
+    const Q: i128 = 100 * POS_SCALE as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let run = |reduce_before_crank: bool| -> (u128, u128, u128, u128) {
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            initial_price: PRICE,
+            max_price_move_bps_per_slot: 24,
+            max_accrual_dt_slots: 1,
+            max_abs_funding_e9_per_slot: 1_000,
+            min_funding_lifetime_slots: 1,
+            ..V16CuMarketParams::default()
+        });
+        env.configure_auth_mark_with_cu(0, PRICE);
+
+        let attacker_owner = Keypair::new();
+        let lp_owner = Keypair::new();
+        let attacker = env.create_portfolio(&attacker_owner);
+        let lp = env.create_portfolio(&lp_owner);
+        env.deposit(&attacker_owner, attacker, DEPOSIT);
+        env.deposit(&lp_owner, lp, DEPOSIT);
+        env.trade_asset_with_cu(0, &attacker_owner, attacker, &lp_owner, lp, -Q, PRICE, 0);
+
+        env.svm.warp_to_slot(1);
+        env.push_auth_mark_with_cu(1, TARGET);
+        for portfolio in [attacker, lp] {
+            env.svm.expire_blockhash();
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        let group_at_one = env.market_state().1;
+        assert_eq!(group_at_one.assets[0].effective_price, PRICE);
+        assert_eq!(group_at_one.assets[0].f_long_num, 0);
+        assert_eq!(group_at_one.assets[0].f_short_num, 0);
+
+        env.svm.warp_to_slot(2);
+        if !reduce_before_crank {
+            for portfolio in [attacker, lp] {
+                env.svm.expire_blockhash();
+                env.crank(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: 2,
+                        observations: crank_observations(0),
+                    },
+                );
+            }
+        }
+
+        // In the attack branch only the short signs: it exits through the public
+        // unilateral-reduction route before any keeper can settle this interval.
+        env.svm.expire_blockhash();
+        env.rebalance_reduce_with_cu(&attacker_owner, attacker, 0, Q as u128);
+
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &env.portfolio_state(attacker)
+        )));
+        let attacker_state = env.portfolio_state(attacker);
+        let lp_state = env.portfolio_state(lp);
+        let lp_claim = (lp_state.capital.get() as i128)
+            .checked_add(lp_state.pnl.get())
+            .expect("lp claim");
+        let attacker_paid = attacker_state.funding_short_paid_atoms_total.get();
+        let lp_received = lp_state.funding_long_received_atoms_total.get();
+        let attacker_capital = attacker_state.capital.get();
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, attacker_capital);
+        (
+            env.token_amount(attacker_dest) as u128,
+            u128::try_from(lp_claim).expect("nonnegative lp claim"),
+            attacker_paid,
+            lp_received,
+        )
+    };
+
+    let control = run(false);
+    let attack = run(true);
+    assert_eq!(control, (999_900, 1_000_100, 100, 100));
+    assert_ne!(control.2, 0, "the control interval must charge funding");
+    assert_eq!(control.2, control.3, "funding must balance between sides");
+    assert_eq!(control.0 + control.1, 2 * DEPOSIT);
+    assert_eq!(attack.0 + attack.1, 2 * DEPOSIT);
+    assert_eq!(
+        attack, control,
+        "unilateral reduction must not erase funding"
+    );
+}
+
+#[test]
 fn v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides() {
     const INITIAL_PRICE: u64 = 1_000_000;
     const FUNDING_RATE_E9: i128 = 1_000;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7697,6 +7697,18 @@ fn v16_attack_rebalance_reduce_cannot_erase_elapsed_premium_funding() {
         env.svm.expire_blockhash();
         env.rebalance_reduce_with_cu(&attacker_owner, attacker, 0, Q as u128);
 
+        // Settle the independent LP's epoch snapshot permissionlessly. Its raw
+        // leg remains in the normal side-reset lifecycle, but its funding claim
+        // must already be economically visible after this bounded step.
+        env.svm.expire_blockhash();
+        env.crank(
+            lp,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(0),
+            },
+        );
+
         assert!(percolator::active_bitmap_is_empty(active_bitmap(
             &env.portfolio_state(attacker)
         )));


### PR DESCRIPTION
## What changed

- Accrue one normal engine-clamped funding segment before `RebalanceReduce` when the bounded mark step rounds to the current effective price but premium funding is nonzero.
- Let the engine settle that funding onto the reducing account before unilateral OI reduction.
- Add a public LiteSVM red/green exploit test and enforce the existing custody CU limit.

## Root cause and impact

`RebalanceReduce` settled the caller at the current K/F cursor and then reduced matching effective OI. A short could therefore reduce to flat before an honest crank during an elapsed premium interval. Full side reset then removed the funding opportunity for the independent long.

The public repro uses AuthMark target `1`, effective price `2`, a 24 bps price cap, and balanced `100 * POS_SCALE` exposure. The bounded price step rounds to zero while premium funding is 100 atoms:

- honest crank first: attacker withdraws `999900`; LP claim is `1000100`; paid/received counters are `(100, 100)`
- attacker reduces first: attacker withdraws `1000000`; LP claim is `1000000`; counters are `(0, 0)`

Only the attacker signs the attack reduction. The LP is independently owned, and its post-reduction claim is settled by a permissionless crank. The test uses only public instructions and no state injection.

The finalized test-only commit `619a46b3` fails on exact main parent `da64be63`; fix commit `90eaf762` passes it. Nonzero pending price moves are intentionally unchanged here so this composes with #263.

## Verification

- `cargo build-sbf --tools-version v1.52 --no-default-features`
- exact-parent red LiteSVM test
- `cargo test --all-targets -- --test-threads=1` (6 host + 566 LiteSVM/CU tests)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with existing warnings)
- `cargo kani --tests --harness kani_v16_premium_funding_rate_is_clamped_and_signed`
- `cargo kani --tests --harness kani_v16_collected_base_fee_cannot_fund_mark_movement`
- `cargo kani --tests --harness kani_v16_fee_supported_mark_clamp_is_directional_and_zero_support_is_noop`
