### PR TITLE
[REAL DoS] Pin lapsed backing settlement fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=5d608a8653a4d2535b3ff7d3a011ccc8f4accc23#5d608a8653a4d2535b3ff7d3a011ccc8f4accc23"
+source = "git+https://github.com/aeyakovenko/percolator?rev=e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63#e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5d608a8653a4d2535b3ff7d3a011ccc8f4accc23" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5d608a8653a4d2535b3ff7d3a011ccc8f4accc23" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63" }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
## Finding
A portfolio can remain permanently uncloseable after valid market resolution when its source backing expires at the resolution slot. The engine attempted K/F settlement before materializing the lapsed backing transition, so `CloseResolvedAccount` repeatedly returned stale/budget errors while the resolved lifecycle exposed no independent rescue path.

## Change
Pin both target and host builds to engine commit `e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63` (aeyakovenko/percolator#149). No wrapper instruction, authority, custody, amount, or destination behavior changes.

## TDD and verification
- Engine RED: `b4b087025bd708d012e46bbf8ddd75ff995734ff`
- Engine GREEN: `e3ea7251ed75f0111ba3cf5a4b87961f6c7cca63`
- Wrapper: 6 unit + 567 `v16_cu` tests passed
- Rebuilt SBF SHA-256: `ba6b50a9b56a7ff678e05473ebf8ed4c01dc9c84cb541342d534e70ccb2c8fb6`
- Meta LiteSVM RED/GREEN covers public init, backing deposit and expiry, positions, crank, controller resolution, and bounded resolved close retries with the real wrapper binary.

This PR is intentionally pin-only and stacked on the current wrapper audit head.