### PR TITLE
[BLOCKER LoF] Bind signed mark pushes to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
   paths; `TradeCpi` / `TradeNoCpi` use the already-stored effective mark for fee and settlement
   accounting.
-- AuthMark markets use **ConfigureAuthMark** (tag 62) and **PushAuthMark** (tag 63), signed by the configured mark authority, to store a direct authority mark without EWMA smoothing.
-- EwmaMark markets use **ConfigureEwmaMark** (tag 35) and **PushEwmaMark** (tag 36), signed by the configured mark authority, to update a smoothed EWMA mark input.
+- AuthMark markets use **ConfigureAuthMark** (tag 62) and **PushAuthMark** (tag 63), signed by the configured mark authority, to store a direct authority mark without EWMA smoothing. Pushes include the current asset `market_id` so a signed report cannot cross an asset restart.
+- EwmaMark markets use **ConfigureEwmaMark** (tag 35) and **PushEwmaMark** (tag 36), signed by the configured mark authority, to update a smoothed EWMA mark input. Pushes carry the same generation binding.
 - The per-slot effective-price movement cap is a risk parameter set at init; there is no standalone `SetOraclePriceCap` instruction in the current ABI.
 
 ### Insurance management
@@ -574,7 +574,7 @@ AuthMark and EwmaMark are authority-pushed pricing modes for markets that do not
 
 AuthMark is the direct authority-mark path:
 
-- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, now_slot, mark_e6 }`.
+- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, market_id, now_slot, mark_e6 }`.
 - **No EWMA configuration**: there is no halflife, mark-min-fee, feed id, confidence filter, invert flag, or unit-scale configuration in the AuthMark API.
 - **Authority boundary**: only the configured mark authority can push a new mark; public cranks can only consume the stored mark.
 - **Adapter-friendly**: a separate oracle adapter PDA can verify Pyth, Chainlink, Switchboard, or custom feed policy, then sign `PushAuthMark` with the resulting mark.
@@ -584,6 +584,7 @@ AuthMark is the direct authority-mark path:
 
 EwmaMark is the smoothed authority-mark path for markets that use an internal mark/index rather than an external oracle.
 
+- **Smoothed mark API**: `ConfigureEwmaMark { asset_index, now_slot, initial_mark_e6, mark_ewma_halflife_slots, mark_min_fee }` and `PushEwmaMark { asset_index, market_id, now_slot, mark_e6 }`.
 - **Mark and index prices**: maintained entirely within the engine; no external oracle feed required for mark settlement.
 - **Premium-based funding**: permissionless cranks compute funding from the spread between mark and index (premium), clamp it to `max_abs_funding_e9_per_slot`, and pass that internally to the engine. The crank instruction's funding-rate field is non-authoritative and must remain zero.
 - **Rate-limited index smoothing**: index price updates are clamped per slot via `clamp_toward_with_dt`, preventing instant mark-to-index jumps. When `dt = 0` or cap is zero, the function returns `index` unchanged (no movement).

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2659,6 +2659,7 @@ pub mod ix {
         },
         PushEwmaMark {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             mark_e6: u64,
         },
@@ -2669,6 +2670,7 @@ pub mod ix {
         },
         PushAuthMark {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             mark_e6: u64,
         },
@@ -2902,6 +2904,7 @@ pub mod ix {
                 },
                 63 => Self::PushAuthMark {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     mark_e6: read_u64(&mut rest)?,
                 },
@@ -2958,6 +2961,7 @@ pub mod ix {
                 },
                 36 => Self::PushEwmaMark {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     mark_e6: read_u64(&mut rest)?,
                 },
@@ -3298,11 +3302,13 @@ pub mod ix {
                 }
                 Self::PushEwmaMark {
                     asset_index,
+                    market_id,
                     now_slot,
                     mark_e6,
                 } => {
                     out.push(36);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, mark_e6);
                 }
@@ -3318,11 +3324,13 @@ pub mod ix {
                 }
                 Self::PushAuthMark {
                     asset_index,
+                    market_id,
                     now_slot,
                     mark_e6,
                 } => {
                     out.push(63);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, mark_e6);
                 }
