### PR TITLE
[HARDENING LoF] Bind rebalance reductions to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - **ForfeitRecoveryLeg** (tag 43)
   - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
 - **RebalanceReduce** (tag 44)
-  - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
+  - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector;
+    the payload binds consent to the program-assigned `portfolio_id`
 - **ClaimResolvedPayoutTopup** (tag 46)
   - permissionless resolved-payout top-up claim; pays only the stored owner receipt token account
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2655,6 +2655,7 @@ pub mod ix {
             b_delta_budget: u128,
         },
         RebalanceReduce {
+            portfolio_id: u64,
             asset_index: u16,
             reduce_q: u128,
         },
@@ -2928,6 +2929,7 @@ pub mod ix {
                     b_delta_budget: read_u128(&mut rest)?,
                 },
                 44 => Self::RebalanceReduce {
+                    portfolio_id: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     reduce_q: read_u128(&mut rest)?,
                 },
@@ -3321,10 +3323,12 @@ pub mod ix {
                     push_u128(&mut out, b_delta_budget);
                 }
                 Self::RebalanceReduce {
+                    portfolio_id,
                     asset_index,
                     reduce_q,
                 } => {
                     out.push(44);
+                    push_u64(&mut out, portfolio_id);
                     push_u16(&mut out, asset_index);
                     push_u128(&mut out, reduce_q);
                 }
@@ -5459,9 +5463,10 @@ pub mod processor {
                 b_delta_budget,
             } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
             Instruction::RebalanceReduce {
+                portfolio_id,
                 asset_index,
                 reduce_q,
-            } => handle_rebalance_reduce(program_id, accounts, asset_index, reduce_q),
+            } => handle_rebalance_reduce(program_id, accounts, portfolio_id, asset_index, reduce_q),
             Instruction::FinalizeResetSide { asset_index, side } => {
                 handle_finalize_reset_side(program_id, accounts, asset_index, side)
             }
