### PR TITLE
[BLOCKER DoS] Prove prospective K/F source expiry progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f87ca00a95b285aef5579639132991697fcbe7c5#f87ca00a95b285aef5579639132991697fcbe7c5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=5997d84eb00c21cb28c49f05e5e2786f5ee2e54e#5997d84eb00c21cb28c49f05e5e2786f5ee2e54e"
+source = "git+https://github.com/aeyakovenko/percolator?rev=090589679cad025c5e0a06c5aba61123d8eef395#090589679cad025c5e0a06c5aba61123d8eef395"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5419f45ac50a29cea52a2f72e5b03aa53cc95538#5419f45ac50a29cea52a2f72e5b03aa53cc95538"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf#ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
+source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4#22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5997d84eb00c21cb28c49f05e5e2786f5ee2e54e#5997d84eb00c21cb28c49f05e5e2786f5ee2e54e"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a21b82ab19130870965e6a88461d1cb270fbbedb#a21b82ab19130870965e6a88461d1cb270fbbedb"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b6827a09add5a4c7e4db074cc45339c691364428#b6827a09add5a4c7e4db074cc45339c691364428"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=b6827a09add5a4c7e4db074cc45339c691364428#b6827a09add5a4c7e4db074cc45339c691364428"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b4901b93e72ba29dcedde7efd513b08eb43fb6ab#b4901b93e72ba29dcedde7efd513b08eb43fb6ab"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=5419f45ac50a29cea52a2f72e5b03aa53cc95538#5419f45ac50a29cea52a2f72e5b03aa53cc95538"
+source = "git+https://github.com/aeyakovenko/percolator?rev=22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4#22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a9baa0833e09a29dd7690049fc6ea4065147fd59#a9baa0833e09a29dd7690049fc6ea4065147fd59"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=55f4026dda2dc5954757e64e54b0cb06a9e143e6#55f4026dda2dc5954757e64e54b0cb06a9e143e6"
+source = "git+https://github.com/aeyakovenko/percolator?rev=6d1d9d7f653dec327e9b95941933afcb8b249432#6d1d9d7f653dec327e9b95941933afcb8b249432"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=090589679cad025c5e0a06c5aba61123d8eef395#090589679cad025c5e0a06c5aba61123d8eef395"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a21b82ab19130870965e6a88461d1cb270fbbedb#a21b82ab19130870965e6a88461d1cb270fbbedb"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a64e33aa1b61e749e42a6fec749b52482ca72db7#a64e33aa1b61e749e42a6fec749b52482ca72db7"
+source = "git+https://github.com/aeyakovenko/percolator?rev=8699a1e09c22dcb41e33032eb2e7d34da40d2b32#8699a1e09c22dcb41e33032eb2e7d34da40d2b32"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=b9b93b21e32a4db0252cba1cc65c09b9557f1aeb#b9b93b21e32a4db0252cba1cc65c09b9557f1aeb"
+source = "git+https://github.com/aeyakovenko/percolator?rev=137556379a1c8e31c59d58321a8de986e188debd#137556379a1c8e31c59d58321a8de986e188debd"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=f212d98919d30f7b15e6872793403a46687674f3#f212d98919d30f7b15e6872793403a46687674f3"
+source = "git+https://github.com/aeyakovenko/percolator?rev=35f6ffec9c52e6237a356af724a04ad7f546e744#35f6ffec9c52e6237a356af724a04ad7f546e744"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "090589679cad025c5e0a06c5aba61123d8eef395" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a21b82ab19130870965e6a88461d1cb270fbbedb" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "090589679cad025c5e0a06c5aba61123d8eef395" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a21b82ab19130870965e6a88461d1cb270fbbedb" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "090589679cad025c5e0a06c5aba61123d8eef395" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "090589679cad025c5e0a06c5aba61123d8eef395" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5997d84eb00c21cb28c49f05e5e2786f5ee2e54e" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f212d98919d30f7b15e6872793403a46687674f3" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b6827a09add5a4c7e4db074cc45339c691364428" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b4901b93e72ba29dcedde7efd513b08eb43fb6ab" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b6827a09add5a4c7e4db074cc45339c691364428" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b4901b93e72ba29dcedde7efd513b08eb43fb6ab" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "35f6ffec9c52e6237a356af724a04ad7f546e744" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ca7f10c2c0e1cd93b3adb25cdd81973c26974cdf" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a64e33aa1b61e749e42a6fec749b52482ca72db7" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "8699a1e09c22dcb41e33032eb2e7d34da40d2b32" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b9b93b21e32a4db0252cba1cc65c09b9557f1aeb" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a21b82ab19130870965e6a88461d1cb270fbbedb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b6827a09add5a4c7e4db074cc45339c691364428" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a21b82ab19130870965e6a88461d1cb270fbbedb" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b6827a09add5a4c7e4db074cc45339c691364428" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9baa0833e09a29dd7690049fc6ea4065147fd59" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "55f4026dda2dc5954757e64e54b0cb06a9e143e6" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "6d1d9d7f653dec327e9b95941933afcb8b249432" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "f87ca00a95b285aef5579639132991697fcbe7c5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "22df6aeaa32f06c3e0e38e7a75f7de2b311eaac4" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "137556379a1c8e31c59d58321a8de986e188debd" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5419f45ac50a29cea52a2f72e5b03aa53cc95538" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5206,7 +5206,7 @@ pub mod processor {
                 handle_convert_released_pnl(program_id, accounts, amount)
             }
             Instruction::CloseResolved { fee_rate_per_slot } => {
-                handle_close_resolved(program_id, accounts, fee_rate_per_slot)
+                handle_close_resolved(program_id, accounts, fee_rate_per_slot, true)
             }
             Instruction::UpdateAuthority { new_pubkey } => {
                 handle_update_authority(program_id, accounts, new_pubkey)
@@ -10240,6 +10240,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         _fee_rate_per_slot: u128,
+        require_payout_accounts: bool,
     ) -> ProgramResult {
         let owner = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10290,7 +10291,7 @@ pub mod processor {
             };
             (cfg, payout)
         };
-        if payout != 0 {
+        if require_payout_accounts || payout != 0 {
             let dest_token = account(accounts, 3)?;
             let vault_token = account(accounts, 4)?;
             let vault_authority_ai = account(accounts, 5)?;
@@ -10308,18 +10309,20 @@ pub mod processor {
                 &cfg_after,
             )?;
             verify_permissionless_payout_dest_token_account(dest_token)?;
-            let payout_u64 = amount_to_u64(payout)?;
-            require_token_balance(vault_token, payout_u64)?;
-            let bump_arr = [bump];
-            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-            transfer_tokens_signed(
-                token_program,
-                vault_token,
-                dest_token,
-                vault_authority_ai,
-                payout_u64,
-                signer_seeds,
-            )?;
+            if payout != 0 {
+                let payout_u64 = amount_to_u64(payout)?;
+                require_token_balance(vault_token, payout_u64)?;
+                let bump_arr = [bump];
+                let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+                transfer_tokens_signed(
+                    token_program,
+                    vault_token,
+                    dest_token,
+                    vault_authority_ai,
+                    payout_u64,
+                    signer_seeds,
+                )?;
+            }
         }
         Ok(())
     }
