### PR TITLE
[BLOCKER LoF] Bind collateral top-ups to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Percolator enforces three layers with distinct responsibilities:
 - **Layout**: header + wrapper config + `MarketGroupV16Account`
 - Holds market-level totals, insurance, oracle/asset state, source-domain credit state, and asset lifecycle state.
 
-The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, co-signed authority rotations, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
+The v16 asset index ABI is `u16`. The current persisted layout is still a fixed-capacity Pod market-group layout, but asset indices are treated as reusable logical slots. A retired asset slot can only be reactivated after the configured shutdown/activation timeout, and reactivation assigns a new monotonic `u64` `market_id` from the market group. `market_id` values are never reused, including when a closed market account is recreated at the same address. Trade instructions, signed collateral contributions, co-signed authority rotations, portfolio legs, and close-progress ledgers carry that id, so neither stale signed intent nor stale state from an old shutdown market can bind to a reused slot.
 
 ### Market generation account
 - **Owner**: Percolator program id
@@ -437,7 +437,14 @@ This section describes intent and operational ordering, not argument-by-argument
   - permissionless side-reset finalization for engine-ready asset sides
   - validates side encoding and engine readiness; it is not an admin override
 - **TopUpInsurance** (tag 9)
-  - transfers collateral into vault; credits insurance fund in engine
+  - `TopUpInsurance { market_id, amount }` transfers collateral into the vault and credits asset 0's insurance fund
+  - the signed `market_id` must match the current base-asset generation
+- **TopUpInsuranceDomain** (tag 56)
+  - `TopUpInsuranceDomain { domain, market_id, amount }` credits one asset-side insurance budget
+  - `market_id` must match the generation owning `domain`
+- **TopUpBackingBucket** (tag 24)
+  - `TopUpBackingBucket { domain, market_id, amount, expiry_slot }` contributes source backing
+  - `market_id` must match the generation owning `domain`
 
 ### Trading
 - **TradeNoCpi**
@@ -790,7 +797,7 @@ Call `InitMarket` with:
   - deposit collateral with `Deposit`
 
 ### Step 3: Fund insurance
-Call `TopUpInsurance` as needed.
+Call `TopUpInsurance` with asset 0's current `market_id` as needed.
 
 ### Step 4: Start keepers
 Run `PermissionlessCrank` continuously.

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2561,16 +2561,19 @@ pub mod ix {
         },
         ClosePortfolio,
         TopUpInsurance {
+            market_id: u64,
             amount: u128,
         },
         TopUpInsuranceDomain {
             domain: u16,
+            market_id: u64,
             amount: u128,
         },
         CloseSlab,
         ResolveMarket,
         TopUpBackingBucket {
             domain: u16,
+            market_id: u64,
             amount: u128,
             expiry_slot: u64,
         },
