### PR TITLE
[BLOCKER LoF] Preserve funded shutdown reclaim windows

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9683,6 +9683,16 @@ pub mod processor {
         {
             return Err(PercolatorError::EngineLockActive.into());
         }
+        if cfg.force_close_delay_slots != 0
+            && force_close_delay_slots < cfg.force_close_delay_slots
+            && (group.header.source_fresh_backing_total_num.get() != 0
+                || group.header.backing_provider_earnings_total.get() != 0
+                || group.header.insurance_domain_budget_remaining_total.get() != 0)
+        {
+            // Mature-shutdown fallback escheats abandoned provider value. Do not let marketauth
+            // retroactively shorten the reclaim window while any such value remains entrusted.
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
         drop(group);

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9668,18 +9668,25 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, mode, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let (mut cfg, group) = state::market_view_mut(&mut market_data)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
-        if mode != MarketModeV16::Live {
+        if group.header.mode != 0 {
             return Err(PercolatorError::EngineLockActive.into());
         }
         if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
             return Err(PercolatorError::OracleStale.into());
         }
+        if cfg.force_close_delay_slots != 0
+            && force_close_delay_slots > cfg.force_close_delay_slots
+            && group.header.c_tot.get() != 0
+        {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        drop(group);
+        state::write_wrapper_config(&mut market_data, &cfg)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,166 @@ fn v16_attack_shutdown_cleanup_escheats_abandoned_insurance_to_base_insurance() 
     );
     assert_eq!(ledger_after.total_principal_atoms, 0);
 }
+
+// A configured shutdown delay is the provider's reclaim window. Marketauth must not shorten that
+// live window after provider value is funded; otherwise it can make its own fallback mature,
+// escheat the provider principal into base insurance, then withdraw that insurance to itself.
+#[test]
+fn v16_attack_funded_shutdown_delay_cannot_shrink() {
+    const BACKING: u128 = 500;
+
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(100, 100);
+    env.update_market_init_fee_policy_with_cu(1);
+
+    let provider = Keypair::new();
+    let provider_key = provider.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &provider,
+        1,
+        1,
+        100,
+        provider_key,
+        provider_key,
+        provider_key,
+        provider_key,
+        1,
+    );
+    let marketauth = env.admin.insecure_clone();
+    let (init_fee_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&marketauth, 0, 1)
+        .expect("remove the base init fee so only provider backing gates the reduction");
+    assert_eq!(env.token_amount(init_fee_dest), 1);
+    let ledger = env.backing_domain_ledger_account();
+    let source = env.token_account(provider_key, BACKING as u64);
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: 2,
+            amount: BACKING,
+            expiry_slot: 1_000,
+        },
+        vec![
+            AccountMeta::new(provider_key, true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
+        ],
+        &[&provider],
+    )
+    .expect("provider funds active backing");
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&marketauth, 1, 2)
+        .expect("marketauth shuts down the asset");
+    env.svm.warp_to_slot(3);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    env.svm.expire_blockhash();
+    let shorten = env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 100,
+            force_close_delay_slots: 1,
+        },
+        vec![
+            AccountMeta::new(marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&marketauth],
+    );
+
+    if shorten.is_ok() {
+        // Exact-parent exploit: the shortened window is now mature. Public fallback cleanup
+        // escheats the independent provider's principal, then marketauth (the base-insurance
+        // operator) extracts the same atoms from the vault.
+        env.svm.warp_to_slot(4);
+        env.svm.expire_blockhash();
+        let admin_dest = env.token_account(marketauth.pubkey(), 0);
+        env.send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain: 2,
+                amount: BACKING,
+            },
+            vec![
+                AccountMeta::new(marketauth.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(admin_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger, false),
+            ],
+            &[&marketauth],
+        )
+        .expect("shortened timeout escheats the provider principal");
+        let (stolen_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&marketauth, 0, BACKING)
+            .expect("marketauth withdraws the escheated base insurance");
+        assert_eq!(
+            env.token_amount(stolen_dest),
+            0,
+            "accepted delay reduction let marketauth steal all provider backing"
+        );
+    }
+
+    assert!(
+        shorten.is_err(),
+        "a live provider reclaim window must reject retroactive shortening"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected policy change must roll back byte-for-byte"
+    );
+    assert_eq!(env.market_state().0.force_close_delay_slots, 100);
+
+    // The independent provider retains the bounded public reclaim path under the original policy.
+    let provider_dest = env.token_account(provider_key, 0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 2,
+            amount: BACKING,
+        },
+        vec![
+            AccountMeta::new(provider_key, true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(provider_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger, false),
+        ],
+        &[&provider],
+    )
+    .expect("provider reclaims principal during the original window");
+    assert_eq!(env.token_amount(provider_dest), BACKING as u64);
+
+    {
+        let mut raw = env.svm.get_account(&env.market).unwrap();
+        let (_, group) = state::market_view_mut(&mut raw.data).unwrap();
+        assert_eq!(group.header.source_fresh_backing_total_num.get(), 0);
+        assert_eq!(group.header.backing_provider_earnings_total.get(), 0);
+        assert_eq!(
+            group.header.insurance_domain_budget_remaining_total.get(),
+            0
+        );
+    }
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: 100,
+            force_close_delay_slots: 1,
+        },
+        vec![
+            AccountMeta::new(marketauth.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&marketauth],
+    )
+    .expect("delay reduction remains live after protected residuals are reclaimed");
+    assert_eq!(env.market_state().0.force_close_delay_slots, 1);
+}


### PR DESCRIPTION
## Impact

On the composed shutdown-escheat and live-policy stack (#226 plus #257), a non-oracle market authority could retroactively shorten a provider reclaim window after shutdown. The exact-parent public LiteSVM reproduction:

- creates a normal permissionless asset under a 100-slot shutdown delay;
- removes the base init-fee insurance so the backing aggregate is the only guard input;
- has an independent provider fund 500 backing atoms through `TopUpBackingBucket`;
- shuts the asset down, changes the live delay from 100 slots to 1, and invokes mature fallback cleanup;
- withdraws the escheated base insurance through the canonical asset-0 operator route.

The RED test completes the extraction and fails with the attacker destination holding exactly 500 atoms. It uses no state injection, dishonest oracle, malformed account, or initialization footgun.

## Fix

Reject retroactive `force_close_delay_slots` reductions while any engine-maintained provider-value aggregate remains nonzero:

- recoverable source backing principal;
- backing-provider earnings;
- remaining domain insurance budget.

The check is O(1), does not scan assets or domains, and leaves first configuration and delay increases unchanged. The regression proves rejected state rolls back byte-for-byte, the provider can reclaim all 500 atoms under the original window, and the same reduction succeeds after every protected residual is withdrawn.

## Stack

This draft is based on #226 because the exploit targets its mature-shutdown escheat fallback. It also contains the production change from #257, which is required to test the composed pending behavior. Rebase it after those dependencies land.

## Verification

- exact-parent public LiteSVM RED: attacker receives 500 atoms
- fixed public LiteSVM GREEN
- adjacent shutdown-escheat tests: green
- adjacent resolve-policy tests: green
- `cargo build-sbf --no-default-features`: green
- 6 wrapper unit tests: green
- 568 LiteSVM/CU tests: green
- full `cargo kani --tests`: did not complete; the generic `Instruction::decode` proof kept increasing its unwind bound through iteration 167 until manually terminated. No property failed, but this is not claimed as a green Kani run.
