### PR TITLE
[HARDENING LoF] Bind matcher grants to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ Positions and PnL use native `i128`/`u128` (`POS_SCALE = 1_000_000`, `ADL_ONE = 
 ### Two trade paths
 - **TradeNoCpi**: no external matcher; used for baseline integration, local testing, and deterministic program-test scenarios.
 - **TradeCpi**: production matcher path; the LP owner configures a matcher program/context once on
-  the LP portfolio with `SetMatcherConfig` (tag 68). Fills then run without the LP owner
+  the LP portfolio with `SetMatcherConfig { portfolio_id, enabled }` (tag 68). The signed grant is
+  bound to that portfolio incarnation. Fills then run without the LP owner
   signing each transaction. Direct LP-signed bilateral trading is `TradeNoCpi`.
 
 ### MatchingEngine trait
@@ -352,7 +353,8 @@ This makes it a "pure identity signer" and prevents it from becoming an attack s
 ### LP matcher config (TradeCpi / BatchTradeCpi)
 Unsigned LP matcher fills require an enabled matcher config stored directly on the LP portfolio.
 
-`SetMatcherConfig` (tag 68) is signed by the LP owner and writes:
+`SetMatcherConfig { portfolio_id, enabled }` (tag 68) is signed by the LP owner, requires the
+portfolio's current program-assigned ID, and writes:
 
 `matcher_program, matcher_context, matcher_delegate, enabled`
 
@@ -447,8 +449,10 @@ This section describes intent and operational ordering, not argument-by-argument
     anti-spoof binding as `TradeCpi`, then all fills apply through the batch path. Bounded to 16
     legs (the matcher's return-data cap).
 - **SetMatcherConfig** (tag 68)
-  - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
-    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.
+  - LP-owner-signed opt-in/out for unsigned LP matcher fills. The payload carries the current
+    `portfolio_id`, so a retained grant cannot arm a later incarnation at the same address. This
+    writes the matcher config tail on the LP portfolio: matcher program, matcher context, matcher
+    delegate, and enabled flag.
 
 ### Oracle / mark management
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -801,7 +801,7 @@ pub mod state {
     }
 
     #[inline]
-    fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
+    pub(crate) fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
         if id == 0 {
             return Err(ProgramError::InvalidAccountData);
@@ -2508,6 +2508,7 @@ pub mod ix {
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
+            portfolio_id: u64,
             enabled: u8,
         },
         ClosePortfolio,
@@ -2775,6 +2776,7 @@ pub mod ix {
                     Self::BatchTradeCpi { legs }
                 }
                 68 => Self::SetMatcherConfig {
+                    portfolio_id: read_u64(&mut rest)?,
                     enabled: read_u8(&mut rest)?,
                 },
                 8 => Self::ClosePortfolio,
@@ -3063,8 +3065,12 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    portfolio_id,
+                    enabled,
+                } => {
                     out.push(68);
+                    push_u64(&mut out, portfolio_id);
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
@@ -5255,9 +5261,10 @@ pub mod processor {
             Instruction::BatchTradeCpi { legs } => {
                 handle_batch_trade_cpi(program_id, accounts, &legs)
             }
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                portfolio_id,
+                enabled,
+            } => handle_set_matcher_config(program_id, accounts, portfolio_id, enabled),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6710,6 +6717,7 @@ pub mod processor {
     fn handle_set_matcher_config<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
         enabled: u8,
     ) -> ProgramResult {
         if enabled > 1 {
@@ -6724,15 +6732,27 @@ pub mod processor {
         expect_owner(lp_portfolio_ai, program_id)?;
         let (header, owner) =
             state::read_portfolio_owner_preflight(&lp_portfolio_ai.try_borrow_data()?)?;
+        let required_len = state::portfolio_account_len_for_market_slots(0)?;
+        // u64::MAX is reserved for the one pre-ID incarnation of a legacy account. InitPortfolio's
+        // checked allocator can never assign it because advancing the counter would overflow.
+        let legacy_portfolio = lp_portfolio_ai.data_len() < required_len;
+        let portfolio_id = if legacy_portfolio {
+            u64::MAX
+        } else {
+            state::read_portfolio_id(&lp_portfolio_ai.try_borrow_data()?)?
+        };
         if header.market_group_id != market_ai.key.to_bytes()
             || header.portfolio_account_id != lp_portfolio_ai.key.to_bytes()
             || owner != lp_owner.key.to_bytes()
         {
             return Err(PercolatorError::Unauthorized.into());
         }
-        let required_len = state::portfolio_account_len_for_market_slots(0)?;
-        if lp_portfolio_ai.data_len() < required_len {
+        if portfolio_id != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        if legacy_portfolio {
             lp_portfolio_ai.realloc(required_len, true)?;
+            state::write_portfolio_id(&mut lp_portfolio_ai.try_borrow_mut_data()?, portfolio_id)?;
         }
         let cfg = if enabled == 0 {
             state::PortfolioMatcherConfigV16::default()

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -2022,8 +2023,22 @@ impl V16CuEnv {
                 AccountMeta::new_readonly(matcher_delegate, false),
             ]);
         }
+        let portfolio_account = self
+            .svm
+            .get_account(&maker_account)
+            .expect("maker portfolio");
+        let portfolio_id = if portfolio_account.data.len()
+            < state::portfolio_account_len_for_market_slots(0).unwrap()
+        {
+            u64::MAX
+        } else {
+            state::read_portfolio_id(&portfolio_account.data).unwrap()
+        };
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id,
+                enabled,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -19293,7 +19308,11 @@ fn v16_attack_signed_matcher_grant_cannot_replay_after_portfolio_reinit() {
             AccountMeta::new_readonly(matcher_context, false),
             AccountMeta::new_readonly(matcher_delegate, false),
         ],
-        data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+        data: ProgInstruction::SetMatcherConfig {
+            portfolio_id: old_portfolio_id,
+            enabled: 1,
+        }
+        .encode(),
     };
     let stale_grant = Transaction::new_signed_with_payer(
         &[heap_ix(), cu_ix(), stale_grant_ix],
@@ -19326,7 +19345,9 @@ fn v16_attack_signed_matcher_grant_cannot_replay_after_portfolio_reinit() {
     assert_ne!(replacement_portfolio_id, old_portfolio_id);
     env.deposit(&victim, victim_portfolio, DEPOSIT);
 
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
     let victim_before_replay = env.svm.get_account(&victim_portfolio).unwrap();
+    let context_before_replay = env.svm.get_account(&matcher_context).unwrap();
     let replay = env.svm.send_transaction(stale_grant);
     if replay.is_ok() {
         let attacker = Keypair::new();
@@ -19399,9 +19420,40 @@ fn v16_attack_signed_matcher_grant_cannot_replay_after_portfolio_reinit() {
         );
     }
 
+    let replay_error = format!("{replay:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::EngineProvenanceMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale matcher grant must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_replay
+    );
     assert_eq!(
         env.svm.get_account(&victim_portfolio).unwrap(),
         victim_before_replay
+    );
+    assert_eq!(
+        env.svm.get_account(&matcher_context).unwrap(),
+        context_before_replay
+    );
+
+    env.set_matcher_config(
+        matcher_program,
+        &victim,
+        victim_portfolio,
+        matcher_context,
+        matcher_delegate,
+        1,
+    );
+    assert_eq!(
+        env.portfolio_matcher_config(victim_portfolio).enabled,
+        1,
+        "a grant signed for the replacement portfolio id remains live"
     );
 }
 
@@ -20728,7 +20780,10 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(lp),
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20793,7 +20848,10 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(victim_lp),
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21154,11 +21212,15 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     );
     env.try_init_auth_matcher_context_with_delegate(matcher_program, &lp_owner, lp, ctx, delegate)
         .expect("init auth matcher context without setting percolator auth");
+    let portfolio_id = env.portfolio_id(lp);
 
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id,
+                enabled: 1,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -21232,7 +21294,10 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     let lp_before_config = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(lp),
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21488,7 +21553,10 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: u64::MAX,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -30691,11 +30759,15 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             },
         )
         .unwrap();
+    let cpi_lp_portfolio_id = env.portfolio_id(p_cpi_lp);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: cpi_lp_portfolio_id,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -19250,6 +19250,161 @@ fn v16_portfolio_incarnation_id_separates_close_and_reuse() {
     assert_eq!(replacement.residual_received_atoms_total.get(), 0);
 }
 
+// A matcher grant belongs to one portfolio incarnation. A transaction signed for a closed
+// incarnation must not restore unsigned-LP trading after the same account address is initialized
+// again and receives fresh capital.
+#[test]
+fn v16_attack_signed_matcher_grant_cannot_replay_after_portfolio_reinit() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 50;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, PRICE);
+
+    let matcher_program = Pubkey::new_unique();
+    env.svm.add_program(
+        matcher_program,
+        &std::fs::read(auth_matcher_program_path()).unwrap(),
+    );
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let old_portfolio_id = env.portfolio_id(victim_portfolio);
+    let (matcher_context, matcher_delegate, _) =
+        env.init_auth_matcher_context_via_system_create(matcher_program, &victim, victim_portfolio);
+    env.set_matcher_config(
+        matcher_program,
+        &victim,
+        victim_portfolio,
+        matcher_context,
+        matcher_delegate,
+        0,
+    );
+
+    let stale_grant_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new_readonly(matcher_context, false),
+            AccountMeta::new_readonly(matcher_delegate, false),
+        ],
+        data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+    };
+    let stale_grant = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_grant_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim],
+        env.svm.latest_blockhash(),
+    );
+
+    env.close_portfolio_with_cu(&victim, victim_portfolio);
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim_portfolio, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio through the System Program");
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        &[&victim],
+    )
+    .expect("reinitialize the same portfolio address");
+    let replacement_portfolio_id = env.portfolio_id(victim_portfolio);
+    assert_ne!(replacement_portfolio_id, old_portfolio_id);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+
+    let victim_before_replay = env.svm.get_account(&victim_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_grant);
+    if replay.is_ok() {
+        let attacker = Keypair::new();
+        let attacker_portfolio = env.create_portfolio(&attacker);
+        env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+        env.try_trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_portfolio,
+            &victim,
+            victim_portfolio,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            -SIZE_Q,
+            0,
+        )
+        .expect("the replayed matcher grant forces fresh victim capital into a long position");
+
+        env.svm.warp_to_slot(11);
+        env.push_auth_mark_with_cu(11, ADVERSE_PRICE);
+        env.crank_steps(
+            victim_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 11,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        env.crank_steps(
+            attacker_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 11,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let attacker_after = env.portfolio_state(attacker_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        let attacker_equity = attacker_after.capital.get() as i128 + attacker_after.pnl.get();
+        assert!(victim_equity < DEPOSIT as i128);
+        assert!(attacker_equity > DEPOSIT as i128);
+
+        env.try_trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_portfolio,
+            &victim,
+            victim_portfolio,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            SIZE_Q,
+            0,
+        )
+        .expect("the attacker closes against the still-unsigned victim at the adverse mark");
+        let attacker_flat = env.portfolio_state(attacker_portfolio);
+        let released = attacker_flat.pnl.get() as u128;
+        assert!(released > 0);
+        env.convert_released_pnl_with_cu(&attacker, attacker_portfolio, released);
+        let withdrawable = env.portfolio_state(attacker_portfolio).capital.get();
+        let destination = env.withdraw(&attacker, attacker_portfolio, withdrawable);
+        assert_eq!(env.token_amount(destination) as u128, withdrawable);
+        assert!(withdrawable > DEPOSIT);
+        panic!(
+            "a matcher grant for portfolio id {old_portfolio_id} opened risk on replacement id \
+             {replacement_portfolio_id}, reduced victim equity from {DEPOSIT} to {victim_equity}, \
+             and let the attacker withdraw {withdrawable}"
+        );
+    }
+
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before_replay
+    );
+}
+
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
 // so dust-notional trades are never free and repeated churn never leaks value to the trader. Attacker
 // success = a fee that floors to 0 (free trade) or insurance that fails to grow on a fee'd dust trade.

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -503,6 +503,33 @@ fn kani_v16_tradecpi_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_set_matcher_config_binds_portfolio_id() {
+    let portfolio_id: u64 = kani::any();
+    let enabled: u8 = kani::any();
+    let extra: u8 = kani::any();
+
+    let instruction = Instruction::SetMatcherConfig {
+        portfolio_id,
+        enabled,
+    };
+    let mut encoded = instruction.encode();
+    assert_eq!(encoded.len(), 10);
+    match Instruction::decode(&encoded).unwrap() {
+        Instruction::SetMatcherConfig {
+            portfolio_id: got_portfolio_id,
+            enabled: got_enabled,
+        } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_enabled, enabled);
+        }
+        _ => unreachable!(),
+    }
+
+    encoded.push(extra);
+    assert!(Instruction::decode(&encoded).is_err());
+}
+
+#[kani::proof]
 fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
     // Audit fix: the ret's echoed fields and abi_version are drawn INDEPENDENTLY of the
     // expected (bound) params, and sizes are full-width i128, so both the accept path AND


### PR DESCRIPTION
## What changed

- bind `SetMatcherConfig` grants to the program-assigned `portfolio_id`
- reject a grant signed for a closed portfolio incarnation before matcher configuration mutates
- migrate the one pre-ID legacy incarnation to a reserved `u64::MAX` identity
- add exact-parent RED and fixed GREEN public LiteSVM coverage plus a focused wire-format proof

## Impact and root cause

`SetMatcherConfig` authorized future unsigned-LP `TradeCpi` calls using only the portfolio pubkey. A retained owner-signed grant could therefore be submitted after that portfolio was closed, publicly re-funded, and initialized again at the same address. On the exact `main` parent, the public LiteSVM reproduction armed the replacement victim portfolio, forced it into a position through the matcher, moved the authenticated mark from 100 to 50, and produced this economic result:

- victim equity: 1,000,000 -> 915,000
- attacker withdrawal: 1,105,000 from a 1,000,000 deposit

The portfolio incarnation counter already existed, but this authorization payload did not consume it. The fix adds the current ID to the signed wire payload and checks it before reallocation or configuration writes. A current-incarnation grant still succeeds.

## TDD commits

- RED: `0567685b` (`test: reproduce matcher grant incarnation replay`)
- GREEN: `f52b2261` (`Bind matcher grants to portfolio incarnations`)

## Verification

- `cargo fmt --check`
- `cargo check --tests`
- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 6 host + 566 LiteSVM/CU tests passed
- `cargo kani --tests --exact --harness kani_v16_set_matcher_config_binds_portfolio_id`: 1/1 harness, 1,505 checks passed

The aggregate Kani command was not used as a gate here because this repository's unrelated variable-length decoder harness is a documented whole-suite expansion wall; the changed wire surface has its own exact focused harness above.