@@ -10713,7 +10716,7 @@ pub mod processor {
         let (_, mode, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         if mode == MarketModeV16::Resolved {
-            return handle_close_resolved(program_id, accounts, 0);
+            return handle_close_resolved(program_id, accounts, 0, false);
         }
         handle_permissionless_crank_zero_copy(
             program_id,

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6337,6 +6337,37 @@ pub mod processor {
         account_b
             .validate_with_market(&group.as_view())
             .map_err(map_v16_error)?;
+        let position_a = signed_position_for_asset_view(&group, &account_a, asset_index_usize)?;
+        let position_b = signed_position_for_asset_view(&group, &account_b, asset_index_usize)?;
+        if position_a == 0 || position_b == 0 {
+            let (residue, residue_position) = match (position_a != 0, position_b != 0) {
+                (true, false) => (&mut account_a, position_a),
+                (false, true) => (&mut account_b, position_b),
+                _ => return Err(PercolatorError::EngineNonProgress.into()),
+            };
+            let side_oi = if residue_position > 0 {
+                asset.oi_eff_long_q.get()
+            } else {
+                asset.oi_eff_short_q.get()
+            };
+            if side_oi != 0 {
+                return Err(PercolatorError::EngineInvalidLeg.into());
+            }
+            // A prior matched force-close can consume the final effective OI
+            // while leaving one ADL terminal residue and no opposite leg to
+            // pair. After the same abandonment delay, settle that dead leg via
+            // the engine's recovery-forfeit path without requiring its owner.
+            group
+                .forfeit_recovery_leg_not_atomic(residue, asset_index_usize, close_q)
+                .map_err(map_v16_error)?;
+            group.validate_shape().map_err(map_v16_error)?;
+            account_a
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error)?;
+            return account_b
+                .validate_with_market(&group.as_view())
+                .map_err(map_v16_error);
+        }
         let leg_a = active_leg_for_asset_view(&account_a, asset_index_usize)?;
         let leg_b = active_leg_for_asset_view(&account_b, asset_index_usize)?;
         if leg_a.side == leg_b.side {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12921,6 +12921,173 @@ fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
     );
 }
 
+// A public ADL reset must not leave an abandoned winner able to block either a
+// later cross-margin liquidation or permissionless side-reset finalization.
+#[test]
+fn v16_attack_prior_reset_obligation_cannot_block_live_asset_liquidation() {
+    let params = V16CuMarketParams {
+        max_portfolio_assets: 2,
+        max_price_move_bps_per_slot: 10_000,
+        ..V16CuMarketParams::default()
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let target_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_loser_owner = Keypair::new();
+    let asset0_loser = env.create_portfolio(&asset0_loser_owner);
+    let asset1_winner_owner = Keypair::new();
+    let asset1_winner = env.create_portfolio(&asset1_winner_owner);
+    env.deposit(&target_owner, target, 300);
+    env.deposit(&asset0_loser_owner, asset0_loser, 290);
+    env.deposit(&asset1_winner_owner, asset1_winner, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_loser_owner,
+        asset0_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &asset1_winner_owner,
+        asset1_winner,
+        &target_owner,
+        target,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_for_asset_as_admin(0, 1, 200);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(asset0_loser, false),
+        ],
+        &[],
+    )
+    .expect("first asset-0 move refreshes the future loser");
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 400);
+    for label in ["asset-0 refresh", "asset-0 liquidation"] {
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(asset0_loser, false),
+                ],
+                &[],
+            )
+            .expect(label);
+        assert_cu_within(label, cu, CRANK_CU_LIMIT);
+    }
+    assert!(!has_active_leg_for_asset(
+        &env.portfolio_state(asset0_loser),
+        0
+    ));
+    let group_after_asset0 = env.market_state().1;
+    assert_eq!(
+        group_after_asset0.assets[0].mode_long,
+        SideModeV16::ResetPending,
+    );
+    assert_eq!(group_after_asset0.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group_after_asset0.assets[0].oi_eff_short_q, 0);
+    assert!(
+        has_active_leg_for_asset(&env.portfolio_state(target), 0),
+        "the public liquidation leaves the winner's prior-reset obligation stored",
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(1, 3, 200);
+    let crank_target = |env: &mut V16CuEnv| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+    };
+    let live_before = active_leg_for_asset(&env.portfolio_state(target), 1)
+        .basis_pos_q
+        .unsigned_abs();
+    let cleanup_cu = crank_target(&mut env)
+        .expect("a keeper must settle and detach the prior-reset obligation without the owner");
+    assert_cu_within(
+        "prior-reset obligation auto-cleanup",
+        cleanup_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_cleanup = env.portfolio_state(target);
+    assert!(
+        !has_active_leg_for_asset(&after_cleanup, 0),
+        "the inert asset-0 obligation no longer blocks reset finalization",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_cleanup, 1)
+            .basis_pos_q
+            .unsigned_abs(),
+        live_before,
+        "cleanup does not mutate the later live position",
+    );
+    assert!(
+        health_cert(&after_cleanup).certified_liq_deficit > 0,
+        "the remaining live asset is independently liquidatable",
+    );
+
+    let liquidation_cu = crank_target(&mut env)
+        .expect("the next keeper call must liquidate the remaining live asset");
+    assert_cu_within(
+        "post-reset-obligation live liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let live_after = if has_active_leg_for_asset(&env.portfolio_state(target), 1) {
+        active_leg_for_asset(&env.portfolio_state(target), 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(live_after < live_before);
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "permissionless finalization after obligation cleanup",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::Normal,
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();
@@ -29318,6 +29485,14 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
             observations: Vec::new(),
         },
     );
+    let (_, group_after_cleanup) = env.market_state();
+    let reset_pending_after_cleanup = group_after_cleanup.assets[0];
+    assert_eq!(
+        reset_pending_after_cleanup.mode_long,
+        SideModeV16::ResetPending
+    );
+    assert_eq!(reset_pending_after_cleanup.stored_pos_count_long, 0);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(long), 0));
     let fresh_short_owner = Keypair::new();
     let fresh_short = env.create_portfolio(&fresh_short_owner);
     env.deposit(&fresh_short_owner, fresh_short, 20_000);
@@ -29352,13 +29527,11 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
 
     let (_, group) = env.market_state();
-    assert_eq!(group.assets[0], reset_pending);
+    assert_eq!(group.assets[0], reset_pending_after_cleanup);
     assert!(percolator::active_bitmap_is_empty(active_bitmap(
         &env.portfolio_state(fresh_short)
     )));
 
-    let forfeit_cu = env.forfeit_recovery_leg_with_cu(&long_owner, long, 0, 1);
-    assert_cu_within("ForfeitRecoveryLeg", forfeit_cu, CUSTODY_CU_LIMIT);
     let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
     assert_cu_within("FinalizeResetSide", finalize_cu, CUSTODY_CU_LIMIT);
     let (_, finalized) = env.market_state();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12772,6 +12772,155 @@ fn v16_bpf_hybrid_fresh_oracle_trade_devnet_difference_axes() {
     }
 }
 
+// A Recovery leg sorted before an unhealthy live leg must not poison auto-crank dispatch.
+#[test]
+fn v16_attack_recovery_first_leg_cannot_block_live_asset_liquidation() {
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(10_000, 1_000);
+    env.configure_auth_mark_for_asset_as_admin(0, 2, 1_000_000);
+    env.configure_auth_mark_for_asset_as_admin(1, 2, 1_000_000);
+
+    let target_owner = Keypair::new();
+    let asset0_counterparty_owner = Keypair::new();
+    let asset1_counterparty_owner = Keypair::new();
+    let target = env.create_portfolio(&target_owner);
+    let asset0_counterparty = env.create_portfolio(&asset0_counterparty_owner);
+    let asset1_counterparty = env.create_portfolio(&asset1_counterparty_owner);
+    env.deposit(&target_owner, target, 160_000);
+    env.deposit(&asset0_counterparty_owner, asset0_counterparty, 100_000_000);
+    env.deposit(&asset1_counterparty_owner, asset1_counterparty, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &target_owner,
+        target,
+        &asset0_counterparty_owner,
+        asset0_counterparty,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &target_owner,
+        target,
+        &asset1_counterparty_owner,
+        asset1_counterparty,
+        -(2 * POS_SCALE as i128),
+        1_000_000,
+        0,
+    );
+
+    env.svm.warp_to_slot(3);
+    env.push_auth_mark_for_asset_as_admin(0, 3, 1_000_000);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 3)
+        .expect("asset 0 enters Recovery while the cross-margin account is open");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery,
+    );
+
+    for slot in 3..=31u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(1, slot, 2_000_000);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(asset1_counterparty, false),
+            ],
+            &[],
+        )
+        .expect("an account whose first leg is live can apply the asset-1 mark");
+    }
+    assert!(
+        env.market_state().1.assets[1].effective_price > 1_050_000,
+        "asset 1 moved enough to make the target short unhealthy",
+    );
+
+    let before_refresh = env.portfolio_state(target);
+    let recovery_basis_before = active_leg_for_asset(&before_refresh, 0).basis_pos_q;
+    let live_basis_before = active_leg_for_asset(&before_refresh, 1).basis_pos_q;
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the selector must skip the Recovery first leg and refresh on live asset 1");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_refresh = env.portfolio_state(target);
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 0).basis_pos_q,
+        recovery_basis_before,
+        "refresh leaves the Recovery leg present and unchanged",
+    );
+    assert_eq!(
+        active_leg_for_asset(&after_refresh, 1).basis_pos_q,
+        live_basis_before,
+        "the first step only refreshes the live leg",
+    );
+    assert!(
+        health_cert(&after_refresh).certified_liq_deficit > 0,
+        "the refreshed cross-margin account is liquidatable on live asset 1",
+    );
+
+    env.svm.expire_blockhash();
+    let liquidation_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 31,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(target, false),
+            ],
+            &[],
+        )
+        .expect("the next auto-crank must liquidate the dispatchable live leg");
+    assert_cu_within(
+        "mixed Recovery/live auto-crank liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let after_liquidation = env.portfolio_state(target);
+    let remaining = if has_active_leg_for_asset(&after_liquidation, 1) {
+        active_leg_for_asset(&after_liquidation, 1)
+            .basis_pos_q
+            .unsigned_abs()
+    } else {
+        0
+    };
+    assert!(remaining < live_basis_before.unsigned_abs());
+    assert_eq!(
+        active_leg_for_asset(&after_liquidation, 0).basis_pos_q,
+        recovery_basis_before,
+        "liquidating asset 1 does not mutate the Recovery asset-0 leg",
+    );
+}
+
 #[test]
 fn v16_bpf_hybrid_mark_uses_ewma_after_hours_then_oracle_when_fresh() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38283,6 +38283,160 @@ fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
     assert!(done.vault >= done.c_tot + done.insurance);
 }
 
