### PR TITLE
[HARDENING LoF] Bind PnL conversion to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,9 @@ This section describes intent and operational ordering, not argument-by-argument
 - **Withdraw** (tag 4)
   - binds the signed payload to the current program-assigned portfolio incarnation ID
   - performs oracle-read + engine checks; withdraws from vault via PDA signer; debits engine
+- **ConvertReleasedPnl** (tag 28)
+  - binds the signed payload to the current program-assigned portfolio incarnation ID
+  - converts currently released, source-backed junior PnL into senior portfolio capital
 - **ClosePortfolio** (tag 8)
   - closes a flat, empty portfolio account and sweeps its rent to the market slab
 - **CloseResolved** (tag 30)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2531,6 +2531,7 @@ pub mod ix {
             amount: u128,
         },
         ConvertReleasedPnl {
+            portfolio_id: u64,
             amount: u128,
         },
         CloseResolved {
@@ -2799,6 +2800,7 @@ pub mod ix {
                     amount: read_u128(&mut rest)?,
                 },
                 28 => Self::ConvertReleasedPnl {
+                    portfolio_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 30 => Self::CloseResolved {
@@ -3100,8 +3102,12 @@ pub mod ix {
                     push_u16(&mut out, domain);
                     push_u128(&mut out, amount);
                 }
-                Self::ConvertReleasedPnl { amount } => {
+                Self::ConvertReleasedPnl {
+                    portfolio_id,
+                    amount,
+                } => {
                     out.push(28);
+                    push_u64(&mut out, portfolio_id);
                     push_u128(&mut out, amount);
                 }
                 Self::CloseResolved { fee_rate_per_slot } => {
@@ -5284,9 +5290,10 @@ pub mod processor {
             Instruction::WithdrawBackingBucket { domain, amount } => {
                 handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
             }
-            Instruction::ConvertReleasedPnl { amount } => {
-                handle_convert_released_pnl(program_id, accounts, amount)
-            }
+            Instruction::ConvertReleasedPnl {
+                portfolio_id,
+                amount,
+            } => handle_convert_released_pnl(program_id, accounts, portfolio_id, amount),
             Instruction::CloseResolved { fee_rate_per_slot } => {
                 handle_close_resolved(program_id, accounts, fee_rate_per_slot)
             }
@@ -5768,7 +5775,7 @@ pub mod processor {
         require_token_balance(vault_token, amount_u64)?;
 
         ensure_portfolio_storage_for_market_slots(portfolio_ai, max_market_slots)?;
-        bind_withdraw_portfolio_id(portfolio_ai, portfolio_id)?;
+        bind_portfolio_id(portfolio_ai, portfolio_id)?;
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
@@ -8389,11 +8396,15 @@ pub mod processor {
     fn handle_convert_released_pnl<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_id: u64,
         amount: u128,
     ) -> ProgramResult {
         if amount == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        let portfolio_ai = account(accounts, 2)?;
+        expect_owner(portfolio_ai, program_id)?;
+        bind_portfolio_id(portfolio_ai, portfolio_id)?;
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode != 0 {
                 return Err(V16Error::LockActive);
@@ -11172,10 +11183,7 @@ pub mod processor {
 
     const LEGACY_PORTFOLIO_ID: u64 = u64::MAX;
 
-    fn bind_withdraw_portfolio_id(
-        portfolio_ai: &AccountInfo,
-        expected_portfolio_id: u64,
-    ) -> ProgramResult {
+    fn bind_portfolio_id(portfolio_ai: &AccountInfo, expected_portfolio_id: u64) -> ProgramResult {
         let required_len = state::portfolio_account_len_for_market_slots(0)?;
         let (actual_portfolio_id, legacy_portfolio) = {
             let data = portfolio_ai.try_borrow_data()?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3367,7 +3367,10 @@ impl V16CuEnv {
         amount: u128,
     ) -> u64 {
         self.send(
-            ProgInstruction::ConvertReleasedPnl { amount },
+            ProgInstruction::ConvertReleasedPnl {
+                portfolio_id: AUTO_PORTFOLIO_ID,
+                amount,
+            },
             vec![
                 AccountMeta::new(owner.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -3629,7 +3632,7 @@ fn send_tx(
     accounts: Vec<AccountMeta>,
     extra_signers: &[&Keypair],
 ) -> Result<u64, String> {
-    bind_test_withdraw_portfolio_id(svm, &mut ix, &accounts);
+    bind_test_portfolio_id(svm, &mut ix, &accounts);
     let instruction = Instruction {
         program_id,
         accounts,
@@ -3649,13 +3652,11 @@ fn send_tx(
         .map_err(|e| format!("{e:?}"))
 }
 
-fn bind_test_withdraw_portfolio_id(
-    svm: &LiteSVM,
-    ix: &mut ProgInstruction,
-    accounts: &[AccountMeta],
-) {
-    let ProgInstruction::Withdraw { portfolio_id, .. } = ix else {
-        return;
+fn bind_test_portfolio_id(svm: &LiteSVM, ix: &mut ProgInstruction, accounts: &[AccountMeta]) {
+    let portfolio_id = match ix {
+        ProgInstruction::Withdraw { portfolio_id, .. }
+        | ProgInstruction::ConvertReleasedPnl { portfolio_id, .. } => portfolio_id,
+        _ => return,
     };
     if *portfolio_id != AUTO_PORTFOLIO_ID {
         return;
@@ -16162,7 +16163,10 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
 
     env.svm.expire_blockhash();
     let convert = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: 1 },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: 1,
+        },
         vec![
             AccountMeta::new(long_owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -16723,6 +16727,7 @@ fn v16_attack_convert_released_pnl_respects_caller_cap() {
     env.svm.expire_blockhash();
     let ra = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -16754,6 +16759,7 @@ fn v16_attack_convert_released_pnl_respects_caller_cap() {
     env.svm.expire_blockhash();
     let rb = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: RELEASED - 1,
         },
         vec![
@@ -16778,7 +16784,10 @@ fn v16_attack_convert_released_pnl_respects_caller_cap() {
     // zero-amount convert is rejected outright.
     env.svm.expire_blockhash();
     let rz = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: 0 },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: 0,
+        },
         vec![
             AccountMeta::new(b_owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -16873,7 +16882,10 @@ fn v16_attack_convert_released_pnl_rejects_cross_market_portfolio_substitution()
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ConvertReleasedPnl { amount: RELEASED },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: RELEASED,
+        },
         vec![
             AccountMeta::new(foreign_owner.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -16905,7 +16917,10 @@ fn v16_attack_convert_released_pnl_rejects_cross_market_portfolio_substitution()
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ConvertReleasedPnl { amount: RELEASED },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: RELEASED,
+        },
         vec![
             AccountMeta::new(local_owner.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -17111,6 +17126,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
     env.svm.expire_blockhash();
     let _ = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -19403,6 +19419,174 @@ fn v16_attack_presigned_withdraw_rejects_reinitialized_portfolio() {
     );
 }
 
+// Conversion can expose released junior PnL to maintenance fees. A retained owner signature from a
+// closed portfolio must not convert a replacement portfolio at the same address and fund a public
+// cranker reward. Every balance and PnL transition in this setup uses a public program instruction.
+#[test]
+fn v16_attack_presigned_convert_rejects_reinitialized_portfolio() {
+    let mut env =
+        V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(1, 1_000, 1_000, 500, 1);
+    env.update_maintenance_fee_policy_with_cu(10_000);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_with_cu(1, 100);
+    env.top_up_backing_bucket(1, 300, 1_000);
+
+    let owner = Keypair::new();
+    let portfolio_account = Keypair::new();
+    let portfolio = portfolio_account.pubkey();
+    env.ensure_signer_account(owner.pubkey());
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &portfolio_account,
+        env.portfolio_account_len,
+        env.program_id,
+    );
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    )
+    .expect("initialize incarnation A");
+
+    let make_released_pnl = |env: &mut V16CuEnv,
+                             winner_owner: &Keypair,
+                             winner: Pubkey,
+                             mark_slot: u64,
+                             start_price: u64| {
+        let loser_owner = Keypair::new();
+        let loser = env.create_portfolio(&loser_owner);
+        env.deposit(winner_owner, winner, 1_000_000);
+        env.deposit(&loser_owner, loser, 1_000_000);
+        env.trade_asset_with_cu(
+            0,
+            winner_owner,
+            winner,
+            &loser_owner,
+            loser,
+            (20 * POS_SCALE) as i128,
+            start_price,
+            0,
+        );
+        env.svm.warp_to_slot(mark_slot);
+        env.push_auth_mark_with_cu(mark_slot, start_price + 5);
+        for account in [loser, winner] {
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: mark_slot,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.trade_asset_with_cu(
+            0,
+            winner_owner,
+            winner,
+            &loser_owner,
+            loser,
+            -(20 * POS_SCALE as i128),
+            start_price + 5,
+            0,
+        );
+        let released = env.portfolio_state(winner).pnl.get();
+        assert!(released > 0, "public trade path must release winner PnL");
+        released as u128
+    };
+
+    let released_a = make_released_pnl(&mut env, &owner, portfolio, 2, 100);
+    let original_id = env.portfolio_id(portfolio);
+    let retained_convert = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                data: ProgInstruction::ConvertReleasedPnl {
+                    portfolio_id: original_id,
+                    amount: u128::MAX,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.convert_released_pnl_with_cu(&owner, portfolio, released_a);
+    let capital_a = env.portfolio_state(portfolio).capital.get();
+    env.withdraw(&owner, portfolio, capital_a);
+    env.close_portfolio_with_cu(&owner, portfolio);
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &portfolio, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio account");
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    )
+    .expect("initialize incarnation B");
+    assert!(env.portfolio_id(portfolio) > original_id);
+
+    let released_b = make_released_pnl(&mut env, &owner, portfolio, 3, 105);
+    let ordinary_capital = env.portfolio_state(portfolio).capital.get();
+    env.withdraw(&owner, portfolio, ordinary_capital);
+    env.crank(
+        portfolio,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(env.portfolio_state(portfolio).capital.get(), 0);
+    assert_eq!(env.portfolio_state(portfolio).pnl.get(), released_b as i128);
+
+    let attacker_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let rejected = env
+        .svm
+        .send_transaction(retained_convert)
+        .expect_err("incarnation A's conversion must not mutate incarnation B");
+    assert!(
+        format!("{rejected:?}").contains("Custom(16)"),
+        "stale conversion must reject with EngineProvenanceMismatch: {rejected:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&portfolio).unwrap(), portfolio_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+
+    env.svm.warp_to_slot(10);
+    env.sync_maintenance_fee_with_cu(portfolio, Some(attacker), 10);
+    assert_eq!(
+        env.portfolio_state(attacker).capital.get(),
+        0,
+        "a rejected stale conversion cannot fund a public cranker reward"
+    );
+    assert_eq!(env.portfolio_state(portfolio).capital.get(), 0);
+    assert_eq!(env.portfolio_state(portfolio).pnl.get(), released_b as i128);
+}
+
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
 // so dust-notional trades are never free and repeated churn never leaks value to the trader. Attacker
 // success = a fee that floors to 0 (free trade) or insurance that fails to grow on a fee'd dust trade.
@@ -19853,7 +20037,10 @@ fn v16_attack_convert_then_withdraw_pays_exactly_backed_amount() {
     // convert the backed pnl into withdrawable capital.
     env.svm.expire_blockhash();
     let cr = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: BACKED },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: BACKED,
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -25286,7 +25473,10 @@ fn v16_attack_resolved_mode_gates_all_live_ops() {
     // ConvertReleasedPnl -> reject
     env.svm.expire_blockhash();
     let r_cv = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: 1 },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: 1,
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -32364,6 +32554,7 @@ fn v16_attack_convert_bounded_by_available_backing() {
     env.svm.expire_blockhash();
     let _ = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -38498,6 +38689,7 @@ fn v16_attack_convert_released_pnl_cannot_mint_from_unbacked_pnl() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -38894,6 +39086,7 @@ fn v16_attack_recovery_blocks_pnl_conversion() {
     env.svm.expire_blockhash();
     let r = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -39147,6 +39340,7 @@ fn v16_attack_convert_then_withdraw_extracts_exactly_backed() {
     env.svm.expire_blockhash();
     let rc = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -43590,6 +43784,7 @@ fn v16_attack_convert_released_pnl_owner_gated() {
     env.svm.expire_blockhash();
     let r1 = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -43610,6 +43805,7 @@ fn v16_attack_convert_released_pnl_owner_gated() {
     env.svm.expire_blockhash();
     let r2 = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -43645,6 +43841,7 @@ fn v16_attack_convert_released_pnl_owner_gated() {
     env.svm.expire_blockhash();
     let ok = env.send(
         ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
             amount: 1_000_000_000,
         },
         vec![
@@ -55108,7 +55305,10 @@ fn v16_attack_convert_released_pnl_rejects_when_resolve_matured() {
 
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::ConvertReleasedPnl { amount: RELEASED },
+        ProgInstruction::ConvertReleasedPnl {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            amount: RELEASED,
+        },
         vec![
             AccountMeta::new(stale_owner.pubkey(), true),
             AccountMeta::new(env.market, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -201,7 +201,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
-    kani::assume(tag == 3 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42);
+    kani::assume(tag == 3 || tag == 9 || tag == 30 || tag == 41 || tag == 42);
     let amount: u128 = kani::any();
 
     let mut data = [0u8; 17];
@@ -211,7 +211,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     match (tag, Instruction::decode(&data).unwrap()) {
         (3, Instruction::Deposit { amount: got }) => assert_eq!(got, amount),
         (9, Instruction::TopUpInsurance { amount: got }) => assert_eq!(got, amount),
-        (28, Instruction::ConvertReleasedPnl { amount: got }) => assert_eq!(got, amount),
         (30, Instruction::CloseResolved { fee_rate_per_slot }) => {
             assert_eq!(fee_rate_per_slot, amount)
         }
@@ -237,6 +236,27 @@ fn kani_v16_withdraw_decode_preserves_portfolio_id_and_amount() {
 
     match Instruction::decode(&data).unwrap() {
         Instruction::Withdraw {
+            portfolio_id: got_id,
+            amount: got_amount,
+        } => {
+            assert_eq!(got_id, portfolio_id);
+            assert_eq!(got_amount, amount);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_convert_decode_preserves_portfolio_id_and_amount() {
+    let portfolio_id: u64 = kani::any();
+    let amount: u128 = kani::any();
+    let mut data = [0u8; 25];
+    data[0] = 28;
+    data[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+    data[9..25].copy_from_slice(&amount.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::ConvertReleasedPnl {
             portfolio_id: got_id,
             amount: got_amount,
         } => {
@@ -1382,7 +1402,13 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
 fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
-    assert_rejects_trailing_byte(Instruction::ConvertReleasedPnl { amount: 1 }, extra);
+    assert_rejects_trailing_byte(
+        Instruction::ConvertReleasedPnl {
+            portfolio_id: 1,
+            amount: 1,
+        },
+        extra,
+    );
     assert_rejects_trailing_byte(
         Instruction::CloseResolved {
             fee_rate_per_slot: 0,


### PR DESCRIPTION
## Summary

- add the market-assigned `portfolio_id` to `ConvertReleasedPnl` tag 28
- reject an ID mismatch before any engine conversion and reuse the explicit `u64::MAX` legacy-account migration path
- add a public-instruction LiteSVM regression and update every caller plus the wire proofs

## Root cause and impact

`ConvertReleasedPnl` authenticated only the owner, market, portfolio address, and amount. A relayer could retain an owner-signed transaction for portfolio incarnation A, wait for A to be closed and the same address and owner to initialize incarnation B, then replay the old conversion against B.

The exact-parent LiteSVM reproducer creates released PnL through normal deposits, backed trades, authenticated mark pushes, and permissionless cranks. After B withdraws all ordinary capital, the stale A conversion moves B junior PnL into fee-bearing capital. A permissionless maintenance crank then receives a positive reward funded by B. This is an independent victim loss, not point inflation or an initialization footgun.

## Security properties

- No new admin or DAO authority is introduced.
- The signed payload names one monotonic portfolio incarnation.
- Mismatches return `EngineProvenanceMismatch` before economic mutation.
- Rejection preserves market, portfolio, and vault bytes; the cranker receives zero.
- Legacy portfolios remain usable only with the explicit `u64::MAX` ID and are migrated through the existing binder.

## TDD evidence

- RED/exploit on exact parent `f72c8bdc076c107fd8085ae60a7bcd9dd03a0e6c`: retained A conversion succeeds against B and a public cranker receives a positive reward.
- GREEN on `15f6d588305f3ec66fd63ed841cde04df818dc04`: `v16_attack_presigned_convert_rejects_reinitialized_portfolio` passes against rebuilt real SBF.
- Full fixed suite: 6 unit tests and 567 LiteSVM tests passed.
- Fixed SBF SHA256: `05bacd937698db9a8acf3d8b77990b3229bc166712ec716a46c9ea9d0a1e729f`.