@@ -2835,16 +2838,19 @@ pub mod ix {
                 },
                 8 => Self::ClosePortfolio,
                 9 => Self::TopUpInsurance {
+                    market_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 56 => Self::TopUpInsuranceDomain {
                     domain: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 13 => Self::CloseSlab,
                 19 => Self::ResolveMarket,
                 24 => Self::TopUpBackingBucket {
                     domain: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                     expiry_slot: read_u64(&mut rest)?,
                 },
@@ -3132,24 +3138,32 @@ pub mod ix {
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
-                Self::TopUpInsurance { amount } => {
+                Self::TopUpInsurance { market_id, amount } => {
                     out.push(9);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, amount);
                 }
-                Self::TopUpInsuranceDomain { domain, amount } => {
+                Self::TopUpInsuranceDomain {
+                    domain,
+                    market_id,
+                    amount,
+                } => {
                     out.push(56);
                     push_u16(&mut out, domain);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, amount);
                 }
                 Self::CloseSlab => out.push(13),
                 Self::ResolveMarket => out.push(19),
                 Self::TopUpBackingBucket {
                     domain,
+                    market_id,
                     amount,
                     expiry_slot,
                 } => {
                     out.push(24);
                     push_u16(&mut out, domain);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, amount);
                     push_u64(&mut out, expiry_slot);
                 }
@@ -5297,19 +5311,29 @@ pub mod processor {
                 handle_set_matcher_config(program_id, accounts, enabled)
             }
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
-            Instruction::TopUpInsurance { amount } => {
-                handle_top_up_insurance(program_id, accounts, amount)
+            Instruction::TopUpInsurance { market_id, amount } => {
+                handle_top_up_insurance(program_id, accounts, market_id, amount)
             }
-            Instruction::TopUpInsuranceDomain { domain, amount } => {
-                handle_top_up_insurance_domain(program_id, accounts, domain, amount)
-            }
+            Instruction::TopUpInsuranceDomain {
+                domain,
+                market_id,
+                amount,
+            } => handle_top_up_insurance_domain(program_id, accounts, domain, market_id, amount),
             Instruction::CloseSlab => handle_close_slab(program_id, accounts),
             Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
             Instruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
-            } => handle_top_up_backing_bucket(program_id, accounts, domain, amount, expiry_slot),
+            } => handle_top_up_backing_bucket(
+                program_id,
+                accounts,
+                domain,
+                market_id,
+                amount,
+                expiry_slot,
+            ),
             Instruction::WithdrawBackingBucket { domain, amount } => {
                 handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
             }
@@ -7191,10 +7215,27 @@ pub mod processor {
         Ok(())
     }
 
+    fn require_asset_generation_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        expected_market_id: u64,
+    ) -> ProgramResult {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if group.markets[asset_index].engine.asset.market_id.get() != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
+        Ok(())
+    }
+
     #[inline(never)]
     fn handle_top_up_insurance<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
         amount: u128,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
@@ -7236,6 +7277,7 @@ pub mod processor {
             if group.header.mode != 0 {
                 return Err(PercolatorError::EngineLockActive.into());
             }
+            require_asset_generation_view(&group, 0, expected_market_id)?;
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             let asset0_insurance_authority =
                 domain_authorities_from_view(&group, &cfg, 0)?.insurance_authority;
@@ -7298,6 +7340,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         domain: u16,
+        expected_market_id: u64,
         amount: u128,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
@@ -7348,6 +7391,7 @@ pub mod processor {
             }
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             require_domain_accepts_live_topup_view(&group, domain)?;
+            require_asset_generation_view(&group, domain / 2, expected_market_id)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain)?;
             expect_live_authority(&authorities.insurance_authority, signer.key)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {
@@ -7632,6 +7676,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         domain: u16,
+        expected_market_id: u64,
         amount: u128,
         expiry_slot: u64,
     ) -> ProgramResult {
@@ -7664,6 +7709,7 @@ pub mod processor {
                 return Err(PercolatorError::EngineLockActive.into());
             }
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
+            require_asset_generation_view(&group, asset_index, expected_market_id)?;
             let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
             (cfg, authorities)
@@ -7683,6 +7729,7 @@ pub mod processor {
             }
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
+            require_asset_generation_view(&group, domain_usize / 2, expected_market_id)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain_usize)?;
             expect_live_authority(&authorities.backing_bucket_authority, signer.key)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -79,6 +79,7 @@ fn v16_attack_insurance_topup_cannot_replay_across_asset_generation() {
         ],
         data: ProgInstruction::TopUpInsuranceDomain {
             domain: DOMAIN,
+            market_id: old_market_id,
             amount: AMOUNT,
         }
         .encode(),
@@ -128,9 +129,17 @@ fn v16_attack_insurance_topup_cannot_replay_across_asset_generation() {
         assert_eq!(env.token_amount(env.vault), vault_before);
     }
 
