### PR TITLE
[BLOCKER LoF] Route negative batch fees to the correct insurance side

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6136,8 +6136,8 @@ pub mod processor {
             let mut remaining_fee_a = outcome.fee_a;
             let mut remaining_fee_b = outcome.fee_b;
             let mut cfg_dirty = false;
-            for (asset_index, oracle_profile, fee_basis_price, fee_quote, abs_size) in
-                leg_ctx.iter_mut()
+            for ((asset_index, oracle_profile, fee_basis_price, fee_quote, abs_size), request) in
+                leg_ctx.iter_mut().zip(requests.iter())
             {
                 let requested_fee_leg =
                     batch_leg_fee(*abs_size, *fee_basis_price, fee_quote.fee_bps)?;
@@ -6149,12 +6149,17 @@ pub mod processor {
                 remaining_fee_b = remaining_fee_b
                     .checked_sub(fee_b)
                     .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                let (fee_long, fee_short) = if request.size_q > 0 {
+                    (fee_a, fee_b)
+                } else {
+                    (fee_b, fee_a)
+                };
                 credit_trade_fees_to_market_budgets_view(
                     &cfg,
                     &mut group,
                     *asset_index,
-                    fee_a,
-                    fee_b,
+                    fee_long,
+                    fee_short,
                 )?;
                 let collected_post_trade_mark =
                     collected_fee_supported_mark_view(oracle_profile, *fee_quote, fee_a, fee_b)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59827,3 +59827,178 @@ fn v16_attack_resolved_adl_winner_can_wind_down_publicly() {
     assert_eq!(terminal.vault, 0);
     assert_eq!(env.token_amount(env.vault), 0);
 }
+
+fn run_negative_fee_domain_terminal_case(path: NoCpiReportedPricePath) -> (u128, u128, u128, u128) {
+    const MARK: u64 = 1_000_000;
+    const FEE: u128 = MARK as u128;
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: MARK,
+        maintenance_fee_per_slot: FEE - 1,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_auth_mark_with_cu(0, MARK);
+    env.update_maintenance_fee_policy_with_cu(10_000);
+
+    let oracle = Keypair::new();
+    env.ensure_signer_account(oracle.pubkey());
+    let admin = env.admin.insecure_clone();
+    env.send(
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: 0,
+            kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
+            new_pubkey: oracle.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin, &oracle],
+    )
+    .expect("separate honest oracle authority");
+
+    let low_owner = Keypair::new();
+    let low = env.create_portfolio(&low_owner);
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let reward_owner = Keypair::new();
+    let reward = env.create_portfolio(&reward_owner);
+    env.deposit(&low_owner, low, FEE);
+    env.deposit(&victim_owner, victim, 2 * FEE);
+    env.trade_asset_with_cu(
+        0,
+        &low_owner,
+        low,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.send(
+        ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 1,
+            mark_e6: MARK,
+        },
+        vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&oracle],
+    )
+    .expect("honest unchanged mark");
+    for p in [low, victim] {
+        for _ in 0..2 {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(p, false),
+                ],
+                &[],
+            );
+        }
+    }
+    env.sync_maintenance_fee_with_cu(low, Some(reward), 1);
+    assert_eq!(env.portfolio_state(low).capital.get(), 1);
+    assert_eq!(env.portfolio_state(reward).capital.get(), FEE - 1);
+
+    env.svm.expire_blockhash();
+    try_no_cpi_reported_price_trade_with_cu(
+        &mut env,
+        path,
+        &low_owner,
+        low,
+        &victim_owner,
+        victim,
+        -(POS_SCALE as i128),
+        MARK,
+        10_000,
+    )
+    .unwrap_or_else(|err| panic!("{path:?} risk-reducing fee trade: {err}"));
+    let (_, after_fee) = env.market_state();
+    let long_budget = after_fee.insurance_domain_budget[0];
+    let short_budget = after_fee.insurance_domain_budget[1];
+    assert_eq!(env.portfolio_state(low).capital.get(), 0);
+    assert_eq!(env.portfolio_state(victim).capital.get(), FEE);
+
+    let reward_dest = env.withdraw(&reward_owner, reward, FEE - 1);
+    assert_eq!(env.token_amount(reward_dest) as u128, FEE - 1);
+    env.close_portfolio_with_cu(&reward_owner, reward);
+    env.close_portfolio_with_cu(&low_owner, low);
+
+    let bankrupt_owner = Keypair::new();
+    let bankrupt = env.create_portfolio(&bankrupt_owner);
+    env.deposit(&bankrupt_owner, bankrupt, FEE);
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &bankrupt_owner,
+        bankrupt,
+        POS_SCALE as i128,
+        MARK,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.send(
+        ProgInstruction::PushAuthMark {
+            asset_index: 0,
+            now_slot: 2,
+            mark_e6: 3 * MARK,
+        },
+        vec![
+            AccountMeta::new(oracle.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&oracle],
+    )
+    .expect("honest adverse mark");
+    for slot in [2u64, 3] {
+        env.svm.warp_to_slot(slot);
+        for _ in 0..3 {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                &[],
+            );
+        }
+    }
+    assert_eq!(env.market_state().1.assets[0].effective_price, 3 * MARK);
+    env.resolve();
+
+    let mut victim_payout = 0u128;
+    for _ in 0..4 {
+        let loser_dest = env.close_resolved(&bankrupt_owner, bankrupt);
+        assert_eq!(env.token_amount(loser_dest), 0);
+        let winner_dest = env.close_resolved(&victim_owner, victim);
+        victim_payout += env.token_amount(winner_dest) as u128;
+    }
+    let (_, terminal) = env.market_state();
+    (victim_payout, terminal.insurance, long_budget, short_budget)
+}
+
+#[test]
+fn probe_negative_batch_fee_domain_can_harm_long_winner() {
+    let single = run_negative_fee_domain_terminal_case(NoCpiReportedPricePath::Single);
+    let batch = run_negative_fee_domain_terminal_case(NoCpiReportedPricePath::Batch);
+    println!("single={single:?} batch={batch:?}");
+    assert_eq!(batch, single);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59995,10 +59995,21 @@ fn run_negative_fee_domain_terminal_case(path: NoCpiReportedPricePath) -> (u128,
     (victim_payout, terminal.insurance, long_budget, short_budget)
 }
 
+// Public LoF regression: batch fee aggregates are keyed by account A/B, while insurance is keyed by
+// long/short side. On a negative leg A is the short, so crediting fee_a to the long domain strands an
+// honest long winner without the fee-funded backstop. The single and batch routes execute identical
+// trades under a separate honest oracle and must produce identical terminal payouts and budgets.
 #[test]
-fn probe_negative_batch_fee_domain_can_harm_long_winner() {
+fn v16_attack_negative_batch_fee_cannot_deprive_long_winner() {
     let single = run_negative_fee_domain_terminal_case(NoCpiReportedPricePath::Single);
     let batch = run_negative_fee_domain_terminal_case(NoCpiReportedPricePath::Batch);
-    println!("single={single:?} batch={batch:?}");
-    assert_eq!(batch, single);
+    assert_eq!(single.0, 1_000_000, "control winner recovers its capital");
+    assert!(
+        single.2 > single.3,
+        "the asymmetric fee must fund the long-winner domain"
+    );
+    assert_eq!(
+        batch, single,
+        "signed batch routing must match single-trade payout and domain accounting"
+    );
 }


### PR DESCRIPTION
## What changed

- Route collected `BatchTradeNoCpi` fees by the signed leg's long/short orientation before crediting per-side insurance budgets.
- Add a public LiteSVM regression that compares identical negative single and batch trades through terminal settlement.

## Root cause and impact

The engine's batch outcome reports `fee_a` and `fee_b` by logical account identity. The wrapper treated those fields as `fee_long` and `fee_short`. For a negative leg, account A is the short side and account B is the long side, so the wrapper credited both fees to the opposite insurance domains.

On the exact pre-fix parent, the public regression produces:

- single route: victim payout 1,000,000; long/short budgets 1,000,000 / 1
- batch route: victim payout 0; long/short budgets 1 / 1,000,000

The sequence uses a normally initialized live market, public instructions only, and a separate honest oracle. The independent long winner loses its entire 1,000,000 capital because the batch route put the collected backstop in the wrong side.

## Stack

This PR targets `codex/fix-resolved-adl-winner-close` and is intentionally stacked on #216. That engine pin is required for the terminal winner to exercise its public resolved-close path; this PR's own diff is two commits and only changes signed batch fee routing plus its regression.

## Verification

- `cargo build-sbf --no-default-features`
- rebuilt all three matcher SBF fixtures
- `cargo test --all-targets`: 567/567 LiteSVM/CU tests pass
- targeted regression passes on fixed head
- `cargo kani --tests`: full run in progress; draft will be updated with the final result