@@ -5429,9 +5437,17 @@ pub mod processor {
             ),
             Instruction::PushEwmaMark {
                 asset_index,
+                market_id,
                 now_slot,
                 mark_e6,
-            } => handle_push_ewma_mark(program_id, accounts, asset_index, now_slot, mark_e6),
+            } => handle_push_ewma_mark(
+                program_id,
+                accounts,
+                asset_index,
+                market_id,
+                now_slot,
+                mark_e6,
+            ),
             Instruction::ConfigureAuthMark {
                 asset_index,
                 now_slot,
@@ -5445,9 +5461,17 @@ pub mod processor {
             ),
             Instruction::PushAuthMark {
                 asset_index,
+                market_id,
                 now_slot,
                 mark_e6,
-            } => handle_push_auth_mark(program_id, accounts, asset_index, now_slot, mark_e6),
+            } => handle_push_auth_mark(
+                program_id,
+                accounts,
+                asset_index,
+                market_id,
+                now_slot,
+                mark_e6,
+            ),
             Instruction::ForceCloseAbandonedAsset {
                 asset_index,
                 now_slot,
@@ -10249,6 +10273,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         mark_e6: u64,
     ) -> ProgramResult {
@@ -10267,6 +10292,15 @@ pub mod processor {
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
             if asset_index_usize >= group.header.config.max_market_slots.get() as usize {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            if group.markets[asset_index_usize]
+                .engine
+                .asset
+                .market_id
+                .get()
+                != expected_market_id
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
             }
             let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index_usize)?;
             if group.header.mode != 0 {
@@ -10330,6 +10364,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         mark_e6: u64,
     ) -> ProgramResult {
@@ -10348,6 +10383,15 @@ pub mod processor {
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
             if asset_index_usize >= group.header.config.max_market_slots.get() as usize {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            if group.markets[asset_index_usize]
+                .engine
+                .asset
+                .market_id
+                .get()
+                != expected_market_id
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
             }
             let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index_usize)?;
             if group.header.mode != 0 {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6176,6 +6176,170 @@ fn v16_attack_signed_asset_authority_rotation_cannot_replay_after_restart() {
     .expect("the same rotation remains live when signed for the current asset generation");
 }
 
+// A signed oracle report is an authorization for one asset generation, not for every future asset
+// that happens to occupy the same slot. Keep the original transaction object across an ordinary
+// shutdown/restart lifecycle and place fresh exposure before replaying it. The old report must be
+// rejected before it can move value against positions that did not exist when the oracle signed.
+#[test]
+fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
+    const PRICE: u64 = 100;
+    const STALE_ADVERSE_PRICE: u64 = 50;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let mut env = V16CuEnv::new();
+    let oracle = env.admin.insecure_clone();
+    env.configure_auth_mark_with_cu(0, PRICE);
+    let old_market_id = env.asset_market_id(0);
+
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 0,
+            mark_e6: STALE_ADVERSE_PRICE,
+        }
+        .encode(),
+    };
+    let stale_report = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &oracle],
+        env.svm.latest_blockhash(),
+    );
+
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(1);
+    env.try_shutdown_asset_with_authority(&oracle, 0, 1)
+        .expect("empty asset shuts down");
+    env.svm.warp_to_slot(2);
+    env.try_restart_asset_oracle_with_authority(&oracle, 0, 2, PRICE)
+        .expect("asset restarts");
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+    env.configure_auth_mark_with_cu(2, PRICE);
+
+    let victim = Keypair::new();
+    let counterparty = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let counterparty_portfolio = env.create_portfolio(&counterparty);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&counterparty, counterparty_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &counterparty,
+        counterparty_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let counterparty_before = env.svm.get_account(&counterparty_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_report);
+    if replay.is_ok() {
+        assert_eq!(
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+                .unwrap()
+                .oracle_target_price_e6,
+            STALE_ADVERSE_PRICE,
+            "the old signed report reached the replacement generation"
+        );
+        env.svm.warp_to_slot(3);
+        env.crank_steps(
+            victim_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        env.crank_steps(
+            counterparty_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let counterparty_after = env.portfolio_state(counterparty_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        let counterparty_equity =
+            counterparty_after.capital.get() as i128 + counterparty_after.pnl.get();
+        assert!(
+            victim_equity < DEPOSIT as i128,
+            "the stale report must move value against fresh exposure"
+        );
+        assert!(
+            counterparty_equity > DEPOSIT as i128,
+            "the stale report must transfer the victim's loss to the counterparty"
+        );
+
+        // The counterparty does not need the victim's cooperation to crystallize the transfer: a
+        // new LP can take over the short at the current mark, after which the released PnL converts
+        // to senior capital and leaves through the ordinary withdrawal instruction.
+        let exit_lp = Keypair::new();
+        let exit_portfolio = env.create_portfolio(&exit_lp);
+        env.deposit(&exit_lp, exit_portfolio, DEPOSIT);
+        env.trade_with_cu(
+            &counterparty,
+            counterparty_portfolio,
+            &exit_lp,
+            exit_portfolio,
+            SIZE_Q,
+            STALE_ADVERSE_PRICE,
+            0,
+        );
+        let counterparty_flat = env.portfolio_state(counterparty_portfolio);
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&counterparty_flat)),
+            "the beneficiary exits without the victim"
+        );
+        let extracted = counterparty_flat.pnl.get() as u128;
+        assert!(
+            extracted > 0,
+            "the stale report creates released positive PnL"
+        );
+        env.convert_released_pnl_with_cu(&counterparty, counterparty_portfolio, extracted);
+        let withdrawable = env.portfolio_state(counterparty_portfolio).capital.get();
+        let destination = env.withdraw(&counterparty, counterparty_portfolio, withdrawable);
+        assert_eq!(env.token_amount(destination) as u128, withdrawable);
+        assert!(
+            withdrawable > DEPOSIT,
+            "the beneficiary extracts victim value through public custody routes"
+        );
+        panic!(
+            "an old-generation oracle report reduced fresh victim equity from {DEPOSIT} to {victim_equity} and let the counterparty withdraw {withdrawable}"
+        );
+    }
+
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale oracle report must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+    assert_eq!(
+        env.svm.get_account(&counterparty_portfolio).unwrap(),
+        counterparty_before
+    );
+}
+
 // Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
 // address reset every asset market_id to its first-generation value. Keep the original, fully
 // signed transaction object across that public lifecycle: rebuilding the instruction after reinit

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2577,12 +2577,14 @@ impl V16CuEnv {
     }
 
     fn push_ewma_mark_with_cu(&mut self, now_slot: u64, mark_e6: u64) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::PushEwmaMark {
                 asset_index: 0,
+                market_id,
                 now_slot,
                 mark_e6,
             },