+// A partial ADL can leave stored basis larger than matched effective OI. If the oracle then dies,
+// the delayed permissionless force-close must not require the abandoned owner to clean the final
+// zero-OI residue: one call nets the matched lot and a second singleton call settles/detaches the
+// residue, after which the side can be finalized without consuming the user's separate PnL claim.
+#[test]
+fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation before recovery",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+    let matched_oi_after_adl = env.market_state().1.assets[0].oi_eff_long_q;
+    assert_eq!(
+        env.market_state().1.assets[0].oi_eff_short_q,
+        matched_oi_after_adl
+    );
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0).basis_pos_q,
+        (2 * POS_SCALE) as i128,
+    );
+    env.svm.warp_to_slot(7);
+    let admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.try_shutdown_asset_with_authority(&admin, 0, 7)
+        .expect("public shutdown enters asset recovery");
+    env.svm.warp_to_slot(8);
+    let cranker = Keypair::new();
+    env.svm.expire_blockhash();
+    let vault_before = env.market_state().1.vault;
+    let first_cu = env
+        .try_force_close_abandoned_asset_with_cu(&cranker, long, short, 0, 8, 2 * POS_SCALE)
+        .expect("the first force close nets the remaining matched exposure");
+    assert_cu_within(
+        "partial-ADL Recovery matched force close",
+        first_cu,
+        TRADE_CU_LIMIT,
+    );
+    let group = env.market_state().1;
+    let long_state = env.portfolio_state(long);
+    let short_state = env.portfolio_state(short);
+    let long_capital_before_cleanup = long_state.capital.get();
+    let long_pnl_before_cleanup = long_state.pnl.get();
+    assert_eq!(group.assets[0].oi_eff_long_q, 0);
+    assert_eq!(group.assets[0].oi_eff_short_q, 0);
+    assert_eq!(
+        active_leg_for_asset(&long_state, 0).basis_pos_q,
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "the matched close leaves only the ADL terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&short_state, 0),
+        "the matched short is fully closed",
+    );
+
+    env.svm.expire_blockhash();
+    let cleanup_cu = env
+        .try_force_close_abandoned_asset_with_cu(
+            &cranker,
+            long,
+            short,
+            0,
+            8,
+            percolator::MAX_VAULT_TVL,
+        )
+        .expect("a singleton zero-OI Recovery residue must be permissionlessly detachable");
+    assert_cu_within(
+        "partial-ADL Recovery singleton cleanup",
+        cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(long), 0),
+        "the abandoned owner is no longer required to detach the terminal residue",
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(short), 0),
+        "both public portfolios are detached",
+    );
+
+    let finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    assert_cu_within(
+        "partial-ADL Recovery side finalization",
+        finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.assets[0].lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_before,
+        "Recovery cleanup moves no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert_eq!(
+        env.portfolio_state(long).capital.get(),
+        long_capital_before_cleanup,
+    );
+    assert_eq!(
+        env.portfolio_state(long).pnl.get(),
+        long_pnl_before_cleanup,
+        "terminal position cleanup preserves the independent user claim",
+    );
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7674,6 +7674,158 @@ fn v16_bpf_permissionless_crank_computes_funding_from_internal_mark_premium() {
 }
 
 #[test]
+fn v16_attack_resolved_close_progresses_after_source_backing_expires_before_loser_settlement() {
+    const PRICE: u64 = 100;
+    const MARK: u64 = 99;
+    const DEPOSIT: u128 = 100_000_000;
+    const SIZE_Q: i128 = 100_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: 1,
+        max_accrual_dt_slots: 1,
+        max_abs_funding_e9_per_slot: 10_000,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long_account, DEPOSIT);
+    env.deposit(&short_owner, short_account, DEPOSIT);
+    env.trade_with_cu(
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    // The one-bps movement cap rounds PRICE * cap / 10_000 to zero. This
+    // commits a funding premium without creating mark-to-market PnL.
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, MARK);
+    env.crank(
+        long_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, primed) = env.market_state();
+    assert_eq!(primed.assets[0].effective_price, PRICE);
+    assert_eq!(primed.assets[0].f_long_num, 0);
+    assert_eq!(primed.assets[0].f_short_num, 0);
+
+    env.svm.warp_to_slot(3);
+    env.crank(
+        long_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, funded) = env.market_state();
+    assert_eq!(funded.assets[0].effective_price, PRICE);
+    assert!(funded.assets[0].f_long_num > 0);
+    assert!(funded.assets[0].f_short_num < 0);
+    env.top_up_backing_bucket(1, 10, 5);
+
+    // Settle only the winner while the source bucket is still fresh. The
+    // short's matching funding loss remains in its leg's F delta.
+    env.svm.warp_to_slot(4);
+    env.crank(
+        long_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: crank_observations(0),
+        },
+    );
+    assert!(
+        env.portfolio_state(long_account).pnl.get() > 0,
+        "the long must settle funding profit before the opposing loss"
+    );
+    assert_eq!(
+        env.portfolio_state(short_account).pnl.get(),
+        0,
+        "the short must still carry its loss only in the unsettled F delta"
+    );
+    let (_, before_expiry) = env.market_state();
+    assert_eq!(
+        before_expiry.source_backing_buckets[1].status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert_eq!(before_expiry.source_backing_buckets[1].expiry_slot, 5);
+
+    env.svm.warp_to_slot(6);
+    env.resolve();
+
+    let long_dest = env.token_account(long_owner.pubkey(), 0);
+    let short_dest = env.token_account(short_owner.pubkey(), 0);
+    let try_close = |env: &mut V16CuEnv, owner: Pubkey, portfolio: Pubkey, dest: Pubkey| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            },
+            vec![
+                AccountMeta::new_readonly(owner, false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[],
+        )
+    };
+
+    let mut last_short = None;
+    let mut last_long = None;
+    for _ in 0..16 {
+        last_short = Some(try_close(
+            &mut env,
+            short_owner.pubkey(),
+            short_account,
+            short_dest,
+        ));
+        last_long = Some(try_close(
+            &mut env,
+            long_owner.pubkey(),
+            long_account,
+            long_dest,
+        ));
+    }
+
+    let long_after = env.portfolio_state(long_account);
+    let short_after = env.portfolio_state(short_account);
+    assert!(
+        percolator::active_bitmap_is_empty(active_bitmap(&long_after))
+            && percolator::active_bitmap_is_empty(active_bitmap(&short_after))
+            && long_after.capital.get() == 0
+            && short_after.capital.get() == 0,
+        "bounded public resolved-close retries must settle both sides after backing expiry; \
+         long_capital={} long_pnl={} long_active={:?} long_result={:?}; \
+         short_capital={} short_pnl={} short_active={:?} short_result={:?}",
+        long_after.capital.get(),
+        long_after.pnl.get(),
+        active_bitmap(&long_after),
+        last_long,
+        short_after.capital.get(),
+        short_after.pnl.get(),
+        active_bitmap(&short_after),
+        last_short,
+    );
+}
+
+#[test]
 fn v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides() {
     const INITIAL_PRICE: u64 = 1_000_000;
     const FUNDING_RATE_E9: i128 = 1_000;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38542,7 +38542,7 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
         )
         .expect("permissionless refresh must expire lapsed Live backing and commit");
     assert_cu_within(
-        "lapsed source-backing auto-crank refresh",
+        "lapsed source-backing expiry step",
         refresh_cu,
         CRANK_CU_LIMIT,
     );
@@ -38551,9 +38551,35 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     let expired = after_refresh.source_backing_buckets[1];
     assert_eq!(expired.status, BackingBucketStatusV16::Expired);
     assert_eq!(expired.fresh_unliened_backing_num, 0);
-    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_ne!(
+        health_cert(&env.portfolio_state(long)).cert_risk_epoch,
+        after_refresh.risk_epoch,
+        "expiry advances risk state, so another bounded crank remains actionable"
+    );
     assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
     assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    env.svm.expire_blockhash();
