### PR TITLE
[BLOCKER LoF] Reject cross-domain bankruptcy insurance drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ab111c7e746de307e02b1caefb99dd5de7611518#ab111c7e746de307e02b1caefb99dd5de7611518"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ab111c7e746de307e02b1caefb99dd5de7611518" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ab111c7e746de307e02b1caefb99dd5de7611518" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59965,3 +59965,134 @@ fn v16_attack_flattened_cross_margin_loss_cannot_drain_unrelated_insurance() {
          close_calls=({loser_close_calls},{asset0_cp_close_calls},{winner_close_calls})"
     );
 }
+
+#[test]
+fn v16_attack_resolved_bankruptcy_cannot_shift_loss_by_winner_close_order() {
+    fn run(close_small_first: bool) -> (u128, u128) {
+        const MARK: u64 = 1_000_000;
+        const ADVERSE_MARK: u64 = 1_100_000;
+        const WINNER_CAPITAL: u128 = 1_000_000;
+        const LOSER_CAPITAL: u128 = 50_001;
+
+        let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+        env.configure_auth_mark_with_cu(0, MARK);
+
+        let small_owner = Keypair::new();
+        let small = env.create_portfolio(&small_owner);
+        let large_owner = Keypair::new();
+        let large = env.create_portfolio(&large_owner);
+        let loser_owner = Keypair::new();
+        let loser = env.create_portfolio(&loser_owner);
+        let accrual_owner = Keypair::new();
+        let accrual = env.create_portfolio(&accrual_owner);
+        env.deposit(&small_owner, small, WINNER_CAPITAL);
+        env.deposit(&large_owner, large, WINNER_CAPITAL);
+        env.deposit(&loser_owner, loser, LOSER_CAPITAL);
+
+        env.trade_asset_with_cu(
+            0,
+            &small_owner,
+            small,
+            &loser_owner,
+            loser,
+            (POS_SCALE / 4) as i128,
+            MARK,
+            0,
+        );
+        env.trade_asset_with_cu(
+            0,
+            &large_owner,
+            large,
+            &loser_owner,
+            loser,
+            (3 * POS_SCALE / 4) as i128,
+            MARK,
+            0,
+        );
+
+        for slot in 1..=50u64 {
+            env.svm.warp_to_slot(slot);
+            env.push_auth_mark_with_cu(slot, ADVERSE_MARK);
+            env.crank(
+                accrual,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        assert_eq!(env.market_state().1.assets[0].effective_price, ADVERSE_MARK);
+        env.close_portfolio_with_cu(&accrual_owner, accrual);
+        env.resolve();
+
+        let close_once = |env: &mut V16CuEnv, owner: &Keypair, portfolio: Pubkey| -> u128 {
+            env.svm.expire_blockhash();
+            let (dest, cu) = env.close_resolved_with_cu(owner, portfolio);
+            assert_cu_within("resolved close-order step", cu, CUSTODY_CU_LIMIT);
+            env.token_amount(dest) as u128
+        };
+        let is_terminal = |env: &V16CuEnv, portfolio: Pubkey| {
+            let account = env.portfolio_state(portfolio);
+            account.capital.get() == 0
+                && account.pnl.get() == 0
+                && percolator::active_bitmap_is_empty(active_bitmap(&account))
+                && (!resolved_receipt(&account).present || resolved_receipt(&account).finalized)
+        };
+        let drive = |env: &mut V16CuEnv, owner: &Keypair, portfolio: Pubkey| -> u128 {
+            let mut payout = 0u128;
+            for _ in 0..16 {
+                payout += close_once(env, owner, portfolio);
+                if is_terminal(env, portfolio) {
+                    return payout;
+                }
+            }
+            panic!("resolved loser did not terminate in 16 bounded calls");
+        };
+
+        let (first_owner, first, remaining) = if close_small_first {
+            (&small_owner, small, large)
+        } else {
+            (&large_owner, large, small)
+        };
+        assert_eq!(
+            close_once(&mut env, first_owner, first),
+            0,
+            "a premature winner may progress, but cannot pay before bankruptcy blockers clear"
+        );
+        assert!(
+            !has_active_leg_for_asset(&env.portfolio_state(first), 0),
+            "the first winner has detached before the loser books terminal debt"
+        );
+        assert!(
+            has_active_leg_for_asset(&env.portfolio_state(remaining), 0),
+            "the other winner still carries the only remaining loss weight"
+        );
+
+        let loser_paid = drive(&mut env, &loser_owner, loser);
+        assert_eq!(loser_paid, 0, "the bankrupt loser has no terminal payout");
+        let after_bankruptcy = env.market_state().1;
+        assert_eq!(
+            (
+                after_bankruptcy.assets[0].b_long_num,
+                after_bankruptcy.assets[0].b_short_num,
+            ),
+            (0, 0),
+            "Resolved bankruptcy is already priced by the payout haircut and must not redistribute \
+             loss through close-order-dependent B weights"
+        );
+        assert_eq!(
+            after_bankruptcy.vault as u64,
+            env.token_amount(env.vault),
+            "terminal debt classification moves no SPL custody"
+        );
+        (
+            after_bankruptcy.assets[0].b_long_num,
+            after_bankruptcy.assets[0].b_short_num,
+        )
+    }
+
+    let small_first = run(true);
+    let large_first = run(false);
+    assert_eq!(small_first, (0, 0));
+    assert_eq!(large_first, (0, 0));
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1677,6 +1677,14 @@ impl V16CuEnv {
         );
         let loss_i128 = i128::try_from(loss).unwrap();
         portfolio.pnl = percolator::V16PodI128::new(-loss_i128);
+        let source = portfolio
+            .source_domains
+            .iter_mut()
+            .find(|source| !source.is_occupied())
+            .expect("security seed has a free source-domain slot");
+        source.domain = percolator::V16PodU32::new(0);
+        source.source_claim_market_id = percolator::V16PodU64::new(group.assets[0].market_id);
+        source.negative_pnl_atoms = percolator::V16PodU128::new(loss);
         group.negative_pnl_account_count += 1;
         portfolio.health_cert.valid = 0;
         state::write_market(&mut market_account.data, &cfg, &group).unwrap();
@@ -1704,6 +1712,14 @@ impl V16CuEnv {
         );
         let loss_i128 = i128::try_from(loss).unwrap();
         portfolio.pnl = percolator::V16PodI128::new(-loss_i128);
+        let source = portfolio
+            .source_domains
+            .iter_mut()
+            .find(|source| !source.is_occupied())
+            .expect("security seed has a free source-domain slot");
+        source.domain = percolator::V16PodU32::new(0);
+        source.source_claim_market_id = percolator::V16PodU64::new(group.assets[0].market_id);
+        source.negative_pnl_atoms = percolator::V16PodU128::new(loss);
         group.negative_pnl_account_count += 1;
         portfolio.health_cert.valid = 0;
         state::write_market(&mut market_account.data, &cfg, &group).unwrap();
@@ -17248,33 +17264,38 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
     );
     assert!(
         has_active_leg_for_asset(&before, 0) && has_active_leg_for_asset(&before, 1),
-        "setup leaves unattributed multi-asset exposure"
+        "setup leaves multi-asset exposure"
     );
     env.resolve();
 
-    env.svm.expire_blockhash();
-    let loser_crank_cu = env
-        .send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: u64::MAX,
-                observations: vec![CrankObservationHint {
-                    asset_index: u16::MAX,
-                    oracle_accounts: u8::MAX,
-                }],
-            },
-            vec![
-                AccountMeta::new_readonly(victim_owner.pubkey(), false),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(victim, false),
-            ],
-            &[],
-        )
-        .expect("resolved deep cross-margin bad debt has public progress");
-    assert_cu_within(
-        "Resolved PermissionlessCrank unattributed bad debt",
-        loser_crank_cu,
-        CRANK_CU_LIMIT,
-    );
+    for _ in 0..percolator::PORTFOLIO_SOURCE_DOMAIN_CAP {
+        if env.portfolio_state(victim).pnl.get() == 0 {
+            break;
+        }
+        env.svm.expire_blockhash();
+        let loser_crank_cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: u64::MAX,
+                    observations: vec![CrankObservationHint {
+                        asset_index: u16::MAX,
+                        oracle_accounts: u8::MAX,
+                    }],
+                },
+                vec![
+                    AccountMeta::new_readonly(victim_owner.pubkey(), false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                &[],
+            )
+            .expect("resolved deep cross-margin bad debt has public progress");
+        assert_cu_within(
+            "Resolved PermissionlessCrank attributed bad debt",
+            loser_crank_cu,
+            CRANK_CU_LIMIT,
+        );
+    }
     let victim_after = env.portfolio_state(victim);
     assert_eq!(
         victim_after.capital.get(),
@@ -59716,4 +59737,231 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     ] {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
+}
+
+// Public cross-margin bankruptcy isolation: after a loss-bearing leg is flattened, aggregate PnL
+// must not be charged to an unrelated surviving leg's insurance domain.
+#[test]
+fn v16_attack_flattened_cross_margin_loss_cannot_drain_unrelated_insurance() {
+    const UNRELATED_Q: u128 = POS_SCALE;
+    let mut env = V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(
+        2, 10_000, 10_000, 10_000, 200,
+    );
+    env.configure_auth_mark_with_cu(0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let provider = Keypair::new();
+    let oracle = Keypair::new();
+    let admin = env.admin.insecure_clone();
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&provider),
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+        provider.pubkey().to_bytes(),
+    )
+    .expect("independent asset-0 insurance provider");
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&oracle),
+        1,
+        processor::ASSET_AUTH_ORACLE,
+        oracle.pubkey().to_bytes(),
+    )
+    .expect("independent honest asset-1 oracle");
+    env.top_up_insurance_domain_with_authority(&provider, 1, 100_000);
+
+    let loser_owner = Keypair::new();
+    let loser = env.create_portfolio(&loser_owner);
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let asset0_cp_owner = Keypair::new();
+    let asset0_cp = env.create_portfolio(&asset0_cp_owner);
+    let observer_owner = Keypair::new();
+    let observer = env.create_portfolio(&observer_owner);
+    env.deposit(&loser_owner, loser, 200);
+    env.deposit(&winner_owner, winner, 10_000);
+    env.deposit(&asset0_cp_owner, asset0_cp, 10_000);
+
+    // Open one position on each asset. Asset 1 will carry the real loss; asset 0 exists only to
+    // leave a selector-visible unrelated leg after the owner exits asset 1.
+    env.trade_asset_with_cu(
+        0,
+        &loser_owner,
+        loser,
+        &asset0_cp_owner,
+        asset0_cp,
+        UNRELATED_Q as i128,
+        100,
+        0,
+    );
+    // The actual loss is entirely on asset 1: loser is short, winner is long.
+    env.trade_asset_with_cu(
+        1,
+        &loser_owner,
+        loser,
+        &winner_owner,
+        winner,
+        -(POS_SCALE as i128),
+        100,
+        0,
+    );
+
+    // Public maintenance sync can legitimately exhaust capital without settling K/F. The asset-0
+    // position remains unrelated while the owner later exits asset 1. No state is injected.
+    env.svm.warp_to_slot(2);
+    env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(1),
+        },
+    );
+    env.sync_maintenance_fee_with_cu(loser, None, 2);
+    let fee_drained = env.portfolio_state(loser);
+    assert_eq!(
+        fee_drained.capital.get(),
+        0,
+        "risk-reducing fee exhausts capital"
+    );
+    assert!(
+        has_active_leg_for_asset(&fee_drained, 0),
+        "asset-0 leg remains"
+    );
+
+    // Advance only through honest authenticated marks. Crank the healthy winner so the loser is not
+    // liquidated before its owner exercises the public risk-reducing exit.
+    let mut mark = 100u64;
+    for slot in 3u64..=12 {
+        mark = mark.checked_mul(2).expect("bounded mark progression");
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_with_authority(1, &oracle, slot, mark);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(observer, false),
+            ],
+            &[],
+        )
+        .expect("advance the honest mark through a healthy account");
+    }
+
+    env.rebalance_reduce_with_cu(&loser_owner, loser, 1, POS_SCALE);
+    let flattened = env.portfolio_state(loser);
+    assert!(
+        !has_active_leg_for_asset(&flattened, 1) && has_active_leg_for_asset(&flattened, 0),
+        "owner flattens the loss leg while retaining only unrelated risk"
+    );
+    assert!(flattened.pnl.get() < 0, "asset-1 debt remains account-wide");
+    assert_eq!(flattened.capital.get(), 0, "loss exhausts loser principal");
+
+    let before = env.market_state().1;
+    let mut liquidation_calls = 0u64;
+    loop {
+        let state = env.portfolio_state(loser);
+        if state.pnl.get() >= 0 && !has_active_leg_for_asset(&state, 0) {
+            break;
+        }
+        assert!(
+            liquidation_calls < 512,
+            "bounded public cranks must settle attributed debt and close unrelated risk"
+        );
+        env.svm.expire_blockhash();
+        let result = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 12,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(loser, false),
+            ],
+            &[],
+        );
+        match result {
+            Ok(_) => liquidation_calls += 1,
+            Err(err) => {
+                assert!(
+                    format!("{err:?}").contains("Custom(23)"),
+                    "only the engine's rollback-safe RecoveryRequired terminal is accepted: {err:?}"
+                );
+                let rolled_back = env.market_state().1;
+                assert_eq!(rolled_back.mode, MarketModeV16::Live);
+                assert_eq!(
+                    rolled_back.insurance_domain_spent[1], before.insurance_domain_spent[1],
+                    "failed terminal crank must roll back all unrelated-domain mutation"
+                );
+                break;
+            }
+        }
+    }
+    let after = env.market_state().1;
+
+    let unrelated_spend = after.insurance_domain_spent[1]
+        .checked_sub(before.insurance_domain_spent[1])
+        .expect("domain spent is monotonic");
+    env.resolve();
+    let close_to_terminal =
+        |env: &mut V16CuEnv, label: &str, owner: &Keypair, portfolio: Pubkey| {
+            let mut payout = 0u128;
+            for calls in 0..512u64 {
+                let account = env.portfolio_state(portfolio);
+                let receipt = resolved_receipt(&account);
+                if percolator::active_bitmap_is_empty(active_bitmap(&account))
+                    && account.capital.get() == 0
+                    && account.pnl.get() == 0
+                    && (!receipt.present || receipt.finalized)
+                {
+                    return (payout, calls);
+                }
+                let dest = env.close_resolved(owner, portfolio);
+                payout += env.token_amount(dest) as u128;
+            }
+            let account = env.portfolio_state(portfolio);
+            panic!(
+            "{label} resolved close failed: capital={} pnl={} active={} b_stale={} receipt={:?}",
+            account.capital.get(),
+            account.pnl.get(),
+            percolator::active_bitmap_count_ones(active_bitmap(&account)),
+            account.b_stale_state,
+            resolved_receipt(&account),
+        );
+        };
+    let (loser_payout, loser_close_calls) =
+        close_to_terminal(&mut env, "loser", &loser_owner, loser);
+    let (asset0_cp_payout, asset0_cp_close_calls) =
+        close_to_terminal(&mut env, "asset0 counterparty", &asset0_cp_owner, asset0_cp);
+    let (winner_payout, winner_close_calls) =
+        close_to_terminal(&mut env, "winner", &winner_owner, winner);
+    let attacker_payout = loser_payout + asset0_cp_payout + winner_payout;
+    let attacker_deposit = 200u128 + 10_000 + 10_000;
+    let attacker_gain = attacker_payout.saturating_sub(attacker_deposit);
+    if unrelated_spend != 0 {
+        assert!(
+            attacker_gain > 0,
+            "pre-fix cross-domain spend must be publicly extractable: payout={attacker_payout}, deposit={attacker_deposit}, spend={unrelated_spend}"
+        );
+    }
+
+    assert_eq!(
+        unrelated_spend, 0,
+        "asset-1 debt must not spend independent asset-0 insurance: \
+         spend={unrelated_spend}, attacker_payout={attacker_payout}, attacker_gain={attacker_gain}, \
+         liquidation_calls={liquidation_calls}, \
+         close_calls=({loser_close_calls},{asset0_cp_close_calls},{winner_close_calls})"
+    );
 }


