### PR TITLE
[BLOCKER LoF] Price pending EWMA overrides at target notional

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -11624,7 +11624,11 @@ pub mod processor {
         let effective_price = asset.effective_price.get();
         let trade_notional = trade_fee_notional_ceil(size_q_abs, accepted_exec_price)?;
         let max_side_oi_q = core::cmp::max(asset.oi_eff_long_q.get(), asset.oi_eff_short_q.get());
-        let max_side_notional = risk_notional_ceil(max_side_oi_q, effective_price)?;
+        // The trade moves the stored target, so value existing OI at the larger of that target
+        // and the lagging engine price. Otherwise a wash trade can cheaply overwrite an honest
+        // rebound while the circuit breaker still holds effective_price near the prior low.
+        let externality_price = core::cmp::max(effective_price, profile.mark_ewma_e6);
+        let max_side_notional = risk_notional_ceil(max_side_oi_q, externality_price)?;
         let mark_externality_notional = core::cmp::max(max_side_notional, trade_notional)
             .checked_mul(2)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,259 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Public regression: a legitimate EWMA round trip can leave the authenticated target far above
+// the bounded engine effective price. A public wash trade must not be able to buy down that pending
+// target for less than the PnL it removes from unrelated open interest.
+#[test]
+fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
+    #[derive(Debug)]
+    struct Outcome {
+        attacker_withdrawn: u128,
+        victim_withdrawn: u128,
+        movement_fee: u128,
+        low_price: u64,
+        final_price: u64,
+    }
+
+    fn run(path: NoCpiReportedPricePath, with_wash: bool) -> Outcome {
+        const BASIS: u64 = 10_000_000;
+        const DIRECTIONAL_Q: i128 = 1_000 * POS_SCALE as i128;
+        const WASH_Q: i128 = 100 * POS_SCALE as i128;
+        const DIRECTIONAL_DEPOSIT: u128 = 20_000_000_000;
+        const WASH_DEPOSIT: u128 = 2_000_000_000;
+
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            initial_price: BASIS,
+            max_trading_fee_bps: 10_000,
+            max_price_move_bps_per_slot: 5_000,
+            ..V16CuMarketParams::default()
+        });
+        env.svm.warp_to_slot(1);
+        env.configure_ewma_mark_with_cu(1, BASIS, 1, 0);
+
+        let admin = env.admin.insecure_clone();
+        let honest_oracle = Keypair::new();
+        env.try_update_per_asset_authority_with_cu(
+            &admin,
+            Some(&honest_oracle),
+            0,
+            processor::ASSET_AUTH_ORACLE,
+            honest_oracle.pubkey().to_bytes(),
+        )
+        .expect("separate honest EWMA authority from the attacker");
+
+        let victim = Keypair::new();
+        let victim_portfolio = env.create_portfolio(&victim);
+        let attacker = Keypair::new();
+        let attacker_portfolio = env.create_portfolio(&attacker);
+        env.deposit(&victim, victim_portfolio, DIRECTIONAL_DEPOSIT);
+        env.deposit(&attacker, attacker_portfolio, DIRECTIONAL_DEPOSIT);
+        env.trade_with_cu(
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+            DIRECTIONAL_Q,
+            BASIS,
+            0,
+        );
+
+        let (wash_long, wash_long_portfolio, wash_short, wash_short_portfolio) =
+            funded_no_cpi_reported_price_pair(&mut env, WASH_DEPOSIT);
+
+        let push = |env: &mut V16CuEnv, slot: u64, mark_e6: u64| {
+            env.svm.expire_blockhash();
+            env.send(
+                ProgInstruction::PushEwmaMark {
+                    asset_index: 0,
+                    now_slot: slot,
+                    mark_e6,
+                },
+                vec![
+                    AccountMeta::new(honest_oracle.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                &[&honest_oracle],
+            )
+            .expect("honest EWMA update");
+        };
+        let crank_directional = |env: &mut V16CuEnv, slot: u64| {
+            for portfolio in [victim_portfolio, attacker_portfolio] {
+                env.svm.expire_blockhash();
+                env.crank(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: slot,
+                        observations: crank_observations(0),
+                    },
+                );
+            }
+        };
+
+        // A legitimate down move is fully published over ordinary bounded one-slot updates. Both
+        // sides remain solvent throughout the move.
+        for slot in 2..=5 {
+            env.svm.warp_to_slot(slot);
+            push(&mut env, slot, 1);
+            crank_directional(&mut env, slot);
+        }
+        let low_price = env.market_state().1.assets[0].effective_price;
+        assert!(low_price < BASIS / 5, "setup must create a large real move");
+
+        // Advance the engine clock at the low price, then let the honest oracle commit a rebound
+        // exactly to the original basis. The rebound is authenticated but still circuit-breaker
+        // pending in the engine.
+        env.svm.warp_to_slot(6);
+        crank_directional(&mut env, 6);
+        let rebound_input = BASIS
+            .checked_mul(2)
+            .unwrap()
+            .checked_sub(low_price)
+            .unwrap();
+        push(&mut env, 6, rebound_input);
+        assert_eq!(env.market_state().0.mark_ewma_e6, BASIS);
+        assert_eq!(env.market_state().1.assets[0].effective_price, low_price);
+
+        env.svm.warp_to_slot(7);
+        let insurance_before = env.market_state().1.insurance;
+        if with_wash {
+            try_no_cpi_reported_price_trade_with_cu(
+                &mut env,
+                path,
+                &wash_long,
+                wash_long_portfolio,
+                &wash_short,
+                wash_short_portfolio,
+                WASH_Q,
+                1,
+                0,
+            )
+            .unwrap_or_else(|err| panic!("{path:?}: manipulating wash open failed: {err}"));
+            try_no_cpi_reported_price_trade_with_cu(
+                &mut env,
+                path,
+                &wash_long,
+                wash_long_portfolio,
+                &wash_short,
+                wash_short_portfolio,
+                -WASH_Q,
+                low_price,
+                0,
+            )
+            .unwrap_or_else(|err| panic!("{path:?}: wash close failed: {err}"));
+        }
+        let movement_fee = env.market_state().1.insurance - insurance_before;
+        let target = env.market_state().0.mark_ewma_e6;
+        if with_wash {
+            assert!(
+                target < BASIS,
+                "the public wash must buy down the honest target"
+            );
+            assert!(movement_fee > 0, "the target move must charge a real fee");
+        } else {
+            assert_eq!(target, BASIS);
+            assert_eq!(movement_fee, 0);
+        }
+
+        // Let bounded permissionless cranks publish the remaining target, then close at that mark.
+        let mut slot = 7u64;
+        loop {
+            crank_directional(&mut env, slot);
+            if env.market_state().1.assets[0].effective_price == target {
+                break;
+            }
+            slot += 1;
+            assert!(slot < 24, "bounded target convergence must finish");
+            env.svm.warp_to_slot(slot);
+        }
+        env.trade_with_cu(
+            &victim,
+            victim_portfolio,
+            &attacker,
+            attacker_portfolio,
+            -DIRECTIONAL_Q,
+            target,
+            0,
+        );
+
+        env.resolve();
+        let victim_dest = env.close_resolved(&victim, victim_portfolio);
+        let attacker_dest = env.close_resolved(&attacker, attacker_portfolio);
+        let wash_long_dest = env.close_resolved(&wash_long, wash_long_portfolio);
+        let wash_short_dest = env.close_resolved(&wash_short, wash_short_portfolio);
+        for (owner, portfolio, dest) in [
+            (victim.pubkey(), victim_portfolio, victim_dest),
+            (attacker.pubkey(), attacker_portfolio, attacker_dest),
+            (wash_long.pubkey(), wash_long_portfolio, wash_long_dest),
+            (wash_short.pubkey(), wash_short_portfolio, wash_short_dest),
+        ] {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::ClaimResolvedPayoutTopup,
+                vec![
+                    AccountMeta::new_readonly(owner, false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                    AccountMeta::new(dest, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                &[],
+            );
+        }
+        let attacker_withdrawn = env.token_amount(attacker_dest) as u128
+            + env.token_amount(wash_long_dest) as u128
+            + env.token_amount(wash_short_dest) as u128;
+        let victim_withdrawn = env.token_amount(victim_dest) as u128;
+        Outcome {
+            attacker_withdrawn,
+            victim_withdrawn,
+            movement_fee,
+            low_price,
+            final_price: target,
+        }
+    }
+
+    const ATTACKER_DEPOSITS: u128 = 24_000_000_000;
+    const VICTIM_DEPOSIT: u128 = 20_000_000_000;
+    let mut outcomes = Vec::new();
+    for path in [
+        NoCpiReportedPricePath::Single,
+        NoCpiReportedPricePath::Batch,
+    ] {
+        let control = run(path, false);
+        let attack = run(path, true);
+        eprintln!("{path:?} pending-EWMA override control={control:?} attack={attack:?}");
+        outcomes.push((path, control, attack));
+    }
+    for (path, control, attack) in outcomes {
+        assert_eq!(attack.low_price, control.low_price);
+        assert!(attack.final_price < control.final_price);
+        assert!(
+            attack.attacker_withdrawn <= ATTACKER_DEPOSITS,
+            "{path:?}: a public mark override yielded net withdrawable attacker profit: deposits={ATTACKER_DEPOSITS}, withdrawn={}, movement_fee={}",
+            attack.attacker_withdrawn,
+            attack.movement_fee,
+        );
+        assert!(
+            attack.victim_withdrawn < VICTIM_DEPOSIT,
+            "{path:?}: the independent long must fund a non-vacuous mark displacement"
+        );
+        let displaced_victim_pnl = control
+            .victim_withdrawn
+            .checked_sub(attack.victim_withdrawn)
+            .expect("the wash moves value away from the victim");
+        assert!(
+            displaced_victim_pnl > 0,
+            "{path:?}: the mark override must be non-vacuous"
+        );
+        assert!(
+            attack.movement_fee >= displaced_victim_pnl,
+            "{path:?}: movement fee {} failed to cover {} of displaced independent-victim PnL",
+            attack.movement_fee,
+            displaced_victim_pnl,
+        );
+    }
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59723,6 +59723,14 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 // target for less than the PnL it removes from unrelated open interest.
 #[test]
 fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
+    #[derive(Clone, Copy, Debug)]
+    enum PendingTargetTradePath {
+        TradeNoCpi,
+        BatchTradeNoCpi,
+        TradeCpi,
+        BatchTradeCpi,
+    }
+
     #[derive(Debug)]
     struct Outcome {
         attacker_withdrawn: u128,
@@ -59732,7 +59740,7 @@ fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
         final_price: u64,
     }
 
-    fn run(path: NoCpiReportedPricePath, with_wash: bool) -> Outcome {
+    fn run(path: PendingTargetTradePath, with_wash: bool) -> Outcome {
         const BASIS: u64 = 10_000_000;
         const DIRECTIONAL_Q: i128 = 1_000 * POS_SCALE as i128;
         const WASH_Q: i128 = 100 * POS_SCALE as i128;
@@ -59777,6 +59785,84 @@ fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
 
         let (wash_long, wash_long_portfolio, wash_short, wash_short_portfolio) =
             funded_no_cpi_reported_price_pair(&mut env, WASH_DEPOSIT);
+        let matcher = match path {
+            PendingTargetTradePath::TradeCpi | PendingTargetTradePath::BatchTradeCpi => Some(
+                auth_matcher_for_lp_via_system_create(&mut env, &wash_short, wash_short_portfolio),
+            ),
+            PendingTargetTradePath::TradeNoCpi | PendingTargetTradePath::BatchTradeNoCpi => None,
+        };
+
+        let trade_wash = |env: &mut V16CuEnv, size_q: i128, exec_price: u64| {
+            env.svm.expire_blockhash();
+            match path {
+                PendingTargetTradePath::TradeNoCpi => env.try_trade_asset_with_cu(
+                    0,
+                    &wash_long,
+                    wash_long_portfolio,
+                    &wash_short,
+                    wash_short_portfolio,
+                    size_q,
+                    exec_price,
+                    0,
+                ),
+                PendingTargetTradePath::BatchTradeNoCpi => env.send(
+                    ProgInstruction::BatchTradeNoCpi {
+                        legs: vec![BatchTradeLeg {
+                            asset_index: 0,
+                            size_q,
+                            exec_price,
+                            fee_bps: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(wash_long.pubkey(), true),
+                        AccountMeta::new(wash_short.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(wash_long_portfolio, false),
+                        AccountMeta::new(wash_short_portfolio, false),
+                    ],
+                    &[&wash_long, &wash_short],
+                ),
+                PendingTargetTradePath::TradeCpi => {
+                    let (matcher_program, ctx, delegate) = matcher.unwrap();
+                    env.try_trade_cpi_with_cu_on_asset(
+                        &wash_long,
+                        wash_long_portfolio,
+                        &wash_short,
+                        wash_short_portfolio,
+                        matcher_program,
+                        ctx,
+                        delegate,
+                        0,
+                        size_q,
+                        0,
+                    )
+                }
+                PendingTargetTradePath::BatchTradeCpi => {
+                    let (matcher_program, ctx, delegate) = matcher.unwrap();
+                    env.send(
+                        ProgInstruction::BatchTradeCpi {
+                            legs: vec![BatchTradeCpiLeg {
+                                asset_index: 0,
+                                size_q,
+                                fee_bps: 0,
+                                limit_price: 0,
+                            }],
+                        },
+                        vec![
+                            AccountMeta::new(wash_long.pubkey(), true),
+                            AccountMeta::new(env.market, false),
+                            AccountMeta::new(wash_long_portfolio, false),
+                            AccountMeta::new(wash_short_portfolio, false),
+                            AccountMeta::new_readonly(matcher_program, false),
+                            AccountMeta::new(ctx, false),
+                            AccountMeta::new_readonly(delegate, false),
+                        ],
+                        &[&wash_long],
+                    )
+                }
+            }
+        };
 
         let push = |env: &mut V16CuEnv, slot: u64, mark_e6: u64| {
             env.svm.expire_blockhash();
@@ -59834,30 +59920,10 @@ fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
         env.svm.warp_to_slot(7);
         let insurance_before = env.market_state().1.insurance;
         if with_wash {
-            try_no_cpi_reported_price_trade_with_cu(
-                &mut env,
-                path,
-                &wash_long,
-                wash_long_portfolio,
-                &wash_short,
-                wash_short_portfolio,
-                WASH_Q,
-                1,
-                0,
-            )
-            .unwrap_or_else(|err| panic!("{path:?}: manipulating wash open failed: {err}"));
-            try_no_cpi_reported_price_trade_with_cu(
-                &mut env,
-                path,
-                &wash_long,
-                wash_long_portfolio,
-                &wash_short,
-                wash_short_portfolio,
-                -WASH_Q,
-                low_price,
-                0,
-            )
-            .unwrap_or_else(|err| panic!("{path:?}: wash close failed: {err}"));
+            trade_wash(&mut env, WASH_Q, 1)
+                .unwrap_or_else(|err| panic!("{path:?}: manipulating wash open failed: {err}"));
+            trade_wash(&mut env, -WASH_Q, low_price)
+                .unwrap_or_else(|err| panic!("{path:?}: wash close failed: {err}"));
         }
         let movement_fee = env.market_state().1.insurance - insurance_before;
         let target = env.market_state().0.mark_ewma_e6;
@@ -59936,8 +60002,10 @@ fn v16_attack_trade_cannot_underpay_to_override_pending_ewma_target() {
     const VICTIM_DEPOSIT: u128 = 20_000_000_000;
     let mut outcomes = Vec::new();
     for path in [
-        NoCpiReportedPricePath::Single,
-        NoCpiReportedPricePath::Batch,
+        PendingTargetTradePath::TradeNoCpi,
+        PendingTargetTradePath::BatchTradeNoCpi,
+        PendingTargetTradePath::TradeCpi,
+        PendingTargetTradePath::BatchTradeCpi,
     ] {
         let control = run(path, false);
         let attack = run(path, true);


### PR DESCRIPTION
## Impact

A public trader could cheaply overwrite a legitimate pending EWMA rebound while the engine circuit-bounded effective price still lagged far below the stored target. The attacker could then realize the displaced PnL against independent open interest.

The exact-parent LiteSVM regression uses only normal public instructions, ordinary SPL accounts, a separate honest oracle authority, and the repository authorized echo matcher. It reproduces through all four trade routes.

On `TradeNoCpi` and one-leg `BatchTradeNoCpi`:

- attacker coalition deposits: `24,000,000,000`
- attacker coalition withdraws: `24,437,499,800`
- independent victim deposits: `20,000,000,000`
- independent victim withdraws: `19,500,000,000`
- movement fee paid: `62,500,200`

On `TradeCpi` and one-leg `BatchTradeCpi`, the normal matcher echoes the lagging engine effective price:

- attacker coalition withdraws: `24,874,999,800`
- independent victim withdraws: `19,000,000,000`
- movement fee paid: `125,000,200`

That is up to `874,999,800` net attacker profit and `1,000,000,000` independent-victim loss without a hostile matcher.

## Root Cause

The wrapper computed EWMA movement fees from existing OI valued at `asset.effective_price`. The movement itself changes `profile.mark_ewma_e6`. When an honest target rebound was pending, the lagging effective price understated the value affected by overwriting that target.

## Fix

Value existing OI at `max(asset.effective_price, profile.mark_ewma_e6)` when deriving the mark externality notional. Existing collected-fee logic then clamps the internal target move without rejecting the trade.

After the fix, all four public routes remain executable. The no-CPI coalition withdraws `23,968,999,800`, losing `31,000,200`; its `62,000,200` collected fee covers `31,000,000` displaced victim PnL. The CPI coalition withdraws `23,937,999,800`, losing `62,000,200`; its `124,000,200` fee covers `62,000,000` displaced victim PnL.

The original test-only commit `11d11c27` is red on its exact parent. Commit `6c302f3e` extends the same exact-parent reproduction through the normal CPI matcher; both CPI routes are red there and green at the fixed head. The attack also remains red when composed with wrapper PR #260 and engine PR #138, so it is not duplicate pending coverage.

## Verification

- `cargo build-sbf --tools-version v1.52`
- built `tests/fixtures/auth_matcher` and `tests/fixtures/hostile_matcher`
- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 LiteSVM/CU tests pass before the CPI route extension
- focused four-route LiteSVM economic regression passes after the extension
- `cargo kani --tests --harness kani_v16_fee_supported_mark_clamp_is_directional_and_zero_support_is_noop`
- `cargo kani --tests --harness kani_v16_collected_base_fee_cannot_fund_mark_movement`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo kani --tests` was also attempted, but the pre-existing unconstrained `kani_v16_unknown_or_truncated_tags_reject` decoder harness remained in CBMC symbolic execution after 15 minutes and was stopped. The two pricing/fee harnesses relevant to this change verify successfully.