### PR TITLE
[HARDENING LoF] Bind recovery forfeits to market generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed close recovery path; optional deposit is transferred first, then the engine cancels the pending close if the cure succeeds
 - **ForfeitRecoveryLeg** (tag 43)
   - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
+  - binds the current asset `market_id`; consent from a retired market generation rejects
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector
 - **ClaimResolvedPayoutTopup** (tag 46)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2704,6 +2704,7 @@ pub mod ix {
         },
         ForfeitRecoveryLeg {
             asset_index: u16,
+            market_id: u64,
             b_delta_budget: u128,
         },
         RebalanceReduce {
@@ -2983,6 +2984,7 @@ pub mod ix {
                 },
                 43 => Self::ForfeitRecoveryLeg {
                     asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     b_delta_budget: read_u128(&mut rest)?,
                 },
                 44 => Self::RebalanceReduce {
@@ -3384,10 +3386,12 @@ pub mod ix {
                 }
                 Self::ForfeitRecoveryLeg {
                     asset_index,
+                    market_id,
                     b_delta_budget,
                 } => {
                     out.push(43);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, b_delta_budget);
                 }
                 Self::RebalanceReduce {
@@ -5503,8 +5507,15 @@ pub mod processor {
             }
             Instruction::ForfeitRecoveryLeg {
                 asset_index,
+                market_id,
                 b_delta_budget,
-            } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
+            } => handle_forfeit_recovery_leg(
+                program_id,
+                accounts,
+                asset_index,
+                market_id,
+                b_delta_budget,
+            ),
             Instruction::RebalanceReduce {
                 asset_index,
                 reduce_q,
@@ -8557,10 +8568,19 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_market_id: u64,
         b_delta_budget: u128,
     ) -> ProgramResult {
         if b_delta_budget == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let market_ai = account(accounts, 1)?;
+        let (_, _, _, current_market_id, _, _) = state::read_market_trade_preflight(
+            &market_ai.try_borrow_data()?,
+            asset_index as usize,
+        )?;
+        if current_market_id != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
         }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3435,9 +3435,11 @@ impl V16CuEnv {
         asset_index: u16,
         b_delta_budget: u128,
     ) -> u64 {
+        let market_id = self.asset_market_id(asset_index);
         self.send(
             ProgInstruction::ForfeitRecoveryLeg {
                 asset_index,
+                market_id,
                 b_delta_budget,
             },
             vec![
@@ -17008,6 +17010,7 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     let forfeit = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1,
         },
         vec![
@@ -29564,6 +29567,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1,
         },
         vec![
@@ -29599,6 +29603,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1,
         },
         vec![
@@ -29745,6 +29750,7 @@ fn v16_attack_recovery_tools_owner_gated() {
     let r1 = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1,
         },
         vec![
@@ -55191,6 +55197,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     let r_grief = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1_000,
         },
         vec![
@@ -55220,6 +55227,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     let r_zero = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 0,
         },
         vec![
@@ -57132,6 +57140,7 @@ fn v16_attack_forfeit_recovery_leg_rejects_when_resolve_matured() {
     let rejected = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: first_generation_market_id(0),
             b_delta_budget: 1,
         },
         vec![
@@ -60572,6 +60581,7 @@ fn v16_attack_forfeit_recovery_leg_cannot_replay_across_market_reinit() {
                 ],
                 data: ProgInstruction::ForfeitRecoveryLeg {
                     asset_index: 0,
+                    market_id: old_market_id,
                     b_delta_budget: 1,
                 }
                 .encode(),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60514,3 +60514,265 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         "valid topup credits exactly the backing"
     );
 }
+
+// A full market close/reinit restarts the portfolio allocator, so portfolio_id alone cannot bind
+// irreversible forfeit consent to the market incarnation. Retain the exact victim-signed request
+// from the old market, then recreate the market and portfolios at the same public addresses. A
+// stale forfeit must not discard the replacement winner's payout.
+#[test]
+fn v16_attack_forfeit_recovery_leg_cannot_replay_across_market_reinit() {
+    const PRICE: u64 = 100;
+    const WIN_PRICE: u64 = 150;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 5_000 * POS_SCALE as i128;
+    const REINIT_SLOT: u64 = 10;
+
+    let params = V16CuMarketParams {
+        max_portfolio_assets: 2,
+        maintenance_margin_bps: 1_000,
+        initial_margin_bps: 1_000,
+        max_price_move_bps_per_slot: 500,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(100, 1);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, PRICE);
+
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let counterparty_portfolio = env.create_portfolio(&admin);
+    let old_market_id = env.asset_market_id(0);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&admin, counterparty_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &admin,
+        counterparty_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("old market enters Recovery");
+    let stale_forfeit = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim_portfolio, false),
+                ],
+                data: ProgInstruction::ForfeitRecoveryLeg {
+                    asset_index: 0,
+                    b_delta_budget: 1,
+                }
+                .encode(),
+            },
+        ],
+        Some(&victim.pubkey()),
+        &[&victim],
+        env.svm.latest_blockhash(),
+    );
+
+    env.forfeit_recovery_leg_with_cu(&victim, victim_portfolio, 0, 1);
+    env.forfeit_recovery_leg_with_cu(&admin, counterparty_portfolio, 0, 1);
+    env.withdraw(&victim, victim_portfolio, DEPOSIT);
+    env.withdraw(&admin, counterparty_portfolio, DEPOSIT);
+    env.close_portfolio_with_cu(&victim, victim_portfolio);
+    env.close_portfolio_with_cu(&admin, counterparty_portfolio);
+    env.resolve();
+    env.close_slab_with_cu();
+
+    env.svm.warp_to_slot(REINIT_SLOT);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    env.send(
+        init_market_instruction(&reinit_params),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("same market address is publicly reinitialized");
+    env.configure_permissionless_resolve_with_cu(101, 1);
+    env.configure_auth_mark_with_cu(REINIT_SLOT, PRICE);
+
+    for (owner, portfolio) in [
+        (&victim, victim_portfolio),
+        (&admin, counterparty_portfolio),
+    ] {
+        env.svm
+            .set_account(
+                portfolio,
+                Account {
+                    lamports: 1_000_000_000,
+                    data: vec![0u8; env.portfolio_account_len],
+                    owner: env.program_id,
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        let init_portfolio = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            data: ProgInstruction::InitPortfolio.encode(),
+        };
+        send_raw_ixs(
+            &mut env.svm,
+            &env.payer,
+            vec![
+                heap_ix(),
+                cu_ix(),
+                ComputeBudgetInstruction::set_compute_unit_price(1),
+                init_portfolio,
+            ],
+            &[owner],
+        )
+        .expect("same portfolio address is publicly reinitialized");
+    }
+    let replacement_market_id = env.asset_market_id(0);
+    assert_ne!(replacement_market_id, old_market_id);
+
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&admin, counterparty_portfolio, DEPOSIT);
+    env.trade_with_cu(
+        &victim,
+        victim_portfolio,
+        &admin,
+        counterparty_portfolio,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    env.svm.warp_to_slot(REINIT_SLOT + 10);
+    env.push_auth_mark_with_cu(REINIT_SLOT + 10, WIN_PRICE);
+    env.crank_steps(
+        counterparty_portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: REINIT_SLOT + 10,
+            observations: crank_observations(0),
+        },
+        4,
+    );
+    let effective_mark = env.market_state().1.assets[0].effective_price;
+    let pending_victim_profit =
+        SIZE_Q.unsigned_abs() * (effective_mark - PRICE) as u128 / POS_SCALE;
+    assert!(pending_victim_profit > 0);
+    assert_eq!(env.portfolio_state(victim_portfolio).pnl.get(), 0);
+
+    env.svm.warp_to_slot(REINIT_SLOT + 11);
+    env.try_shutdown_asset_with_authority(&admin, 0, REINIT_SLOT + 11)
+        .expect("replacement market enters Recovery at the honest mark");
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim_portfolio).unwrap();
+    let replay = env.svm.send_transaction(stale_forfeit);
+    if replay.is_ok() {
+        let victim_after = env.portfolio_state(victim_portfolio);
+        let victim_equity = victim_after.capital.get() as i128 + victim_after.pnl.get();
+        assert!(percolator::active_bitmap_is_empty(active_bitmap(
+            &victim_after
+        )));
+
+        env.resolve();
+        env.svm.warp_to_slot(REINIT_SLOT + 12);
+        let counterparty_dest = env.close_resolved(&admin, counterparty_portfolio);
+        let victim_dest = env.close_resolved(&victim, victim_portfolio);
+        let counterparty_out = env.token_amount(counterparty_dest) as u128;
+        let victim_out = env.token_amount(victim_dest) as u128;
+        env.close_portfolio_with_cu(&admin, counterparty_portfolio);
+        env.close_portfolio_with_cu(&victim, victim_portfolio);
+        let (_, stuck) = env.market_state();
+        assert_eq!(stuck.c_tot, 0);
+        assert_eq!(stuck.insurance, 0);
+        assert_eq!(stuck.materialized_portfolio_count, 0);
+        assert_eq!(stuck.vault, pending_victim_profit);
+
+        let close_dest = env.token_account(admin.pubkey(), 0);
+        let close_slab = env.send(
+            ProgInstruction::CloseSlab,
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new(close_dest, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(env.market_generation, false),
+                AccountMeta::new_readonly(system_program::ID, false),
+            ],
+            &[&admin],
+        );
+        assert!(close_slab.is_err());
+        panic!(
+            "a forfeit signed for market {old_market_id} executed in replacement market \
+             {replacement_market_id}, discarded {pending_victim_profit} of victim PnL, paid the \
+             victim only {victim_out} (equity {victim_equity}), paid the counterparty \
+             {counterparty_out}, and stranded {} in a slab that cannot close: {close_slab:?}",
+            stuck.vault,
+        );
+    }
+
+    let replay_error = format!("{replay:?}");
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale forfeit must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_before
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -209,6 +209,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let side: u8 = kani::any();
     let b_delta_budget: u128 = kani::any();
     let reduce_q: u128 = kani::any();
