### PR TITLE
[HARDENING LoF] Bind retained portfolio authority to incarnation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   together with its starting counters and require the same tuple before crystallization or claim;
   counter deltas must use checked subtraction. Closing and recreating the same portfolio pubkey gets
   a different ID, so a stale snapshot cannot authenticate the replacement account. IDs are local to
-  one market, so `portfolio_id` alone is not an identity. **✅**
-  (`v16_portfolio_incarnation_id_separates_close_and_reuse`.)
+  one market, so `portfolio_id` alone is not an identity.
+  Signed portfolio-scoped authority is bound the same way: no-CPI trades carry both current
+  portfolio IDs, matcher-CPI trades carry the taker's current ID, and `SetMatcherConfig` carries
+  the LP's current ID. Retained instructions from a closed account therefore cannot create risk or
+  matcher authority in its replacement incarnation. **✅**
+  (`v16_portfolio_incarnation_id_separates_close_and_reuse`,
+  `v16_attack_trade_replay_cannot_cross_portfolio_incarnation`,
+  `v16_trade_routes_reject_stale_portfolio_incarnation_in_every_signed_role`.)
 
 ### Governance & admin keys
 - **Per-asset admin keys, isolated — uniform across all assets including asset 0** — one asset's admin
@@ -434,22 +440,25 @@ This section describes intent and operational ordering, not argument-by-argument
 
 ### Trading
 - **TradeNoCpi**
-  - trade without external matcher (used for testing / deterministic scenarios)
+  - trade without external matcher (used for testing / deterministic scenarios); the signed
+    payload carries the current taker and LP `portfolio_id` values
 - **TradeCpi**
   - trade via LP-chosen matcher CPI with strict binding + validation. The LP portfolio must already
-    store an enabled matcher config for the passed matcher program/context/delegate tuple.
+    store an enabled matcher config for the passed matcher program/context/delegate tuple; the
+    signed payload carries the current taker `portfolio_id`
 - **BatchTradeNoCpi** (tag 66)
   - atomic multi-leg batch (up to the portfolio asset cap) against one taker/LP pair; each leg's
     **signed** `size_q` sets its direction, so a single batch can carry a mixed long/short spread.
     The engine settles both accounts once, applies every leg, then runs a **single end-state
     initial-margin check** — interim legs need not be individually margin-feasible. Current v1 batch
     execution rejects if any backing-domain trade-fee policy is configured, so those fees are not
-    silently skipped.
+    silently skipped. The batch payload carries the current taker and LP `portfolio_id` values.
 - **BatchTradeCpi** (tag 67)
   - same atomic multi-leg batch routed through an external matcher: **one** batched matcher CPI
     (matcher tag 3) fills every leg against a single LP, each return is validated under the same
     anti-spoof binding as `TradeCpi`, then all fills apply through the batch path. Bounded to 16