@@ -2615,12 +2617,14 @@ impl V16CuEnv {
     }
 
     fn push_auth_mark_with_cu(&mut self, now_slot: u64, mark_e6: u64) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::PushAuthMark {
                 asset_index: 0,
+                market_id,
                 now_slot,
                 mark_e6,
             },
@@ -2663,12 +2667,14 @@ impl V16CuEnv {
         now_slot: u64,
         mark_e6: u64,
     ) -> u64 {
+        let market_id = self.asset_market_id(asset_index);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::PushAuthMark {
                 asset_index,
+                market_id,
                 now_slot,
                 mark_e6,
             },
@@ -2715,12 +2721,14 @@ impl V16CuEnv {
         mark_e6: u64,
     ) -> u64 {
         self.ensure_signer_account(authority.pubkey());
+        let market_id = self.asset_market_id(asset_index);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::PushAuthMark {
                 asset_index,
+                market_id,
                 now_slot,
                 mark_e6,
             },
@@ -6176,12 +6184,17 @@ fn v16_attack_signed_asset_authority_rotation_cannot_replay_after_restart() {
     .expect("the same rotation remains live when signed for the current asset generation");
 }
 
+#[derive(Clone, Copy, Debug)]
+enum AssetGenerationMarkPath {
+    Auth,
+    Ewma,
+}
+
 // A signed oracle report is an authorization for one asset generation, not for every future asset
 // that happens to occupy the same slot. Keep the original transaction object across an ordinary
 // shutdown/restart lifecycle and place fresh exposure before replaying it. The old report must be
 // rejected before it can move value against positions that did not exist when the oracle signed.
-#[test]
-fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
+fn run_signed_mark_generation_replay(path: AssetGenerationMarkPath) {
     const PRICE: u64 = 100;
     const STALE_ADVERSE_PRICE: u64 = 50;
     const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
@@ -6189,21 +6202,37 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
 
     let mut env = V16CuEnv::new();
     let oracle = env.admin.insecure_clone();
-    env.configure_auth_mark_with_cu(0, PRICE);
+    match path {
+        AssetGenerationMarkPath::Auth => {
+            env.configure_auth_mark_with_cu(0, PRICE);
+        }
+        AssetGenerationMarkPath::Ewma => {
+            env.configure_ewma_mark_with_cu(0, PRICE, 1, 0);
+        }
+    }
     let old_market_id = env.asset_market_id(0);
 
+    let stale_instruction = match path {
+        AssetGenerationMarkPath::Auth => ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            market_id: old_market_id,
+            now_slot: 0,
+            mark_e6: STALE_ADVERSE_PRICE,
+        },
+        AssetGenerationMarkPath::Ewma => ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            market_id: old_market_id,
+            now_slot: 0,
+            mark_e6: STALE_ADVERSE_PRICE,
+        },
+    };
     let stale_ix = Instruction {
         program_id: env.program_id,
         accounts: vec![
             AccountMeta::new(oracle.pubkey(), true),
             AccountMeta::new(env.market, false),
         ],
-        data: ProgInstruction::PushAuthMark {
-            asset_index: 0,
-            now_slot: 0,
-            mark_e6: STALE_ADVERSE_PRICE,
-        }
-        .encode(),
+        data: stale_instruction.encode(),
     };
     let stale_report = Transaction::new_signed_with_payer(
         &[heap_ix(), cu_ix(), stale_ix],
@@ -6221,7 +6250,14 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         .expect("asset restarts");
     let new_market_id = env.asset_market_id(0);
     assert_ne!(new_market_id, old_market_id);
-    env.configure_auth_mark_with_cu(2, PRICE);
+    match path {
+        AssetGenerationMarkPath::Auth => {
+            env.configure_auth_mark_with_cu(2, PRICE);
+        }
+        AssetGenerationMarkPath::Ewma => {
+            env.configure_ewma_mark_with_cu(2, PRICE, 1, 0);
+        }
+    }
 
     let victim = Keypair::new();
     let counterparty = Keypair::new();
@@ -6239,23 +6275,30 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         0,
     );
 
+    let replay_slot = match path {
+        AssetGenerationMarkPath::Auth => 2,
+        AssetGenerationMarkPath::Ewma => 3,
+    };
+    env.svm.warp_to_slot(replay_slot);
     let market_before = env.svm.get_account(&env.market).unwrap();
     let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
     let counterparty_before = env.svm.get_account(&counterparty_portfolio).unwrap();
     let replay = env.svm.send_transaction(stale_report);
     if replay.is_ok() {
-        assert_eq!(
+        let landed_mark =
             state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
                 .unwrap()
-                .oracle_target_price_e6,
-            STALE_ADVERSE_PRICE,
-            "the old signed report reached the replacement generation"
+                .oracle_target_price_e6;
+        assert!(
+            landed_mark < PRICE,
+            "{path:?}: the old signed report reached and moved the replacement generation"
         );
-        env.svm.warp_to_slot(3);
+        let crank_slot = replay_slot + 1;
+        env.svm.warp_to_slot(crank_slot);
         env.crank_steps(
             victim_portfolio,
             ProgInstruction::PermissionlessCrank {
-                now_slot: 3,
+                now_slot: crank_slot,
                 observations: crank_observations(0),
             },
             4,
@@ -6263,7 +6306,7 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         env.crank_steps(
             counterparty_portfolio,
             ProgInstruction::PermissionlessCrank {
-                now_slot: 3,
+                now_slot: crank_slot,
                 observations: crank_observations(0),
             },
             4,
@@ -6275,11 +6318,11 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
             counterparty_after.capital.get() as i128 + counterparty_after.pnl.get();
         assert!(
             victim_equity < DEPOSIT as i128,
-            "the stale report must move value against fresh exposure"
+            "{path:?}: the stale report must move value against fresh exposure"
         );
         assert!(
             counterparty_equity > DEPOSIT as i128,
-            "the stale report must transfer the victim's loss to the counterparty"
+            "{path:?}: the stale report must transfer the victim's loss to the counterparty"
         );
 
         // The counterparty does not need the victim's cooperation to crystallize the transfer: a
@@ -6288,24 +6331,25 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         let exit_lp = Keypair::new();
         let exit_portfolio = env.create_portfolio(&exit_lp);
         env.deposit(&exit_lp, exit_portfolio, DEPOSIT);
+        let exit_price = env.market_state().1.assets[0].effective_price;
         env.trade_with_cu(
             &counterparty,
             counterparty_portfolio,
             &exit_lp,
             exit_portfolio,
             SIZE_Q,
-            STALE_ADVERSE_PRICE,
+            exit_price,
             0,
         );
         let counterparty_flat = env.portfolio_state(counterparty_portfolio);
         assert!(
             percolator::active_bitmap_is_empty(active_bitmap(&counterparty_flat)),
-            "the beneficiary exits without the victim"
+            "{path:?}: the beneficiary exits without the victim"
         );
         let extracted = counterparty_flat.pnl.get() as u128;
         assert!(
             extracted > 0,
-            "the stale report creates released positive PnL"
+            "{path:?}: the stale report creates released positive PnL"
         );
         env.convert_released_pnl_with_cu(&counterparty, counterparty_portfolio, extracted);
         let withdrawable = env.portfolio_state(counterparty_portfolio).capital.get();
@@ -6313,10 +6357,10 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         assert_eq!(env.token_amount(destination) as u128, withdrawable);
         assert!(
             withdrawable > DEPOSIT,
-            "the beneficiary extracts victim value through public custody routes"
+            "{path:?}: the beneficiary extracts victim value through public custody routes"
         );
         panic!(
-            "an old-generation oracle report reduced fresh victim equity from {DEPOSIT} to {victim_equity} and let the counterparty withdraw {withdrawable}"
+            "{path:?}: an old-generation oracle report reduced fresh victim equity from {DEPOSIT} to {victim_equity} and let the counterparty withdraw {withdrawable}"
         );
     }
 
@@ -6327,7 +6371,7 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
     );
     assert!(
         replay_error.contains(&expected_error),
-        "stale oracle report must fail with {expected_error}, got {replay_error}"
+        "{path:?}: stale oracle report must fail with {expected_error}, got {replay_error}"
     );
     assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
     assert_eq!(
@@ -6338,6 +6382,13 @@ fn v16_attack_signed_auth_mark_cannot_replay_after_asset_restart() {
         env.svm.get_account(&counterparty_portfolio).unwrap(),
         counterparty_before
     );
+}
+
+#[test]
+fn v16_attack_signed_mark_push_cannot_replay_after_asset_restart() {
+    for path in [AssetGenerationMarkPath::Auth, AssetGenerationMarkPath::Ewma] {
+        run_signed_mark_generation_replay(path);
+    }
 }
 
 // Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
@@ -16862,6 +16913,7 @@ fn v16_attack_cross_margin_divergent_moves_conserve() {
         90,
         ProgInstruction::PushAuthMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 10,
             mark_e6: 90,
         },
@@ -17979,6 +18031,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
             &mut env,
             ProgInstruction::PushAuthMark {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 now_slot: slot,
                 mark_e6: mark,
             },
@@ -18204,6 +18257,7 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
             &mut env,
             ProgInstruction::PushAuthMark {
                 asset_index: 1,
+                market_id: first_generation_market_id((1) as u16),
                 now_slot: slot,
                 mark_e6: mark,
             },
@@ -19692,6 +19746,7 @@ fn v16_attack_extreme_auth_mark_push_rejected_or_safe() {
             &env.payer,
             ProgInstruction::PushAuthMark {
                 asset_index: 0,
+                market_id: first_generation_market_id((0) as u16),
                 now_slot: 5,
                 mark_e6: mark,
             },
@@ -20499,6 +20554,7 @@ fn v16_attack_cross_margin_solvent_account_not_unfairly_liquidated() {
         &mut env,
         ProgInstruction::PushAuthMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 10,
             mark_e6: 110,
         },
@@ -23637,6 +23693,7 @@ fn v16_attack_out_of_range_asset_index_rejected() {
             &env.payer,
             ProgInstruction::PushAuthMark {
                 asset_index: bad,
+                market_id: first_generation_market_id((bad) as u16),
                 now_slot: 1,
                 mark_e6: 100,
             },
@@ -27972,6 +28029,7 @@ fn v16_attack_permissionless_asset_oracle_cannot_block_base_resolve_matured() {
     let stale_asset_push = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 40,
             mark_e6: 102,
         },
@@ -30482,6 +30540,7 @@ fn v16_attack_cross_margin_divergent_close_conserves() {
         &mut env,
         ProgInstruction::PushAuthMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 10,
             mark_e6: 90,
         },
@@ -41375,6 +41434,7 @@ fn v16_attack_cross_margin_netting_conserves() {
     let _ = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 2,
             mark_e6: 110,
         },
@@ -43264,6 +43324,7 @@ fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
     let auth_push = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 9_999_999,
         },
@@ -43287,6 +43348,7 @@ fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
     let ewma_push = env.send(
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 9_999_999,
         },
@@ -44625,6 +44687,7 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 9_999_999,
         },
@@ -44653,6 +44716,7 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 150,
         },
@@ -44919,6 +44983,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &mut env,
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 0,
         },
@@ -44928,6 +44993,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &mut env,
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: over_max,
         },