@@ -217,15 +218,18 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 
     let forfeit = Instruction::ForfeitRecoveryLeg {
         asset_index,
+        market_id,
         b_delta_budget,
     }
     .encode();
     match Instruction::decode(&forfeit).unwrap() {
         Instruction::ForfeitRecoveryLeg {
             asset_index: got_asset,
+            market_id: got_market_id,
             b_delta_budget: got_budget,
         } => {
             assert_eq!(got_asset, asset_index);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_budget, b_delta_budget);
         }
         _ => unreachable!(),
@@ -288,6 +292,17 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
         Instruction::SyncMaintenanceFee { now_slot: got } => assert_eq!(got, now_slot),
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_forfeit_market_generation_payload_is_rejected() {
+    let asset_index: u16 = kani::any();
+    let b_delta_budget: u128 = kani::any();
+    let mut legacy = [0u8; 19];
+    legacy[0] = 43;
+    legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    legacy[3..19].copy_from_slice(&b_delta_budget.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 }
 
 #[kani::proof]
@@ -1394,6 +1409,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::ForfeitRecoveryLeg {
             asset_index: 0,
+            market_id: 1,
             b_delta_budget: 1,
         },
         extra,


### PR DESCRIPTION
## What changed

- Add the current asset `market_id` to the owner-signed `ForfeitRecoveryLeg` payload.
- Reject consent from a retired market generation before entering the engine mutation.
- Prove wire round-trip preservation and rejection of the legacy unbound payload with Kani.
- Retain a public LiteSVM RED/GREEN lifecycle with exact rollback assertions.

## Root cause and impact

`ForfeitRecoveryLeg` is irreversible consent to discard one portfolio's recovery claim, but its payload identified only the market address and asset slot. After `CloseSlab` and public `InitMarket` reuse of the same address, a transaction signed for the retired market could execute against a replacement portfolio and position.

The exact-parent RED commit is `e3310eca`. It closes and recreates the market and portfolios through public instructions, changes the persistent asset generation from 1 to 3, opens a fresh winning position, and replays the old victim-signed forfeit. The replay discards 100,000 of replacement-victim PnL, pays the victim only 1,000,000 principal, leaves exactly 100,000 in the canonical vault after all portfolios close, and makes public `CloseSlab` fail with `EngineLockActive`.

The fix is `cf15ff73`. A stale tag-43 request now fails with `AssetGenerationMismatch` and SVM rollback leaves the market and victim portfolio byte-identical.

## Dependency

This PR is intentionally based on #231, which supplies the persistent market-generation PDA and changing `market_id` across full market recreation. #278 independently binds the same instruction to `portfolio_id`; after both dependencies land, tag 43 must carry both boundaries.

## Verification

- Exact-parent public LiteSVM RED, then GREEN with exact error and rollback checks
- `cargo build-sbf --tools-version v1.52 --no-default-features`
- `cargo test --all-targets`: 5 unit and 569 LiteSVM/CU tests passed
- `cargo kani --tests --exact --harness kani_v16_recovery_close_progress_decode_preserves_wire_fields`: 1,524 checks, 0 failures
- `cargo kani --tests --exact --harness kani_v16_legacy_unbound_forfeit_market_generation_payload_is_rejected`: 831 checks, 0 failures
- `cargo fmt --all -- --check`
- `git diff --check`
