### PR TITLE
[HARDENING LoF] Bind signed trades to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ Benefits:
 Positions and PnL use native `i128`/`u128` (`POS_SCALE = 1_000_000`, `ADL_ONE = 1_000_000_000_000_000`). There are no I256/U256 wrapper types for positions or PnL. Positions use the ADL A/K coefficient mechanism defined in the spec.
 
 ### Two trade paths
-- **TradeNoCpi**: no external matcher; used for baseline integration, local testing, and deterministic program-test scenarios.
+- **TradeNoCpi**: no external matcher; used for baseline integration, local testing, and deterministic program-test scenarios. Its signed payload binds both program-assigned portfolio incarnation IDs.
 - **TradeCpi**: production matcher path; the LP owner configures a matcher program/context once on
   the LP portfolio with `SetMatcherConfig` (tag 68). Fills then run without the LP owner
-  signing each transaction. Direct LP-signed bilateral trading is `TradeNoCpi`.
+  signing each transaction. The taker's signed payload binds both portfolio incarnation IDs. Direct
+  LP-signed bilateral trading is `TradeNoCpi`.
 
 ### MatchingEngine trait
 The `MatchingEngine` trait is defined in the Percolator program (not in the engine crate). The engine is a pure recorder of state transitions and does not define the matching interface. Two implementations exist: `NoOpMatcher` (TradeNoCpi) and `CpiMatcher` (TradeCpi).
@@ -429,6 +430,9 @@ This section describes intent and operational ordering, not argument-by-argument
   - transfers collateral into vault; credits insurance fund in engine
 
 ### Trading
+- Every single or batch trade carries `[account_a_portfolio_id, account_b_portfolio_id]`. The IDs
+  must match the current program-assigned incarnations before matcher CPI or engine mutation, so a
+  retained signature cannot bind to an account recreated at the same address.
 - **TradeNoCpi**
   - trade without external matcher (used for testing / deterministic scenarios)
 - **TradeCpi**

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -801,7 +801,7 @@ pub mod state {
     }
 
     #[inline]