@@ -44941,6 +45007,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &env.payer,
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 120,
         },
@@ -44983,6 +45050,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &mut env,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 4,
             mark_e6: 0,
         },
@@ -44992,6 +45060,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &mut env,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 4,
             mark_e6: over_max,
         },
@@ -45005,6 +45074,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 4,
             mark_e6: 220,
         },
@@ -48493,6 +48563,7 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
         &env.payer,
         ProgInstruction::PushEwmaMark {
             asset_index: HIGH_ASSET as u16,
+            market_id: first_generation_market_id((HIGH_ASSET as u16) as u16),
             now_slot: LIQUIDATION_SLOT,
             mark_e6: 300,
         },
@@ -57847,6 +57918,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_mark() {
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 9_999_999,
         },
@@ -57876,6 +57948,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_mark() {
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 150,
         },
@@ -57940,6 +58013,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
         &env.payer,
         ProgInstruction::PushEwmaMark {
             asset_index: 1,
+            market_id: first_generation_market_id((1) as u16),
             now_slot: 2,
             mark_e6: 150,
         },
@@ -57963,6 +58037,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
         &env.payer,
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 9_999_999,
         },
@@ -57991,6 +58066,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
         &env.payer,
         ProgInstruction::PushEwmaMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 150,
         },
@@ -58881,6 +58957,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     let r0 = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 110,
         },