+    let certify_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("the next bounded auto-crank must certify after expiry");
+    assert_cu_within(
+        "post-expiry account certification",
+        certify_cu,
+        CRANK_CU_LIMIT,
+    );
+    assert!(health_cert(&env.portfolio_state(long)).valid);
 
     let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
         .basis_pos_q

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38437,6 +38437,140 @@ fn v16_attack_partial_adl_recovery_residue_can_be_force_closed_without_owner() {
     );
 }
 
+// Live source-backing expiry liveness: this is a fully public path to a source-backed claim.
+// A partial ADL realizes the loser's capital as Fresh backing for the winner. Once that bucket
+// expires, a later adverse move must not make RefreshAccount return EngineStale forever: SVM
+// rollback would restore the same lapsed-Fresh predicate after every keeper attempt and block the
+// owner's risk-reducing trade. Auto-crank must apply the canonical expiry transition, preserve
+// custody, certify both accounts, and leave the owner able to reduce the position.
+#[test]
+fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    env.deposit(&long_owner, long, 40);
+    env.deposit(&short_owner, short, 410);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    for slot in 2..=30 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 300);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    for portfolio in [short, long] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 30,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.crank(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+    );
+    let after_short_group = env.market_state().1;
+    let after_short_long = active_leg_for_asset(&env.portfolio_state(long), 0);
+    let after_short_short = active_leg_for_asset(&env.portfolio_state(short), 0);
+    assert_eq!(after_short_group.assets[0].b_long_num, 0);
+    assert_eq!(after_short_group.assets[0].b_short_num, 0);
+    assert!(!after_short_long.b_stale && !after_short_short.b_stale);
+    let generated_backing = after_short_group.source_backing_buckets[1];
+    assert_eq!(generated_backing.status, BackingBucketStatusV16::Fresh);
+    assert!(
+        generated_backing.fresh_unliened_backing_num > 0,
+        "public partial ADL must create real source backing for the winner"
+    );
+
+    for slot in 31..=160 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 1);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    let before_refresh = env.market_state().1;
+    let lapsed = before_refresh.source_backing_buckets[1];
+    assert_eq!(lapsed.status, BackingBucketStatusV16::Fresh);
+    assert!(lapsed.expiry_slot < 160, "backing is observably lapsed");
+    assert!(env.portfolio_state(long).pnl.get() > 0);
+    let vault_before = before_refresh.vault;
+    let vault_tokens_before = env.token_amount(env.vault);
+
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 160,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+        .expect("permissionless refresh must expire lapsed Live backing and commit");
+    assert_cu_within(
+        "lapsed source-backing auto-crank refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let after_refresh = env.market_state().1;
+    let expired = after_refresh.source_backing_buckets[1];
+    assert_eq!(expired.status, BackingBucketStatusV16::Expired);
+    assert_eq!(expired.fresh_unliened_backing_num, 0);
+    assert!(health_cert(&env.portfolio_state(long)).valid);
+    assert_eq!(after_refresh.vault, vault_before, "expiry moves no custody");
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before);
+
+    let long_before_exit = active_leg_for_asset(&env.portfolio_state(long), 0)
+        .basis_pos_q
+        .unsigned_abs();
+    let exit_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, POS_SCALE / 4);
+    assert_cu_within("post-expiry user risk reduction", exit_cu, CUSTODY_CU_LIMIT);
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(long), 0)
+            .basis_pos_q
+            .unsigned_abs(),
+        long_before_exit - POS_SCALE / 4,
+    );
+    let done = env.market_state().1;
+    assert_eq!(done.vault, vault_before);
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -38147,6 +38147,142 @@ fn v16_attack_adl_deleverage_conserves_and_shrinks_winner_claim() {
     );
 }
 
