### PR TITLE
[HARDENING LoF] Bind recovery forfeits to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - **CureAndCancelClose** (tag 42)
   - owner-signed close recovery path; optional deposit is transferred first, then the engine cancels the pending close if the cure succeeds
 - **ForfeitRecoveryLeg** (tag 43)
-  - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
+  - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget; the signed
+    payload includes the program-assigned `portfolio_id`, so consent cannot cross account reuse
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
 - **ClaimResolvedPayoutTopup** (tag 46)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2651,6 +2651,7 @@ pub mod ix {
             optional_deposit: u128,
         },
         ForfeitRecoveryLeg {
+            portfolio_id: u64,
             asset_index: u16,
             b_delta_budget: u128,
         },
@@ -2924,6 +2925,7 @@ pub mod ix {
                     optional_deposit: read_u128(&mut rest)?,
                 },
                 43 => Self::ForfeitRecoveryLeg {
+                    portfolio_id: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     b_delta_budget: read_u128(&mut rest)?,
                 },
@@ -3313,10 +3315,12 @@ pub mod ix {
                     push_u128(&mut out, optional_deposit);
                 }
                 Self::ForfeitRecoveryLeg {
+                    portfolio_id,
                     asset_index,
                     b_delta_budget,
                 } => {
                     out.push(43);
+                    push_u64(&mut out, portfolio_id);
                     push_u16(&mut out, asset_index);
                     push_u128(&mut out, b_delta_budget);
                 }