-    legs (the matcher's return-data cap).
+    legs (the matcher's return-data cap). The signed payload carries the current taker
+    `portfolio_id`.
 - **SetMatcherConfig** (tag 68)
   - LP-owner-signed opt-in/out for unsigned LP matcher fills. The payload includes the current
     `portfolio_id`; the instruction writes matcher program, matcher context, matcher delegate, and
@@ -503,7 +512,8 @@ Percolator treats a matcher like a price/size oracle **with rules** chosen by th
 
 ### What Percolator enforces (non-negotiable)
 - **Signer checks**: the taker/user signs matcher fills; `TradeNoCpi` / `BatchTradeNoCpi`
-  require both owners to sign
+  require both owners to sign. Every signed trade also commits to the current incarnation IDs of
+  the portfolio roles authorized by those signatures.
 - **LP owner identity**: matcher-routed fills read the LP owner from the LP portfolio; no LP owner
   account is supplied at fill time. Unsigned matcher-routed fills require an enabled matcher config
   set by that LP owner.
@@ -780,8 +790,9 @@ Call `TopUpInsurance` as needed.
 Run `PermissionlessCrank` continuously.
 
 ### Step 5: Enable trading
-- Use `TradeNoCpi` for local testing or deterministic environments
-- Use `TradeCpi` for production execution via matcher CPI
+- Read the participating portfolios' current `portfolio_id` values immediately before signing.
+- Use `TradeNoCpi` for local testing or deterministic environments, signing both IDs.
+- Use `TradeCpi` for production execution via matcher CPI, signing the taker's ID.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,8 @@ This makes it a "pure identity signer" and prevents it from becoming an attack s
 ### LP matcher config (TradeCpi / BatchTradeCpi)
 Unsigned LP matcher fills require an enabled matcher config stored directly on the LP portfolio.
 
-`SetMatcherConfig` (tag 68) is signed by the LP owner and writes:
+`SetMatcherConfig` (tag 68) is signed by the LP owner, carries the portfolio's current
+`portfolio_id`, and writes:
 
 `matcher_program, matcher_context, matcher_delegate, enabled`
 
@@ -360,6 +361,9 @@ During `TradeCpi` / `BatchTradeCpi`, Percolator reads this LP-account config and
 instruction's matcher program, matcher context, and matcher delegate PDA to match it byte-for-byte.
 Extra matcher CPI tail accounts begin immediately after the matcher delegate. Disabled configs,
 wrong matcher program/context/delegate, wrong LP owner, or wrong LP portfolio all reject.
+An incarnation mismatch also rejects, so an authorization retained from a closed portfolio cannot
+bind a later account at the same address. Legacy portfolios without the ID tail use ID 0 until
+they are closed; every new incarnation has a nonzero program-assigned ID.
 
 ### Matcher context (TradeCpi)
 - account owned by matcher program
@@ -447,8 +451,9 @@ This section describes intent and operational ordering, not argument-by-argument
     anti-spoof binding as `TradeCpi`, then all fills apply through the batch path. Bounded to 16
     legs (the matcher's return-data cap).
 - **SetMatcherConfig** (tag 68)
-  - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
-    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.
+  - LP-owner-signed opt-in/out for unsigned LP matcher fills. The payload includes the current
+    `portfolio_id`; the instruction writes matcher program, matcher context, matcher delegate, and
+    enabled flag only when that incarnation matches.
 
 ### Oracle / mark management
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
@@ -761,7 +766,8 @@ Call `InitMarket` with:
   - deploy or choose matcher program
   - create matcher context account owned by matcher program
   - create a portfolio with `InitPortfolio`
-  - call `SetMatcherConfig` with the LP owner signing the exact matcher program/context/delegate tuple
+  - call `SetMatcherConfig` with the LP owner signing the current `portfolio_id` and exact matcher
+    program/context/delegate tuple
   - deposit collateral with `Deposit`
 - User:
   - create a portfolio with `InitPortfolio`

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -800,6 +800,17 @@ pub mod state {
         Ok(id)
     }
 
+    /// Matcher authorization predates the portfolio-incarnation tail. Bind legacy portfolios to
+    /// generation zero; any later `InitPortfolio` writes a nonzero ID, so a retained legacy
+    /// authorization cannot cross the close/reinitialize boundary either.
+    pub fn read_portfolio_matcher_incarnation_id(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        if data.len() < PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN {
+            return Ok(0);
+        }
+        read_u64(data, PORTFOLIO_ID_OFF)
+    }
+
     #[inline]
     fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
@@ -2508,6 +2519,7 @@ pub mod ix {
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
+            portfolio_id: u64,
             enabled: u8,
         },
         ClosePortfolio,
@@ -2775,6 +2787,7 @@ pub mod ix {
                     Self::BatchTradeCpi { legs }
                 }
                 68 => Self::SetMatcherConfig {
+                    portfolio_id: read_u64(&mut rest)?,
                     enabled: read_u8(&mut rest)?,
                 },
                 8 => Self::ClosePortfolio,
@@ -3063,8 +3076,12 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    portfolio_id,
+                    enabled,
+                } => {
                     out.push(68);
+                    push_u64(&mut out, portfolio_id);
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
@@ -5255,9 +5272,10 @@ pub mod processor {
             Instruction::BatchTradeCpi { legs } => {
                 handle_batch_trade_cpi(program_id, accounts, &legs)
             }
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                portfolio_id,
+                enabled,
+            } => handle_set_matcher_config(program_id, accounts, portfolio_id, enabled),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6710,6 +6728,7 @@ pub mod processor {
     fn handle_set_matcher_config<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
         enabled: u8,
     ) -> ProgramResult {
         if enabled > 1 {
@@ -6729,6 +6748,11 @@ pub mod processor {
             || owner != lp_owner.key.to_bytes()
         {
             return Err(PercolatorError::Unauthorized.into());
+        }
+        if state::read_portfolio_matcher_incarnation_id(&lp_portfolio_ai.try_borrow_data()?)?
+            != expected_portfolio_id
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         let required_len = state::portfolio_account_len_for_market_slots(0)?;
         if lp_portfolio_ai.data_len() < required_len {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -800,10 +800,10 @@ pub mod state {
         Ok(id)
     }
 
-    /// Matcher authorization predates the portfolio-incarnation tail. Bind legacy portfolios to
+    /// Portfolio-scoped authorization predates the incarnation tail. Bind legacy portfolios to
     /// generation zero; any later `InitPortfolio` writes a nonzero ID, so a retained legacy
     /// authorization cannot cross the close/reinitialize boundary either.
-    pub fn read_portfolio_matcher_incarnation_id(data: &[u8]) -> Result<u64, ProgramError> {
+    pub fn read_portfolio_incarnation_id(data: &[u8]) -> Result<u64, ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
         if data.len() < PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN {
             return Ok(0);
@@ -2497,12 +2497,15 @@ pub mod ix {
             observations: Vec<CrankObservationHint>,
         },
         TradeNoCpi {
+            taker_portfolio_id: u64,
+            lp_portfolio_id: u64,
             asset_index: u16,
             size_q: i128,
             exec_price: u64,
             fee_bps: u64,
         },
         TradeCpi {
+            taker_portfolio_id: u64,
             asset_index: u16,
             size_q: i128,
             fee_bps: u64,
@@ -2511,11 +2514,14 @@ pub mod ix {
         /// Atomic multi-leg batch: apply every leg against one taker/LP pair with a single
         /// end-state initial-margin check (interim legs need not be individually margin-feasible).
         BatchTradeNoCpi {
+            taker_portfolio_id: u64,
+            lp_portfolio_id: u64,
             legs: Vec<BatchTradeLeg>,
         },
         /// Atomic multi-leg batch routed through an external matcher: one batched matcher CPI fills
         /// every leg against a single LP, then all fills apply with one end-state margin check.
         BatchTradeCpi {
+            taker_portfolio_id: u64,
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
@@ -2743,18 +2749,23 @@ pub mod ix {
                     }
                 }
                 6 => Self::TradeNoCpi {
+                    taker_portfolio_id: read_u64(&mut rest)?,
+                    lp_portfolio_id: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     exec_price: read_u64(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                 },
                 10 => Self::TradeCpi {
+                    taker_portfolio_id: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     size_q: read_i128(&mut rest)?,
                     fee_bps: read_u64(&mut rest)?,
                     limit_price: read_u64(&mut rest)?,
                 },
                 66 => {
+                    let taker_portfolio_id = read_u64(&mut rest)?;
+                    let lp_portfolio_id = read_u64(&mut rest)?;
                     let n = read_u8(&mut rest)? as usize;
                     if n > BATCH_TRADE_DECODE_MAX_LEGS {
                         return Err(ProgramError::InvalidInstructionData);
@@ -2768,9 +2779,14 @@ pub mod ix {
                             fee_bps: read_u64(&mut rest)?,
                         });
                     }
-                    Self::BatchTradeNoCpi { legs }
+                    Self::BatchTradeNoCpi {
+                        taker_portfolio_id,
+                        lp_portfolio_id,
+                        legs,
+                    }
                 }
                 67 => {
+                    let taker_portfolio_id = read_u64(&mut rest)?;
                     let n = read_u8(&mut rest)? as usize;
                     if n > BATCH_TRADE_DECODE_MAX_LEGS {
                         return Err(ProgramError::InvalidInstructionData);
@@ -2784,7 +2800,10 @@ pub mod ix {
                             limit_price: read_u64(&mut rest)?,
                         });
                     }
-                    Self::BatchTradeCpi { legs }
+                    Self::BatchTradeCpi {
+                        taker_portfolio_id,
+                        legs,
+                    }
                 }
                 68 => Self::SetMatcherConfig {
                     portfolio_id: read_u64(&mut rest)?,
@@ -3033,31 +3052,43 @@ pub mod ix {
                     }
                 }
                 Self::TradeNoCpi {
+                    taker_portfolio_id,
+                    lp_portfolio_id,
                     asset_index,
                     size_q,
                     exec_price,
                     fee_bps,
                 } => {
                     out.push(6);
+                    push_u64(&mut out, taker_portfolio_id);
+                    push_u64(&mut out, lp_portfolio_id);
                     push_u16(&mut out, asset_index);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, exec_price);
                     push_u64(&mut out, fee_bps);
                 }
                 Self::TradeCpi {
+                    taker_portfolio_id,
                     asset_index,
                     size_q,
                     fee_bps,
                     limit_price,
                 } => {
                     out.push(10);
+                    push_u64(&mut out, taker_portfolio_id);
                     push_u16(&mut out, asset_index);
                     push_i128(&mut out, size_q);
                     push_u64(&mut out, fee_bps);
                     push_u64(&mut out, limit_price);
                 }
-                Self::BatchTradeNoCpi { ref legs } => {
+                Self::BatchTradeNoCpi {
+                    taker_portfolio_id,
+                    lp_portfolio_id,
+                    ref legs,
+                } => {
                     out.push(66);
+                    push_u64(&mut out, taker_portfolio_id);
+                    push_u64(&mut out, lp_portfolio_id);
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
@@ -3066,8 +3097,12 @@ pub mod ix {
                         push_u64(&mut out, leg.fee_bps);
                     }
                 }
-                Self::BatchTradeCpi { ref legs } => {
+                Self::BatchTradeCpi {
+                    taker_portfolio_id,
+                    ref legs,
+                } => {
                     out.push(67);
+                    push_u64(&mut out, taker_portfolio_id);
                     out.push(legs.len() as u8);
                     for leg in legs.iter() {
                         push_u16(&mut out, leg.asset_index);
@@ -5241,6 +5276,8 @@ pub mod processor {
                 observations,
             } => handle_permissionless_crank(program_id, accounts, now_slot, observations),
             Instruction::TradeNoCpi {
+                taker_portfolio_id,
+                lp_portfolio_id,
                 asset_index,
                 size_q,
                 exec_price,
@@ -5248,12 +5285,15 @@ pub mod processor {
             } => handle_trade_nocpi(
                 program_id,
                 accounts,
+                taker_portfolio_id,
+                lp_portfolio_id,
                 asset_index,
                 size_q,
                 exec_price,
                 fee_bps,
             ),
             Instruction::TradeCpi {
+                taker_portfolio_id,
                 asset_index,
                 size_q,
                 fee_bps,
@@ -5261,17 +5301,27 @@ pub mod processor {
             } => handle_trade_cpi(
                 program_id,
                 accounts,
+                taker_portfolio_id,
                 asset_index,
                 size_q,
                 fee_bps,
                 limit_price,
             ),
-            Instruction::BatchTradeNoCpi { legs } => {
-                handle_batch_trade_nocpi(program_id, accounts, &legs)
-            }
-            Instruction::BatchTradeCpi { legs } => {
-                handle_batch_trade_cpi(program_id, accounts, &legs)
-            }
+            Instruction::BatchTradeNoCpi {
+                taker_portfolio_id,
+                lp_portfolio_id,
+                legs,
+            } => handle_batch_trade_nocpi(
+                program_id,
+                accounts,
+                taker_portfolio_id,
+                lp_portfolio_id,
+                &legs,
+            ),
+            Instruction::BatchTradeCpi {
+                taker_portfolio_id,
+                legs,
+            } => handle_batch_trade_cpi(program_id, accounts, taker_portfolio_id, &legs),
             Instruction::SetMatcherConfig {
                 portfolio_id,
                 enabled,
@@ -6000,6 +6050,8 @@ pub mod processor {
     fn handle_batch_trade_nocpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_taker_portfolio_id: u64,
+        expected_lp_portfolio_id: u64,
         legs: &[ix::BatchTradeLeg],
     ) -> ProgramResult {
         let signer_a = account(accounts, 0)?;
@@ -6017,6 +6069,13 @@ pub mod processor {
         expect_owner(account_b_ai, program_id)?;
         if account_a_ai.key == account_b_ai.key {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if state::read_portfolio_incarnation_id(&account_a_ai.try_borrow_data()?)?
+            != expected_taker_portfolio_id
+            || state::read_portfolio_incarnation_id(&account_b_ai.try_borrow_data()?)?
+                != expected_lp_portfolio_id
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         for leg in legs {
             ensure_valid_reported_trade_price(leg.exec_price)?;
@@ -6220,6 +6279,8 @@ pub mod processor {
     fn handle_trade_nocpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_taker_portfolio_id: u64,
+        expected_lp_portfolio_id: u64,
         asset_index: u16,
         size_q: i128,
         exec_price: u64,
@@ -6240,6 +6301,13 @@ pub mod processor {
         expect_owner(account_b_ai, program_id)?;
         if account_a_ai.key == account_b_ai.key {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        if state::read_portfolio_incarnation_id(&account_a_ai.try_borrow_data()?)?
+            != expected_taker_portfolio_id
+            || state::read_portfolio_incarnation_id(&account_b_ai.try_borrow_data()?)?
+                != expected_lp_portfolio_id
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         ensure_valid_reported_trade_price(exec_price)?;
         let (_cfg_pre, mode_pre, max_market_slots, _) =
@@ -6541,6 +6609,7 @@ pub mod processor {
     fn handle_trade_cpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_taker_portfolio_id: u64,
         asset_index: u16,
         size_q: i128,
         fee_bps: u64,
@@ -6608,6 +6677,11 @@ pub mod processor {
         }
         if account_a_owner != signer_a.key.to_bytes() {
             return Err(PercolatorError::Unauthorized.into());
+        }
+        if state::read_portfolio_incarnation_id(&account_a_ai.try_borrow_data()?)?
+            != expected_taker_portfolio_id
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         let account_b_owner_key = Pubkey::new_from_array(account_b_owner);
         let (delegate, bump) = derive_matcher_delegate(
@@ -6749,7 +6823,7 @@ pub mod processor {
         {
             return Err(PercolatorError::Unauthorized.into());
         }
-        if state::read_portfolio_matcher_incarnation_id(&lp_portfolio_ai.try_borrow_data()?)?
+        if state::read_portfolio_incarnation_id(&lp_portfolio_ai.try_borrow_data()?)?
             != expected_portfolio_id
         {
             return Err(PercolatorError::EngineProvenanceMismatch.into());
@@ -6851,6 +6925,7 @@ pub mod processor {
     fn handle_batch_trade_cpi<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_taker_portfolio_id: u64,
         legs: &[ix::BatchTradeCpiLeg],
     ) -> ProgramResult {
         if legs.is_empty() || legs.len() > MATCHER_BATCH_MAX_LEGS {
@@ -6962,6 +7037,11 @@ pub mod processor {
         }
         if account_a_owner != signer_a.key.to_bytes() {
             return Err(PercolatorError::Unauthorized.into());
+        }
+        if state::read_portfolio_incarnation_id(&account_a_ai.try_borrow_data()?)?
+            != expected_taker_portfolio_id
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         let account_b_owner_key = Pubkey::new_from_array(account_b_owner);
         let (delegate, bump) = derive_matcher_delegate(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20552,6 +20552,175 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     );
 }
 
+// Public retained-intent regression: a matcher authorization signed for one portfolio
+// incarnation must not become valid again after that address is closed and reinitialized. The LP
+// does not sign CPI fills, so replaying the old authorization would let the matcher create fresh
+// victim exposure and extract its honest mark loss through an attacker-owned taker account.
+#[test]
+fn v16_attack_matcher_config_replay_cannot_bind_reinitialized_portfolio() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+    const INITIAL_MARK: u64 = 100;
+    const FINAL_MARK: u64 = 200;
+    const EXPECTED_PNL: u128 = 100_000;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, INITIAL_MARK);
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let old_portfolio_id = env.portfolio_id(victim);
+    let matcher_context = Pubkey::new_unique();
+    let matcher_delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &victim,
+        &victim_owner.pubkey(),
+        &matcher_program,
+        &matcher_context,
+    );
+    env.try_init_auth_matcher_context_with_delegate(
+        matcher_program,
+        &victim_owner,
+        victim,
+        matcher_context,
+        matcher_delegate,
+    )
+    .expect("initialize matcher context for the first incarnation");
+
+    // The matcher receives this fully signed transaction but withholds it until the LP account is
+    // closed and recreated. Keep the blockhash live while ordinary public lifecycle calls execute.
+    let retained_authorization = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new_readonly(env.market, false),
+                    AccountMeta::new(victim, false),
+                    AccountMeta::new_readonly(matcher_program, false),
+                    AccountMeta::new_readonly(matcher_context, false),
+                    AccountMeta::new_readonly(matcher_delegate, false),
+                ],
+                data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed address through the System Program");
+    send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![
+            heap_ix(),
+            ComputeBudgetInstruction::set_compute_unit_limit(1_399_999),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::InitPortfolio.encode(),
+            },
+        ],
+        &[&victim_owner],
+    )
+    .expect("reinitialize the same portfolio address for the same owner");
+    let replacement_portfolio_id = env.portfolio_id(victim);
+    assert_ne!(replacement_portfolio_id, old_portfolio_id);
+
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    let attacker_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+
+    let replay = env.svm.send_transaction(retained_authorization);
+    if replay.is_ok() {
+        env.trade_cpi_with_cu(
+            &attacker_owner,
+            attacker,
+            &victim_owner,
+            victim,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            SIZE_Q,
+            0,
+        );
+        env.svm.warp_to_slot(1);
+        env.push_auth_mark_with_cu(1, FINAL_MARK);
+        for portfolio in [attacker, victim] {
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.trade_cpi_with_cu(
+            &attacker_owner,
+            attacker,
+            &victim_owner,
+            victim,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            -SIZE_Q,
+            0,
+        );
+        env.convert_released_pnl_with_cu(&attacker_owner, attacker, EXPECTED_PNL);
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT + EXPECTED_PNL);
+        let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT - EXPECTED_PNL);
+        let attacker_payout = env.token_amount(attacker_dest) as u128;
+        let victim_payout = env.token_amount(victim_dest) as u128;
+        assert!(
+            attacker_payout <= DEPOSIT && victim_payout >= DEPOSIT,
+            "old portfolio {old_portfolio_id} matcher authorization replayed onto incarnation \
+             {replacement_portfolio_id}: attacker extracted {attacker_payout}, independent victim \
+             recovered only {victim_payout}"
+        );
+    } else {
+        assert_eq!(env.portfolio_matcher_config(victim).enabled, 0);
+        let unauthorized_fill = env.try_trade_cpi_with_cu_on_asset(
+            &attacker_owner,
+            attacker,
+            &victim_owner,
+            victim,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            SIZE_Q,
+            0,
+        );
+        assert!(
+            unauthorized_fill.is_err(),
+            "rejected stale authorization must leave unsigned LP fills disabled"
+        );
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT);
+        let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT);
+        assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
+        assert_eq!(env.token_amount(victim_dest) as u128, DEPOSIT);
+    }
+}
+
 #[test]
 fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -1482,6 +1483,8 @@ impl V16CuEnv {
     ) -> Result<u64, String> {
         self.send(
             ProgInstruction::TradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 asset_index,
                 size_q,
                 exec_price,
@@ -2010,7 +2013,7 @@ impl V16CuEnv {
         enabled: u8,
     ) -> Result<Pubkey, String> {
         self.svm.expire_blockhash();
-        let portfolio_id = state::read_portfolio_matcher_incarnation_id(
+        let portfolio_id = state::read_portfolio_incarnation_id(
             &self
                 .svm
                 .get_account(&maker_account)
@@ -2172,6 +2175,7 @@ impl V16CuEnv {
         ];
         self.send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index,
                 size_q,
                 fee_bps,
@@ -3632,10 +3636,48 @@ fn send_tx(
     svm: &mut LiteSVM,
     program_id: Pubkey,
     payer: &Keypair,
-    ix: ProgInstruction,
+    mut ix: ProgInstruction,
     accounts: Vec<AccountMeta>,
     extra_signers: &[&Keypair],
 ) -> Result<u64, String> {
+    // Most tests exercise current intents. Keep their call sites focused on the behavior under test
+    // while encoding the same explicit incarnation values production clients must read and sign.
+    // Tests for stale IDs set nonzero values themselves and are never rewritten here.
+    let portfolio_id_at = |index: usize| {
+        let key = accounts.get(index)?.pubkey;
+        let account = svm.get_account(&key)?;
+        state::read_portfolio_incarnation_id(&account.data).ok()
+    };
+    match &mut ix {
+        ProgInstruction::TradeNoCpi {
+            taker_portfolio_id,
+            lp_portfolio_id,
+            ..
+        }
+        | ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id,
+            lp_portfolio_id,
+            ..
+        } => {
+            if *taker_portfolio_id == 0 {
+                *taker_portfolio_id = portfolio_id_at(3).unwrap_or(0);
+            }
+            if *lp_portfolio_id == 0 {
+                *lp_portfolio_id = portfolio_id_at(4).unwrap_or(0);
+            }
+        }
+        ProgInstruction::TradeCpi {
+            taker_portfolio_id, ..
+        }
+        | ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id, ..
+        } => {
+            if *taker_portfolio_id == 0 {
+                *taker_portfolio_id = portfolio_id_at(2).unwrap_or(0);
+            }
+        }
+        _ => {}
+    }
     let instruction = Instruction {
         program_id,
         accounts,
@@ -13426,6 +13468,8 @@ fn execute_account_residual_counter_trade_path(
         AccountResidualCounterTradePath::BatchTradeNoCpi => env
             .send(
                 ProgInstruction::BatchTradeNoCpi {
+                    taker_portfolio_id: 0,
+                    lp_portfolio_id: 0,
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
                         size_q,
@@ -13448,6 +13492,7 @@ fn execute_account_residual_counter_trade_path(
                 auth_matcher_for_lp_via_system_create(env, lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    taker_portfolio_id: 0,
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
                         size_q,
@@ -13593,6 +13638,7 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
                 auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    taker_portfolio_id: 0,
                     legs: vec![
                         BatchTradeCpiLeg {
                             asset_index: 0,
@@ -13623,6 +13669,8 @@ fn v16_bpf_account_residual_reward_counter_accumulates_across_batch_legs() {
         } else {
             env.send(
                 ProgInstruction::BatchTradeNoCpi {
+                    taker_portfolio_id: 0,
+                    lp_portfolio_id: 0,
                     legs: vec![
                         BatchTradeLeg {
                             asset_index: 0,
@@ -13768,6 +13816,8 @@ fn execute_backing_residual_counter_trade_path(
         BackingResidualCounterTradePath::BatchTradeNoCpi => env
             .send(
                 ProgInstruction::BatchTradeNoCpi {
+                    taker_portfolio_id: 0,
+                    lp_portfolio_id: 0,
                     legs: vec![BatchTradeLeg {
                         asset_index: 0,
                         size_q,
@@ -13789,6 +13839,7 @@ fn execute_backing_residual_counter_trade_path(
             let (matcher_program, ctx, delegate) = auth_matcher_for_lp(env, lp_owner, lp_account);
             env.send(
                 ProgInstruction::BatchTradeCpi {
+                    taker_portfolio_id: 0,
                     legs: vec![BatchTradeCpiLeg {
                         asset_index: 0,
                         size_q,
@@ -15955,6 +16006,8 @@ fn v16_attack_account_type_confusion_rejected() {
     env.svm.expire_blockhash();
     let r2 = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -19382,6 +19435,8 @@ fn v16_attack_batch_subatom_fee_reconstruction_uses_ceil_notional() {
     let before_insurance = env.market_state().1.insurance;
     env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sub_atom_size,
@@ -20484,6 +20539,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     env.svm.expire_blockhash();
     let single = env.send(
         ProgInstruction::TradeCpi {
+            taker_portfolio_id: 0,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -20512,6 +20568,7 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
@@ -20753,6 +20810,7 @@ fn v16_attack_trade_replay_cannot_cross_portfolio_incarnation() {
     let victim = env.create_portfolio(&victim_owner);
     let attacker = env.create_portfolio(&attacker_owner);
     let old_portfolio_id = env.portfolio_id(victim);
+    let attacker_portfolio_id = env.portfolio_id(attacker);
 
     let retained_trade = Transaction::new_signed_with_payer(
         &[
@@ -20768,6 +20826,8 @@ fn v16_attack_trade_replay_cannot_cross_portfolio_incarnation() {
                     AccountMeta::new(attacker, false),
                 ],
                 data: ProgInstruction::TradeNoCpi {
+                    taker_portfolio_id: old_portfolio_id,
+                    lp_portfolio_id: attacker_portfolio_id,
                     asset_index: 0,
                     size_q: -SIZE_Q,
                     exec_price: INITIAL_MARK,
@@ -20845,6 +20905,221 @@ fn v16_attack_trade_replay_cannot_cross_portfolio_incarnation() {
              only {victim_payout}"
         );
     } else {
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT);
+        let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT);
+        assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
+        assert_eq!(env.token_amount(victim_dest) as u128, DEPOSIT);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PortfolioIncarnationTradePath {
+    TradeNoCpiTaker,
+    TradeNoCpiLp,
+    BatchTradeNoCpiTaker,
+    BatchTradeNoCpiLp,
+    TradeCpiTaker,
+    BatchTradeCpiTaker,
+}
+
+// The economic red case above exercises direct bilateral trading end to end. This matrix verifies
+// that every trade wire checks every portfolio role whose authority comes from that signed intent:
+// both signers on no-CPI routes and the taker on matcher-CPI routes. Current-ID controls remain
+// covered throughout the positive trade/CU suite.
+#[test]
+fn v16_trade_routes_reject_stale_portfolio_incarnation_in_every_signed_role() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+
+    for path in [
+        PortfolioIncarnationTradePath::TradeNoCpiTaker,
+        PortfolioIncarnationTradePath::TradeNoCpiLp,
+        PortfolioIncarnationTradePath::BatchTradeNoCpiTaker,
+        PortfolioIncarnationTradePath::BatchTradeNoCpiLp,
+        PortfolioIncarnationTradePath::TradeCpiTaker,
+        PortfolioIncarnationTradePath::BatchTradeCpiTaker,
+    ] {
+        let mut env = V16CuEnv::new();
+        env.configure_auth_mark_with_cu(0, 100);
+        let victim_owner = Keypair::new();
+        let attacker_owner = Keypair::new();
+        let victim = env.create_portfolio(&victim_owner);
+        let attacker = env.create_portfolio(&attacker_owner);
+        let old_victim_id = env.portfolio_id(victim);
+        let attacker_id = env.portfolio_id(attacker);
+        let (matcher_program, matcher_ctx, matcher_delegate) =
+            auth_matcher_for_lp_via_system_create(&mut env, &attacker_owner, attacker);
+
+        env.close_portfolio_with_cu(&victim_owner, victim);
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            system_instruction::transfer(&env.payer.pubkey(), &victim, 1_000_000_000),
+            &[],
+        )
+        .expect("re-fund closed victim address");
+        send_raw_ixs(
+            &mut env.svm,
+            &env.payer,
+            vec![
+                heap_ix(),
+                ComputeBudgetInstruction::set_compute_unit_limit(1_399_999),
+                Instruction {
+                    program_id: env.program_id,
+                    accounts: vec![
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(victim, false),
+                    ],
+                    data: ProgInstruction::InitPortfolio.encode(),
+                },
+            ],
+            &[&victim_owner],
+        )
+        .expect("reinitialize victim at the same address");
+        assert_ne!(env.portfolio_id(victim), old_victim_id);
+        env.deposit(&victim_owner, victim, DEPOSIT);
+        env.deposit(&attacker_owner, attacker, DEPOSIT);
+
+        let (trade, accounts, signers): (ProgInstruction, Vec<AccountMeta>, Vec<&Keypair>) =
+            match path {
+                PortfolioIncarnationTradePath::TradeNoCpiTaker => (
+                    ProgInstruction::TradeNoCpi {
+                        taker_portfolio_id: old_victim_id,
+                        lp_portfolio_id: attacker_id,
+                        asset_index: 0,
+                        size_q: -SIZE_Q,
+                        exec_price: 100,
+                        fee_bps: 0,
+                    },
+                    vec![
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(attacker_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(victim, false),
+                        AccountMeta::new(attacker, false),
+                    ],
+                    vec![&victim_owner, &attacker_owner],
+                ),
+                PortfolioIncarnationTradePath::TradeNoCpiLp => (
+                    ProgInstruction::TradeNoCpi {
+                        taker_portfolio_id: attacker_id,
+                        lp_portfolio_id: old_victim_id,
+                        asset_index: 0,
+                        size_q: SIZE_Q,
+                        exec_price: 100,
+                        fee_bps: 0,
+                    },
+                    vec![
+                        AccountMeta::new(attacker_owner.pubkey(), true),
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(attacker, false),
+                        AccountMeta::new(victim, false),
+                    ],
+                    vec![&attacker_owner, &victim_owner],
+                ),
+                PortfolioIncarnationTradePath::BatchTradeNoCpiTaker => (
+                    ProgInstruction::BatchTradeNoCpi {
+                        taker_portfolio_id: old_victim_id,
+                        lp_portfolio_id: attacker_id,
+                        legs: vec![BatchTradeLeg {
+                            asset_index: 0,
+                            size_q: -SIZE_Q,
+                            exec_price: 100,
+                            fee_bps: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(attacker_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(victim, false),
+                        AccountMeta::new(attacker, false),
+                    ],
+                    vec![&victim_owner, &attacker_owner],
+                ),
+                PortfolioIncarnationTradePath::BatchTradeNoCpiLp => (
+                    ProgInstruction::BatchTradeNoCpi {
+                        taker_portfolio_id: attacker_id,
+                        lp_portfolio_id: old_victim_id,
+                        legs: vec![BatchTradeLeg {
+                            asset_index: 0,
+                            size_q: SIZE_Q,
+                            exec_price: 100,
+                            fee_bps: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(attacker_owner.pubkey(), true),
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(attacker, false),
+                        AccountMeta::new(victim, false),
+                    ],
+                    vec![&attacker_owner, &victim_owner],
+                ),
+                PortfolioIncarnationTradePath::TradeCpiTaker => (
+                    ProgInstruction::TradeCpi {
+                        taker_portfolio_id: old_victim_id,
+                        asset_index: 0,
+                        size_q: -SIZE_Q,
+                        fee_bps: 0,
+                        limit_price: 0,
+                    },
+                    vec![
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(victim, false),
+                        AccountMeta::new(attacker, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(matcher_ctx, false),
+                        AccountMeta::new_readonly(matcher_delegate, false),
+                    ],
+                    vec![&victim_owner],
+                ),
+                PortfolioIncarnationTradePath::BatchTradeCpiTaker => (
+                    ProgInstruction::BatchTradeCpi {
+                        taker_portfolio_id: old_victim_id,
+                        legs: vec![BatchTradeCpiLeg {
+                            asset_index: 0,
+                            size_q: -SIZE_Q,
+                            fee_bps: 0,
+                            limit_price: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(victim_owner.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(victim, false),
+                        AccountMeta::new(attacker, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(matcher_ctx, false),
+                        AccountMeta::new_readonly(matcher_delegate, false),
+                    ],
+                    vec![&victim_owner],
+                ),
+            };
+
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let victim_before = env.svm.get_account(&victim).unwrap();
+        let attacker_before = env.svm.get_account(&attacker).unwrap();
+        env.svm.expire_blockhash();
+        let rejected = env
+            .send(trade, accounts, &signers)
+            .expect_err("stale portfolio incarnation must reject");
+        let expected = format!(
+            "Custom({})",
+            PercolatorError::EngineProvenanceMismatch as u32
+        );
+        assert!(
+            rejected.contains(&expected),
+            "{path:?}: expected {expected}, got {rejected}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(env.svm.get_account(&attacker).unwrap(), attacker_before);
+
         let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT);
         let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT);
         assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
@@ -21046,6 +21321,7 @@ fn v16_attack_tradecpi_matcher_config_arguments_must_match_account_bytes() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -21163,6 +21439,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -21203,6 +21480,7 @@ fn v16_attack_batch_tradecpi_matcher_config_arguments_must_match_account_bytes()
     env.svm.expire_blockhash();
     let ok = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -21435,6 +21713,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -21467,6 +21746,7 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     env.svm.expire_blockhash();
     let self_batch = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: (5 * POS_SCALE) as i128,
@@ -21782,6 +22062,7 @@ fn v16_attack_permissionless_lp_cpi_rejects_wrong_delegate_owner_or_account_bind
     );
 
     let batch_ix = ProgInstruction::BatchTradeCpi {
+        taker_portfolio_id: 0,
         legs: vec![BatchTradeCpiLeg {
             asset_index: 0,
             size_q: sz,
@@ -21853,6 +22134,8 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
     env.svm.expire_blockhash();
     let single = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: (10 * POS_SCALE) as i128,
             exec_price: 100,
@@ -21874,6 +22157,8 @@ fn v16_attack_nocpi_trades_still_require_lp_owner_signature() {
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -21936,6 +22221,7 @@ fn v16_attack_tradecpi_limit_price_enforced() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: (10 * POS_SCALE) as i128,
                 fee_bps: 100,
@@ -22064,6 +22350,7 @@ fn v16_attack_tradecpi_self_trade_rejected() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeCpi {
+            taker_portfolio_id: 0,
             asset_index: 0,
             size_q: (10 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -22696,6 +22983,8 @@ fn v16_attack_non_owner_cannot_withdraw_or_trade() {
     env.svm.expire_blockhash();
     let r_tr = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -27265,6 +27554,8 @@ fn v16_attack_non_base_slot_zero_profile_stale_rejects_trade() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -27557,6 +27848,8 @@ fn v16_attack_non_base_trade_rejects_after_base_resolve_matured() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 101,
@@ -27711,6 +28004,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
     let fresh_err = env
         .send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 1,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -27739,6 +28033,7 @@ fn v16_attack_non_base_tradecpi_rejects_before_matcher_after_base_resolve_mature
     let stale_err = env
         .send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 1,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -28906,6 +29201,8 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -29063,6 +29360,8 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -30677,6 +30976,8 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "TradeNoCpi",
             ProgInstruction::TradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 exec_price: 100,
@@ -30694,6 +30995,8 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "BatchTradeNoCpi",
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -30713,6 +31016,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "TradeCpi",
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 fee_bps: 100,
@@ -30732,6 +31036,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         reject_atomically(
             "BatchTradeCpi",
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -30774,6 +31079,8 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -30877,6 +31184,7 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
@@ -31561,6 +31869,8 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -37222,6 +37532,8 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 1,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -37666,6 +37978,8 @@ fn try_no_cpi_reported_price_trade_with_cu(
         ),
         NoCpiReportedPricePath::Batch => env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q,
@@ -41130,6 +41444,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_carry_protocol_state() {
         ]
     };
     let ix = |asset_index, size_q| ProgInstruction::TradeCpi {
+        taker_portfolio_id: 0,
         asset_index,
         size_q,
         fee_bps: 100,
@@ -41262,6 +41577,7 @@ fn v16_attack_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     env.svm.expire_blockhash();
     let rejected = env.send(
         ProgInstruction::TradeCpi {
+            taker_portfolio_id: 0,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -41350,6 +41666,7 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_carry_protocol_state() {
     let victim_before = env.portfolio_state(victim);
     let sz = (5 * POS_SCALE) as i128;
     let ix = ProgInstruction::BatchTradeCpi {
+        taker_portfolio_id: 0,
         legs: vec![
             BatchTradeCpiLeg {
                 asset_index: 0,
@@ -41524,7 +41841,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs: legs.clone(),
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -41566,7 +41886,10 @@ fn v16_attack_batch_tradecpi_matcher_tail_cannot_forward_taker_signer() {
     env.svm.set_account(ctx, honest_ctx).unwrap();
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -43065,6 +43388,8 @@ fn v16_attack_tradenocpi_self_trade_rejected() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,
@@ -43125,6 +43450,8 @@ fn v16_attack_batch_trade_self_trade_rejected() {
     env.svm.expire_blockhash();
     let direct = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![batch_leg],
         },
         vec![
@@ -43158,6 +43485,7 @@ fn v16_attack_batch_trade_self_trade_rejected() {
     env.svm.expire_blockhash();
     let cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
@@ -48796,6 +49124,8 @@ fn v16_bpf_batch_trade_executes_mixed_direction_spread() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 0,
@@ -48854,6 +49184,8 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let duplicate_nocpi = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -48915,6 +49247,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let duplicate_cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -48974,6 +49307,7 @@ fn v16_attack_batch_duplicate_asset_legs_reject_atomically() {
     env.svm.expire_blockhash();
     let clean = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -49087,7 +49421,10 @@ fn v16_attack_batch_tradecpi_duplicate_assets_reject_before_hostile_matcher_cpi(
             .unwrap();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -49255,6 +49592,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
         (
             "TradeCpi",
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: POS_SCALE as i128,
                 fee_bps: 0,
@@ -49264,6 +49602,7 @@ fn v16_attack_drain_only_existing_risk_increase_rejects_before_hostile_matcher_c
         (
             "BatchTradeCpi",
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: POS_SCALE as i128,
@@ -49340,6 +49679,8 @@ fn v16_bpf_batch_trade_checks_margin_on_final_portfolio_only() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![
                     BatchTradeLeg {
                         asset_index: 1,
@@ -49401,7 +49742,11 @@ fn v16_bpf_batch_trade_14_legs_under_tx_limit() {
         .collect();
     let cu = env
         .send(
-            ProgInstruction::BatchTradeNoCpi { legs },
+            ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(lp.pubkey(), true),
@@ -49482,6 +49827,8 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: nocpi_legs(OVER),
             },
             vec![
@@ -49504,6 +49851,8 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let ok = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: nocpi_legs(CAP),
             },
             vec![
@@ -49542,6 +49891,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: cpi_legs(OVER),
             },
             vec![
@@ -49567,6 +49917,7 @@ fn v16_attack_batch_over_portfolio_leg_cap_rejects_atomically() {
         env.svm.expire_blockhash();
         let ok = env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: cpi_legs(CAP),
             },
             vec![
@@ -49690,7 +50041,10 @@ fn v16_attack_batch_tradecpi_configured_leg_cap_rejects_before_hostile_matcher_c
             .collect();
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -49775,7 +50129,11 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
         .collect();
     env.svm.expire_blockhash();
     let no_cpi = env.send(
-        ProgInstruction::BatchTradeNoCpi { legs: no_cpi_legs },
+        ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
+            legs: no_cpi_legs,
+        },
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(maker.pubkey(), true),
@@ -49809,7 +50167,10 @@ fn v16_attack_batch_decode_oversized_vectors_reject_before_allocation() {
         .collect();
     env.svm.expire_blockhash();
     let cpi = env.send(
-        ProgInstruction::BatchTradeCpi { legs: cpi_legs },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs: cpi_legs,
+        },
         vec![],
         &[],
     );
@@ -49851,6 +50212,7 @@ fn v16_bpf_batch_trade_cpi_executes_mixed_spread_through_matcher() {
     let cu = env
         .send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
@@ -49920,6 +50282,8 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
     env.svm.expire_blockhash();
     let nocpi = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -49958,6 +50322,7 @@ fn v16_attack_batch_trades_reject_with_backing_fee_policy() {
     env.svm.expire_blockhash();
     let cpi = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![BatchTradeCpiLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -50046,6 +50411,8 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
         env.svm.expire_blockhash();
         let rejected = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: sz,
@@ -50091,6 +50458,8 @@ fn v16_attack_backing_fee_policy_count_clears_batch_liveness() {
     env.svm.expire_blockhash();
     let reopened = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -50206,6 +50575,8 @@ fn v16_attack_non_active_asset_cannot_enable_backing_fee_batch_gate() {
         env.svm.expire_blockhash();
         let batch = env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q: sz,
@@ -50351,6 +50722,8 @@ fn v16_attack_retired_reused_asset_backing_fee_policy_cannot_stick_batch_gate() 
     env.svm.expire_blockhash();
     let batch = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![BatchTradeLeg {
                 asset_index: 0,
                 size_q: sz,
@@ -50477,6 +50850,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
         let fresh_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    taker_portfolio_id: 0,
                     asset_index: 1,
                     size_q: POS_SCALE as i128,
                     fee_bps: 0,
@@ -50543,6 +50917,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
             let rejected = if batch {
                 env.send(
                     ProgInstruction::BatchTradeCpi {
+                        taker_portfolio_id: 0,
                         legs: vec![BatchTradeCpiLeg {
                             asset_index: 1,
                             size_q: POS_SCALE as i128,
@@ -50556,6 +50931,7 @@ fn v16_attack_inactive_asset_tradecpi_rejects_before_hostile_matcher_cpi() {
             } else {
                 env.send(
                     ProgInstruction::TradeCpi {
+                        taker_portfolio_id: 0,
                         asset_index: 1,
                         size_q: POS_SCALE as i128,
                         fee_bps: 0,
@@ -50609,6 +50985,7 @@ fn v16_attack_batch_cpi_fee_bps_bounded_for_permissionless_lp() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -50709,7 +51086,10 @@ fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {
     env.svm.expire_blockhash();
     let cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs,
+            },
             vec![
                 AccountMeta::new(taker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -50856,7 +51236,11 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
         .collect();
     env.svm.expire_blockhash();
     env.send(
-        ProgInstruction::BatchTradeNoCpi { legs: seed_legs },
+        ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
+            legs: seed_legs,
+        },
         vec![
             AccountMeta::new(seed_taker.pubkey(), true),
             AccountMeta::new(seed_lp.pubkey(), true),
@@ -50895,7 +51279,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let rejected = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs: legs.clone(),
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50928,7 +51315,10 @@ fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
     env.svm.expire_blockhash();
     let allowed_cu = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs,
+            },
             matcher_accounts(
                 taker.pubkey(),
                 env.market,
@@ -50977,6 +51367,8 @@ fn v16_attack_batch_fees_isolated_to_each_asset_domain() {
     let sz = (10 * POS_SCALE) as i128;
     env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -51033,6 +51425,8 @@ fn v16_attack_batch_cannot_force_counterparty_underwater() {
     let sz = (50 * POS_SCALE) as i128; // notional 5000, IM 500 >> LP capital 50
     let res = env.send(
         ProgInstruction::BatchTradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             legs: vec![
                 BatchTradeLeg {
                     asset_index: 0,
@@ -51176,6 +51570,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -51207,6 +51602,7 @@ fn v16_attack_batch_cpi_per_leg_limit_aborts_whole_batch() {
     env.svm.expire_blockhash();
     let ok = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -51295,7 +51691,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs: legs.clone(),
+        },
         accounts(&env, ctx, delegate),
         &[&taker],
     );
@@ -51335,7 +51734,10 @@ fn v16_attack_batch_tradecpi_zero_fill_rejects_atomically() {
         env.init_matcher_context_authorized(matcher_program, &lp, lp_portfolio);
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs,
+        },
         accounts(&env, ok_ctx, ok_delegate),
         &[&taker],
     );
@@ -51403,7 +51805,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
     env.svm.warp_to_slot(4);
     env.svm.expire_blockhash();
     let fresh = env.send(
-        ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs: legs.clone(),
+        },
         accounts(&env),
         &[&taker],
     );
@@ -51425,7 +51830,10 @@ fn v16_attack_batch_tradecpi_rejects_stale_resolve_matured_atomically() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::BatchTradeCpi { legs },
+        ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
+            legs,
+        },
         accounts(&env),
         &[&taker],
     );
@@ -51574,7 +51982,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let fresh_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs: legs.clone(),
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51597,7 +52008,10 @@ fn v16_attack_batch_tradecpi_stale_rejects_before_hostile_matcher_cpi() {
     env.svm.expire_blockhash();
     let stale_err = env
         .send(
-            ProgInstruction::BatchTradeCpi { legs },
+            ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
+                legs,
+            },
             accounts(&env),
             &[&taker],
         )
@@ -51717,6 +52131,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         let fresh_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    taker_portfolio_id: 0,
                     asset_index: 0,
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
@@ -51749,6 +52164,7 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         let stale_err = env
             .send(
                 ProgInstruction::TradeCpi {
+                    taker_portfolio_id: 0,
                     asset_index: 0,
                     size_q: -(POS_SCALE as i128),
                     fee_bps: 0,
@@ -51872,7 +52288,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let fresh_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs: legs.clone() },
+                ProgInstruction::BatchTradeCpi {
+                    taker_portfolio_id: 0,
+                    legs: legs.clone(),
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51899,7 +52318,10 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         let stale_err = env
             .send(
-                ProgInstruction::BatchTradeCpi { legs },
+                ProgInstruction::BatchTradeCpi {
+                    taker_portfolio_id: 0,
+                    legs,
+                },
                 accounts(&env),
                 &[&taker],
             )
@@ -51995,6 +52417,7 @@ fn v16_attack_batch_tradecpi_fee_bps_rejects_before_hostile_matcher_cpi() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -52129,6 +52552,7 @@ fn v16_attack_batch_tradecpi_backing_fee_policy_rejects_before_hostile_matcher_c
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![BatchTradeCpiLeg {
                     asset_index: 0,
                     size_q: (5 * POS_SCALE) as i128,
@@ -52236,6 +52660,8 @@ fn v16_attack_batch_nocpi_stale_reject_rolls_back_legacy_realloc() {
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::BatchTradeNoCpi {
+                taker_portfolio_id: 0,
+                lp_portfolio_id: 0,
                 legs: vec![BatchTradeLeg {
                     asset_index: 0,
                     size_q,
@@ -52499,6 +52925,7 @@ fn v16_attack_hostile_matcher_batch_returns_all_rejected() {
         env.svm.expire_blockhash();
         let result = env.send(
             ProgInstruction::BatchTradeCpi {
+                taker_portfolio_id: 0,
                 legs: vec![
                     BatchTradeCpiLeg {
                         asset_index: 0,
@@ -52650,6 +53077,7 @@ fn v16_attack_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::TradeCpi {
+            taker_portfolio_id: 0,
             asset_index: 0,
             size_q: (5 * POS_SCALE) as i128,
             fee_bps: 100,
@@ -52745,6 +53173,7 @@ fn v16_attack_batch_tradecpi_rejects_unapproved_unsigned_lp_matcher() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id: 0,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -53764,6 +54193,7 @@ fn v16_attack_hostile_matcher_single_tradecpi_returns_all_rejected() {
         let m = metas(env);
         let result = env.send(
             ProgInstruction::TradeCpi {
+                taker_portfolio_id: 0,
                 asset_index: 0,
                 size_q: sz,
                 fee_bps: 100,
@@ -53892,6 +54322,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
     let program_id = env.program_id;
     let market = env.market;
     let taker_key = taker.pubkey();
+    let taker_portfolio_id = env.portfolio_id(ta);
     let batch_ix = || Instruction {
         program_id,
         accounts: vec![
@@ -53904,6 +54335,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_batch_return_data() {
             AccountMeta::new_readonly(delegate, false),
         ],
         data: ProgInstruction::BatchTradeCpi {
+            taker_portfolio_id,
             legs: vec![
                 BatchTradeCpiLeg {
                     asset_index: 0,
@@ -54008,6 +54440,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
     let program_id = env.program_id;
     let market = env.market;
     let taker_key = taker.pubkey();
+    let taker_portfolio_id = env.portfolio_id(ta);
     let single_ix = || Instruction {
         program_id,
         accounts: vec![
@@ -54020,6 +54453,7 @@ fn v16_attack_hostile_matcher_no_write_cannot_replay_stale_single_context() {
             AccountMeta::new_readonly(delegate, false),
         ],
         data: ProgInstruction::TradeCpi {
+            taker_portfolio_id,
             asset_index: 0,
             size_q,
             fee_bps: 100,
@@ -55515,6 +55949,8 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     env.svm.expire_blockhash();
     let stale_trade = env.send(
         ProgInstruction::TradeNoCpi {
+            taker_portfolio_id: 0,
+            lp_portfolio_id: 0,
             asset_index: 0,
             size_q: POS_SCALE as i128,
             exec_price: 100,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20736,6 +20736,122 @@ fn v16_attack_matcher_config_replay_cannot_bind_reinitialized_portfolio() {
     }
 }
 
+// A retained co-signed trade is another portfolio-scoped authority. It must not create exposure in
+// a replacement account at the same address after InitPortfolio assigns a new incarnation ID.
+#[test]
+fn v16_attack_trade_replay_cannot_cross_portfolio_incarnation() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+    const INITIAL_MARK: u64 = 100;
+    const FINAL_MARK: u64 = 200;
+    const EXPECTED_PNL: u128 = 100_000;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, INITIAL_MARK);
+    let victim_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    let old_portfolio_id = env.portfolio_id(victim);
+
+    let retained_trade = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(attacker_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                    AccountMeta::new(attacker, false),
+                ],
+                data: ProgInstruction::TradeNoCpi {
+                    asset_index: 0,
+                    size_q: -SIZE_Q,
+                    exec_price: INITIAL_MARK,
+                    fee_bps: 0,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner, &attacker_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund closed victim address");
+    send_raw_ixs(
+        &mut env.svm,
+        &env.payer,
+        vec![
+            heap_ix(),
+            ComputeBudgetInstruction::set_compute_unit_limit(1_399_999),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::InitPortfolio.encode(),
+            },
+        ],
+        &[&victim_owner],
+    )
+    .expect("reinitialize victim at the same address");
+    let replacement_portfolio_id = env.portfolio_id(victim);
+    assert_ne!(replacement_portfolio_id, old_portfolio_id);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+
+    let replay = env.svm.send_transaction(retained_trade);
+    if replay.is_ok() {
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
+            -SIZE_Q
+        );
+        env.svm.warp_to_slot(1);
+        env.push_auth_mark_with_cu(1, FINAL_MARK);
+        for portfolio in [victim, attacker] {
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.rebalance_reduce_with_cu(&attacker_owner, attacker, 0, SIZE_Q as u128);
+        env.convert_released_pnl_with_cu(&attacker_owner, attacker, EXPECTED_PNL);
+        env.forfeit_recovery_leg_with_cu(&victim_owner, victim, 0, 1);
+
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT + EXPECTED_PNL);
+        let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT - EXPECTED_PNL);
+        let attacker_payout = env.token_amount(attacker_dest) as u128;
+        let victim_payout = env.token_amount(victim_dest) as u128;
+        assert!(
+            attacker_payout <= DEPOSIT && victim_payout >= DEPOSIT,
+            "trade signed for portfolio {old_portfolio_id} replayed against replacement \
+             {replacement_portfolio_id}: attacker extracted {attacker_payout}, victim recovered \
+             only {victim_payout}"
+        );
+    } else {
+        let attacker_dest = env.withdraw(&attacker_owner, attacker, DEPOSIT);
+        let victim_dest = env.withdraw(&victim_owner, victim, DEPOSIT);
+        assert_eq!(env.token_amount(attacker_dest) as u128, DEPOSIT);
+        assert_eq!(env.token_amount(victim_dest) as u128, DEPOSIT);
+    }
+}
+
 #[test]
 fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2010,6 +2010,14 @@ impl V16CuEnv {
         enabled: u8,
     ) -> Result<Pubkey, String> {
         self.svm.expire_blockhash();
+        let portfolio_id = state::read_portfolio_matcher_incarnation_id(
+            &self
+                .svm
+                .get_account(&maker_account)
+                .ok_or_else(|| "missing maker portfolio".to_string())?
+                .data,
+        )
+        .map_err(|err| format!("read matcher portfolio incarnation: {err:?}"))?;
         let mut accounts = vec![
             AccountMeta::new(maker_owner.pubkey(), true),
             AccountMeta::new_readonly(self.market, false),
@@ -2023,7 +2031,10 @@ impl V16CuEnv {
             ]);
         }
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id,
+                enabled,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -20607,7 +20618,11 @@ fn v16_attack_matcher_config_replay_cannot_bind_reinitialized_portfolio() {
                     AccountMeta::new_readonly(matcher_context, false),
                     AccountMeta::new_readonly(matcher_delegate, false),
                 ],
-                data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+                data: ProgInstruction::SetMatcherConfig {
+                    portfolio_id: old_portfolio_id,
+                    enabled: 1,
+                }
+                .encode(),
             },
         ],
         Some(&env.payer.pubkey()),
@@ -20742,7 +20757,10 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(lp),
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20807,7 +20825,10 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(victim_lp),
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21172,7 +21193,10 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id: env.portfolio_id(lp),
+                enabled: 1,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -21246,7 +21270,10 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     let lp_before_config = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: env.portfolio_id(lp),
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21502,7 +21529,10 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: 0,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -30705,11 +30735,15 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             },
         )
         .unwrap();
+    let cpi_lp_portfolio_id = env.portfolio_id(p_cpi_lp);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: cpi_lp_portfolio_id,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -444,25 +444,33 @@ fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
+    let taker_portfolio_id: u64 = kani::any();
+    let lp_portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 51];
     data[0] = 6;
-    data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&exec_price.to_le_bytes());
-    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[1..9].copy_from_slice(&taker_portfolio_id.to_le_bytes());
+    data[9..17].copy_from_slice(&lp_portfolio_id.to_le_bytes());
+    data[17..19].copy_from_slice(&asset_index.to_le_bytes());
+    data[19..35].copy_from_slice(&size_q.to_le_bytes());
+    data[35..43].copy_from_slice(&exec_price.to_le_bytes());
+    data[43..51].copy_from_slice(&fee_bps.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeNoCpi {
+            taker_portfolio_id: got_taker_portfolio_id,
+            lp_portfolio_id: got_lp_portfolio_id,
             asset_index: got_asset,
             size_q: got_size,
             exec_price: got_price,
             fee_bps: got_fee,
         } => {
+            assert_eq!(got_taker_portfolio_id, taker_portfolio_id);
+            assert_eq!(got_lp_portfolio_id, lp_portfolio_id);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_size, size_q);
             assert_eq!(got_price, exec_price);
@@ -474,25 +482,29 @@ fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_tradecpi_decode_preserves_wire_fields() {
+    let taker_portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let fee_bps: u64 = kani::any();
     let limit_price: u64 = kani::any();
 
-    let mut data = [0u8; 35];
+    let mut data = [0u8; 43];
     data[0] = 10;
-    data[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    data[3..19].copy_from_slice(&size_q.to_le_bytes());
-    data[19..27].copy_from_slice(&fee_bps.to_le_bytes());
-    data[27..35].copy_from_slice(&limit_price.to_le_bytes());
+    data[1..9].copy_from_slice(&taker_portfolio_id.to_le_bytes());
+    data[9..11].copy_from_slice(&asset_index.to_le_bytes());
+    data[11..27].copy_from_slice(&size_q.to_le_bytes());
+    data[27..35].copy_from_slice(&fee_bps.to_le_bytes());
+    data[35..43].copy_from_slice(&limit_price.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TradeCpi {
+            taker_portfolio_id: got_taker_portfolio_id,
             asset_index: got_asset,
             size_q: got_size,
             fee_bps: got_fee,
             limit_price: got_limit,
         } => {
+            assert_eq!(got_taker_portfolio_id, taker_portfolio_id);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_size, size_q);
             assert_eq!(got_fee, fee_bps);
@@ -500,6 +512,17 @@ fn kani_v16_tradecpi_decode_preserves_wire_fields() {
         }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_single_trade_payloads_are_rejected() {
+    let mut nocpi: [u8; 35] = kani::any();
+    nocpi[0] = 6;
+    assert!(Instruction::decode(&nocpi).is_err());
+
+    let mut cpi: [u8; 35] = kani::any();
+    cpi[0] = 10;
+    assert!(Instruction::decode(&cpi).is_err());
 }
 
 #[kani::proof]
@@ -763,12 +786,16 @@ fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle() {
+    let taker_portfolio_id: u64 = kani::any();
+    let lp_portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
     let exec_price: u64 = kani::any();
     let fee_bps: u64 = kani::any();
 
     let data = Instruction::BatchTradeNoCpi {
+        taker_portfolio_id,
+        lp_portfolio_id,
         legs: vec![percolator_prog::ix::BatchTradeLeg {
             asset_index,
             size_q,
@@ -780,12 +807,54 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
 
     assert_eq!(data[0], 66);
     match Instruction::decode(&data).unwrap() {
-        Instruction::BatchTradeNoCpi { legs } => {
+        Instruction::BatchTradeNoCpi {
+            taker_portfolio_id: got_taker_portfolio_id,
+            lp_portfolio_id: got_lp_portfolio_id,
+            legs,
+        } => {
+            assert_eq!(got_taker_portfolio_id, taker_portfolio_id);
+            assert_eq!(got_lp_portfolio_id, lp_portfolio_id);
             assert_eq!(legs.len(), 1);
             assert_eq!(legs[0].asset_index, asset_index);
             assert_eq!(legs[0].size_q, size_q);
             assert_eq!(legs[0].exec_price, exec_price);
             assert_eq!(legs[0].fee_bps, fee_bps);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_batch_trade_cpi_decode_preserves_portfolio_incarnation() {
+    let taker_portfolio_id: u64 = kani::any();
+    let asset_index: u16 = kani::any();
+    let size_q: i128 = kani::any();
+    let fee_bps: u64 = kani::any();
+    let limit_price: u64 = kani::any();
+
+    let data = Instruction::BatchTradeCpi {
+        taker_portfolio_id,
+        legs: vec![percolator_prog::ix::BatchTradeCpiLeg {
+            asset_index,
+            size_q,
+            fee_bps,
+            limit_price,
+        }],
+    }
+    .encode();
+
+    assert_eq!(data[0], 67);
+    match Instruction::decode(&data).unwrap() {
+        Instruction::BatchTradeCpi {
+            taker_portfolio_id: got_taker_portfolio_id,
+            legs,
+        } => {
+            assert_eq!(got_taker_portfolio_id, taker_portfolio_id);
+            assert_eq!(legs.len(), 1);
+            assert_eq!(legs[0].asset_index, asset_index);
+            assert_eq!(legs[0].size_q, size_q);
+            assert_eq!(legs[0].fee_bps, fee_bps);
+            assert_eq!(legs[0].limit_price, limit_price);
         }
         _ => unreachable!(),
     }
@@ -1218,6 +1287,8 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::TradeNoCpi {
+            taker_portfolio_id: 1,
+            lp_portfolio_id: 2,
             asset_index: 0,
             size_q: 1,
             exec_price: 100,
@@ -1227,6 +1298,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::TradeCpi {
+            taker_portfolio_id: 1,
             asset_index: 0,
             size_q: 1,
             fee_bps: 0,

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -653,6 +653,34 @@ fn kani_v16_legacy_permissionless_crank_size_payload_is_rejected() {
 }
 
 #[kani::proof]
+fn kani_v16_matcher_config_decode_preserves_portfolio_incarnation() {
+    let portfolio_id: u64 = kani::any();
+    let enabled: u8 = kani::any();
+    let mut data = [0u8; 10];
+    data[0] = 68;
+    data[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+    data[9] = enabled;
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::SetMatcherConfig {
+            portfolio_id: got_id,
+            enabled: got_enabled,
+        } => {
+            assert_eq!(got_id, portfolio_id);
+            assert_eq!(got_enabled, enabled);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_matcher_config_payload_is_rejected() {
+    let enabled: u8 = kani::any();
+    let legacy = [68, enabled];
+    assert!(Instruction::decode(&legacy).is_err());
+}
+
+#[kani::proof]
 fn kani_v16_update_authority_decode_preserves_wire_fields() {
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;


### PR DESCRIPTION
## Public reproductions

This PR closes one root cause across two retained, portfolio-scoped authorities: a signed instruction bound only to a portfolio address and owner could be submitted after that empty account was closed and publicly reinitialized at the same address for an independently funded replacement incarnation.

1. **Matcher authorization replay.** A matcher retained an LP-owner-signed `SetMatcherConfig` for incarnation 1, replayed it after reinitialization, and thereby enabled unsigned CPI fills on incarnation 2.
2. **Signed trade replay.** An attacker retained a valid co-signed `TradeNoCpi` for incarnation 1, replayed it after reinitialization, and opened a short in the replacement victim while opening the attacker long.

Both exact-parent LiteSVM RED cases use only public wrapper, System, and SPL instructions, normal initialized markets, and honest AuthMark movement from 100 to 200. No protocol state is injected. After public crank, reduction/forfeit, conversion, and real SPL withdrawals:

- attacker deposits 1,000,000 and withdraws 1,100,000
- independent replacement victim deposits 1,000,000 and withdraws 900,000

TDD history preserves the RED cases in `b9ed144d` and `75c59653`.

## Fix

- Add the current program-assigned `portfolio_id` to every signed portfolio role:
  - `TradeNoCpi` and `BatchTradeNoCpi`: taker and LP IDs
  - `TradeCpi` and `BatchTradeCpi`: taker ID
  - `SetMatcherConfig`: LP ID
- Reject an incarnation mismatch before engine mutation, matcher request sequencing, or matcher CPI.
- Bind pre-ID legacy portfolios to sentinel ID 0; a later close/reinitialize writes a nonzero ID, so retained legacy authority cannot cross that boundary.
- Reject old unbound fixed-length trade and matcher-config wire payloads.

## Coverage

- Economic public GREEN for both exploit variants: retained authority rejects and both parties withdraw their original 1,000,000.
- Six-route matrix checks every signed role across single/batch and no-CPI/CPI trades, exact error propagation, byte-identical rollback, and complete withdrawals.
- Current-ID positive routes remain covered by the full trade and CU suite.
- Direct raw-transaction audit confirms every encoded trade fixture carries an explicit current or intentionally stale ID.
- Wrapper-specific Kani proofs cover all four changed trade encodings, matcher-config encoding, and rejection of legacy unbound fixed-length payloads.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 6 unit tests and 568/568 LiteSVM/CU tests passed
- Six focused Kani wire/legacy harnesses passed (0 failures)
- `cargo fmt --all -- --check`
- `git diff --check`

This intentionally changes instruction tags 6, 10, 66, 67, and 68. Clients must read the current portfolio IDs immediately before constructing and signing these instructions.