### PR TITLE
[HARDENING LoF] Bind RebalanceReduce to market generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
+  - binds the current asset `market_id`; retained consent from a retired market generation rejects
 - **ClaimResolvedPayoutTopup** (tag 46)
   - permissionless resolved-payout top-up claim; pays only the stored owner receipt token account
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2708,6 +2708,7 @@ pub mod ix {
         },
         RebalanceReduce {
             asset_index: u16,
+            market_id: u64,
             reduce_q: u128,
         },
         FinalizeResetSide {
@@ -2987,6 +2988,7 @@ pub mod ix {
                 },
                 44 => Self::RebalanceReduce {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     reduce_q: read_u128(&mut rest)?,
                 },
                 45 => Self::FinalizeResetSide {
@@ -3392,10 +3394,12 @@ pub mod ix {
                 }
                 Self::RebalanceReduce {
                     asset_index,
+                    market_id,
                     reduce_q,
                 } => {
                     out.push(44);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, reduce_q);
                 }
                 Self::FinalizeResetSide { asset_index, side } => {
@@ -5507,8 +5511,9 @@ pub mod processor {
             } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
             Instruction::RebalanceReduce {
                 asset_index,
+                market_id,
                 reduce_q,
-            } => handle_rebalance_reduce(program_id, accounts, asset_index, reduce_q),
+            } => handle_rebalance_reduce(program_id, accounts, asset_index, market_id, reduce_q),
             Instruction::FinalizeResetSide { asset_index, side } => {
                 handle_finalize_reset_side(program_id, accounts, asset_index, side)
             }
@@ -8577,10 +8582,19 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         reduce_q: u128,
     ) -> ProgramResult {
         if reduce_q == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let market_ai = account(accounts, 1)?;
+        let (_, _, _, current_market_id, _, _) = state::read_market_trade_preflight(
+            &market_ai.try_borrow_data()?,
+            asset_index as usize,
+        )?;
+        if current_market_id != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
         }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3457,9 +3457,11 @@ impl V16CuEnv {
         asset_index: u16,
         reduce_q: u128,
     ) -> u64 {
+        let market_id = self.asset_market_id(asset_index);
         self.send(
             ProgInstruction::RebalanceReduce {
                 asset_index,
+                market_id,
                 reduce_q,
             },
             vec![
@@ -16986,9 +16988,11 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     assert_unchanged(&env, "ConvertReleasedPnl alias rejection");
 
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let reduce = env.send(
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id,
             reduce_q: POS_SCALE,
         },
         vec![
@@ -29241,9 +29245,11 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     let mallory = Keypair::new();
     env.ensure_signer_account(mallory.pubkey());
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let r_grief = env.send(
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id,
             reduce_q: POS_SCALE,
         },
         vec![
@@ -29273,6 +29279,7 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     let r_owner = env.send(
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id,
             reduce_q: POS_SCALE,
         },
         vec![
@@ -29395,6 +29402,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             reduce_q,
         },
         vec![
@@ -29429,6 +29437,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             reduce_q,
         },
         vec![
@@ -57228,9 +57237,11 @@ fn v16_attack_rebalance_reduce_rejects_when_resolve_matured() {
     let vault_before = env.svm.get_account(&env.vault).unwrap();
 
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let rejected = env.send(
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id,
             reduce_q: remaining,
         },
         vec![
@@ -58543,9 +58554,11 @@ fn v16_attack_rebalance_reduce_overshoot_clamps_to_flat_no_flip() {
     // The owner force-reduces with reduce_q FAR larger than the position (3x). The clamp must cap the
     // reduction at the position size, landing exactly flat — never flipping the long into a short.
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let r = env.send(
         ProgInstruction::RebalanceReduce {
             asset_index: 0,
+            market_id,
             reduce_q: 3 * POS_SCALE,
         },
         vec![
@@ -60558,6 +60571,7 @@ fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
                 ],
                 data: ProgInstruction::RebalanceReduce {
                     asset_index: 0,
+                    market_id: old_market_id,
                     reduce_q: NEW_SIZE_Q as u128,
                 }
                 .encode(),
@@ -60635,10 +60649,7 @@ fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
     env.configure_auth_mark_with_cu(REINIT_SLOT, 100);
     assert_ne!(env.asset_market_id(0), old_market_id);
 
-    for (owner, portfolio) in [
-        (&victim_owner, victim),
-        (&attacker_owner, attacker),
-    ] {
+    for (owner, portfolio) in [(&victim_owner, victim), (&attacker_owner, attacker)] {
         env.svm
             .set_account(
                 portfolio,
@@ -60693,10 +60704,25 @@ fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
         .expect("refresh replacement at the adverse mark");
     }
 
-    let replayed = env.svm.send_transaction(retained_reduce).is_ok();
-    if replayed {
-        assert!(!has_active_leg_for_asset(&env.portfolio_state(victim), 0));
-    }
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let attacker_before = env.svm.get_account(&attacker).unwrap();
+    let replay_error = env
+        .svm
+        .send_transaction(retained_reduce)
+        .expect_err("old market generation must reject");
+    let replay_error = format!("{replay_error:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale RebalanceReduce must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+    assert_eq!(env.svm.get_account(&attacker).unwrap(), attacker_before);
 
     env.svm.expire_blockhash();
     env.svm.warp_to_slot(REINIT_SLOT + 2);
@@ -60710,17 +60736,15 @@ fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
             },
         );
     }
-    if !replayed {
-        env.trade_with_cu(
-            &victim_owner,
-            victim,
-            &attacker_owner,
-            attacker,
-            -NEW_SIZE_Q,
-            100,
-            0,
-        );
-    }
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        -NEW_SIZE_Q,
+        100,
+        0,
+    );
 
     env.resolve();
     let victim_dest = env.close_resolved(&victim_owner, victim);
@@ -60728,7 +60752,7 @@ fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
     let victim_payout = env.token_amount(victim_dest) as u128;
     let attacker_payout = env.token_amount(attacker_dest) as u128;
     assert!(
-        !replayed && victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
+        victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
         "rebalance consent for market {old_market_id} replayed into market {}: victim={victim_payout}, attacker={attacker_payout}",
         env.asset_market_id(0),
     );

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60514,3 +60514,222 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+#[test]
+fn v16_attack_rebalance_reduce_cannot_replay_across_market_reinit() {
+    const DEPOSIT: u128 = 1_000_000;
+    const OLD_SIZE_Q: i128 = 2_000 * POS_SCALE as i128;
+    const NEW_SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+    const REINIT_SLOT: u64 = 11;
+
+    let params = V16CuMarketParams::default();
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_with_cu(0, 100);
+    let admin = env.admin.insecure_clone();
+
+    let victim_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        OLD_SIZE_Q,
+        100,
+        0,
+    );
+    let old_market_id = env.asset_market_id(0);
+
+    env.svm.expire_blockhash();
+    let retained_reduce = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::RebalanceReduce {
+                    asset_index: 0,
+                    reduce_q: NEW_SIZE_Q as u128,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        -OLD_SIZE_Q,
+        100,
+        0,
+    );
+    env.withdraw(&victim_owner, victim, DEPOSIT);
+    env.withdraw(&attacker_owner, attacker, DEPOSIT);
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    env.close_portfolio_with_cu(&attacker_owner, attacker);
+    env.resolve();
+    env.close_slab_with_cu();
+    assert_eq!(env.svm.get_account(&env.market).unwrap().lamports, 0);
+
+    env.svm.warp_to_slot(REINIT_SLOT);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    env.send(
+        init_market_instruction(&reinit_params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("same market address is publicly reinitialized");
+    env.configure_auth_mark_with_cu(REINIT_SLOT, 100);
+    assert_ne!(env.asset_market_id(0), old_market_id);
+
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&attacker_owner, attacker),
+    ] {
+        env.svm
+            .set_account(
+                portfolio,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: vec![0u8; env.portfolio_account_len],
+                    owner: env.program_id,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        env.send(
+            ProgInstruction::InitPortfolio,
+            vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[owner],
+        )
+        .expect("same portfolio address is publicly reinitialized");
+    }
+
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        NEW_SIZE_Q,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(REINIT_SLOT + 1);
+    env.push_auth_mark_with_cu(REINIT_SLOT + 1, 50);
+    for portfolio in [victim, attacker] {
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: REINIT_SLOT + 1,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        )
+        .expect("refresh replacement at the adverse mark");
+    }
+
+    let replayed = env.svm.send_transaction(retained_reduce).is_ok();
+    if replayed {
+        assert!(!has_active_leg_for_asset(&env.portfolio_state(victim), 0));
+    }
+
+    env.svm.expire_blockhash();
+    env.svm.warp_to_slot(REINIT_SLOT + 2);
+    env.push_auth_mark_with_cu(REINIT_SLOT + 2, 100);
+    for portfolio in [victim, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: REINIT_SLOT + 2,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    if !replayed {
+        env.trade_with_cu(
+            &victim_owner,
+            victim,
+            &attacker_owner,
+            attacker,
+            -NEW_SIZE_Q,
+            100,
+            0,
+        );
+    }
+
+    env.resolve();
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let attacker_dest = env.close_resolved(&attacker_owner, attacker);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let attacker_payout = env.token_amount(attacker_dest) as u128;
+    assert!(
+        !replayed && victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
+        "rebalance consent for market {old_market_id} replayed into market {}: victim={victim_payout}, attacker={attacker_payout}",
+        env.asset_market_id(0),
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -209,6 +209,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let side: u8 = kani::any();
     let b_delta_budget: u128 = kani::any();
     let reduce_q: u128 = kani::any();
@@ -233,15 +234,18 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 
     let rebalance = Instruction::RebalanceReduce {
         asset_index,
+        market_id,
         reduce_q,
     }
     .encode();
     match Instruction::decode(&rebalance).unwrap() {
         Instruction::RebalanceReduce {
             asset_index: got_asset,
+            market_id: got_market_id,
             reduce_q: got_reduce,
         } => {
             assert_eq!(got_asset, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_reduce, reduce_q);
         }
         _ => unreachable!(),
@@ -288,6 +292,17 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
         Instruction::SyncMaintenanceFee { now_slot: got } => assert_eq!(got, now_slot),
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_rebalance_market_generation_payload_is_rejected() {
+    let asset_index: u16 = kani::any();
+    let reduce_q: u128 = kani::any();
+    let mut legacy = [0u8; 19];
+    legacy[0] = 44;
+    legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    legacy[3..19].copy_from_slice(&reduce_q.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 }
 
 #[kani::proof]
@@ -1401,6 +1416,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::RebalanceReduce {
             asset_index: 0,
+            market_id: 1,
             reduce_q: 1,
         },
         extra,


### PR DESCRIPTION
## What changed

- add the current asset `market_id` to the owner-signed `RebalanceReduce` wire payload
- reject a retained tag-44 instruction with `AssetGenerationMismatch` before entering the engine
- prove wire round-trip and rejection of the legacy unbound payload with Kani
- retain an end-to-end LiteSVM RED/GREEN exploit test with exact error and rollback assertions

## Root cause and impact

`RebalanceReduce` was owner-signed but did not identify the market incarnation. After a market was closed and publicly reinitialized at the same address, its portfolio allocator restarted. A transaction retained from the old market could therefore execute against a replacement portfolio at the same address and reduce fresh exposure at an attacker-selected later mark.

The exact-parent RED commit is `ac577b59`. It recreates the market and both portfolios at the same public addresses, reopens fresh exposure, replays the old signed reduction at an adverse mark, and demonstrates an independent-victim transfer: victim payout 950,000; attacker payout 1,050,000.

## Dependency and interaction

This is intentionally based on #231, which supplies the persistent market-generation PDA and changing `market_id` across full market recreation.

#292 independently binds `RebalanceReduce` to `portfolio_id`. Neither boundary subsumes the other. After #231 lands, this PR and #292 must be rebased/combined so tag 44 binds both `market_id` and `portfolio_id`.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets`: 5 unit + 569 LiteSVM/CU tests passed
- `cargo kani --tests --exact --harness kani_v16_recovery_close_progress_decode_preserves_wire_fields`
- `cargo kani --tests --exact --harness kani_v16_legacy_unbound_rebalance_market_generation_payload_is_rejected`
- `cargo fmt --all -- --check`
- `git diff --check`