### PR DESCRIPTION
## Finding

A public cross-margin sequence could create debt on asset 1, flatten that loss-bearing leg through the normal risk-reducing route, and retain an unrelated asset-0 leg. The engine retained only aggregate negative PnL, so later permissionless liquidation inferred the debt domain from the surviving leg and spent an independent asset-0 insurance provider's funds.

On exact wrapper parent `da64be639168b496833dd4c701607a94fcb06b6c` with engine `143e68c4917ed0400a27b952f036a5677047cd84`, the retained LiteSVM RED test shows:

- unrelated asset-0 insurance spent: `100100`
- attacker-controlled payout: `115300`
- attacker net gain: `95100`
- bounded public progression: one liquidation call and resolved-close calls `(0, 220, 1)`

The reproduction uses only public initialization, SPL deposits, zero-sum trades, authenticated mark updates, maintenance sync, owner-authorized risk reduction, permissionless crank, resolve, and resolved close. It does not mutate account state or assume a dishonest oracle.

## Fix

This PR pins engine commit `ab111c7e746de307e02b1caefb99dd5de7611518` from engine PR #148 and retains the public regression. The engine persists negative-PnL provenance by insurance domain and settles principal, insurance, and terminal losses against that recorded source after the originating leg exits.

Two existing synthetic security fixtures now initialize the new provenance field so their injected negative-PnL state remains structurally valid. The resolved deep-insolvency lifecycle test performs one bounded public crank per recorded debt domain, matching the engine's one-action-per-call liveness contract.

## Verification

- `cargo build-sbf --tools-version v1.52`: passed against immutable engine pin `ab111c7e`.
- `cargo test --all-targets`: 6 unit tests and 566 LiteSVM/CU tests passed.
- The new public exploit regression and four cross-margin/liveness-sensitive targeted tests passed.
- Wrapper Kani compiled successfully. Three concrete decoder harnesses passed, including the all-active-payload truncation proof (`0/847` failed), and the symbolic one-byte unknown/truncated-tag harness passed separately with a checked unwind bound (`0/814` failed). The unchanged grouped oracle/asset trailing-byte proof did not terminate under bounded CaDiCaL, Kissat, or Bitwuzla attempts; no property failure was reported. This is not claimed as a full wrapper Kani pass, and neither wrapper production code nor `tests/v16_kani.rs` differs from `main`.
- Engine PR #148: 160 native/fuzz tests and eleven focused Kani harnesses passed on `ab111c7e`. The full 246-engine-harness roster was not rerun.

## Dependency

Draft until a final engine commit from aeyakovenko/percolator#148 is merged. The wrapper pin is immutable and can be updated to the merge commit if GitHub changes it.