-    assert!(
-        replay.is_err(),
+    let replay_error = replay.expect_err(&format!(
         "stale generation-{old_market_id} top-up debited {AMOUNT} victim atoms and let the generation-{new_market_id} operator withdraw them"
+    ));
+    let replay_error = format!("{replay_error:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale top-up must fail with {expected_error}, got {replay_error}"
     );
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
@@ -141,6 +150,31 @@ fn v16_attack_insurance_topup_cannot_replay_across_asset_generation() {
         env.svm.get_account(&victim_source).unwrap(),
         source_before,
         "rejected stale top-up must not debit the victim"
+    );
+
+    const CURRENT_AMOUNT: u128 = 7;
+    let current_source = env.token_account(victim.pubkey(), CURRENT_AMOUNT as u64);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpInsuranceDomain {
+            domain: DOMAIN,
+            market_id: new_market_id,
+            amount: CURRENT_AMOUNT,
+        },
+        vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(current_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&victim],
+    )
+    .expect("current-generation collateral contribution remains live");
+    assert_eq!(env.token_amount(current_source), 0);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        CURRENT_AMOUNT
     );
 }
 
@@ -2909,11 +2943,12 @@ impl V16CuEnv {
     }
 
     fn top_up_insurance_from_admin_token_with_cu(&mut self, source: Pubkey, amount: u128) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance { market_id, amount },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2933,12 +2968,14 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> u64 {
+        let market_id = self.asset_market_id(domain / 2);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -2955,6 +2992,7 @@ impl V16CuEnv {
     }
 
     fn top_up_insurance_with_cu(&mut self, amount: u128) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(0);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -2972,7 +3010,7 @@ impl V16CuEnv {
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance { market_id, amount },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2991,6 +3029,7 @@ impl V16CuEnv {
         ledger: Pubkey,
         amount: u128,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(0);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3008,7 +3047,7 @@ impl V16CuEnv {
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance { market_id, amount },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -3029,6 +3068,7 @@ impl V16CuEnv {
         domain: u16,
         amount: u128,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         self.ensure_signer_account(authority.pubkey());
         let source = Pubkey::new_unique();
         self.svm
@@ -3047,7 +3087,11 @@ impl V16CuEnv {
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsuranceDomain { domain, amount },
+            ProgInstruction::TopUpInsuranceDomain {
+                domain,
+                market_id,
+                amount,
+            },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -3068,6 +3112,7 @@ impl V16CuEnv {
         domain: u16,
         amount: u128,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         self.ensure_signer_account(authority.pubkey());
         let source = Pubkey::new_unique();
         self.svm
@@ -3086,7 +3131,11 @@ impl V16CuEnv {
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsuranceDomain { domain, amount },
+            ProgInstruction::TopUpInsuranceDomain {
+                domain,
+                market_id,
+                amount,
+            },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -3107,6 +3156,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3126,6 +3176,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3149,6 +3200,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3168,6 +3220,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3192,6 +3245,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> Pubkey {
+        let market_id = self.asset_market_id(domain / 2);
         self.ensure_signer_account(authority.pubkey());
         let source = self.token_account(authority.pubkey(), amount as u64);
         send_tx(
@@ -3200,6 +3254,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -4068,6 +4123,7 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
         &payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 77,
             expiry_slot: 10,
         },
@@ -4123,7 +4179,10 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::TopUpInsurance { amount: 33 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 33,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -4379,6 +4438,7 @@ fn top_up_backing_bucket_to_market(
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain,
+            market_id: first_generation_market_id(domain / 2),
             amount,
             expiry_slot,
         },
@@ -4617,7 +4677,10 @@ fn v16_bpf_failed_insurance_topup_transfer_rolls_back_budget_and_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 100,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -4670,6 +4733,7 @@ fn v16_bpf_failed_domain_insurance_topup_transfer_rolls_back_budget_and_ledger()
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 100,
         },
         vec![
@@ -4726,6 +4790,7 @@ fn v16_bpf_failed_backing_topup_transfer_rolls_back_bucket_and_ledger() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 100,
             expiry_slot: 10,
         },
@@ -6785,6 +6850,7 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
     let insurance_topup = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 2,
+            market_id: first_generation_market_id((2) / 2),
             amount: 77,
         },
         vec![
@@ -6813,6 +6879,7 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
     let backing_topup = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 2,
+            market_id: first_generation_market_id((2) / 2),
             amount: 88,
             expiry_slot: 10,
         },
@@ -23799,6 +23866,7 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 100,
             expiry_slot: 10,
         },
@@ -24162,6 +24230,7 @@ fn v16_attack_insurance_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 100,
         },
         vec![
@@ -24428,7 +24497,10 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24459,6 +24531,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 30,
         },
         vec![
@@ -24491,6 +24564,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 40,
             expiry_slot: 10,
         },
@@ -24522,7 +24596,10 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24555,6 +24632,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 30,
         },
         vec![
@@ -24587,6 +24665,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 40,
             expiry_slot: 10,
         },
@@ -24717,7 +24796,10 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 100,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24853,7 +24935,10 @@ fn v16_attack_terminal_withdraw_insurance_rejects_portfolio_as_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 100,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -25222,7 +25307,10 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_insurance_source = env.token_account(admin.pubkey(), 25);
     env.svm.expire_blockhash();
     let top_up_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -25249,6 +25337,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_domain = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 20,
         },
         vec![
@@ -25277,6 +25366,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 30,
             expiry_slot: 10,
         },
@@ -25439,7 +25529,10 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_insurance_source = env.token_account(admin.pubkey(), 25);
     env.svm.expire_blockhash();
     let top_up_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -25462,6 +25555,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_domain = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 20,
         },
         vec![
@@ -25486,6 +25580,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 30,
             expiry_slot: 10,
         },
@@ -25707,13 +25802,17 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
 
     reject_alias(
         &mut env,
-        ProgInstruction::TopUpInsurance { amount: 500 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 500,
+        },
         "TopUpInsurance",
     );
     reject_alias(
         &mut env,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 500,
         },
         "TopUpInsuranceDomain",
@@ -25723,6 +25822,7 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
         &mut env,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 500,
             expiry_slot,
         },
@@ -26033,7 +26133,10 @@ fn v16_attack_insurance_topup_pinned_to_canonical_vault() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 500 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 500,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -26099,6 +26202,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 500,
         },
         vec![
@@ -26141,6 +26245,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 700,
             expiry_slot: 10_000,
         },
@@ -26208,6 +26313,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: BAD_DOMAIN,
+            market_id: first_generation_market_id((BAD_DOMAIN) / 2),
             amount: 123,
         },
         vec![
@@ -26238,6 +26344,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: BAD_DOMAIN,
+            market_id: first_generation_market_id((BAD_DOMAIN) / 2),
             amount: 456,
             expiry_slot: 10_000,
         },