@@ -8487,11 +8492,17 @@ pub mod processor {
     fn handle_rebalance_reduce<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
         asset_index: u16,
         reduce_q: u128,
     ) -> ProgramResult {
         if reduce_q == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let portfolio_ai = account(accounts, 2)?;
+        expect_owner(portfolio_ai, program_id)?;
+        if state::read_portfolio_id(&portfolio_ai.try_borrow_data()?)? != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,168 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A signed unilateral reduction authorizes irreversible exposure removal. Reusing the same
+// portfolio address must not let an old incarnation's consent close a replacement position at an
+// adverse mark and lock the counterparty's temporary profit before the mark recovers.
+#[test]
+fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
+    const DEPOSIT: u128 = 1_000_000;
+    const OLD_SIZE_Q: i128 = 2_000 * POS_SCALE as i128;
+    const NEW_SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let victim_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    let old_portfolio_id = env.portfolio_id(victim);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        OLD_SIZE_Q,
+        100,
+        0,
+    );
+
+    // Keep the exact fee-paid, owner-signed transaction while incarnation 1 really has enough
+    // exposure for it to be a valid reduction.
+    env.svm.expire_blockhash();
+    let retained_reduce = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::RebalanceReduce {
+                    asset_index: 0,
+                    reduce_q: NEW_SIZE_Q as u128,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    // Exit and publicly reincarnate the exact same program-owned address without expiring the
+    // retained transaction's blockhash.
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        -OLD_SIZE_Q,
+        100,
+        0,
+    );
+    let old_dest = env.withdraw(&victim_owner, victim, DEPOSIT);
+    assert_eq!(env.token_amount(old_dest) as u128, DEPOSIT);
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio through System Program");
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    )
+    .expect("initialize replacement portfolio");
+    assert_ne!(env.portfolio_id(victim), old_portfolio_id);
+
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        NEW_SIZE_Q,
+        100,
+        0,
+    );
+
+    // The authenticated mark falls temporarily. A normal refresh realizes the loss, but the
+    // replacement position would recover when the honest mark returns unless stale consent can
+    // irreversibly reduce it now.
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 50);
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[],
+    )
+    .expect("refresh replacement at the adverse mark");
+    assert!(env.portfolio_state(victim).capital.get() < DEPOSIT);
+
+    let replay = env.svm.send_transaction(retained_reduce);
+    let replayed = replay.is_ok();
+    if replayed {
+        assert!(
+            !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+            "control: stale reduction closed the replacement position"
+        );
+    }
+
+    env.svm.expire_blockhash();
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 100);
+    for portfolio in [victim, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    if !replayed {
+        env.trade_with_cu(
+            &victim_owner,
+            victim,
+            &attacker_owner,
+            attacker,
+            -NEW_SIZE_Q,
+            100,
+            0,
+        );
+    }
+
+    env.resolve();
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let attacker_dest = env.close_resolved(&attacker_owner, attacker);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let attacker_payout = env.token_amount(attacker_dest) as u128;
+    assert!(
+        !replayed && victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
+        "rebalance consent for portfolio {old_portfolio_id} replayed onto replacement {}: \
+         victim recovered {victim_payout}, attacker extracted {attacker_payout}",
+        env.portfolio_id(victim),
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3427,8 +3427,10 @@ impl V16CuEnv {
         asset_index: u16,
         reduce_q: u128,
     ) -> u64 {
+        let portfolio_id = self.portfolio_id(portfolio);
         self.send(
             ProgInstruction::RebalanceReduce {
+                portfolio_id,
                 asset_index,
                 reduce_q,
             },
@@ -16145,6 +16147,7 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     env.svm.expire_blockhash();
     let reduce = env.send(
         ProgInstruction::RebalanceReduce {
+            portfolio_id: 1,
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28469,6 +28472,7 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::RebalanceReduce {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28498,6 +28502,7 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     env.svm.expire_blockhash();
     let r_owner = env.send(
         ProgInstruction::RebalanceReduce {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28612,6 +28617,8 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
     let foreign_before = env.svm.get_account(&foreign).unwrap();
     let local_before = env.svm.get_account(&local).unwrap();
     let vault_b_before = env.svm.get_account(&vault_b).unwrap();
+    let foreign_portfolio_id = env.portfolio_id(foreign);
+    let local_portfolio_id = env.portfolio_id(local);
     let reduce_q = POS_SCALE / 2;
     env.svm.expire_blockhash();
     let rejected = send_tx(
@@ -28619,6 +28626,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::RebalanceReduce {
+            portfolio_id: foreign_portfolio_id,
             asset_index: 0,
             reduce_q,
         },
@@ -28653,6 +28661,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::RebalanceReduce {
+            portfolio_id: local_portfolio_id,
             asset_index: 0,
             reduce_q,
         },
@@ -56323,6 +56332,7 @@ fn v16_attack_rebalance_reduce_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let rejected = env.send(
         ProgInstruction::RebalanceReduce {
+            portfolio_id: env.portfolio_id(long),
             asset_index: 0,
             reduce_q: remaining,
         },
@@ -57638,6 +57648,7 @@ fn v16_attack_rebalance_reduce_overshoot_clamps_to_flat_no_flip() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::RebalanceReduce {
+            portfolio_id: env.portfolio_id(pa),
             asset_index: 0,
             reduce_q: 3 * POS_SCALE,
         },
@@ -59762,6 +59773,7 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
                     AccountMeta::new(victim, false),
                 ],
                 data: ProgInstruction::RebalanceReduce {
+                    portfolio_id: old_portfolio_id,
                     asset_index: 0,
                     reduce_q: NEW_SIZE_Q as u128,
                 }
@@ -59835,6 +59847,19 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
         &[],
     )
     .expect("refresh replacement at the adverse mark");
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker, false),
+        ],
+        &[],
+    )
+    .expect("refresh counterparty at the adverse mark");
     assert!(env.portfolio_state(victim).capital.get() < DEPOSIT);
 
     let replay = env.svm.send_transaction(retained_reduce);

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -268,6 +268,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
+    let portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let side: u8 = kani::any();
     let b_delta_budget: u128 = kani::any();
@@ -292,15 +293,18 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     }
 
     let rebalance = Instruction::RebalanceReduce {
+        portfolio_id,
         asset_index,
         reduce_q,
     }
     .encode();
     match Instruction::decode(&rebalance).unwrap() {
         Instruction::RebalanceReduce {
+            portfolio_id: got_portfolio_id,
             asset_index: got_asset,
             reduce_q: got_reduce,
         } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_reduce, reduce_q);
         }
@@ -348,6 +352,17 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
         Instruction::SyncMaintenanceFee { now_slot: got } => assert_eq!(got, now_slot),
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_rebalance_payload_is_rejected() {
+    let asset_index: u16 = kani::any();
+    let reduce_q: u128 = kani::any();
+    let mut legacy = [0u8; 19];
+    legacy[0] = 44;
+    legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    legacy[3..19].copy_from_slice(&reduce_q.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 }
 
 #[kani::proof]
@@ -1380,6 +1395,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::RebalanceReduce {
+            portfolio_id: 1,
             asset_index: 0,
             reduce_q: 1,
         },


### PR DESCRIPTION
## What changed

- add a public LiteSVM regression that closes and recreates the same portfolio address, then replays an owner-signed `RebalanceReduce` from the old incarnation
- bind tag 44 to the program-assigned `portfolio_id`
- reject a mismatched incarnation before entering engine mutation
- reject the legacy unbound 19-byte payload and document the wire-format change

## Root cause and impact

`RebalanceReduce` authorized irreversible exposure removal but authenticated only the owner, portfolio address, asset, and amount. A transaction signed for an old portfolio incarnation remained valid after that address was publicly closed and reinitialized.

The exact-parent RED test uses only public program/System Program transitions. At a temporary authenticated mark move from 100 to 50, the stale consent closes the replacement victim position. When the mark returns to 100, terminal payouts are victim 950,000 and independent attacker 1,050,000. The replacement portfolio has a different program-assigned ID (1 -> 3), so binding that ID prevents the replay.

## Validation

- exact-parent RED at `408daae0` against parent `da64be63`
- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 6 unit + 566 LiteSVM/CU tests pass
- `cargo kani --tests --harness kani_v16_recovery_close_progress_decode_preserves_wire_fields`
- `cargo kani --tests --harness kani_v16_legacy_unbound_rebalance_payload_is_rejected`
- `cargo fmt --all -- --check`
- `git diff --check`

This intentionally changes the tag-44 payload ABI; clients must include the current portfolio incarnation ID.