-    fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
+    pub(crate) fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
         if id == 0 {
             return Err(ProgramError::InvalidAccountData);
@@ -2486,12 +2486,14 @@ pub mod ix {
             observations: Vec<CrankObservationHint>,
         },
         TradeNoCpi {
+            portfolio_ids: [u64; 2],
             asset_index: u16,
             size_q: i128,
             exec_price: u64,
             fee_bps: u64,
         },
         TradeCpi {
+            portfolio_ids: [u64; 2],
             asset_index: u16,
             size_q: i128,
             fee_bps: u64,
@@ -2500,11 +2502,13 @@ pub mod ix {
         /// Atomic multi-leg batch: apply every leg against one taker/LP pair with a single
         /// end-state initial-margin check (interim legs need not be individually margin-feasible).
         BatchTradeNoCpi {
+            portfolio_ids: [u64; 2],
             legs: Vec<BatchTradeLeg>,
         },
         /// Atomic multi-leg batch routed through an external matcher: one batched matcher CPI fills
         /// every leg against a single LP, then all fills apply with one end-state margin check.
         BatchTradeCpi {
+            portfolio_ids: [u64; 2],
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
@@ -2731,18 +2735,21 @@ pub mod ix {
                     }
                 }
                 6 => Self::TradeNoCpi {
+                    portfolio_ids: [read_u64(&mut rest)?, read_u64(&mut rest)?],
                     asset_index: read_u16(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     exec_price: read_u64(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                 },
                 10 => Self::TradeCpi {
+                    portfolio_ids: [read_u64(&mut rest)?, read_u64(&mut rest)?],
                     asset_index: read_u16(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                     limit_price: read_u64(&mut rest)?,
                 },
                 66 => {
+                    let portfolio_ids = [read_u64(&mut rest)?, read_u64(&mut rest)?];
                     let n = read_u8(&mut rest)? as usize;
                     if n > BATCH_TRADE_DECODE_MAX_LEGS {
                         return Err(ProgramError::InvalidInstructionData);
@@ -2756,9 +2763,13 @@ pub mod ix {
                             fee_bps: read_u64(&mut rest)?,
                         });
                     }
-                    Self::BatchTradeNoCpi { legs }
+                    Self::BatchTradeNoCpi {
+                        portfolio_ids,
+                        legs,
+                    }
                 }
                 67 => {
+                    let portfolio_ids = [read_u64(&mut rest)?, read_u64(&mut rest)?];
                     let n = read_u8(&mut rest)? as usize;
                     if n > BATCH_TRADE_DECODE_MAX_LEGS {
                         return Err(ProgramError::InvalidInstructionData);
@@ -2772,7 +2783,10 @@ pub mod ix {
                             limit_price: read_u64(&mut rest)?,
                         });
                     }
-                    Self::BatchTradeCpi { legs }
+                    Self::BatchTradeCpi {
+                        portfolio_ids,
+                        legs,
+                    }
                 }
                 68 => Self::SetMatcherConfig {
                     enabled: read_u8(&mut rest)?,
@@ -3020,31 +3034,42 @@ pub mod ix {
                     }
                 }
                 Self::TradeNoCpi {
+                    portfolio_ids,
                     asset_index,
                     size_q,
                     exec_price,
                     fee_bps,
                 } => {
                     out.push(6);
+                    push_u64(&mut out, portfolio_ids[0]);
+                    push_u64(&mut out, portfolio_ids[1]);
                     push_u16(&mut out, asset_index);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, exec_price);
                     push_u64(&mut out, fee_bps);
                 }
                 Self::TradeCpi {
+                    portfolio_ids,
                     asset_index,
                     size_q,
                     fee_bps,
                     limit_price,
                 } => {
                     out.push(10);
+                    push_u64(&mut out, portfolio_ids[0]);
+                    push_u64(&mut out, portfolio_ids[1]);
                     push_u16(&mut out, asset_index);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, fee_bps);
                     push_u64(&mut out, limit_price);
                 }
-                Self::BatchTradeNoCpi { ref legs } => {
+                Self::BatchTradeNoCpi {
+                    portfolio_ids,
+                    ref legs,
+                } => {
                     out.push(66);
+                    push_u64(&mut out, portfolio_ids[0]);
+                    push_u64(&mut out, portfolio_ids[1]);
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
@@ -3053,8 +3078,13 @@ pub mod ix {
                         push_u64(&mut out, leg.fee_bps);
                     }
                 }
-                Self::BatchTradeCpi { ref legs } => {
+                Self::BatchTradeCpi {
+                    portfolio_ids,
+                    ref legs,
+                } => {
                     out.push(67);
+                    push_u64(&mut out, portfolio_ids[0]);
+                    push_u64(&mut out, portfolio_ids[1]);
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
@@ -5224,6 +5254,7 @@ pub mod processor {
                 observations,
             } => handle_permissionless_crank(program_id, accounts, now_slot, observations),
             Instruction::TradeNoCpi {
+                portfolio_ids,
                 asset_index,
                 size_q,
                 exec_price,
@@ -5231,12 +5262,14 @@ pub mod processor {
             } => handle_trade_nocpi(
                 program_id,
                 accounts,
+                portfolio_ids,
                 asset_index,
                 size_q,
                 exec_price,
                 fee_bps,
             ),
             Instruction::TradeCpi {
+                portfolio_ids,
                 asset_index,
                 size_q,
                 fee_bps,
@@ -5244,17 +5277,20 @@ pub mod processor {
             } => handle_trade_cpi(
                 program_id,
                 accounts,
+                portfolio_ids,
                 asset_index,
                 size_q,
                 fee_bps,
                 limit_price,
             ),
-            Instruction::BatchTradeNoCpi { legs } => {
-                handle_batch_trade_nocpi(program_id, accounts, &legs)
-            }
-            Instruction::BatchTradeCpi { legs } => {
-                handle_batch_trade_cpi(program_id, accounts, &legs)
-            }
+            Instruction::BatchTradeNoCpi {
+                portfolio_ids,
+                legs,
+            } => handle_batch_trade_nocpi(program_id, accounts, portfolio_ids, &legs),
+            Instruction::BatchTradeCpi {
+                portfolio_ids,
+                legs,
+            } => handle_batch_trade_cpi(program_id, accounts, portfolio_ids, &legs),
             Instruction::SetMatcherConfig { enabled } => {
                 handle_set_matcher_config(program_id, accounts, enabled)
             }
@@ -5786,6 +5822,52 @@ pub mod processor {
         )
     }
 
+    const LEGACY_PORTFOLIO_ID: u64 = u64::MAX;
+
+    fn bind_trade_portfolio_id(
+        portfolio_ai: &AccountInfo,
+        expected_portfolio_id: u64,
+    ) -> ProgramResult {
+        let required_len = state::portfolio_account_len_for_market_slots(0)?;
+        let (actual_portfolio_id, legacy_portfolio) = {
+            let data = portfolio_ai.try_borrow_data()?;
+            state::read_portfolio_owner_preflight(&data)?;
+            if data.len() < required_len {
+                (LEGACY_PORTFOLIO_ID, true)
+            } else {
+                match state::read_portfolio_id(&data) {
+                    Ok(id) => (id, false),
+                    Err(_) if data[constants::PORTFOLIO_ID_OFF..required_len] == [0u8; 8] => {
+                        (LEGACY_PORTFOLIO_ID, true)
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        };
+        if actual_portfolio_id != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        if legacy_portfolio {
+            if portfolio_ai.data_len() < required_len {
+                portfolio_ai.realloc(required_len, true)?;
+            }
+            state::write_portfolio_id(
+                &mut portfolio_ai.try_borrow_mut_data()?,
+                LEGACY_PORTFOLIO_ID,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn bind_trade_portfolio_ids(
+        account_a_ai: &AccountInfo,
+        account_b_ai: &AccountInfo,
+        portfolio_ids: [u64; 2],
+    ) -> ProgramResult {
+        bind_trade_portfolio_id(account_a_ai, portfolio_ids[0])?;
+        bind_trade_portfolio_id(account_b_ai, portfolio_ids[1])
+    }
+
     #[inline(never)]
     fn handle_trade_nocpi_zero_copy<'a>(
         _program_id: &Pubkey,
@@ -5982,6 +6064,7 @@ pub mod processor {
     fn handle_batch_trade_nocpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_ids: [u64; 2],
         legs: &[ix::BatchTradeLeg],
     ) -> ProgramResult {
         let signer_a = account(accounts, 0)?;
@@ -6008,6 +6091,7 @@ pub mod processor {
         if mode_pre != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
         }
+        bind_trade_portfolio_ids(account_a_ai, account_b_ai, portfolio_ids)?;
         handle_batch_execute_zero_copy(
             program_id,
             signer_a.key,
@@ -6202,6 +6286,7 @@ pub mod processor {
     fn handle_trade_nocpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_ids: [u64; 2],
         asset_index: u16,
         size_q: i128,
         exec_price: u64,
@@ -6229,6 +6314,7 @@ pub mod processor {
         if mode_pre != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
         }
+        bind_trade_portfolio_ids(account_a_ai, account_b_ai, portfolio_ids)?;
         handle_trade_nocpi_zero_copy(
             program_id,
             signer_a.key,
@@ -6523,6 +6609,7 @@ pub mod processor {
     fn handle_trade_cpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_ids: [u64; 2],
         asset_index: u16,
         size_q: i128,
         fee_bps: u64,
@@ -6553,6 +6640,7 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        bind_trade_portfolio_ids(account_a_ai, account_b_ai, portfolio_ids)?;
 
         let (cfg_pre, mode_pre, current_slot_pre, oracle_price, max_trading_fee_bps) =
             state::read_market_trade_preflight(
@@ -6827,6 +6915,7 @@ pub mod processor {
     fn handle_batch_trade_cpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_ids: [u64; 2],
         legs: &[ix::BatchTradeCpiLeg],
     ) -> ProgramResult {
         if legs.is_empty() || legs.len() > MATCHER_BATCH_MAX_LEGS {
@@ -6857,6 +6946,7 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        bind_trade_portfolio_ids(account_a_ai, account_b_ai, portfolio_ids)?;
 
         // Preflight: market must be Live, the taker owner must sign, and each leg's oracle price
         // is read for matcher request/return binding.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -19250,6 +19250,161 @@ fn v16_portfolio_incarnation_id_separates_close_and_reuse() {
     assert_eq!(replacement.residual_received_atoms_total.get(), 0);
 }
 
+// A signed trade is consent for the named portfolio incarnation, not every later account that may
+// occupy the same address. Retain the exact transaction while the victim closes and publicly
+// recreates that address, then prove that replay cannot put fresh victim capital at risk.
+#[test]
+fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 50;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, PRICE);
+
+    let victim = Keypair::new();
+    let attacker = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let attacker_portfolio = env.create_portfolio(&attacker);
+    let old_portfolio_id = env.portfolio_id(victim_portfolio);
+
+    let stale_open_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(victim.pubkey(), true),
+            AccountMeta::new_readonly(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new(attacker_portfolio, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            size_q: SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let stale_close_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(victim.pubkey(), true),
+            AccountMeta::new_readonly(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new(attacker_portfolio, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            size_q: -SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let signed_blockhash = env.svm.latest_blockhash();
+    let stale_open = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_open_ix],
+        Some(&attacker.pubkey()),
+        &[&attacker, &victim],
+        signed_blockhash,
+    );
+    let stale_close = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_close_ix],
+        Some(&attacker.pubkey()),
+        &[&attacker, &victim],
+        signed_blockhash,
+    );
+
+    env.close_portfolio_with_cu(&victim, victim_portfolio);
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim_portfolio, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio through the System Program");
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        &[&victim],
+    )
+    .expect("reinitialize the victim portfolio address");
+    let replacement_portfolio_id = env.portfolio_id(victim_portfolio);
+    assert_ne!(replacement_portfolio_id, old_portfolio_id);
+
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let victim_before_replay = env.svm.get_account(&victim_portfolio).unwrap();
+    let attacker_before_replay = env.svm.get_account(&attacker_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_open);
+    if replay.is_ok() {
+        env.svm.warp_to_slot(11);
+        env.push_auth_mark_with_cu(11, ADVERSE_PRICE);
+        env.crank_steps(
+            victim_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 11,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        env.crank_steps(
+            attacker_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 11,
+                observations: crank_observations(0),
+            },
+            4,
+        );
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let attacker_after = env.portfolio_state(attacker_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        let attacker_equity = attacker_after.capital.get() as i128 + attacker_after.pnl.get();
+        assert!(victim_equity < DEPOSIT as i128);
+        assert!(attacker_equity > DEPOSIT as i128);
+
+        env.svm
+            .send_transaction(stale_close)
+            .expect("the second retained transaction closes at the replacement market's mark");
+        let attacker_flat = env.portfolio_state(attacker_portfolio);
+        let released = attacker_flat.pnl.get() as u128;
+        assert!(released > 0);
+        env.convert_released_pnl_with_cu(&attacker, attacker_portfolio, released);
+        let withdrawable = env.portfolio_state(attacker_portfolio).capital.get();
+        let destination = env.withdraw(&attacker, attacker_portfolio, withdrawable);
+        assert_eq!(env.token_amount(destination) as u128, withdrawable);
+        assert!(withdrawable > DEPOSIT);
+        panic!(
+            "a trade signed for portfolio id {old_portfolio_id} opened risk on replacement id \
+             {replacement_portfolio_id}, reduced victim equity from {DEPOSIT} to {victim_equity}, \
+             and let the attacker withdraw {withdrawable}"
+        );
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_replay
+    );
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before_replay
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_portfolio).unwrap(),
+        attacker_before_replay
+    );
+}
+
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
 // so dust-notional trades are never free and repeated churn never leaks value to the trader. Attacker
 // success = a fee that floors to 0 (free trade) or insurance that fails to grow on a fee'd dust trade.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -493,6 +494,10 @@ fn cu_ix() -> Instruction {
 fn heap_ix() -> Instruction {
     ComputeBudgetInstruction::request_heap_frame(128 * 1024)
 }
+
+// Test callers use this sentinel and `send_tx` resolves it from the public account bytes before the
+// transaction is signed. Production callers must encode the two current portfolio IDs explicitly.
+const AUTO_PORTFOLIO_IDS: [u64; 2] = [0, 0];
 
 struct V16CuEnv {
     svm: LiteSVM,
@@ -1482,6 +1487,7 @@ impl V16CuEnv {
     ) -> Result<u64, String> {
         self.send(
             ProgInstruction::TradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index,
                 size_q,
                 exec_price,
@@ -2161,6 +2167,7 @@ impl V16CuEnv {
         ];
         self.send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index,
                 size_q,
                 fee_bps,
@@ -3621,10 +3628,11 @@ fn send_tx(
     svm: &mut LiteSVM,
     program_id: Pubkey,
     payer: &Keypair,
-    ix: ProgInstruction,
+    mut ix: ProgInstruction,
     accounts: Vec<AccountMeta>,
     extra_signers: &[&Keypair],
 ) -> Result<u64, String> {
+    bind_test_trade_portfolio_ids(svm, &mut ix, &accounts);
     let instruction = Instruction {
         program_id,
         accounts,
@@ -3642,6 +3650,49 @@ fn send_tx(
     svm.send_transaction(tx)
         .map(|meta| meta.compute_units_consumed)
         .map_err(|e| format!("{e:?}"))
+}
+
+fn bind_test_trade_portfolio_ids(
+    svm: &LiteSVM,
+    ix: &mut ProgInstruction,
+    accounts: &[AccountMeta],
+) {
+    let (portfolio_ids, account_a_index, account_b_index) = match ix {
+        ProgInstruction::TradeNoCpi { portfolio_ids, .. }
+        | ProgInstruction::BatchTradeNoCpi { portfolio_ids, .. } => (portfolio_ids, 3, 4),
+        ProgInstruction::TradeCpi { portfolio_ids, .. }
+        | ProgInstruction::BatchTradeCpi { portfolio_ids, .. } => (portfolio_ids, 2, 3),
+        _ => return,
+    };
+    if *portfolio_ids != AUTO_PORTFOLIO_IDS {
+        return;
+    }
+    let Some(account_a) = accounts.get(account_a_index) else {
+        return;
+    };
+    let Some(account_b) = accounts.get(account_b_index) else {
+        return;
+    };
+    let Some(account_a_id) = test_portfolio_id(svm, account_a.pubkey) else {
+        return;
+    };
+    let Some(account_b_id) = test_portfolio_id(svm, account_b.pubkey) else {
+        return;
+    };
+    *portfolio_ids = [account_a_id, account_b_id];
+}
+
+fn test_portfolio_id(svm: &LiteSVM, portfolio: Pubkey) -> Option<u64> {
+    let account = svm.get_account(&portfolio)?;
+    let required_len = state::portfolio_account_len_for_market_slots(0).ok()?;
+    if account.data.len() < required_len {
+        Some(u64::MAX)
+    } else {
+        state::read_portfolio_id(&account.data).ok().or_else(|| {
+            (account.data[percolator_prog::constants::PORTFOLIO_ID_OFF..required_len] == [0u8; 8])
+                .then_some(u64::MAX)
+        })
+    }
 }
 
 fn send_raw_tx(
@@ -13415,6 +13466,7 @@ fn execute_account_residual_counter_trade_path(
         AccountResidualCounterTradePath::BatchTradeNoCpi => env
             .send(
                 ProgInstruction::BatchTradeNoCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
                         size_q,
@@ -13437,6 +13489,7 @@ fn execute_account_residual_counter_trade_path(
                 auth_matcher_for_lp_via_system_create(env, lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
                         size_q,
@@ -13582,6 +13635,7 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
                 auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![
                         BatchTradeCpiLeg {
                             asset_index: 0,
@@ -13612,6 +13666,7 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
         } else {
             env.send(
                 ProgInstruction::BatchTradeNoCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![
                         BatchTradeLeg {
                             asset_index: 0,
@@ -13757,6 +13812,7 @@ fn execute_backing_residual_counter_trade_path(
         BackingResidualCounterTradePath::BatchTradeNoCpi => env
             .send(
                 ProgInstruction::BatchTradeNoCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
                         size_q,
@@ -13778,6 +13834,7 @@ fn execute_backing_residual_counter_trade_path(
             let (matcher_program, ctx, delegate) = auth_matcher_for_lp(env, lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
                         size_q,
@@ -15944,6 +16001,7 @@ fn v16_attack_account_type_confusion_rejected() {
     env.svm.expire_blockhash();
     let r2 = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -19269,6 +19327,7 @@ fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
     let victim_portfolio = env.create_portfolio(&victim);
     let attacker_portfolio = env.create_portfolio(&attacker);
     let old_portfolio_id = env.portfolio_id(victim_portfolio);
+    let attacker_portfolio_id = env.portfolio_id(attacker_portfolio);
 
     let stale_open_ix = Instruction {
         program_id: env.program_id,
@@ -19280,6 +19339,7 @@ fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
             AccountMeta::new(attacker_portfolio, false),
         ],
         data: ProgInstruction::TradeNoCpi {
+            portfolio_ids: [old_portfolio_id, attacker_portfolio_id],
             asset_index: 0,
             size_q: SIZE_Q,
             exec_price: PRICE,
@@ -19297,6 +19357,7 @@ fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
             AccountMeta::new(attacker_portfolio, false),
         ],
         data: ProgInstruction::TradeNoCpi {
+            portfolio_ids: [old_portfolio_id, attacker_portfolio_id],
             asset_index: 0,
             size_q: -SIZE_Q,
             exec_price: PRICE,
@@ -19391,6 +19452,15 @@ fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
         );
     }
 
+    let replay_error = format!("{replay:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::EngineProvenanceMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale trade must fail with {expected_error}, got {replay_error}"
+    );
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
         market_before_replay
@@ -19403,6 +19473,136 @@ fn v16_attack_signed_trade_cannot_replay_after_portfolio_reinit() {
         env.svm.get_account(&attacker_portfolio).unwrap(),
         attacker_before_replay
     );
+
+    env.svm.expire_blockhash();
+    let stale_batch = env.send(
+        ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: [old_portfolio_id, attacker_portfolio_id],
+            legs: vec![BatchTradeLeg {
+                asset_index: 0,
+                size_q: SIZE_Q,
+                exec_price: PRICE,
+                fee_bps: 0,
+            }],
+        },
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new(attacker_portfolio, false),
+        ],
+        &[&victim, &attacker],
+    );
+    assert!(
+        format!("{stale_batch:?}").contains(&expected_error),
+        "stale batch trade must fail with {expected_error}, got {stale_batch:?}"
+    );
+
+    let matcher_program = Pubkey::new_unique();
+    env.svm.add_program(
+        matcher_program,
+        &std::fs::read(auth_matcher_program_path()).unwrap(),
+    );
+    let (matcher_context, matcher_delegate, _) = env.init_auth_matcher_context_via_system_create(
+        matcher_program,
+        &attacker,
+        attacker_portfolio,
+    );
+    env.set_matcher_config(
+        matcher_program,
+        &attacker,
+        attacker_portfolio,
+        matcher_context,
+        matcher_delegate,
+        1,
+    );
+    let cpi_market_before = env.svm.get_account(&env.market).unwrap();
+    let cpi_victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let cpi_attacker_before = env.svm.get_account(&attacker_portfolio).unwrap();
+    let cpi_context_before = env.svm.get_account(&matcher_context).unwrap();
+    for (label, instruction) in [
+        (
+            "TradeCpi",
+            ProgInstruction::TradeCpi {
+                portfolio_ids: [old_portfolio_id, attacker_portfolio_id],
+                asset_index: 0,
+                size_q: SIZE_Q,
+                fee_bps: 0,
+                limit_price: 0,
+            },
+        ),
+        (
+            "BatchTradeCpi",
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: [old_portfolio_id, attacker_portfolio_id],
+                legs: vec![BatchTradeCpiLeg {
+                    asset_index: 0,
+                    size_q: SIZE_Q,
+                    fee_bps: 0,
+                    limit_price: 0,
+                }],
+            },
+        ),
+    ] {
+        env.svm.expire_blockhash();
+        let stale_cpi = env.send(
+            instruction,
+            vec![
+                AccountMeta::new(victim.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim_portfolio, false),
+                AccountMeta::new(attacker_portfolio, false),
+                AccountMeta::new_readonly(matcher_program, false),
+                AccountMeta::new(matcher_context, false),
+                AccountMeta::new_readonly(matcher_delegate, false),
+            ],
+            &[&victim],
+        );
+        assert!(
+            format!("{stale_cpi:?}").contains(&expected_error),
+            "stale {label} must fail with {expected_error}, got {stale_cpi:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), cpi_market_before);
+        assert_eq!(
+            env.svm.get_account(&victim_portfolio).unwrap(),
+            cpi_victim_before
+        );
+        assert_eq!(
+            env.svm.get_account(&attacker_portfolio).unwrap(),
+            cpi_attacker_before
+        );
+        assert_eq!(
+            env.svm.get_account(&matcher_context).unwrap(),
+            cpi_context_before
+        );
+    }
+
+    env.svm.expire_blockhash();
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &attacker,
+        attacker_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &attacker,
+        attacker_portfolio,
+        -SIZE_Q,
+        PRICE,
+        0,
+    );
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &env.portfolio_state(victim_portfolio)
+    )));
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &env.portfolio_state(attacker_portfolio)
+    )));
 }
 
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
@@ -19526,6 +19726,7 @@ fn v16_attack_batch_subatom_fee_reconstruction_uses_ceil_notional() {
     let before_insurance = env.market_state().1.insurance;
     env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sub_atom_size,
@@ -20628,6 +20829,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     env.svm.expire_blockhash();
     let single = env.send(
         ProgInstruction::TradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -20656,6 +20858,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
@@ -20895,6 +21098,7 @@ fn v16_attack_tradecpi_matcher_config_arguments_must_match_account_bytes() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -21012,6 +21216,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -21052,6 +21257,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
     env.svm.expire_blockhash();
     let ok = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -21278,6 +21484,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -21310,6 +21517,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     env.svm.expire_blockhash();
     let self_batch = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
@@ -21406,6 +21614,17 @@ fn v16_attack_set_matcher_config_reallocs_legacy_lp_portfolio_safely() {
     assert_eq!(auth_state.matcher_program, matcher_program.to_bytes());
     assert_eq!(auth_state.matcher_context, ctx.to_bytes());
     assert_eq!(auth_state.matcher_delegate, delegate.to_bytes());
+    assert_eq!(
+        &lp_after_config.data
+            [percolator_prog::constants::PORTFOLIO_ID_OFF..env.portfolio_account_len],
+        &[0u8; 8],
+        "growing an old matcher config leaves an unassigned incarnation tail"
+    );
+    assert_eq!(
+        test_portfolio_id(&env.svm, lp),
+        Some(u64::MAX),
+        "the trade encoder addresses a grown legacy portfolio by its reserved incarnation"
+    );
 
     env.deposit(&taker_owner, taker, 1_000_000);
     env.deposit(&lp_owner, lp, 1_000_000);
@@ -21622,6 +21841,7 @@ fn v16_attack_permissionless_lp_cpi_rejects_wrong_delegate_owner_or_account_bind
     );
 
     let batch_ix = ProgInstruction::BatchTradeCpi {
+        portfolio_ids: AUTO_PORTFOLIO_IDS,
         legs: vec![BatchTradeCpiLeg {
             asset_index: 0,
             size_q: sz,
@@ -21693,6 +21913,7 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
     env.svm.expire_blockhash();
     let single = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: (10 * POS_SCALE) as i128,
             exec_price: 100,
@@ -21714,6 +21935,7 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -21776,6 +21998,7 @@ fn v16_attack_tradecpi_limit_price_enforced() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: (10 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -21904,6 +22127,7 @@ fn v16_attack_tradecpi_self_trade_rejected() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: (10 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -22536,6 +22760,7 @@ fn v16_attack_non_owner_cannot_withdraw_or_trade() {
     env.svm.expire_blockhash();
     let r_tr = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -27105,6 +27330,7 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -27397,6 +27623,7 @@ fn v16_attack_non_base_trade_rejects_after_base_resolve_matured() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 101,
@@ -27551,6 +27778,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
     let fresh_err = env
         .send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 1,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -27579,6 +27807,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
     let stale_err = env
         .send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 1,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -28746,6 +28975,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -28903,6 +29133,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -30517,6 +30748,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "TradeNoCpi",
             ProgInstruction::TradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 exec_price: 100,
@@ -30534,6 +30766,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "BatchTradeNoCpi",
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -30553,6 +30786,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "TradeCpi",
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -30572,6 +30806,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "BatchTradeCpi",
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -30614,6 +30849,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -30713,6 +30949,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
@@ -31397,6 +31634,7 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -37058,6 +37296,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -37502,6 +37741,7 @@ fn try_no_cpi_reported_price_trade_with_cu(
         ),
         NoCpiReportedPricePath::Batch => env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q,
@@ -40966,6 +41206,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_carry_protocol_state() {
         ]
     };
     let ix = |asset_index, size_q| ProgInstruction::TradeCpi {
+        portfolio_ids: AUTO_PORTFOLIO_IDS,
         asset_index,
         size_q,
         fee_bps: 100,
@@ -41098,6 +41339,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     env.svm.expire_blockhash();
     let rejected = env.send(
         ProgInstruction::TradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -41186,6 +41428,7 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_carry_protocol_state() {
     let victim_before = env.portfolio_state(victim);
     let sz = (5 * POS_SCALE) as i128;
     let ix = ProgInstruction::BatchTradeCpi {
+        portfolio_ids: AUTO_PORTFOLIO_IDS,
         legs: vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
@@ -41360,7 +41603,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: legs.clone(),
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -41402,7 +41648,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     env.svm.set_account(ctx, honest_ctx).unwrap();
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -42901,6 +43150,7 @@ fn v16_attack_tradenocpi_self_trade_rejected() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -42961,6 +43211,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
     env.svm.expire_blockhash();
     let direct = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![batch_leg],
         },
         vec![
@@ -42994,6 +43245,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
     env.svm.expire_blockhash();
     let cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
@@ -48632,6 +48884,7 @@ fn v16_bpf_batch_trade_executes_mixed_direction_spread() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 0,
@@ -48690,6 +48943,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let duplicate_nocpi = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -48751,6 +49005,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let duplicate_cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -48810,6 +49065,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let clean = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -48923,7 +49179,10 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
             .unwrap();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -49091,6 +49350,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
         (
             "TradeCpi",
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 fee_bps: 0,
@@ -49100,6 +49360,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
         (
             "BatchTradeCpi",
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -49176,6 +49437,7 @@ fn v16_bpf_batch_trade_checks_margin_on_final_portfolio_only() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 1,
@@ -49237,7 +49499,10 @@ fn v16_bpf_batch_trade_14_legs_under_tx_limit() {
         .collect();
     let cu = env
         .send(
-            ProgInstruction::BatchTradeNoCpi { legs },
+            ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(lp.pubkey(), true),
@@ -49318,6 +49583,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: nocpi_legs(OVER),
             },
             vec![
@@ -49340,6 +49606,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let ok = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: nocpi_legs(CAP),
             },
             vec![
@@ -49378,6 +49645,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: cpi_legs(OVER),
             },
             vec![
@@ -49403,6 +49671,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let ok = env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: cpi_legs(CAP),
             },
             vec![
@@ -49526,7 +49795,10 @@ fn v16_attack_batch_tradecpi_configured_leg_cap_rejects_before_hostile_matcher_c
             .collect();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -49611,7 +49883,10 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
         .collect();
     env.svm.expire_blockhash();
     let no_cpi = env.send(
-        ProgInstruction::BatchTradeNoCpi { legs: no_cpi_legs },
+        ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: no_cpi_legs,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(maker.pubkey(), true),
@@ -49645,7 +49920,10 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
         .collect();
     env.svm.expire_blockhash();
     let cpi = env.send(
-        ProgInstruction::BatchTradeCpi { legs: cpi_legs },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: cpi_legs,
+        },
         vec![],
         &[],
     );
@@ -49687,6 +49965,7 @@ fn v16_bpf_batch_trade_cpi_executes_mixed_spread_through_matcher() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
@@ -49756,6 +50035,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
     env.svm.expire_blockhash();
     let nocpi = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -49794,6 +50074,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
     env.svm.expire_blockhash();
     let cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -49882,6 +50163,7 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: sz,
@@ -49927,6 +50209,7 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
     env.svm.expire_blockhash();
     let reopened = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -50042,6 +50325,7 @@ fn v16_attack_non_active_asset_cannot_enable_backing_fee_batch_gate() {
         env.svm.expire_blockhash();
         let batch = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: sz,
@@ -50187,6 +50471,7 @@ fn v16_attack_retired_reused_asset_backing_fee_policy_cannot_stick_batch_gate() 
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -50313,6 +50598,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
         let fresh_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     asset_index: 1,
                     size_q: POS_SCALE as i128,
                     fee_bps: 0,
@@ -50379,6 +50665,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
             let rejected = if batch {
                 env.send(
                     ProgInstruction::BatchTradeCpi {
+                        portfolio_ids: AUTO_PORTFOLIO_IDS,
                         legs: vec![BatchTradeCpiLeg {
                             asset_index: 1,
                             size_q: POS_SCALE as i128,
@@ -50392,6 +50679,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
             } else {
                 env.send(
                     ProgInstruction::TradeCpi {
+                        portfolio_ids: AUTO_PORTFOLIO_IDS,
                         asset_index: 1,
                         size_q: POS_SCALE as i128,
                         fee_bps: 0,
@@ -50445,6 +50733,7 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -50545,7 +50834,10 @@ fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {
     env.svm.expire_blockhash();
     let cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -50692,7 +50984,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
         .collect();
     env.svm.expire_blockhash();
     env.send(
-        ProgInstruction::BatchTradeNoCpi { legs: seed_legs },
+        ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: seed_legs,
+        },
         vec![
             AccountMeta::new(seed_taker.pubkey(), true),
             AccountMeta::new(seed_lp.pubkey(), true),
@@ -50731,7 +51026,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let rejected = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs: legs.clone(),
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50764,7 +51062,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let allowed_cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50813,6 +51114,7 @@ fn v16_attack_batch_fees_isolated_to_each_asset_domain() {
     let sz = (10 * POS_SCALE) as i128;
     env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -50869,6 +51171,7 @@ fn v16_attack_batch_cannot_force_counterparty_underwater() {
     let sz = (50 * POS_SCALE) as i128; // notional 5000, IM 500 >> LP capital 50
     let res = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -51012,6 +51315,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -51043,6 +51347,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     env.svm.expire_blockhash();
     let ok = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -51131,7 +51436,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: legs.clone(),
+        },
         accounts(&env, ctx, delegate),
         &[&taker],
     );
@@ -51171,7 +51479,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
         env.init_matcher_context_authorized(matcher_program, &lp, lp_portfolio);
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs,
+        },
         accounts(&env, ok_ctx, ok_delegate),
         &[&taker],
     );
@@ -51239,7 +51550,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
     env.svm.warp_to_slot(4);
     env.svm.expire_blockhash();
     let fresh = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs: legs.clone(),
+        },
         accounts(&env),
         &[&taker],
     );
@@ -51261,7 +51575,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
+            legs,
+        },
         accounts(&env),
         &[&taker],
     );
@@ -51410,7 +51727,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let fresh_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs: legs.clone(),
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51433,7 +51753,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let stale_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
+                legs,
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51553,6 +51876,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         let fresh_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     asset_index: 0,
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
@@ -51585,6 +51909,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         let stale_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
                     asset_index: 0,
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
@@ -51708,7 +52033,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let fresh_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+                ProgInstruction::BatchTradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
+                    legs: legs.clone(),
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51735,7 +52063,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let stale_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs },
+                ProgInstruction::BatchTradeCpi {
+                    portfolio_ids: AUTO_PORTFOLIO_IDS,
+                    legs,
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51831,6 +52162,7 @@ fn v16_attack_batch_tradecpi_fee_bps_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -51965,6 +52297,7 @@ fn v16_attack_batch_tradecpi_backing_fee_policy_rejects_before_hostile_matcher_c
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -52072,6 +52405,7 @@ fn v16_attack_batch_nocpi_stale_reject_rolls_back_legacy_realloc() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeNoCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q,
@@ -52335,6 +52669,7 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
         env.svm.expire_blockhash();
         let result = env.send(
             ProgInstruction::BatchTradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
@@ -52486,6 +52821,7 @@ fn v16_attack_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -52581,6 +52917,7 @@ fn v16_attack_batch_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -53600,6 +53937,7 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
         let m = metas(env);
         let result = env.send(
             ProgInstruction::TradeCpi {
+                portfolio_ids: AUTO_PORTFOLIO_IDS,
                 asset_index: 0,
                 size_q: sz,
                 fee_bps: 100,
@@ -53740,6 +54078,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
             AccountMeta::new_readonly(delegate, false),
         ],
         data: ProgInstruction::BatchTradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -53856,6 +54195,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
             AccountMeta::new_readonly(delegate, false),
         ],
         data: ProgInstruction::TradeCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q,
             fee_bps: 100,
@@ -55351,6 +55691,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            portfolio_ids: AUTO_PORTFOLIO_IDS,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -444,25 +444,30 @@ fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
+    let portfolio_ids: [u64; 2] = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 51];
     data[0] = 6;
-    data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&exec_price.to_le_bytes());
-    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[1..9].copy_from_slice(&portfolio_ids[0].to_le_bytes());
+    data[9..17].copy_from_slice(&portfolio_ids[1].to_le_bytes());
+    data[17..19].copy_from_slice(&asset_index.to_le_bytes());
+    data[19..35].copy_from_slice(&size_q.to_le_bytes());
+    data[35..43].copy_from_slice(&exec_price.to_le_bytes());
+    data[43..51].copy_from_slice(&fee_bps.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeNoCpi {
+            portfolio_ids: got_portfolio_ids,
             asset_index: got_asset,
             size_q: got_size,
             exec_price: got_price,
             fee_bps: got_fee,
         } => {
+            assert_eq!(got_portfolio_ids, portfolio_ids);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_size, size_q);
             assert_eq!(got_price, exec_price);
@@ -474,25 +479,30 @@ fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_tradecpi_decode_preserves_wire_fields() {
+    let portfolio_ids: [u64; 2] = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let fee_bps: u64 = kani::any();
     let limit_price: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 51];
     data[0] = 10;
-    data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&fee_bps.to_le_bytes());
-    data[27..35].copy_from_slice(&limit_price.to_le_bytes());
+    data[1..9].copy_from_slice(&portfolio_ids[0].to_le_bytes());
+    data[9..17].copy_from_slice(&portfolio_ids[1].to_le_bytes());
+    data[17..19].copy_from_slice(&asset_index.to_le_bytes());
+    data[19..35].copy_from_slice(&size_q.to_le_bytes());
+    data[35..43].copy_from_slice(&fee_bps.to_le_bytes());
+    data[43..51].copy_from_slice(&limit_price.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeCpi {
+            portfolio_ids: got_portfolio_ids,
             asset_index: got_asset,
             size_q: got_size,
             fee_bps: got_fee,
             limit_price: got_limit,
         } => {
+            assert_eq!(got_portfolio_ids, portfolio_ids);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_size, size_q);
             assert_eq!(got_fee, fee_bps);
@@ -735,12 +745,14 @@ fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle() {
+    let portfolio_ids: [u64; 2] = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
 
     let data = Instruction::BatchTradeNoCpi {
+        portfolio_ids,
         legs: vec![percolator_prog::ix::BatchTradeLeg {
             asset_index,
             size_q,
@@ -752,12 +764,41 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
 
     assert_eq!(data[0], 66);
     match Instruction::decode(&data).unwrap() {
-        Instruction::BatchTradeNoCpi { legs } => {
+        Instruction::BatchTradeNoCpi {
+            portfolio_ids: got_portfolio_ids,
+            legs,
+        } => {
+            assert_eq!(got_portfolio_ids, portfolio_ids);
             assert_eq!(legs.len(), 1);
             assert_eq!(legs[0].asset_index, asset_index);
             assert_eq!(legs[0].size_q, size_q);
             assert_eq!(legs[0].exec_price, exec_price);
             assert_eq!(legs[0].fee_bps, fee_bps);
+        }
+        _ => unreachable!(),
+    }
+
+    let cpi_data = Instruction::BatchTradeCpi {
+        portfolio_ids,
+        legs: vec![percolator_prog::ix::BatchTradeCpiLeg {
+            asset_index,
+            size_q,
+            fee_bps,
+            limit_price: exec_price,
+        }],
+    }
+    .encode();
+    match Instruction::decode(&cpi_data).unwrap() {
+        Instruction::BatchTradeCpi {
+            portfolio_ids: got_portfolio_ids,
+            legs,
+        } => {
+            assert_eq!(got_portfolio_ids, portfolio_ids);
+            assert_eq!(legs.len(), 1);
+            assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].size_q, size_q);
+            assert_eq!(legs[0].fee_bps, fee_bps);
+            assert_eq!(legs[0].limit_price, exec_price);
         }
         _ => unreachable!(),
     }
@@ -1190,6 +1231,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::TradeNoCpi {
+            portfolio_ids: [1, 2],
             asset_index: 0,
             size_q: 1,
             exec_price: 100,
@@ -1199,6 +1241,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::TradeCpi {
+            portfolio_ids: [1, 2],
             asset_index: 0,
             size_q: 1,
             fee_bps: 0,


### PR DESCRIPTION
## Finding

A counterparty can retain two fully signed public `TradeNoCpi` transactions for an old portfolio incarnation, wait for that portfolio address to be closed and publicly reinitialized, then order the retained open and close around an honest mark move. The signatures bind only account pubkeys, so before this fix they authorize risk against fresh replacement capital.

The exact-parent LiteSVM RED repro uses ordinary instructions and retained transaction objects, with no state injection:

- victim replacement equity falls from 1,000,000 to 915,000 atoms
- attacker exits custody with 1,105,000 atoms from a 1,000,000-atom deposit
- the mark move is an honest AuthMark update from 100 to 50

RED: `b304de33`
GREEN: `4505f934`

## Fix

All four signed trade payloads now bind both program-assigned portfolio incarnation IDs and validate them before matcher CPI or engine mutation: `TradeNoCpi`, `TradeCpi`, `BatchTradeNoCpi`, and `BatchTradeCpi`. Existing pre-ID portfolios receive a reserved legacy incarnation on first trade; already-grown zero-filled legacy tails are handled without reallocation.

The GREEN test checks exact `EngineProvenanceMismatch`, byte-for-byte rollback, all four routes, matcher-context non-execution on stale IDs, and a current-incarnation open/close control.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 6 host + 566 LiteSVM/CU tests pass
- `kani_v16_tradenocpi_decode_preserves_wire_fields`: 845 checks pass
- `kani_v16_tradecpi_decode_preserves_wire_fields`: 845 checks pass
- batch no-CPI/CPI wire proof: 1,645 checks pass