@@ -29803,6 +29910,7 @@ fn v16_attack_topup_insurance_domain_authority_gated() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 500,
         },
         vec![
@@ -32687,6 +32795,7 @@ fn v16_attack_topup_backing_bucket_authority_gated() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 500,
             expiry_slot: 10_000,
         },
@@ -32852,6 +32961,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_earnings
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 2,
+            market_id: first_generation_market_id((2) / 2),
             amount: 300,
             expiry_slot: 10_000,
         },
@@ -34444,7 +34554,10 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
 
         env.svm.expire_blockhash();
         let result = env.send(
-            ProgInstruction::TopUpInsurance { amount: 2 },
+            ProgInstruction::TopUpInsurance {
+                market_id: first_generation_market_id(0),
+                amount: 2,
+            },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -34492,6 +34605,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         let result = env.send(
             ProgInstruction::TopUpInsuranceDomain {
                 domain: 0,
+                market_id: first_generation_market_id((0) / 2),
                 amount: 2,
             },
             vec![
@@ -34518,6 +34632,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         env.send(
             ProgInstruction::TopUpInsuranceDomain {
                 domain: 0,
+                market_id: first_generation_market_id((0) / 2),
                 amount: 1,
             },
             vec![
@@ -34557,6 +34672,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         let result = env.send(
             ProgInstruction::TopUpBackingBucket {
                 domain: 1,
+                market_id: first_generation_market_id((1) / 2),
                 amount: 2,
                 expiry_slot: 10_000,
             },
@@ -36211,6 +36327,7 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
             &env.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain: 0,
+                market_id: first_generation_market_id((0) / 2),
                 amount,
                 expiry_slot: expiry,
             },
@@ -56229,7 +56346,10 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
 
     env.svm.expire_blockhash();
     let stale_global_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 20 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 20,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -56248,6 +56368,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let stale_insurance = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 25,
         },
         vec![
@@ -56268,6 +56389,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let stale_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 30,
             expiry_slot: 100,
         },
@@ -58963,7 +59085,10 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 11 },
+        ProgInstruction::TopUpInsurance {
+            market_id: first_generation_market_id(0),
+            amount: 11,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -58993,6 +59118,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            market_id: first_generation_market_id((0) / 2),
             amount: 12,
         },
         vec![
@@ -59024,6 +59150,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id((1) / 2),
             amount: 13,
             expiry_slot: 10_000,
         },
@@ -60579,6 +60706,7 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         env.send(
             ProgInstruction::TopUpBackingBucket {
                 domain: 1,
+                market_id: first_generation_market_id((1) / 2),
                 amount: 50,
                 expiry_slot: expiry,
             },

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -39,6 +39,111 @@ const fn first_generation_market_id(asset_index: u16) -> u64 {
     asset_index as u64 + 1
 }
 
+// A collateral top-up is a signed value-transfer intent. Reusing an asset slot must invalidate an
+// intent signed for the old generation; otherwise the replacement creator can name the old signer
+// as insurance_authority, name itself as insurance_operator, replay the transfer, and withdraw the
+// victim's tokens. Every transition below uses the public wrapper and ordinary SPL accounts.
+#[test]
+fn v16_attack_insurance_topup_cannot_replay_across_asset_generation() {
+    const ASSET: u16 = 1;
+    const DOMAIN: u16 = ASSET * 2;
+    const AMOUNT: u128 = 250_000;
+
+    let mut env = V16CuEnv::new();
+    let victim = Keypair::new();
+    let old_operator = Keypair::new();
+    let attacker = Keypair::new();
+    env.ensure_signer_account(victim.pubkey());
+    env.ensure_signer_account(attacker.pubkey());
+
+    env.svm.warp_to_slot(1);
+    env.activate_asset_with_authorities(
+        ASSET,
+        1,
+        100,
+        victim.pubkey(),
+        old_operator.pubkey(),
+        victim.pubkey(),
+        victim.pubkey(),
+    );
+    let old_market_id = env.asset_market_id(ASSET);
+    let victim_source = env.token_account(victim.pubkey(), AMOUNT as u64);
+    let stale_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::TopUpInsuranceDomain {
+            domain: DOMAIN,
+            amount: AMOUNT,
+        }
+        .encode(),
+    };
+    let stale_topup = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        ASSET,
+        2,
+        0,
+    );
+    env.svm.warp_to_slot(3);
+    env.activate_asset_with_authorities(
+        ASSET,
+        3,
+        200,
+        victim.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+    );
+    let new_market_id = env.asset_market_id(ASSET);
+    assert_ne!(new_market_id, old_market_id);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let source_before = env.svm.get_account(&victim_source).unwrap();
+    let vault_before = env.token_amount(env.vault);
+    let replay = env.svm.send_transaction(stale_topup);
+    if replay.is_ok() {
+        assert_eq!(env.token_amount(victim_source), 0);
+        assert_eq!(env.token_amount(env.vault), vault_before + AMOUNT as u64);
+        assert_eq!(
+            env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+            AMOUNT
+        );
+        let (attacker_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker, ASSET, AMOUNT)
+            .expect("replacement insurance operator extracts replayed victim collateral");
+        assert_eq!(env.token_amount(attacker_dest), AMOUNT as u64);
+        assert_eq!(env.token_amount(env.vault), vault_before);
+    }
+
+    assert!(
+        replay.is_err(),
+        "stale generation-{old_market_id} top-up debited {AMOUNT} victim atoms and let the generation-{new_market_id} operator withdraw them"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale top-up must leave the replacement market unchanged"
+    );
+    assert_eq!(
+        env.svm.get_account(&victim_source).unwrap(),
+        source_before,
+        "rejected stale top-up must not debit the victim"
+    );
+}
+
 fn crank_observations(asset_index: u16) -> Vec<CrankObservationHint> {
     vec![CrankObservationHint {
         asset_index,

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -141,9 +141,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
-    kani::assume(
-        tag == 3 || tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42,
-    );
+    kani::assume(tag == 3 || tag == 4 || tag == 28 || tag == 30 || tag == 41 || tag == 42);
     let amount: u128 = kani::any();
 
     let mut data = [0u8; 17];
@@ -153,7 +151,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     match (tag, Instruction::decode(&data).unwrap()) {
         (3, Instruction::Deposit { amount: got }) => assert_eq!(got, amount),
         (4, Instruction::Withdraw { amount: got }) => assert_eq!(got, amount),
-        (9, Instruction::TopUpInsurance { amount: got }) => assert_eq!(got, amount),
         (28, Instruction::ConvertReleasedPnl { amount: got }) => assert_eq!(got, amount),
         (30, Instruction::CloseResolved { fee_rate_per_slot }) => {
             assert_eq!(fee_rate_per_slot, amount)
@@ -173,18 +170,37 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let amount: u128 = kani::any();
 
-    let mut top_up = [0u8; 19];
+    let mut base_top_up = [0u8; 25];
+    base_top_up[0] = 9;
+    base_top_up[1..9].copy_from_slice(&market_id.to_le_bytes());
+    base_top_up[9..25].copy_from_slice(&amount.to_le_bytes());
+    match Instruction::decode(&base_top_up).unwrap() {
+        Instruction::TopUpInsurance {
+            market_id: got_market_id,
+            amount: got_amount,
+        } => {
+            assert_eq!(got_market_id, market_id);
+            assert_eq!(got_amount, amount);
+        }
+        _ => unreachable!(),
+    }
+
+    let mut top_up = [0u8; 27];
     top_up[0] = 56;
     top_up[1..3].copy_from_slice(&domain.to_le_bytes());
-    top_up[3..19].copy_from_slice(&amount.to_le_bytes());
+    top_up[3..11].copy_from_slice(&market_id.to_le_bytes());
+    top_up[11..27].copy_from_slice(&amount.to_le_bytes());
     match Instruction::decode(&top_up).unwrap() {
         Instruction::TopUpInsuranceDomain {
             domain: got_domain,
+            market_id: got_market_id,
             amount: got_amount,
         } => {
             assert_eq!(got_domain, domain);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_amount, amount);
         }
         _ => unreachable!(),
@@ -293,22 +309,26 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let amount: u128 = kani::any();
     let expiry_slot: u64 = kani::any();
 
-    let mut data = [0u8; 27];
+    let mut data = [0u8; 35];
     data[0] = 24;
     data[1..3].copy_from_slice(&domain.to_le_bytes());
-    data[3..19].copy_from_slice(&amount.to_le_bytes());
-    data[19..27].copy_from_slice(&expiry_slot.to_le_bytes());
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11..27].copy_from_slice(&amount.to_le_bytes());
+    data[27..35].copy_from_slice(&expiry_slot.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TopUpBackingBucket {
             domain: got_domain,
+            market_id: got_market_id,
             amount: got_amount,
             expiry_slot: got_expiry,
         } => {
             assert_eq!(got_domain, domain);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_amount, amount);
             assert_eq!(got_expiry, expiry_slot);
         }
@@ -671,6 +691,20 @@ fn kani_v16_legacy_unbound_authority_payloads_are_rejected() {
 
     assert!(Instruction::decode(&legacy_market).is_err());
     assert!(Instruction::decode(&legacy_asset).is_err());
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_collateral_topup_payloads_are_rejected() {
+    let mut base_insurance: [u8; 17] = kani::any();
+    base_insurance[0] = 9;
+    let mut domain_insurance: [u8; 19] = kani::any();
+    domain_insurance[0] = 56;
+    let mut backing_bucket: [u8; 27] = kani::any();
+    backing_bucket[0] = 24;
+
+    assert!(Instruction::decode(&base_insurance).is_err());
+    assert!(Instruction::decode(&domain_insurance).is_err());
+    assert!(Instruction::decode(&backing_bucket).is_err());
 }
 
 #[kani::proof]
@@ -1161,10 +1195,17 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(Instruction::InitPortfolio, extra);
     assert_rejects_trailing_byte(Instruction::Deposit { amount: 1 }, extra);
     assert_rejects_trailing_byte(Instruction::Withdraw { amount: 1 }, extra);
-    assert_rejects_trailing_byte(Instruction::TopUpInsurance { amount: 1 }, extra);
+    assert_rejects_trailing_byte(
+        Instruction::TopUpInsurance {
+            market_id: 1,
+            amount: 1,
+        },
+        extra,
+    );
     assert_rejects_trailing_byte(
         Instruction::TopUpBackingBucket {
             domain: 1,
+            market_id: 1,
             amount: 1,
             expiry_slot: 10,
         },


### PR DESCRIPTION
## Summary

- add the current asset `market_id` to `TopUpInsurance`, `TopUpInsuranceDomain`, and `TopUpBackingBucket`
- reject a signed collateral contribution when its generation does not match the live asset slot
- prove the new wire fields round-trip and reject every legacy generation-unbound top-up payload

## Impact

This closes a public stale-signature loss-of-funds path. A victim could sign an insurance contribution for one asset generation without submitting it. After a compromised market authority retired the empty asset and activated a replacement in the same slot, it could retain the victim as `insurance_authority`, assign itself as `insurance_operator`, replay the victim's old transaction, and withdraw the credited collateral.

The LiteSVM reproduction uses only public wrapper instructions, normal market/asset initialization, and ordinary SPL token accounts. On the vulnerable parent it debits 250,000 atoms from the victim and lets the replacement operator withdraw all 250,000 atoms.

## Root cause

Collateral contribution instructions authenticated the signer and logical domain, but the signed payload did not identify the asset incarnation. Slot reuse therefore changed the beneficiary and withdrawal authority without invalidating retained signatures.

This PR is intentionally based on #231 because that PR supplies the persistent monotonic generation source required to keep the binding sound across full market-account recreation.

## TDD evidence

- RED: `c8d1f8aa` on exact parent `4c5753f0` reproduces the 250,000-atom victim loss.
- GREEN: `1517bfe2` rejects the identical retained transaction with `AssetGenerationMismatch`, preserves the victim source and market byte-for-byte, and accepts a current-generation positive control.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets` (5 library + 569 LiteSVM/CU tests passed)
- `cargo kani --tests --exact --harness kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields`
- `cargo kani --tests --exact --harness kani_v16_top_up_backing_bucket_decode_preserves_wire_fields`
- `cargo kani --tests --exact --harness kani_v16_legacy_unbound_collateral_topup_payloads_are_rejected`
- `cargo fmt --all -- --check`
- `git diff --check`