+// Public LoF/DoS regression: partial ADL leaves the winner's stored basis larger than matched
+// effective OI. Before the fix, a normal max-work RebalanceReduce aborts with
+// EngineCounterUnderflow; reducing exactly the remaining effective OI once instead leaves a
+// Normal-mode, zero-OI residue that every later reduction also rejects. The exit must clamp to
+// matched OI, establish the reset epoch, and leave both residual accounts finitely crankable.
+#[test]
+fn v16_attack_partial_adl_max_exit_and_both_residues_finish_permissionlessly() {
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(0, 100);
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000);
+    env.deposit(&short_owner, short, 900);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        (2 * POS_SCALE) as i128,
+        100,
+        0,
+    );
+
+    env.svm.warp_to_slot(6);
+    env.push_auth_mark_with_cu(6, 500);
+    for portfolio in [short, long] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 6,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    let liquidation_cu = env.crank_steps(
+        short,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 6,
+            observations: crank_observations(0),
+        },
+        2,
+    );
+    assert_cu_within(
+        "partial-ADL refresh and liquidation",
+        liquidation_cu,
+        CRANK_CU_LIMIT,
+    );
+
+    let (_, adl) = env.market_state();
+    let winner = env.portfolio_state(long);
+    assert_eq!(winner.legs[0].basis_pos_q.get(), (2 * POS_SCALE) as i128);
+    let matched_oi_after_adl = adl.assets[0].oi_eff_long_q;
+    assert_eq!(adl.assets[0].oi_eff_short_q, matched_oi_after_adl);
+    assert!(matched_oi_after_adl > 0);
+    assert!(matched_oi_after_adl < 2 * POS_SCALE);
+    assert_eq!(adl.assets[0].mode_long, SideModeV16::Normal);
+    let vault_after_adl = adl.vault;
+
+    // This max-work request is the old red path. It must consume only the remaining matched
+    // exposure rather than subtracting the full stored basis from smaller effective OI.
+    let reduce_cu = env.rebalance_reduce_with_cu(&long_owner, long, 0, 2 * POS_SCALE);
+    assert_cu_within(
+        "partial-ADL max RebalanceReduce",
+        reduce_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let (_, reset) = env.market_state();
+    assert_eq!(reset.assets[0].oi_eff_long_q, 0);
+    assert_eq!(reset.assets[0].oi_eff_short_q, 0);
+    assert_eq!(reset.assets[0].mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.assets[0].mode_short, SideModeV16::ResetPending);
+    assert_eq!(
+        env.portfolio_state(long).legs[0].basis_pos_q.get(),
+        (2 * POS_SCALE - matched_oi_after_adl) as i128,
+        "only effective exposure is reduced; terminal stored residue remains for settlement"
+    );
+
+    let mut max_cleanup_cu = 0;
+    for portfolio in [long, short] {
+        for _ in 0..3 {
+            if percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))) {
+                break;
+            }
+            max_cleanup_cu = max_cleanup_cu.max(env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 6,
+                    observations: crank_observations(0),
+                },
+            ));
+        }
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))),
+            "each prior-reset residue must detach in finitely many unsigned cranks"
+        );
+    }
+    assert_cu_within(
+        "partial-ADL residue cleanup",
+        max_cleanup_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let long_finalize_cu = env.finalize_reset_side_with_cu(0, 0);
+    let short_finalize_cu = env.finalize_reset_side_with_cu(0, 1);
+    assert_cu_within(
+        "partial-ADL long finalize",
+        long_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_cu_within(
+        "partial-ADL short finalize",
+        short_finalize_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let (_, done) = env.market_state();
+    assert_eq!(done.assets[0].mode_long, SideModeV16::Normal);
+    assert_eq!(done.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(done.assets[0].stored_pos_count_long, 0);
+    assert_eq!(done.assets[0].stored_pos_count_short, 0);
+    assert_eq!(
+        done.vault, vault_after_adl,
+        "exit and cleanup move no custody"
+    );
+    assert_eq!(done.vault as u64, env.token_amount(env.vault));
+    assert!(done.vault >= done.c_tot + done.insurance);
+}
+
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open
 // risk. With no keeper size input, the engine selects a full close, books the residual, and preserves
 // custody and balanced OI.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -33442,6 +33442,287 @@ fn v16_attack_backing_expiry_no_overpay() {
     );
 }
 
+// A junior winner captures the resolved payout snapshot before an independent winner's lapsed
+// Fresh source bucket is expired by terminal realization. The newly released junior funds must
+// raise every receipt's common payout rate, independent of terminal close order.
+#[test]
+fn v16_attack_post_snapshot_backing_expiry_preserves_winner_entitlements() {
+    const CAPITAL: u128 = 1_000;
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, 100);
+    env.configure_auth_mark_for_asset_as_admin(1, 0, 100);
+
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let victim_loser_owner = Keypair::new();
+    let victim_loser = env.create_portfolio(&victim_loser_owner);
+    let attacker_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    let attacker_loser_owner = Keypair::new();
+    let attacker_loser = env.create_portfolio(&attacker_loser_owner);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&victim_loser_owner, victim_loser),
+        (&attacker_owner, attacker),
+        (&attacker_loser_owner, attacker_loser),
+    ] {
+        env.deposit(owner, portfolio, CAPITAL);
+    }
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &victim_loser_owner,
+        victim_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &attacker_owner,
+        attacker,
+        &attacker_loser_owner,
+        attacker_loser,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+
+    // Crystallize both winners and flatten every position while the victim bucket is still fresh.
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 140);
+    env.push_auth_mark_for_asset_as_admin(1, 2, 140);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: vec![
+                CrankObservationHint {
+                    asset_index: 0,
+                    oracle_accounts: 0,
+                },
+                CrankObservationHint {
+                    asset_index: 1,
+                    oracle_accounts: 0,
+                },
+            ],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(keeper, false),
+        ],
+        &[],
+    )
+    .expect("public keeper publishes both authenticated marks");
+    for portfolio in [victim_loser, victim] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    for portfolio in [attacker_loser, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(1),
+            },
+        );
+    }
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &victim_loser_owner,
+        victim_loser,
+        -(POS_SCALE as i128),
+        140,
+        0,
+    );
+    for portfolio in [victim, victim_loser] {
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))),
+            "the independent victim pair is flat before expiry"
+        );
+    }
+    assert!(has_active_leg_for_asset(&env.portfolio_state(attacker), 1));
+    assert!(has_active_leg_for_asset(
+        &env.portfolio_state(attacker_loser),
+        1
+    ));
+    assert!(env.portfolio_state(victim).pnl.get() > 0);
+    assert!(env.portfolio_state(attacker).pnl.get() > 0);
+
+    let flat = env.market_state().1;
+    assert_eq!(
+        flat.source_backing_buckets[3].status,
+        BackingBucketStatusV16::Fresh,
+        "the attacker's public losing counterparty creates source backing"
+    );
+    let lapse_slot = flat.source_backing_buckets[3]
+        .expiry_slot
+        .max(flat.source_backing_buckets[1].expiry_slot)
+        .checked_add(1)
+        .unwrap();
+    env.svm.warp_to_slot(lapse_slot);
+    // A nonzero reverse move makes the active winner refresh through its now-lapsed source claim.
+    env.push_auth_mark_for_asset_as_admin(1, lapse_slot, 130);
+    env.crank(
+        keeper,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: lapse_slot,
+            observations: crank_observations(1),
+        },
+    );
+    env.crank(
+        attacker,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: lapse_slot,
+            observations: vec![],
+        },
+    );
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[3].status,
+        BackingBucketStatusV16::Expired,
+        "a public live crank expires the attacker's active source bucket"
+    );
+    let close_slot = lapse_slot.checked_add(1).unwrap();
+    env.svm.warp_to_slot(close_slot);
+    env.push_auth_mark_for_asset_as_admin(1, close_slot, 140);
+    env.crank(
+        keeper,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: close_slot,
+            observations: crank_observations(1),
+        },
+    );
+    for portfolio in [attacker_loser, attacker] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: close_slot,
+                observations: vec![],
+            },
+            4,
+        );
+    }
+    env.trade_asset_with_cu(
+        1,
+        &attacker_owner,
+        attacker,
+        &attacker_loser_owner,
+        attacker_loser,
+        -(POS_SCALE as i128),
+        140,
+        0,
+    );
+    for portfolio in [victim, victim_loser, attacker, attacker_loser] {
+        assert!(
+            percolator::active_bitmap_is_empty(active_bitmap(&env.portfolio_state(portfolio))),
+            "all positions are publicly flattened before resolution"
+        );
+    }
+    let pre = env.market_state().1;
+    assert_eq!(pre.assets[0].effective_price, 140);
+    assert_eq!(pre.assets[1].effective_price, 140);
+    assert_eq!(
+        pre.source_backing_buckets[1].status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert!(pre.source_backing_buckets[1].expiry_slot < lapse_slot);
+    assert_eq!(
+        pre.source_backing_buckets[3].status,
+        BackingBucketStatusV16::Expired
+    );
+    assert!(
+        env.portfolio_state(attacker).pnl.get() > 0,
+        "the post-expiry favorable move leaves a public junior claim"
+    );
+
+    env.resolve();
+    let close_sum = |env: &mut V16CuEnv, owner: &Keypair, portfolio: Pubkey| -> (u128, u64) {
+        let mut out = 0;
+        let mut max_cu = 0;
+        for _ in 0..8 {
+            let (dest, cu) = env.close_resolved_with_cu(owner, portfolio);
+            out += env.token_amount(dest) as u128;
+            max_cu = max_cu.max(cu);
+        }
+        (out, max_cu)
+    };
+    let (victim_loser_out, victim_loser_cu) =
+        close_sum(&mut env, &victim_loser_owner, victim_loser);
+    let (attacker_loser_out, attacker_loser_cu) =
+        close_sum(&mut env, &attacker_loser_owner, attacker_loser);
+    let (mut attacker_out, attacker_cu) = close_sum(&mut env, &attacker_owner, attacker);
+    let after_snapshot = env.market_state().1;
+    assert!(after_snapshot.payout_snapshot_captured);
+    assert_eq!(
+        after_snapshot.source_backing_buckets[1].status,
+        BackingBucketStatusV16::Fresh,
+        "unrelated winner must not have touched victim's source bucket"
+    );
+    let (victim_out, victim_cu) = close_sum(&mut env, &victim_owner, victim);
+    let (attacker_topup, attacker_topup_cu) = close_sum(&mut env, &attacker_owner, attacker);
+    attacker_out += attacker_topup;
+    let done = env.market_state().1;
+    eprintln!(
+        "terminal expiry probe: loser_v={victim_loser_out} loser_a={attacker_loser_out} attacker={attacker_out} victim={victim_out} vault={} c_tot={} insurance={} snapshot={} rate={}/{} bucket={:?}",
+        done.vault,
+        done.c_tot,
+        done.insurance,
+        done.payout_snapshot,
+        done.resolved_payout_ledger.current_payout_rate_num,
+        done.resolved_payout_ledger.current_payout_rate_den,
+        done.source_backing_buckets[1].status,
+    );
+    assert_eq!(victim_loser_out, CAPITAL - 40);
+    assert_eq!(attacker_loser_out, CAPITAL - 40);
+    assert_eq!(attacker_out, CAPITAL + 40);
+    assert_eq!(victim_out, CAPITAL + 40);
+    assert_eq!(
+        victim_loser_out + attacker_loser_out + attacker_out + victim_out,
+        4 * CAPITAL,
+        "both independent zero-sum trades conserve every deposited atom"
+    );
+    assert_eq!(
+        done.vault, 0,
+        "no post-snapshot junior residual is stranded"
+    );
+    assert_eq!(done.resolved_payout_ledger.snapshot_residual, 80);
+    assert_eq!(
+        done.resolved_payout_ledger.current_payout_rate_num,
+        done.resolved_payout_ledger.current_payout_rate_den,
+        "both 40-atom winner claims reach the full terminal rate"
+    );
+    for (label, cu) in [
+        ("victim loser resolved close", victim_loser_cu),
+        ("attacker loser resolved close", attacker_loser_cu),
+        ("attacker resolved close", attacker_cu),
+        ("victim resolved close", victim_cu),
+        ("attacker resolved topup", attacker_topup_cu),
+    ] {
+        assert_cu_within(label, cu, CUSTODY_CU_LIMIT);
+    }
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&victim_loser_owner, victim_loser),
+        (&attacker_owner, attacker),
+        (&attacker_loser_owner, attacker_loser),
+        (&keeper_owner, keeper),
+    ] {
+        env.close_portfolio_with_cu(owner, portfolio);
+    }
+    env.close_slab_with_cu();
+}
+
 // security.md sweep — large-amount deposit boundary + TVL cap (#37): the vault is capped at
 // MAX_VAULT_TVL (overflow prevention). A deposit above the cap must reject; a large deposit just below
 // it must credit exactly (no truncation/wraparound in the u128 aggregates) and round-trip exactly.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7942,6 +7942,183 @@ fn v16_attack_resolved_close_prepares_lapsed_source_before_pending_mark_loss() {
 
     let mut last_long = None;
     let mut last_short = None;