@@ -5455,9 +5459,16 @@ pub mod processor {
                 handle_cure_and_cancel_close(program_id, accounts, optional_deposit)
             }
             Instruction::ForfeitRecoveryLeg {
+                portfolio_id,
                 asset_index,
                 b_delta_budget,
-            } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
+            } => handle_forfeit_recovery_leg(
+                program_id,
+                accounts,
+                portfolio_id,
+                asset_index,
+                b_delta_budget,
+            ),
             Instruction::RebalanceReduce {
                 asset_index,
                 reduce_q,
@@ -8467,11 +8478,17 @@ pub mod processor {
     fn handle_forfeit_recovery_leg<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
         asset_index: u16,
         b_delta_budget: u128,
     ) -> ProgramResult {
         if b_delta_budget == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let portfolio_ai = account(accounts, 2)?;
+        expect_owner(portfolio_ai, program_id)?;
+        if state::read_portfolio_id(&portfolio_ai.try_borrow_data()?)? != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -19250,6 +19250,224 @@ fn v16_portfolio_incarnation_id_separates_close_and_reuse() {
     assert_eq!(replacement.residual_received_atoms_total.get(), 0);
 }
 
+// A recovery-leg forfeit is consent to discard value on one portfolio incarnation, not every
+// future account that may occupy the same address. Retain the exact owner-signed transaction while
+// the old account exits, then exercise a fresh position through public lifecycle instructions.
+#[test]
+fn v16_probe_signed_forfeit_cannot_replay_after_portfolio_reinit() {
+    const PRICE: u64 = 100;
+    const WIN_PRICE: u64 = 150;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (5_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, PRICE);
+
+    let victim = Keypair::new();
+    let victim_account = Keypair::new();
+    let victim_portfolio = victim_account.pubkey();
+    env.ensure_signer_account(victim.pubkey());
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &victim_account,
+        env.portfolio_account_len,
+        env.program_id,
+    );
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        &[&victim],
+    )
+    .expect("initialize the first victim incarnation");
+    let old_portfolio_id = env.portfolio_id(victim_portfolio);
+    let attacker_portfolio = env.create_portfolio(&admin);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&admin, attacker_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &admin,
+        attacker_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("old generation enters Recovery");
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        data: ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: 0,
+            b_delta_budget: 1,
+        }
+        .encode(),
+    };
+    let stale_forfeit = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&admin.pubkey()),
+        &[&admin, &victim],
+        env.svm.latest_blockhash(),
+    );
+
+    env.forfeit_recovery_leg_with_cu(&victim, victim_portfolio, 0, 1);
+    env.forfeit_recovery_leg_with_cu(&admin, attacker_portfolio, 0, 1);
+    let old_dest = env.withdraw(&victim, victim_portfolio, DEPOSIT);
+    assert_eq!(env.token_amount(old_dest) as u128, DEPOSIT);
+    env.close_portfolio_with_cu(&victim, victim_portfolio);
+
+    env.svm.warp_to_slot(3);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 3, PRICE)
+        .expect("empty asset restarts");
+    env.configure_auth_mark_with_cu(3, PRICE);
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim_portfolio, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio through the System Program");
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+        ],
+        &[&victim],
+    )
+    .expect("initialize the replacement victim incarnation");
+    let replacement_portfolio_id = env.portfolio_id(victim_portfolio);
+    assert_ne!(replacement_portfolio_id, old_portfolio_id);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &admin,
+        attacker_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(13);
+    env.push_auth_mark_with_cu(13, WIN_PRICE);
+    env.crank_steps(
+        attacker_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 13,
+            observations: crank_observations(0),
+        },
+        4,
+    );
+    let victim_marked = env.portfolio_state(victim_portfolio);
+    let (_, marked_group) = env.market_state();
+    let effective_mark = marked_group.assets[0].effective_price;
+    assert!(
+        effective_mark > PRICE,
+        "the honest mark must move before the stale forfeit"
+    );
+    assert_eq!(
+        victim_marked.pnl.get(),
+        0,
+        "the winner is intentionally uncranked"
+    );
+    let pending_victim_profit =
+        SIZE_Q.unsigned_abs() * (effective_mark - PRICE) as u128 / POS_SCALE;
+    assert!(pending_victim_profit > 0);
+
+    env.svm.warp_to_slot(14);
+    env.try_shutdown_asset_with_authority(&admin, 0, 14)
+        .expect("replacement generation enters Recovery at the honest mark");
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_forfeit);
+    if replay.is_ok() {
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &victim_after
+        )));
+
+        env.resolve();
+        env.svm.warp_to_slot(15);
+        let attacker_dest = env.close_resolved(&admin, attacker_portfolio);
+        let victim_dest = env.close_resolved(&victim, victim_portfolio);
+        let attacker_out = env.token_amount(attacker_dest) as u128;
+        let victim_out = env.token_amount(victim_dest) as u128;
+        let attacker_after = env.portfolio_state(attacker_portfolio);
+        let victim_after_close = env.portfolio_state(victim_portfolio);
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &attacker_after
+        )));
+        assert_eq!(attacker_after.capital.get(), 0);
+        assert_eq!(attacker_after.pnl.get(), 0);
+        assert_eq!(victim_after_close.capital.get(), 0);
+        assert_eq!(victim_after_close.pnl.get(), 0);
+        env.close_portfolio_with_cu(&admin, attacker_portfolio);
+        env.close_portfolio_with_cu(&victim, victim_portfolio);
+        let (_, stuck) = env.market_state();
+        assert_eq!(stuck.c_tot, 0);
+        assert_eq!(stuck.insurance, 0);
+        assert_eq!(stuck.materialized_portfolio_count, 0);
+        assert_eq!(stuck.vault, pending_victim_profit);
+
+        let close_dest = env.token_account(admin.pubkey(), 0);
+        env.svm.expire_blockhash();
+        let close_slab = env.send(
+            ProgInstruction::CloseSlab,
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new(close_dest, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&admin],
+        );
+        assert!(close_slab.is_err());
+        panic!(
+            "a forfeit signed for portfolio id {old_portfolio_id} detached replacement id \
+             {replacement_portfolio_id}, discarded {pending_victim_profit} of honest positive PnL, \
+             paid the victim only {victim_out} (equity {victim_equity}), paid the counterparty \
+             {attacker_out}, and permanently stranded {} in a slab that cannot close: {close_slab:?}",
+            stuck.vault,
+        );
+    }
+
+    let replay_error = format!("{replay:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::EngineProvenanceMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale forfeit must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+}
+
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
 // so dust-notional trades are never free and repeated churn never leaks value to the trader. Attacker
 // success = a fee that floors to 0 (free trade) or insurance that fails to grow on a fee'd dust trade.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -3405,8 +3406,10 @@ impl V16CuEnv {
         asset_index: u16,
         b_delta_budget: u128,
     ) -> u64 {
+        let portfolio_id = self.portfolio_id(portfolio);
         self.send(
             ProgInstruction::ForfeitRecoveryLeg {
+                portfolio_id,
                 asset_index,
                 b_delta_budget,
             },
@@ -16164,6 +16167,7 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     env.svm.expire_blockhash();
     let forfeit = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: 1,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -19312,6 +19316,7 @@ fn v16_probe_signed_forfeit_cannot_replay_after_portfolio_reinit() {
             AccountMeta::new(victim_portfolio, false),
         ],
         data: ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: old_portfolio_id,
             asset_index: 0,
             b_delta_budget: 1,
         }
@@ -19319,8 +19324,8 @@ fn v16_probe_signed_forfeit_cannot_replay_after_portfolio_reinit() {
     };
     let stale_forfeit = Transaction::new_signed_with_payer(
         &[heap_ix(), cu_ix(), stale_ix],
-        Some(&admin.pubkey()),
-        &[&admin, &victim],
+        Some(&victim.pubkey()),
+        &[&victim],
         env.svm.latest_blockhash(),
     );
 
@@ -28999,12 +29004,15 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
     let local_before = env.svm.get_account(&local).unwrap();
     let vault_a_before = env.svm.get_account(&env.vault).unwrap();
     let vault_b_before = env.svm.get_account(&vault_b).unwrap();
+    let foreign_portfolio_id = env.portfolio_id(foreign);
+    let local_portfolio_id = env.portfolio_id(local);
     env.svm.expire_blockhash();
     let rejected = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: foreign_portfolio_id,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -29040,6 +29048,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         env.program_id,
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: local_portfolio_id,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -29186,6 +29195,7 @@ fn v16_attack_recovery_tools_owner_gated() {
     env.svm.expire_blockhash();
     let r1 = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -54502,6 +54512,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             b_delta_budget: 1_000,
         },
@@ -54531,6 +54542,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             b_delta_budget: 0,
         },
