### PR TITLE
[BLOCKER LoF] Bind oracle configuration to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   `UpdateAssetLifecycle { action: RETIRE, asset_index: 0 }` rejects, so asset 0 is never returned to
   the permissionless reusable-slot pool. Once any asset 0..N is in RECOVERY and every position/loss plus
   value-bearing source/backing/reservation state for that asset is gone,
-  `RestartAssetOracle { asset_index, ... }` signed by that asset's `asset_admin` atomically retires the old market id,
+  `RestartAssetOracle { asset_index, market_id, ... }` signed by that asset's `asset_admin` atomically retires the old market id,
   activates a fresh market id at the supplied initial price, preserves that asset's authority keys and
   funded insurance-domain budgets, and returns the asset to ACTIVE. New legs bind to the new monotonic
   `market_id`; stale legs cannot leak through restart. **✅**
@@ -304,7 +304,7 @@ Percolator enforces three layers with distinct responsibilities:
 - **Layout**: header + wrapper config + `MarketGroupV16Account`
 - Holds market-level totals, insurance, oracle/asset state, source-domain credit state, and asset lifecycle state.
 
-The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, co-signed authority rotations, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
+The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, oracle configuration and restart instructions, mark pushes, co-signed authority rotations, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
 
 ### Market generation account
 - **Owner**: Percolator program id
@@ -401,7 +401,7 @@ This section describes intent and operational ordering, not argument-by-argument
     until `force_close_delay_slots` elapses; signer is `marketauth` or that asset's `asset_admin`
   - ordinary `RETIRE` rejects `asset_index = 0`; asset 0 is restarted, not reused
 - **RestartAssetOracle** (tag 69)
-  - `RestartAssetOracle { asset_index, now_slot, initial_price }`, signed by that asset's `asset_admin`
+  - `RestartAssetOracle { asset_index, market_id, now_slot, initial_price }`, signed by that asset's `asset_admin`
   - after the target asset is already RECOVERY and empty of positions/loss plus value-bearing
     source/backing/reservation state, atomically retires the old market id, activates a fresh market id
     at the supplied initial price, preserves authority keys and funded insurance-domain budgets, then
@@ -468,8 +468,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
   paths; `TradeCpi` / `TradeNoCpi` use the already-stored effective mark for fee and settlement
   accounting.
-- AuthMark markets use **ConfigureAuthMark** (tag 62) and **PushAuthMark** (tag 63), signed by the configured mark authority, to store a direct authority mark without EWMA smoothing. Pushes include the current asset `market_id` so a signed report cannot cross an asset restart.
-- EwmaMark markets use **ConfigureEwmaMark** (tag 35) and **PushEwmaMark** (tag 36), signed by the configured mark authority, to update a smoothed EWMA mark input. Pushes carry the same generation binding.
+- AuthMark markets use **ConfigureAuthMark** (tag 62) and **PushAuthMark** (tag 63), signed by the configured mark authority, to store a direct authority mark without EWMA smoothing. Both include the current asset `market_id` so signed configuration or report intent cannot cross an asset restart.
+- EwmaMark markets use **ConfigureEwmaMark** (tag 35) and **PushEwmaMark** (tag 36), signed by the configured mark authority, to update a smoothed EWMA mark input. Both carry the same generation binding; Hybrid configuration does as well.
 - The per-slot effective-price movement cap is a risk parameter set at init; there is no standalone `SetOraclePriceCap` instruction in the current ABI.
 
 ### Insurance management
@@ -574,7 +574,7 @@ AuthMark and EwmaMark are authority-pushed pricing modes for markets that do not
 
 AuthMark is the direct authority-mark path:
 
-- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, market_id, now_slot, mark_e6 }`.
+- **Direct mark API**: `ConfigureAuthMark { asset_index, market_id, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, market_id, now_slot, mark_e6 }`.
 - **No EWMA configuration**: there is no halflife, mark-min-fee, feed id, confidence filter, invert flag, or unit-scale configuration in the AuthMark API.
 - **Authority boundary**: only the configured mark authority can push a new mark; public cranks can only consume the stored mark.
 - **Adapter-friendly**: a separate oracle adapter PDA can verify Pyth, Chainlink, Switchboard, or custom feed policy, then sign `PushAuthMark` with the resulting mark.
@@ -584,7 +584,7 @@ AuthMark is the direct authority-mark path:
 
 EwmaMark is the smoothed authority-mark path for markets that use an internal mark/index rather than an external oracle.
 
-- **Smoothed mark API**: `ConfigureEwmaMark { asset_index, now_slot, initial_mark_e6, mark_ewma_halflife_slots, mark_min_fee }` and `PushEwmaMark { asset_index, market_id, now_slot, mark_e6 }`.
+- **Smoothed mark API**: `ConfigureEwmaMark { asset_index, market_id, now_slot, initial_mark_e6, mark_ewma_halflife_slots, mark_min_fee }` and `PushEwmaMark { asset_index, market_id, now_slot, mark_e6 }`.
 - **Mark and index prices**: maintained entirely within the engine; no external oracle feed required for mark settlement.
 - **Premium-based funding**: permissionless cranks compute funding from the spread between mark and index (premium), clamp it to `max_abs_funding_e9_per_slot`, and pass that internally to the engine. The crank instruction's funding-rate field is non-authoritative and must remain zero.
 - **Rate-limited index smoothing**: index price updates are clamped per slot via `clamp_toward_with_dt`, preventing instant mark-to-index jumps. When `dt = 0` or cap is zero, the function returns `index` unchanged (no movement).

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2637,6 +2637,7 @@ pub mod ix {
         },
         ConfigureHybridOracle {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             now_unix_ts: i64,
             oracle_leg_count: u8,
@@ -2652,6 +2653,7 @@ pub mod ix {
         },
         ConfigureEwmaMark {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             initial_mark_e6: u64,
             mark_ewma_halflife_slots: u64,
@@ -2665,6 +2667,7 @@ pub mod ix {
         },
         ConfigureAuthMark {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             initial_mark_e6: u64,
         },
@@ -2681,6 +2684,7 @@ pub mod ix {
         },
         RestartAssetOracle {
             asset_index: u16,
+            market_id: u64,
             now_slot: u64,
             initial_price: u64,
         },
@@ -2899,6 +2903,7 @@ pub mod ix {
                 },
                 62 => Self::ConfigureAuthMark {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     initial_mark_e6: read_u64(&mut rest)?,
                 },
@@ -2915,6 +2920,7 @@ pub mod ix {
                 },
                 69 => Self::RestartAssetOracle {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     initial_price: read_u64(&mut rest)?,
                 },
@@ -2935,6 +2941,7 @@ pub mod ix {
                 },
                 34 => Self::ConfigureHybridOracle {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     now_unix_ts: read_i64(&mut rest)?,
                     oracle_leg_count: read_u8(&mut rest)?,
@@ -2954,6 +2961,7 @@ pub mod ix {
                 },
                 35 => Self::ConfigureEwmaMark {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     initial_mark_e6: read_u64(&mut rest)?,
                     mark_ewma_halflife_slots: read_u64(&mut rest)?,
@@ -3256,6 +3264,7 @@ pub mod ix {
                 }
                 Self::ConfigureHybridOracle {
                     asset_index,
+                    market_id,
                     now_slot,
                     now_unix_ts,
                     oracle_leg_count,
@@ -3271,6 +3280,7 @@ pub mod ix {
                 } => {
                     out.push(34);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_i64(&mut out, now_unix_ts);
                     out.push(oracle_leg_count);
@@ -3288,6 +3298,7 @@ pub mod ix {
                 }
                 Self::ConfigureEwmaMark {
                     asset_index,
+                    market_id,
                     now_slot,
                     initial_mark_e6,
                     mark_ewma_halflife_slots,
@@ -3295,6 +3306,7 @@ pub mod ix {
                 } => {
                     out.push(35);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, initial_mark_e6);
                     push_u64(&mut out, mark_ewma_halflife_slots);
@@ -3314,11 +3326,13 @@ pub mod ix {
                 }
                 Self::ConfigureAuthMark {
                     asset_index,
+                    market_id,
                     now_slot,
                     initial_mark_e6,
                 } => {
                     out.push(62);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, initial_mark_e6);
                 }
@@ -3346,11 +3360,13 @@ pub mod ix {
                 }
                 Self::RestartAssetOracle {
                     asset_index,
+                    market_id,
                     now_slot,
                     initial_price,
                 } => {
                     out.push(69);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, initial_price);
                 }
@@ -5161,6 +5177,22 @@ pub mod processor {
         Ok(())
     }
 
+    fn require_asset_generation_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        expected_market_id: u64,
+    ) -> ProgramResult {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if group.markets[asset_index].engine.asset.market_id.get() != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
+        Ok(())
+    }
+
     fn reset_empty_asset_oracle_anchor_view(
         group: &mut state::MarketViewMutV16<'_>,
         asset_index: usize,
@@ -5391,6 +5423,7 @@ pub mod processor {
             }
             Instruction::ConfigureHybridOracle {
                 asset_index,
+                market_id,
                 now_slot,
                 now_unix_ts,
                 oracle_leg_count,
@@ -5407,6 +5440,7 @@ pub mod processor {
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 now_slot,
                 now_unix_ts,
                 oracle_leg_count,
@@ -5422,6 +5456,7 @@ pub mod processor {
             ),
             Instruction::ConfigureEwmaMark {
                 asset_index,
+                market_id,
                 now_slot,
                 initial_mark_e6,
                 mark_ewma_halflife_slots,
@@ -5430,6 +5465,7 @@ pub mod processor {
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 now_slot,
                 initial_mark_e6,
                 mark_ewma_halflife_slots,
@@ -5450,12 +5486,14 @@ pub mod processor {
             ),
             Instruction::ConfigureAuthMark {
                 asset_index,
+                market_id,
                 now_slot,
                 initial_mark_e6,
             } => handle_configure_auth_mark(
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 now_slot,
                 initial_mark_e6,
             ),
@@ -5485,12 +5523,14 @@ pub mod processor {
             ),
             Instruction::RestartAssetOracle {
                 asset_index,
+                market_id,
                 now_slot,
                 initial_price,
             } => handle_restart_asset_oracle(
                 program_id,
                 accounts,
                 asset_index,
+                market_id,
                 now_slot,
                 initial_price,
             ),
@@ -9120,6 +9160,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         initial_price: u64,
     ) -> ProgramResult {
@@ -9142,10 +9183,7 @@ pub mod processor {
                 return Err(PercolatorError::OracleStale.into());
             }
             let asset_index = asset_index as usize;
-            let configured_slots = group.header.config.max_market_slots.get() as usize;
-            if asset_index >= configured_slots || asset_index >= group.markets.len() {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
+            require_asset_generation_view(&group, asset_index, expected_market_id)?;
             if authenticated_slot < group.header.current_slot.get() {
                 return Err(PercolatorError::EngineStale.into());
             }
@@ -9903,6 +9941,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         now_unix_ts: i64,
         oracle_leg_count: u8,
@@ -9945,9 +9984,7 @@ pub mod processor {
         let cfg_after = {
             let mut data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
-            if asset_index_usize >= group.header.config.max_market_slots.get() as usize {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
+            require_asset_generation_view(&group, asset_index_usize, expected_market_id)?;
             if authenticated_slot < group.header.current_slot.get() {
                 return Err(PercolatorError::EngineStale.into());
             }
@@ -10050,6 +10087,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         initial_mark_e6: u64,
         mark_ewma_halflife_slots: u64,
@@ -10071,9 +10109,7 @@ pub mod processor {
         let cfg_after = {
             let mut data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
-            if asset_index_usize >= group.header.config.max_market_slots.get() as usize {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
+            require_asset_generation_view(&group, asset_index_usize, expected_market_id)?;
             if authenticated_slot < group.header.current_slot.get() {
                 return Err(PercolatorError::EngineStale.into());
             }
@@ -10163,6 +10199,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         now_slot: u64,
         initial_mark_e6: u64,
     ) -> ProgramResult {
@@ -10179,9 +10216,7 @@ pub mod processor {
         let cfg_after = {
             let mut data = market_ai.try_borrow_mut_data()?;
             let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
-            if asset_index_usize >= group.header.config.max_market_slots.get() as usize {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
+            require_asset_generation_view(&group, asset_index_usize, expected_market_id)?;
             if authenticated_slot < group.header.current_slot.get() {
                 return Err(PercolatorError::EngineStale.into());
             }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6391,6 +6391,169 @@ fn v16_attack_signed_mark_push_cannot_replay_after_asset_restart() {
     }
 }
 
+// Oracle configuration is also a signed price authorization. A retained configuration for an old
+// empty asset must not reset a replacement generation's entry anchor immediately before a trade
+// that was signed against the visible current anchor.
+#[test]
+fn v16_attack_signed_auth_config_cannot_replay_after_asset_restart() {
+    const PRICE: u64 = 100;
+    const STALE_ENTRY_PRICE: u64 = 50;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let mut env = V16CuEnv::new();
+    let oracle = env.admin.insecure_clone();
+    env.configure_auth_mark_with_cu(0, PRICE);
+    let old_market_id = env.asset_market_id(0);
+    let stale_config_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            now_slot: 0,
+            initial_mark_e6: STALE_ENTRY_PRICE,
+        }
+        .encode(),
+    };
+    let stale_config = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_config_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &oracle],
+        env.svm.latest_blockhash(),
+    );
+
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(1);
+    env.try_shutdown_asset_with_authority(&oracle, 0, 1)
+        .expect("empty asset shuts down");
+    env.svm.warp_to_slot(2);
+    env.try_restart_asset_oracle_with_authority(&oracle, 0, 2, PRICE)
+        .expect("asset restarts");
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+    env.configure_auth_mark_with_cu(2, PRICE);
+
+    let beneficiary = Keypair::new();
+    let victim = Keypair::new();
+    let beneficiary_portfolio = env.create_portfolio(&beneficiary);
+    let victim_portfolio = env.create_portfolio(&victim);
+    env.deposit(&beneficiary, beneficiary_portfolio, DEPOSIT);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+
+    // The beneficiary retains a trade signed while the replacement asset visibly anchors at 100.
+    // Positive size makes the beneficiary long and the independent victim short.
+    let trade_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(beneficiary.pubkey(), true),
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(beneficiary_portfolio, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            market_id: new_market_id,
+            size_q: SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let signed_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), trade_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &beneficiary, &victim],
+        env.svm.latest_blockhash(),
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let beneficiary_before = env.svm.get_account(&beneficiary_portfolio).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_config);
+    if replay.is_ok() {
+        let stale_profile =
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+                .unwrap();
+        assert_eq!(stale_profile.oracle_target_price_e6, STALE_ENTRY_PRICE);
+        env.svm
+            .send_transaction(signed_trade)
+            .expect("the retained current-generation trade lands after the stale reconfiguration");
+
+        env.svm.warp_to_slot(3);
+        env.push_auth_mark_for_asset_with_authority(0, &oracle, 3, PRICE);
+        for portfolio in [beneficiary_portfolio, victim_portfolio] {
+            env.crank_steps(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 3,
+                    observations: crank_observations(0),
+                },
+                4,
+            );
+        }
+        let beneficiary_after = env.portfolio_state(beneficiary_portfolio);
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let beneficiary_equity =
+            beneficiary_after.capital.get() as i128 + beneficiary_after.pnl.get();
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        assert!(beneficiary_equity > DEPOSIT as i128);
+        assert!(victim_equity < DEPOSIT as i128);
+
+        let exit_lp = Keypair::new();
+        let exit_portfolio = env.create_portfolio(&exit_lp);
+        env.deposit(&exit_lp, exit_portfolio, DEPOSIT);
+        let exit_price = env.market_state().1.assets[0].effective_price;
+        env.trade_with_cu(
+            &exit_lp,
+            exit_portfolio,
+            &beneficiary,
+            beneficiary_portfolio,
+            SIZE_Q,
+            exit_price,
+            0,
+        );
+        let beneficiary_flat = env.portfolio_state(beneficiary_portfolio);
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &beneficiary_flat
+        )));
+        let released = beneficiary_flat.pnl.get() as u128;
+        assert!(released > 0);
+        env.convert_released_pnl_with_cu(&beneficiary, beneficiary_portfolio, released);
+        let withdrawable = env.portfolio_state(beneficiary_portfolio).capital.get();
+        let destination = env.withdraw(&beneficiary, beneficiary_portfolio, withdrawable);
+        assert_eq!(env.token_amount(destination) as u128, withdrawable);
+        assert!(withdrawable > DEPOSIT);
+        panic!(
+            "an old-generation oracle configuration reset fresh entry from {PRICE} to \
+             {STALE_ENTRY_PRICE}, reduced victim equity to {victim_equity}, and let the \
+             beneficiary withdraw {withdrawable}"
+        );
+    }
+
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale oracle configuration must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&beneficiary_portfolio).unwrap(),
+        beneficiary_before
+    );
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+}
+
 // Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
 // address reset every asset market_id to its first-generation value. Keep the original, fully
 // signed transaction object across that public lifecycle: rebuilding the instruction after reinit

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -971,6 +971,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::RestartAssetOracle {
+                market_id: 0,
                 asset_index,
                 now_slot,
                 initial_price,
@@ -2418,6 +2419,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureHybridOracle {
+                market_id: 0,
                 asset_index: 0,
                 now_slot,
                 now_unix_ts,
@@ -2530,6 +2532,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureHybridOracle {
+                market_id: 0,
                 asset_index,
                 now_slot,
                 now_unix_ts,
@@ -2561,6 +2564,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureEwmaMark {
+                market_id: 0,
                 asset_index: 0,
                 now_slot,
                 initial_mark_e6,
@@ -2603,6 +2607,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index: 0,
                 now_slot,
                 initial_mark_e6,
@@ -2648,6 +2653,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index,
                 now_slot,
                 initial_mark_e6,
@@ -2700,6 +2706,7 @@ impl V16CuEnv {
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index,
                 now_slot,
                 initial_mark_e6,
@@ -3659,10 +3666,11 @@ fn send_tx(
     svm: &mut LiteSVM,
     program_id: Pubkey,
     payer: &Keypair,
-    ix: ProgInstruction,
+    mut ix: ProgInstruction,
     accounts: Vec<AccountMeta>,
     extra_signers: &[&Keypair],
 ) -> Result<u64, String> {
+    bind_test_oracle_generation(svm, &mut ix, &accounts);
     let instruction = Instruction {
         program_id,
         accounts,
@@ -3680,6 +3688,47 @@ fn send_tx(
     svm.send_transaction(tx)
         .map(|meta| meta.compute_units_consumed)
         .map_err(|e| format!("{e:?}"))
+}
+
+fn bind_test_oracle_generation(svm: &LiteSVM, ix: &mut ProgInstruction, accounts: &[AccountMeta]) {
+    let (asset_index, market_id) = match ix {
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index,
+            market_id,
+            ..
+        }
+        | ProgInstruction::ConfigureEwmaMark {
+            asset_index,
+            market_id,
+            ..
+        }
+        | ProgInstruction::ConfigureAuthMark {
+            asset_index,
+            market_id,
+            ..
+        }
+        | ProgInstruction::RestartAssetOracle {
+            asset_index,
+            market_id,
+            ..
+        } => (*asset_index as usize, market_id),
+        _ => return,
+    };
+    if *market_id != 0 {
+        return;
+    }
+    let Some(market) = accounts
+        .get(1)
+        .and_then(|meta| svm.get_account(&meta.pubkey))
+    else {
+        return;
+    };
+    let Ok((_, group)) = state::read_market(&market.data) else {
+        return;
+    };
+    if let Some(asset) = group.assets.get(asset_index) {
+        *market_id = asset.market_id;
+    }
 }
 
 fn send_raw_tx(
@@ -5240,6 +5289,7 @@ fn v16_attack_privileged_reactivate_rekeys_retired_slot_authorities() {
     env.svm.expire_blockhash();
     let old_oracle_reconfig = env.send(
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 5,
             initial_mark_e6: 300,
@@ -5264,6 +5314,7 @@ fn v16_attack_privileged_reactivate_rekeys_retired_slot_authorities() {
     env.svm.expire_blockhash();
     let new_oracle_reconfig = env.send(
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 5,
             initial_mark_e6: 300,
@@ -6395,6 +6446,18 @@ fn v16_attack_signed_mark_push_cannot_replay_after_asset_restart() {
 // empty asset must not reset a replacement generation's entry anchor immediately before a trade
 // that was signed against the visible current anchor.
 #[test]
+fn v16_legacy_unbound_oracle_configuration_payloads_fail_closed() {
+    for (tag, old_len) in [(34, 156), (35, 35), (62, 19), (69, 19)] {
+        let mut old_wire = vec![0u8; old_len];
+        old_wire[0] = tag;
+        assert!(
+            ProgInstruction::decode(&old_wire).is_err(),
+            "legacy tag {tag} payload must fail closed without an asset generation"
+        );
+    }
+}
+
+#[test]
 fn v16_attack_signed_auth_config_cannot_replay_after_asset_restart() {
     const PRICE: u64 = 100;
     const STALE_ENTRY_PRICE: u64 = 50;
@@ -6412,6 +6475,7 @@ fn v16_attack_signed_auth_config_cannot_replay_after_asset_restart() {
             AccountMeta::new(env.market, false),
         ],
         data: ProgInstruction::ConfigureAuthMark {
+            market_id: old_market_id,
             asset_index: 0,
             now_slot: 0,
             initial_mark_e6: STALE_ENTRY_PRICE,
@@ -6552,6 +6616,95 @@ fn v16_attack_signed_auth_config_cannot_replay_after_asset_restart() {
         env.svm.get_account(&victim_portfolio).unwrap(),
         victim_before
     );
+
+    for (label, instruction) in [
+        (
+            "ConfigureEwmaMark",
+            ProgInstruction::ConfigureEwmaMark {
+                asset_index: 0,
+                market_id: old_market_id,
+                now_slot: 2,
+                initial_mark_e6: STALE_ENTRY_PRICE,
+                mark_ewma_halflife_slots: 1,
+                mark_min_fee: 0,
+            },
+        ),
+        (
+            "RestartAssetOracle",
+            ProgInstruction::RestartAssetOracle {
+                asset_index: 0,
+                market_id: old_market_id,
+                now_slot: 2,
+                initial_price: STALE_ENTRY_PRICE,
+            },
+        ),
+    ] {
+        env.svm.expire_blockhash();
+        let before = env.svm.get_account(&env.market).unwrap();
+        let rejected = env.send(
+            instruction,
+            vec![
+                AccountMeta::new(oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&oracle],
+        );
+        assert!(
+            format!("{rejected:?}").contains(&expected_error),
+            "stale {label} must fail with {expected_error}, got {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), before);
+    }
+
+    let feed = [7u8; 32];
+    let feed_account = env.set_pyth_price(&feed, PRICE as i64, 0, 2);
+    env.svm.expire_blockhash();
+    let before_hybrid = env.svm.get_account(&env.market).unwrap();
+    let stale_hybrid = env.send(
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 0,
+            market_id: old_market_id,
+            now_slot: 2,
+            now_unix_ts: 2,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 10,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: [feed, [0u8; 32], [0u8; 32]],
+        },
+        vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(feed_account, false),
+        ],
+        &[&oracle],
+    );
+    assert!(
+        format!("{stale_hybrid:?}").contains(&expected_error),
+        "stale ConfigureHybridOracle must fail with {expected_error}, got {stale_hybrid:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), before_hybrid);
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            market_id: new_market_id,
+            now_slot: 2,
+            initial_mark_e6: PRICE,
+        },
+        vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&oracle],
+    )
+    .expect("the current generation remains oracle-configurable");
 }
 
 // Before the persistent generation account, a full CloseSlab + InitMarket cycle at the same market
@@ -7332,6 +7485,7 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
         env.program_id,
         &env.payer,
         ProgInstruction::RestartAssetOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 3,
             initial_price: 250,
@@ -7403,6 +7557,7 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
         env.program_id,
         &env.payer,
         ProgInstruction::RestartAssetOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 8,
             initial_price: 250,
@@ -7423,6 +7578,7 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
         env.program_id,
         &env.payer,
         ProgInstruction::RestartAssetOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 8,
             initial_price: 250,
@@ -7505,6 +7661,7 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 8,
             initial_mark_e6: 250,
@@ -16985,6 +17142,7 @@ fn v16_attack_cross_margin_two_asset_conservation() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -17052,6 +17210,7 @@ fn v16_attack_cross_margin_divergent_moves_conserve() {
         0,
         100,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -18152,6 +18311,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
     cfg(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -18380,6 +18540,7 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
     cfg_asset1(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -20677,6 +20838,7 @@ fn v16_attack_cross_margin_solvent_account_not_unfairly_liquidated() {
     cfg(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -23573,6 +23735,7 @@ fn v16_attack_non_admin_cannot_resolve_or_configure() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 0,
             initial_mark_e6: 999_999,
@@ -30681,6 +30844,7 @@ fn v16_attack_cross_margin_divergent_close_conserves() {
     cfg(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -33513,6 +33677,7 @@ fn v16_attack_max_leg_multi_asset_conserves() {
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index: ai,
                 now_slot: 0,
                 initial_mark_e6: 100,
@@ -33761,6 +33926,7 @@ fn v16_attack_ewma_mark_halflife_zero_safe() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -34121,6 +34287,7 @@ fn v16_attack_retire_asset_authority_gated() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -34235,6 +34402,7 @@ fn v16_attack_per_asset_crank_isolation() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -35279,6 +35447,7 @@ fn v16_attack_per_asset_funding_isolation() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: IP,
@@ -35416,6 +35585,7 @@ fn v16_attack_fee_redirect_split_lands_correctly() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -36045,6 +36215,7 @@ fn v16_attack_fee_redirect_full_boundary() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -37704,6 +37875,7 @@ fn v16_attack_force_close_healthy_asset_rejected() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
@@ -38026,6 +38198,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 1,
             initial_mark_e6: 100,
@@ -43328,6 +43501,7 @@ fn v16_attack_hybrid_oracle_scalar_bounds_reject_atomically() {
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureHybridOracle {
+                market_id: 0,
                 asset_index: 0,
                 now_slot: 1,
                 now_unix_ts: 100,
@@ -43376,6 +43550,7 @@ fn v16_attack_hybrid_oracle_scalar_bounds_reject_atomically() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureHybridOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             now_unix_ts: 100,
@@ -44913,6 +45088,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 200,
@@ -44941,6 +45117,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 200,
@@ -44971,6 +45148,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureHybridOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             now_unix_ts: 1,
@@ -45009,6 +45187,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 200,
@@ -45062,6 +45241,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
     reject_unchanged(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 0,
@@ -45071,6 +45251,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
     reject_unchanged(
         &mut env,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: over_max,
@@ -45080,6 +45261,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
     reject_unchanged(
         &mut env,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 0,
@@ -45091,6 +45273,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
     reject_unchanged(
         &mut env,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: over_max,
@@ -45102,6 +45285,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
     reject_unchanged(
         &mut env,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 100,
@@ -45117,6 +45301,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 100,
@@ -45193,6 +45378,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 3,
             initial_mark_e6: 200,
@@ -45296,6 +45482,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 500,
@@ -45322,6 +45509,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 500,
@@ -45354,6 +45542,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureHybridOracle {
+            market_id: 0,
             asset_index: 0,
             now_slot: 1,
             now_unix_ts: 1,
@@ -45771,6 +45960,7 @@ fn v16_attack_market_exceeds_64_assets_position_holds_any_14_legs() {
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index: ai,
                 now_slot: TRADE_SLOT,
                 initial_mark_e6: PRICE,
@@ -48541,6 +48731,7 @@ fn v16_attack_non_admin_activate_cannot_install_authorities() {
     env.svm.expire_blockhash();
     let r_mark = env.send(
         ProgInstruction::ConfigureAuthMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 1,
             initial_mark_e6: 1_000_000,
@@ -48679,6 +48870,7 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: HIGH_ASSET as u16,
             now_slot: TRADE_SLOT,
             initial_mark_e6: PRICE,
@@ -58152,6 +58344,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigureEwmaMark {
+            market_id: 0,
             asset_index: 1,
             now_slot: 1,
             initial_mark_e6: 100,
@@ -58283,6 +58476,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index: 0,
                 now_slot: 1,
                 initial_mark_e6: 250,
@@ -58309,6 +58503,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureAuthMark {
+                market_id: 0,
                 asset_index: 1,
                 now_slot: 1,
                 initial_mark_e6: 250,
@@ -58342,6 +58537,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureEwmaMark {
+                market_id: 0,
                 asset_index: 0,
                 now_slot: 1,
                 initial_mark_e6: 250,
@@ -58370,6 +58566,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureEwmaMark {
+                market_id: 0,
                 asset_index: 1,
                 now_slot: 1,
                 initial_mark_e6: 250,
@@ -58410,6 +58607,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureHybridOracle {
+                market_id: 0,
                 asset_index: 0,
                 now_slot: 1,
                 now_unix_ts: 1,
@@ -58447,6 +58645,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
             env.program_id,
             &env.payer,
             ProgInstruction::ConfigureHybridOracle {
+                market_id: 0,
                 asset_index: 1,
                 now_slot: 1,
                 now_unix_ts: 1,

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -676,11 +676,13 @@ fn kani_v16_legacy_unbound_authority_payloads_are_rejected() {
 #[kani::proof]
 fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let now_slot: u64 = kani::any();
     let initial_price: u64 = kani::any();
 
     let data = Instruction::RestartAssetOracle {
         asset_index,
+        market_id,
         now_slot,
         initial_price,
     }
@@ -689,10 +691,12 @@ fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
     match Instruction::decode(&data).unwrap() {
         Instruction::RestartAssetOracle {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_slot,
             initial_price: got_price,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_slot, now_slot);
             assert_eq!(got_price, initial_price);
         }
@@ -943,6 +947,7 @@ fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
 #[kani::unwind(34)]
 fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let oracle_leg_count: u8 = kani::any();
     let oracle_leg_flags: u8 = kani::any();
     let invert: u8 = kani::any();
@@ -965,27 +970,29 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 156];
+    let mut data = [0u8; 164];
     data[0] = 34;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..11].copy_from_slice(&now_slot.to_le_bytes());
-    data[11..19].copy_from_slice(&now_unix_ts.to_le_bytes());
-    data[19] = oracle_leg_count;
-    data[20] = oracle_leg_flags;
-    data[21..29].copy_from_slice(&max_staleness_secs.to_le_bytes());
-    data[29..37].copy_from_slice(&hybrid_soft_stale_slots.to_le_bytes());
-    data[37..45].copy_from_slice(&mark_ewma_halflife_slots.to_le_bytes());
-    data[45..53].copy_from_slice(&mark_min_fee.to_le_bytes());
-    data[53] = invert;
-    data[54..58].copy_from_slice(&unit_scale.to_le_bytes());
-    data[58..60].copy_from_slice(&conf_filter_bps.to_le_bytes());
-    data[60..92].copy_from_slice(&feeds[0]);
-    data[92..124].copy_from_slice(&feeds[1]);
-    data[124..156].copy_from_slice(&feeds[2]);
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11..19].copy_from_slice(&now_slot.to_le_bytes());
+    data[19..27].copy_from_slice(&now_unix_ts.to_le_bytes());
+    data[27] = oracle_leg_count;
+    data[28] = oracle_leg_flags;
+    data[29..37].copy_from_slice(&max_staleness_secs.to_le_bytes());
+    data[37..45].copy_from_slice(&hybrid_soft_stale_slots.to_le_bytes());
+    data[45..53].copy_from_slice(&mark_ewma_halflife_slots.to_le_bytes());
+    data[53..61].copy_from_slice(&mark_min_fee.to_le_bytes());
+    data[61] = invert;
+    data[62..66].copy_from_slice(&unit_scale.to_le_bytes());
+    data[66..68].copy_from_slice(&conf_filter_bps.to_le_bytes());
+    data[68..100].copy_from_slice(&feeds[0]);
+    data[100..132].copy_from_slice(&feeds[1]);
+    data[132..164].copy_from_slice(&feeds[2]);
 
     match Instruction::decode(&data).unwrap() {
         Instruction::ConfigureHybridOracle {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_now_slot,
             now_unix_ts: got_now_unix,
             oracle_leg_count: got_count,
@@ -1000,6 +1007,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
             oracle_leg_feeds: got_feeds,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_now_slot, now_slot);
             assert_eq!(got_now_unix, now_unix_ts);
             assert_eq!(got_count, oracle_leg_count);
@@ -1030,22 +1038,25 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
     let mark_min_fee: u64 = kani::any();
     let push_mark_e6: u64 = kani::any();
 
-    let mut configure = [0u8; 35];
+    let mut configure = [0u8; 43];
     configure[0] = 35;
     configure[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    configure[3..11].copy_from_slice(&now_slot.to_le_bytes());
-    configure[11..19].copy_from_slice(&initial_mark_e6.to_le_bytes());
-    configure[19..27].copy_from_slice(&mark_ewma_halflife_slots.to_le_bytes());
-    configure[27..35].copy_from_slice(&mark_min_fee.to_le_bytes());
+    configure[3..11].copy_from_slice(&market_id.to_le_bytes());
+    configure[11..19].copy_from_slice(&now_slot.to_le_bytes());
+    configure[19..27].copy_from_slice(&initial_mark_e6.to_le_bytes());
+    configure[27..35].copy_from_slice(&mark_ewma_halflife_slots.to_le_bytes());
+    configure[35..43].copy_from_slice(&mark_min_fee.to_le_bytes());
     match Instruction::decode(&configure).unwrap() {
         Instruction::ConfigureEwmaMark {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_now,
             initial_mark_e6: got_mark,
             mark_ewma_halflife_slots: got_halflife,
             mark_min_fee: got_min_fee,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, initial_mark_e6);
             assert_eq!(got_halflife, mark_ewma_halflife_slots);
@@ -1075,18 +1086,21 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut configure_auth = [0u8; 19];
+    let mut configure_auth = [0u8; 27];
     configure_auth[0] = 62;
     configure_auth[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    configure_auth[3..11].copy_from_slice(&now_slot.to_le_bytes());
-    configure_auth[11..19].copy_from_slice(&initial_mark_e6.to_le_bytes());
+    configure_auth[3..11].copy_from_slice(&market_id.to_le_bytes());
+    configure_auth[11..19].copy_from_slice(&now_slot.to_le_bytes());
+    configure_auth[19..27].copy_from_slice(&initial_mark_e6.to_le_bytes());
     match Instruction::decode(&configure_auth).unwrap() {
         Instruction::ConfigureAuthMark {
             asset_index: got_asset_index,
+            market_id: got_market_id,
             now_slot: got_now,
             initial_mark_e6: got_mark,
         } => {
             assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, initial_mark_e6);
         }
@@ -1317,6 +1331,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::ConfigureHybridOracle {
             asset_index: 0,
+            market_id: 1,
             now_slot: 1,
             now_unix_ts: 1,
             oracle_leg_count: 1,
@@ -1335,6 +1350,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::ConfigureEwmaMark {
             asset_index: 0,
+            market_id: 1,
             now_slot: 1,
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 1,
@@ -1354,6 +1370,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::ConfigureAuthMark {
             asset_index: 0,
+            market_id: 1,
             now_slot: 1,
             initial_mark_e6: 100,
         },
@@ -1365,6 +1382,15 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             market_id: 1,
             now_slot: 2,
             mark_e6: 101,
+        },
+        extra,
+    );
+    assert_rejects_trailing_byte(
+        Instruction::RestartAssetOracle {
+            asset_index: 0,
+            market_id: 1,
+            now_slot: 2,
+            initial_price: 100,
         },
         extra,
     );


### PR DESCRIPTION
## Finding

A fully signed `ConfigureAuthMark` transaction retained from an old, empty asset generation remained valid after public shutdown/restart reused the same asset slot. An attacker can land it immediately before a fresh-generation trade signed against the visible replacement anchor. The stale configuration resets the entry anchor, and the honest current-generation mark update realizes the artificial PnL against an independent victim.

The exact-parent LiteSVM RED repro uses only ordinary public instructions and retained `Transaction` objects. With deposits of 1,000,000 each, the victim finishes at 750,000 equity and the beneficiary exits and withdraws 1,250,000. No account bytes are injected.

## Fix

Bind `ConfigureHybridOracle`, `ConfigureEwmaMark`, `ConfigureAuthMark`, and `RestartAssetOracle` to the current asset `market_id`, rejecting stale generations before reading feeds or mutating state. Legacy unbound payloads fail closed. Current-generation configuration remains functional.

This PR is intentionally stacked on #275 (and transitively #231) because it extends the same generation primitive to a distinct signed authorization surface.

## TDD

- RED `3bcac346`: exact public LiteSVM replay; victim 1,000,000 -> 750,000, beneficiary withdraws 1,250,000
- GREEN `c5ca015b`: stale Auth/EWMA/Hybrid/Restart rejected with byte-identical rollback; current-generation Auth succeeds

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 5 host + 571 LiteSVM/CU tests pass
- Kani wire proofs: Restart 1,517 checks; EWMA/Auth 853 checks; Hybrid 878 checks
- `cargo fmt --check`
- `git diff --check`