+    let mut max_close_cu = 0u64;
+    for _ in 0..16 {
+        let long_result = try_close(&mut env, long_owner.pubkey(), long_account, long_dest);
+        if let Ok(cu) = &long_result {
+            max_close_cu = max_close_cu.max(*cu);
+        }
+        last_long = Some(long_result);
+        let short_result = try_close(&mut env, short_owner.pubkey(), short_account, short_dest);
+        if let Ok(cu) = &short_result {
+            max_close_cu = max_close_cu.max(*cu);
+        }
+        last_short = Some(short_result);
+    }
+
+    let long_after = env.portfolio_state(long_account);
+    let short_after = env.portfolio_state(short_account);
+    assert!(
+        percolator::active_bitmap_is_empty(active_bitmap(&long_after))
+            && percolator::active_bitmap_is_empty(active_bitmap(&short_after))
+            && long_after.capital.get() == 0
+            && short_after.capital.get() == 0,
+        "bounded closes must prepare lapsed backing before settling the winner's adverse K delta; \
+         long_capital={} long_pnl={} long_active={:?} long_result={:?}; \
+         short_capital={} short_pnl={} short_active={:?} short_result={:?}",
+        long_after.capital.get(),
+        long_after.pnl.get(),
+        active_bitmap(&long_after),
+        last_long,
+        short_after.capital.get(),
+        short_after.pnl.get(),
+        active_bitmap(&short_after),
+        last_short,
+    );
+    assert!(
+        max_close_cu <= 1_000_000,
+        "prospective-source resolved close consumed {max_close_cu} CU",
+    );
+}
+
+#[test]
+fn v16_attack_resolved_close_expires_prospective_source_before_positive_k_settlement() {
+    const PRICE: u64 = 100;
+    const LOW_PRICE: u64 = 98;
+    const REBOUND_PRICE: u64 = 99;
+    const DEPOSIT: u128 = 100_000_000;
+    const SIZE_Q: i128 = 100_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: 200,
+        max_accrual_dt_slots: 1,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let neutral_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    let neutral_account = env.create_portfolio(&neutral_owner);
+    env.deposit(&long_owner, long_account, DEPOSIT);
+    env.deposit(&short_owner, short_account, DEPOSIT);
+    env.trade_with_cu(
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    env.top_up_backing_bucket(0, 93, 8);
+    env.top_up_backing_bucket(1, 32, 8);
+
+    // Settle only the long at the low mark. Its loss moves into principal and
+    // its K snapshot advances; the short keeps the full favorable delta.
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, LOW_PRICE);
+    env.crank(
+        neutral_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(env.market_state().1.assets[0].effective_price, LOW_PRICE);
+
+    env.svm.warp_to_slot(3);
+    env.crank(
+        long_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(env.portfolio_state(long_account).pnl.get(), 0);
+    assert!(env.portfolio_state(long_account).capital.get() < DEPOSIT);
+    assert_eq!(env.portfolio_state(short_account).pnl.get(), 0);
+
+    // Rebound slightly. Relative to their different snapshots, both legs now
+    // carry positive K deltas while neither portfolio has realized positive
+    // PnL or acquired a source-domain record.
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_for_asset_as_admin(0, 4, REBOUND_PRICE);
+    env.crank(
+        neutral_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        REBOUND_PRICE
+    );
+    let long_before = env.portfolio_state(long_account);
+    let short_before = env.portfolio_state(short_account);
+    assert_eq!(long_before.pnl.get(), 0);
+    assert_eq!(short_before.pnl.get(), 0);
+    assert!(long_before
+        .source_domains
+        .iter()
+        .all(|source| !source.is_occupied()));
+    assert!(short_before
+        .source_domains
+        .iter()
+        .all(|source| !source.is_occupied()));
+
+    env.svm.warp_to_slot(9);
+    for _ in 0..8 {
+        if env.market_state().1.assets[0].slot_last == 9 {
+            break;
+        }
+        env.crank(
+            neutral_account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 9,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    let (_, before_resolve) = env.market_state();
+    assert_eq!(before_resolve.assets[0].slot_last, 9);
+    assert_eq!(
+        before_resolve.source_backing_buckets[0].status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert_eq!(before_resolve.source_backing_buckets[0].expiry_slot, 8);
+    assert_eq!(before_resolve.pnl_matured_pos_tot, 0);
+    env.resolve();
+
+    let long_dest = env.token_account(long_owner.pubkey(), 0);
+    let short_dest = env.token_account(short_owner.pubkey(), 0);
+    let try_close = |env: &mut V16CuEnv, owner: Pubkey, portfolio: Pubkey, dest: Pubkey| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            },
+            vec![
+                AccountMeta::new_readonly(owner, false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[],
+        )
+    };
+
+    let mut last_long = None;
+    let mut last_short = None;
     for _ in 0..16 {
         last_long = Some(try_close(
             &mut env,
@@ -7964,7 +8141,7 @@ fn v16_attack_resolved_close_prepares_lapsed_source_before_pending_mark_loss() {
             && percolator::active_bitmap_is_empty(active_bitmap(&short_after))
             && long_after.capital.get() == 0
             && short_after.capital.get() == 0,
-        "bounded closes must prepare lapsed backing before settling the winner's adverse K delta; \
+        "bounded public closes must expire the future K/F source before settlement; \
          long_capital={} long_pnl={} long_active={:?} long_result={:?}; \
          short_capital={} short_pnl={} short_active={:?} short_result={:?}",
         long_after.capital.get(),
@@ -7975,6 +8152,117 @@ fn v16_attack_resolved_close_prepares_lapsed_source_before_pending_mark_loss() {
         short_after.pnl.get(),
         active_bitmap(&short_after),
         last_short,
+    );
+}
+
+#[test]
+fn v16_cu_resolved_close_scans_max_lapsed_prospective_kf_sources_below_limit() {
+    const N: u16 = 14;
+    const PRICE: u64 = 100;
+    const OWNER_DEPOSIT: u128 = 100_000_000;
+    const COUNTERPARTY_DEPOSIT: u128 = 1_000_000;
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(N, 1_000, 1_000, 500);
+    for asset_index in 0..N {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, PRICE);
+    }
+
+    let owner = Keypair::new();
+    let owner_account = env.create_portfolio(&owner);
+    env.deposit(&owner, owner_account, OWNER_DEPOSIT);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+    for asset_index in 0..N {
+        let counterparty_owner = Keypair::new();
+        let counterparty = env.create_portfolio(&counterparty_owner);
+        env.deposit(&counterparty_owner, counterparty, COUNTERPARTY_DEPOSIT);
+        env.trade_asset_with_cu(
+            asset_index,
+            &owner,
+            owner_account,
+            &counterparty_owner,
+            counterparty,
+            POS_SCALE as i128,
+            PRICE,
+            0,
+        );
+        env.top_up_backing_bucket(2 * asset_index + 1, 100, 4);
+    }
+
+    // The first 13 long legs have adverse pending K, while the last has a
+    // positive pending K claim. Every prospective short-side source is lapsed,
+    // forcing the preflight to inspect the full bounded leg roster.
+    env.svm.warp_to_slot(5);
+    for asset_index in 0..N {
+        let mark = if asset_index + 1 == N { 101 } else { 99 };
+        env.push_auth_mark_for_asset_as_admin(asset_index, 5, mark);
+        for _ in 0..8 {
+            if env.market_state().1.assets[asset_index as usize].slot_last == 5 {
+                break;
+            }
+            env.crank(
+                keeper,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 5,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+        assert_eq!(
+            env.market_state().1.assets[asset_index as usize].slot_last,
+            5,
+        );
+    }
+    let before = env.portfolio_state(owner_account);
+    assert_eq!(
+        active_bitmap(&before)
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>(),
+        N as u32,
+    );
+    assert_eq!(before.pnl.get(), 0);
+    assert!(before
+        .source_domains
+        .iter()
+        .all(|source| !source.is_occupied()));
+    let prospective_domain = 2 * (N - 1) + 1;
+    let (_, before_resolve) = env.market_state();
+    assert_eq!(
+        before_resolve.source_backing_buckets[prospective_domain as usize].status,
+        BackingBucketStatusV16::Fresh,
+    );
+    assert_eq!(
+        before_resolve.source_backing_buckets[prospective_domain as usize].expiry_slot,
+        4,
+    );
+    env.resolve();
+
+    let dest = env.token_account(owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    let cu = env
+        .send(
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            },
+            vec![
+                AccountMeta::new_readonly(owner.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(owner_account, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[],
+        )
+        .expect("max-shape prospective-source preflight must land");
+    assert!(
+        cu <= 1_000_000,
+        "max-shape prospective-source preflight consumed {cu} CU",
+    );
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[prospective_domain as usize].status,
+        BackingBucketStatusV16::Expired,
     );
 }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -7826,6 +7826,159 @@ fn v16_attack_resolved_close_progresses_after_source_backing_expires_before_lose
 }
 
 #[test]
+fn v16_attack_resolved_close_prepares_lapsed_source_before_pending_mark_loss() {
+    const PRICE: u64 = 100;
+    const UP_PRICE: u64 = 101;
+    const DEPOSIT: u128 = 100_000_000;
+    const SIZE_Q: i128 = 100_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: 100,
+        max_accrual_dt_slots: 1,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let neutral_owner = Keypair::new();
+    let long_account = env.create_portfolio(&long_owner);
+    let short_account = env.create_portfolio(&short_owner);
+    let neutral_account = env.create_portfolio(&neutral_owner);
+    env.deposit(&long_owner, long_account, DEPOSIT);
+    env.deposit(&short_owner, short_account, DEPOSIT);
+    env.trade_with_cu(
+        &long_owner,
+        long_account,
+        &short_owner,
+        short_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    // Accrue the upward move through a flat third-party account, then settle
+    // it only into the long. The long now owns a source-attributed positive
+    // claim while the short has not yet materialized its matching loss.
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, UP_PRICE);
+    env.crank(
+        neutral_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(env.market_state().1.assets[0].effective_price, UP_PRICE);
+
+    env.svm.warp_to_slot(3);
+    env.crank(
+        long_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    assert!(
+        env.portfolio_state(long_account).pnl.get() > 0,
+        "the long must realize source-attributed mark profit"
+    );
+    env.top_up_backing_bucket(1, 10, 5);
+
+    // Reverse the mark through the flat account. The long keeps its positive
+    // source claim but now carries an unsettled adverse K delta.
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_for_asset_as_admin(0, 4, PRICE);
+    env.crank(
+        neutral_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(5);
+    env.crank(
+        neutral_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 5,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, before_resolve) = env.market_state();
+    assert_eq!(before_resolve.assets[0].effective_price, PRICE);
+    assert_eq!(before_resolve.assets[0].slot_last, 5);
+    assert_eq!(
+        before_resolve.source_backing_buckets[1].status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert_eq!(before_resolve.source_backing_buckets[1].expiry_slot, 5);
+    assert!(env.portfolio_state(long_account).pnl.get() > 0);
+
+    env.resolve();
+
+    let long_dest = env.token_account(long_owner.pubkey(), 0);
+    let short_dest = env.token_account(short_owner.pubkey(), 0);
+    let try_close = |env: &mut V16CuEnv, owner: Pubkey, portfolio: Pubkey, dest: Pubkey| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            },
+            vec![
+                AccountMeta::new_readonly(owner, false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[],
+        )
+    };
+
+    let mut last_long = None;
+    let mut last_short = None;
+    for _ in 0..16 {
+        last_long = Some(try_close(
+            &mut env,
+            long_owner.pubkey(),
+            long_account,
+            long_dest,
+        ));
+        last_short = Some(try_close(
+            &mut env,
+            short_owner.pubkey(),
+            short_account,
+            short_dest,
+        ));
+    }
+
+    let long_after = env.portfolio_state(long_account);
+    let short_after = env.portfolio_state(short_account);
+    assert!(
+        percolator::active_bitmap_is_empty(active_bitmap(&long_after))
+            && percolator::active_bitmap_is_empty(active_bitmap(&short_after))
+            && long_after.capital.get() == 0
+            && short_after.capital.get() == 0,
+        "bounded closes must prepare lapsed backing before settling the winner's adverse K delta; \
+         long_capital={} long_pnl={} long_active={:?} long_result={:?}; \
+         short_capital={} short_pnl={} short_active={:?} short_result={:?}",
+        long_after.capital.get(),
+        long_after.pnl.get(),
+        active_bitmap(&long_after),
+        last_long,
+        short_after.capital.get(),
+        short_after.pnl.get(),
+        active_bitmap(&short_after),
+        last_short,
+    );
+}
+
+#[test]
 fn v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides() {
     const INITIAL_PRICE: u64 = 1_000_000;
     const FUNDING_RATE_E9: i128 = 1_000;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2729,24 +2729,67 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
-        let cu = self
-            .send(
+        let max_cu = self
+            .drive_close_resolved_with_cu(owner.pubkey(), portfolio, dest, self.vault)
+            .expect("close resolved");
+        (dest, max_cu)
+    }
+
+    fn drive_close_resolved_with_cu(
+        &mut self,
+        owner: Pubkey,
+        portfolio: Pubkey,
+        dest: Pubkey,
+        vault: Pubkey,
+    ) -> Result<u64, String> {
+        let max_steps = 3 * percolator::PORTFOLIO_SOURCE_DOMAIN_CAP
+            + 2 * percolator::V16_MAX_PORTFOLIO_ASSETS_N
+            + 16;
+        let mut max_cu = 0u64;
+        for _ in 0..max_steps {
+            let market_before = self.svm.get_account(&self.market).unwrap();
+            let portfolio_before = self.svm.get_account(&portfolio).unwrap();
+            self.svm.expire_blockhash();
+            let cu = self.send(
                 ProgInstruction::CloseResolved {
                     fee_rate_per_slot: 0,
                 },
                 vec![
-                    AccountMeta::new_readonly(owner.pubkey(), false),
+                    AccountMeta::new_readonly(owner, false),
                     AccountMeta::new(self.market, false),
                     AccountMeta::new(portfolio, false),
                     AccountMeta::new(dest, false),
-                    AccountMeta::new(self.vault, false),
+                    AccountMeta::new(vault, false),
                     AccountMeta::new_readonly(self.vault_authority, false),
                     AccountMeta::new_readonly(spl_token::ID, false),
                 ],
                 &[],
-            )
-            .expect("close resolved");
-        (dest, cu)
+            )?;
+            max_cu = max_cu.max(cu);
+
+            let state = self.portfolio_state(portfolio);
+            let terminal = state.capital.get() == 0
+                && state.pnl.get() == 0
+                && percolator::active_bitmap_is_empty(active_bitmap(&state))
+                && state
+                    .source_domains
+                    .iter()
+                    .all(|source| source.source_claim_bound_num.get() == 0)
+                && state.stale_state == 0
+                && state.b_stale_state == 0;
+            if terminal {
+                return Ok(max_cu);
+            }
+
+            let made_progress = self.svm.get_account(&self.market).unwrap() != market_before
+                || self.svm.get_account(&portfolio).unwrap() != portfolio_before;
+            if !made_progress {
+                // Another account still gates the global resolved payout. Let
+                // the caller advance that account before retrying this one.
+                return Ok(max_cu);
+            }
+        }
+        Err("resolved close exceeded its bounded progress rank".to_string())
     }
 
     fn top_up_insurance(&mut self, amount: u128) -> Pubkey {
@@ -18175,23 +18218,8 @@ fn v16_attack_resolved_payout_dual_mint_replay_extracts_nothing() {
     );
 
     let secondary_dest = env.token_account_for_mint(secondary, lo_owner.pubkey(), 0);
-    env.svm.expire_blockhash();
     let secondary_close_cu = env
-        .send(
-            ProgInstruction::CloseResolved {
-                fee_rate_per_slot: 0,
-            },
-            vec![
-                AccountMeta::new_readonly(lo_owner.pubkey(), false),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(lo, false),
-                AccountMeta::new(secondary_dest, false),
-                AccountMeta::new(secondary_vault, false),
-                AccountMeta::new_readonly(env.vault_authority, false),
-                AccountMeta::new_readonly(spl_token::ID, false),
-            ],
-            &[],
-        )
+        .drive_close_resolved_with_cu(lo_owner.pubkey(), lo, secondary_dest, secondary_vault)
         .expect("close resolved through secondary reserve");
     assert_cu_within(
         "CloseResolved secondary payout",
@@ -18550,22 +18578,8 @@ fn v16_attack_terminal_secondary_payouts_reject_noncanonical_vault() {
         "owner receives no payout from rejected non-canonical close"
     );
 
-    env.svm.expire_blockhash();
-    let accepted_close = env.send(
-        ProgInstruction::CloseResolved {
-            fee_rate_per_slot: 0,
-        },
-        vec![
-            AccountMeta::new_readonly(lo_owner.pubkey(), false),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(lo, false),
-            AccountMeta::new(secondary_dest, false),
-            AccountMeta::new(secondary_vault, false),
-            AccountMeta::new_readonly(env.vault_authority, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-        ],
-        &[],
-    );
+    let accepted_close =
+        env.drive_close_resolved_with_cu(lo_owner.pubkey(), lo, secondary_dest, secondary_vault);
     assert!(
         accepted_close.is_ok(),
         "canonical secondary CloseResolved still pays: {accepted_close:?}"
@@ -38595,6 +38609,265 @@ fn v16_attack_lapsed_live_source_backing_does_not_stale_loop_auto_crank() {
     let done = env.market_state().1;
     assert_eq!(done.vault, vault_before);
     assert_eq!(done.vault as u64, env.token_amount(env.vault));
+}
+
+// Public max-shape regression: ordinary trades can leave one winner with both
+// historical source domains for all 14 portfolio assets. Before the fix, both
+// fresh and lapsed backing variants exhausted the 1.4M-CU SVM ceiling forever.
+fn run_resolved_close_28_public_source_domains(close_slot: u64, expected_lapsed: usize) {
+    const N: u16 = 14;
+    const OPEN_PRICE: u64 = 100;
+    const HIGH_PRICE: u64 = 200;
+    const WINNER_CAPITAL: u128 = 100_000;
+    const LOSER_CAPITAL: u128 = 1_000;
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(N, 1_000, 1_000, 500);
+    for asset_index in 0..N {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, 0, OPEN_PRICE);
+    }
+
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    env.deposit(&winner_owner, winner, WINNER_CAPITAL);
+    let keeper_owner = Keypair::new();
+    let keeper = env.create_portfolio(&keeper_owner);
+
+    let mut short_losers = Vec::new();
+    for asset_index in 0..N {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        env.deposit(&owner, portfolio, LOSER_CAPITAL);
+        env.trade_asset_with_cu(
+            asset_index,
+            &winner_owner,
+            winner,
+            &owner,
+            portfolio,
+            POS_SCALE as i128,
+            OPEN_PRICE,
+            0,
+        );
+        short_losers.push((owner, portfolio));
+    }
+
+    env.svm.warp_to_slot(20);
+    for asset_index in 0..N {
+        env.push_auth_mark_for_asset_as_admin(asset_index, 20, HIGH_PRICE);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: crank_observations(asset_index),
+            },
+        );
+    }
+    for (asset_index, (_, portfolio)) in short_losers.iter().enumerate() {
+        env.crank(
+            *portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: crank_observations(asset_index as u16),
+            },
+        );
+    }
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        N as usize,
+        "the public long-winning cycle creates one odd source domain per asset",
+    );
+    for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
+        env.trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            -((2 * POS_SCALE) as i128),
+            HIGH_PRICE,
+            0,
+        );
+    }
+    assert_eq!(
+        active_bitmap(&env.portfolio_state(winner))
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>(),
+        N as u32,
+        "the risk-neutral flips keep one short leg per asset",
+    );
+
+    env.svm.warp_to_slot(40);
+    for asset_index in 0..N {
+        env.push_auth_mark_for_asset_as_admin(asset_index, 40, OPEN_PRICE);
+        env.crank(
+            keeper,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index),
+            },
+        );
+    }
+    for (asset_index, (_, portfolio)) in short_losers.iter().enumerate() {
+        env.crank(
+            *portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(asset_index as u16),
+            },
+        );
+    }
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 40,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(winner)
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count(),
+        (2 * N) as usize,
+        "the public short-winning cycle adds every even source domain",
+    );
+    for (asset_index, (owner, portfolio)) in short_losers.iter().enumerate() {
+        env.trade_asset_with_cu(
+            asset_index as u16,
+            &winner_owner,
+            winner,
+            owner,
+            *portfolio,
+            POS_SCALE as i128,
+            OPEN_PRICE,
+            0,
+        );
+    }
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &env.portfolio_state(winner)
+    )));
+
+    let live = env.market_state().1;
+    for domain in 0..(2 * N) as usize {
+        assert_eq!(
+            live.source_backing_buckets[domain].status,
+            BackingBucketStatusV16::Fresh,
+        );
+    }
+    let lapsed_initial = live.source_backing_buckets[..(2 * N) as usize]
+        .iter()
+        .filter(|bucket| bucket.expiry_slot <= close_slot)
+        .count();
+    assert_eq!(lapsed_initial, expected_lapsed);
+    env.svm.warp_to_slot(close_slot);
+    env.resolve();
+    let dest = env.token_account_for_mint(env.mint, winner_owner.pubkey(), 0);
+    let internal_vault_before = env.market_state().1.vault;
+    let token_vault_before = env.token_amount(env.vault);
+    let dest_before = env.token_amount(dest);
+    let mut rank = 2 * N as usize + lapsed_initial;
+    let expected_calls = rank + 1;
+    let mut calls = 0usize;
+    let mut max_cu = 0u64;
+    loop {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let winner_before = env.svm.get_account(&winner).unwrap();
+        let vault_before = env.token_amount(env.vault);
+        let destination_before = env.token_amount(dest);
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::CloseResolved {
+                    fee_rate_per_slot: 0,
+                },
+                vec![
+                    AccountMeta::new_readonly(winner_owner.pubkey(), false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(winner, false),
+                    AccountMeta::new(dest, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                &[],
+            )
+            .expect("every bounded resolved-close continuation must land");
+        calls += 1;
+        max_cu = max_cu.max(cu);
+        assert!(
+            cu <= 1_000_000,
+            "bounded resolved-close continuation consumed {cu} CU",
+        );
+        let portfolio_after = env.portfolio_state(winner);
+        let source_claims_after = portfolio_after
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count();
+        let market_after = env.market_state().1;
+        let lapsed_fresh_after = market_after.source_backing_buckets[..(2 * N) as usize]
+            .iter()
+            .filter(|bucket| {
+                bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= close_slot
+            })
+            .count();
+        let next_rank = source_claims_after + lapsed_fresh_after;
+        let closed = portfolio_after.capital.get() == 0
+            && portfolio_after.pnl.get() == 0
+            && source_claims_after == 0;
+        if closed {
+            assert_eq!(next_rank, 0);
+            break;
+        }
+        assert_eq!(
+            next_rank + 1,
+            rank,
+            "every successful continuation must strictly decrease the public terminal rank",
+        );
+        assert!(
+            env.svm.get_account(&env.market).unwrap() != market_before
+                || env.svm.get_account(&winner).unwrap() != winner_before,
+            "a nonterminal successful close must mutate its progress state",
+        );
+        assert_eq!(env.token_amount(env.vault), vault_before);
+        assert_eq!(env.token_amount(dest), destination_before);
+        rank = next_rank;
+        assert!(calls <= expected_calls);
+    }
+    assert_eq!(calls, expected_calls);
+    assert!(max_cu > 0);
+    let payout = env.token_amount(dest) - dest_before;
+    assert!(payout > 0);
+    assert_eq!(token_vault_before - env.token_amount(env.vault), payout);
+    assert_eq!(
+        internal_vault_before - env.market_state().1.vault,
+        payout as u128,
+    );
+    assert_eq!(
+        env.market_state().1.vault as u64,
+        env.token_amount(env.vault)
+    );
+}
+
+#[test]
+fn v16_attack_resolved_close_28_fresh_source_domains_makes_bounded_progress() {
+    run_resolved_close_28_public_source_domains(40, 0);
+}
+
+#[test]
+fn v16_attack_resolved_close_28_lapsed_source_domains_makes_bounded_progress() {
+    run_resolved_close_28_public_source_domains(200, 28);
 }
 
 // A deeply insolvent single-leg account cannot be partially liquidated while leaving uncovered open


### PR DESCRIPTION
## Finding

This public LiteSVM TDD reproduction proves a persistent resolved-close DoS after the fix in #291: asynchronous K snapshots can leave positive prospective K/F settlement against a Fresh backing domain that lapses before either portfolio records that source domain.

The exact-parent RED uses only public instructions and normal initialized state: deposits, a trade, authenticated mark moves, permissionless cranks, resolution, and alternating honest `CloseResolved` calls. Every bounded close attempt reaches the same engine error and rolls back; one side retains its unresolved PnL and the other remains active, so neither honest caller can finish payout and withdrawal.

## Change

- Pin the stacked engine fix that expires one lapsed prospective K/F source before settlement.
- Keep the exact public lifecycle as the green regression.
- Add a 14-active-leg CU test that forces the preflight to inspect the full roster before finding the only positive source.
- Track every successful close in the lifecycle under the 1,000,000-CU instruction ceiling.

## Verification

- Exact-parent test is RED at `9cbae705` with engine `b6827a09`
- Engine production regression and liveness-rank Kani proof pass
- Full engine suite: 168 tests pass
- Full wrapper matrix: 5 unit + 575 LiteSVM/CU tests pass
- Existing 28-domain resolved-close CU tests pass after the flat-portfolio fast path

Stacked on #291; this is a distinct prospective-source blocker not handled by that PR.