@@ -56442,6 +56454,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let rejected = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(stale_long),
             asset_index: 0,
             b_delta_budget: 1,
         },

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -268,6 +268,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
+    let portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let side: u8 = kani::any();
     let b_delta_budget: u128 = kani::any();
@@ -276,15 +277,18 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let now_slot: u64 = kani::any();
 
     let forfeit = Instruction::ForfeitRecoveryLeg {
+        portfolio_id,
         asset_index,
         b_delta_budget,
     }
     .encode();
     match Instruction::decode(&forfeit).unwrap() {
         Instruction::ForfeitRecoveryLeg {
+            portfolio_id: got_portfolio_id,
             asset_index: got_asset,
             b_delta_budget: got_budget,
         } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_budget, b_delta_budget);
         }
@@ -348,6 +352,14 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
         Instruction::SyncMaintenanceFee { now_slot: got } => assert_eq!(got, now_slot),
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_forfeit_payload_is_rejected() {
+    let mut legacy_payload: [u8; 19] = kani::any();
+    legacy_payload[0] = 43;
+
+    assert!(Instruction::decode(&legacy_payload).is_err());
 }
 
 #[kani::proof]
@@ -1373,6 +1385,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::ForfeitRecoveryLeg {
+            portfolio_id: 1,
             asset_index: 0,
             b_delta_budget: 1,
         },


### PR DESCRIPTION
## Root cause

`ForfeitRecoveryLeg` authorized an irreversible value-discarding operation using only the owner signature, portfolio address, and asset slot. It did not bind that consent to the program-assigned portfolio incarnation ID. A signed transaction retained from an old incarnation could therefore execute against a newly initialized portfolio at the same address while its recent blockhash remained valid.

## Public LiteSVM reproduction

The RED commit `2f2b0252` uses only ordinary wrapper and System Program instructions:

1. Initialize a market and two funded portfolios, then open a position.
2. Enter asset recovery and retain an owner-authorized forfeit transaction for portfolio ID 1.
3. Clear, withdraw, and close that portfolio.
4. Re-fund the same address through the System Program and initialize portfolio ID 3.
5. Open a fresh position, move the honest authenticated mark from 100 to its bounded effective value, and enter recovery again.
6. Rebroadcast the retained transaction.

Before the fix, the stale consent detached the replacement winner, discarded 100,000 units of positive PnL, paid the victim only its 1,000,000 principal, and left 100,000 units orphaned in a resolved slab. After both portfolios were paid and closed, `c_tot`, insurance, and the portfolio count were zero but `vault` remained 100,000; public `CloseSlab` failed with `EngineLockActive`.

The final fixture makes the retained transaction fee-paid and signed only by the victim, so rebroadcast does not require a privileged key. Market authority is used only for the documented bounded asset shutdown/restart lifecycle; account data is never injected or rewritten.

## Fix

- Add the monotonic `portfolio_id` to the signed `ForfeitRecoveryLeg` wire payload.
- Reject an ID mismatch before entering the engine mutation.
- Update all positive callers to read and supply the current incarnation.
- Prove symbolic wire round-trip preservation and universal rejection of the legacy unbound payload.

## Verification

- `cargo build-sbf --no-default-features`
- Exact public LiteSVM replay: PASS after failing on the RED parent
- `cargo test --all-targets`: 6 host + 566 LiteSVM/CU tests PASS
- `cargo kani --tests --harness kani_v16_recovery_close_progress_decode_preserves_wire_fields`: PASS
- `cargo kani --tests --harness kani_v16_legacy_unbound_forfeit_payload_is_rejected`: PASS
- `cargo fmt --check`
- `git diff --check`

This PR intentionally fixes only cross-incarnation consent replay. Whether a current-incarnation voluntary forfeit can create a terminal residual is a separate engine-level question and is not masked here.