@@ -58925,6 +59002,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     let r_old = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 3,
             mark_e6: 120,
         },
@@ -58948,6 +59026,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     let r_new = env.send(
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 3,
             mark_e6: 120,
         },
@@ -60587,6 +60666,7 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_default_runtime_authorities
         &env.payer,
         ProgInstruction::PushAuthMark {
             asset_index: 0,
+            market_id: first_generation_market_id((0) as u16),
             now_slot: 2,
             mark_e6: 777,
         },

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -1022,6 +1022,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
 
     let now_slot: u64 = kani::any();
     let initial_mark_e6: u64 = kani::any();
@@ -1053,18 +1054,21 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut push = [0u8; 19];
+    let mut push = [0u8; 27];
     push[0] = 36;
     push[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    push[3..11].copy_from_slice(&now_slot.to_le_bytes());
-    push[11..19].copy_from_slice(&push_mark_e6.to_le_bytes());
+    push[3..11].copy_from_slice(&market_id.to_le_bytes());
+    push[11..19].copy_from_slice(&now_slot.to_le_bytes());
+    push[19..27].copy_from_slice(&push_mark_e6.to_le_bytes());
     match Instruction::decode(&push).unwrap() {
         Instruction::PushEwmaMark {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_now,
             mark_e6: got_mark,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, push_mark_e6);
         }
@@ -1089,18 +1093,21 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut push_auth = [0u8; 19];
+    let mut push_auth = [0u8; 27];
     push_auth[0] = 63;
     push_auth[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    push_auth[3..11].copy_from_slice(&now_slot.to_le_bytes());
-    push_auth[11..19].copy_from_slice(&push_mark_e6.to_le_bytes());
+    push_auth[3..11].copy_from_slice(&market_id.to_le_bytes());
+    push_auth[11..19].copy_from_slice(&now_slot.to_le_bytes());
+    push_auth[19..27].copy_from_slice(&push_mark_e6.to_le_bytes());
     match Instruction::decode(&push_auth).unwrap() {
         Instruction::PushAuthMark {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_now,
             mark_e6: got_mark,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, push_mark_e6);
         }
@@ -1338,6 +1345,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::PushEwmaMark {
             asset_index: 0,
+            market_id: 1,
             now_slot: 2,
             mark_e6: 101,
         },
@@ -1354,6 +1362,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::PushAuthMark {
             asset_index: 0,
+            market_id: 1,
             now_slot: 2,
             mark_e6: 101,
         },


### PR DESCRIPTION
## What changed

- add the current asset `market_id` to signed `PushAuthMark` and `PushEwmaMark` payloads
- reject a retained report when its generation differs from the live asset occupying that slot
- add public LiteSVM lifecycle coverage for direct and smoothed authority-mark paths
- extend the mark wire-field Kani harness over the generation field

## Impact and root cause

The mark authority signed a slot index, timestamp, and price, but not the asset incarnation. A signed report retained from an empty old asset could therefore land after permissionless shutdown/restart of that slot and move the mark against positions opened only in the replacement generation.

On the vulnerable parent, the public LiteSVM lifecycle uses ordinary configure, shutdown, restart, deposit, trade, crank, PnL conversion, and withdrawal instructions. The stale report produced extractable transfers from fresh independent victim capital:

- AuthMark: victim equity 1,000,000 -> 750,000; beneficiary withdrawal 1,250,000
- EwmaMark: victim equity 1,000,000 -> 875,000; beneficiary withdrawal 1,125,000

The signed asset `market_id` now identifies the intended incarnation, and mismatch rejection occurs before market or portfolio mutation. Current-generation pushes remain valid.

This PR is stacked on #231 because that PR supplies the persistent market-generation boundary used by the fix.

## TDD commits

- RED: `f0135bd1` (`test: reproduce stale oracle report generation replay`)
- GREEN: `22bc6e78` (`Bind mark pushes to asset generations`)

## Verification

- `cargo fmt --check`
- `cargo check --tests`
- `cargo build-sbf --tools-version v1.52`
- focused AuthMark/EwmaMark public LiteSVM reproduction passed on the fixed program
- `cargo test --all-targets`: 5 host + 569 LiteSVM/CU tests passed
- `cargo kani --tests --exact --harness kani_v16_ewma_mark_decode_preserves_wire_fields`: 1/1 harness, 847 checks passed

The aggregate Kani run reached the repository's known variable-length trailing-byte decoder expansion wall and was stopped after more than 20 minutes. The changed mark wire surface is covered by the exact focused harness above.
