### PR TITLE
[HARDENING LoF] Bind matcher grants to portfolio incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ Positions and PnL use native `i128`/`u128` (`POS_SCALE = 1_000_000`, `ADL_ONE = 
 ### Two trade paths
 - **TradeNoCpi**: no external matcher; used for baseline integration, local testing, and deterministic program-test scenarios.
 - **TradeCpi**: production matcher path; the LP owner configures a matcher program/context once on
-  the LP portfolio with `SetMatcherConfig` (tag 68). Fills then run without the LP owner
-  signing each transaction. Direct LP-signed bilateral trading is `TradeNoCpi`.
+  the LP portfolio with an incarnation-bound `SetMatcherConfig` (tag 68). Fills then run without
+  the LP owner signing each transaction. Direct LP-signed bilateral trading is `TradeNoCpi`.
 
 ### MatchingEngine trait
 The `MatchingEngine` trait is defined in the Percolator program (not in the engine crate). The engine is a pure recorder of state transitions and does not define the matching interface. Two implementations exist: `NoOpMatcher` (TradeNoCpi) and `CpiMatcher` (TradeCpi).
@@ -358,7 +358,8 @@ This makes it a "pure identity signer" and prevents it from becoming an attack s
 ### LP matcher config (TradeCpi / BatchTradeCpi)
 Unsigned LP matcher fills require an enabled matcher config stored directly on the LP portfolio.
 
-`SetMatcherConfig` (tag 68) is signed by the LP owner and writes:
+`SetMatcherConfig` (tag 68) is signed by the LP owner, names the portfolio's monotonic ID, and
+writes:
 
 `matcher_program, matcher_context, matcher_delegate, enabled`
 
@@ -461,7 +462,9 @@ This section describes intent and operational ordering, not argument-by-argument
     the leg vector.
 - **SetMatcherConfig** (tag 68)
   - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
-    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.
+    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag. The
+    payload names the current portfolio ID so a retained grant cannot authorize a replacement
+    incarnation at the same account address.
 
 ### Oracle / mark management
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
@@ -776,7 +779,8 @@ Call `InitMarket` with:
   - deploy or choose matcher program
   - create matcher context account owned by matcher program
   - create a portfolio with `InitPortfolio`
-  - call `SetMatcherConfig` with the LP owner signing the exact matcher program/context/delegate tuple
+  - call `SetMatcherConfig` with the LP owner signing the current portfolio ID and exact matcher
+    program/context/delegate tuple
   - deposit collateral with `Deposit`
 - User:
   - create a portfolio with `InitPortfolio`

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2517,6 +2517,7 @@ pub mod ix {
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
+            portfolio_id: u64,
             enabled: u8,
         },
         ClosePortfolio,
@@ -2802,6 +2803,7 @@ pub mod ix {
                     }
                 }
                 68 => Self::SetMatcherConfig {
+                    portfolio_id: read_u64(&mut rest)?,
                     enabled: read_u8(&mut rest)?,
                 },
                 8 => Self::ClosePortfolio,
@@ -3115,8 +3117,12 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    portfolio_id,
+                    enabled,
+                } => {
                     out.push(68);
+                    push_u64(&mut out, portfolio_id);
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
@@ -5338,9 +5344,10 @@ pub mod processor {
                 account_b_portfolio_id,
                 &legs,
             ),
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                portfolio_id,
+                enabled,
+            } => handle_set_matcher_config(program_id, accounts, portfolio_id, enabled),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6818,6 +6825,7 @@ pub mod processor {
     fn handle_set_matcher_config<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_id: u64,
         enabled: u8,
     ) -> ProgramResult {
         if enabled > 1 {
@@ -6838,6 +6846,7 @@ pub mod processor {
         {
             return Err(PercolatorError::Unauthorized.into());
         }
+        bind_portfolio_id(lp_portfolio_ai, portfolio_id)?;
         let required_len = state::portfolio_account_len_for_market_slots(0)?;
         if lp_portfolio_ai.data_len() < required_len {
             lp_portfolio_ai.realloc(required_len, true)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2026,7 +2026,10 @@ impl V16CuEnv {
             ]);
         }
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id: AUTO_PORTFOLIO_ID,
+                enabled,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -3660,6 +3663,9 @@ fn bind_test_portfolio_ids(svm: &LiteSVM, ix: &mut ProgInstruction, accounts: &[
     match ix {
         ProgInstruction::Withdraw { portfolio_id, .. }
         | ProgInstruction::ConvertReleasedPnl { portfolio_id, .. } => {
+            bind_test_portfolio_id_at(svm, portfolio_id, accounts, 2);
+        }
+        ProgInstruction::SetMatcherConfig { portfolio_id, .. } => {
             bind_test_portfolio_id_at(svm, portfolio_id, accounts, 2);
         }
         ProgInstruction::TradeNoCpi {
@@ -19815,6 +19821,272 @@ fn v16_attack_presigned_trade_rejects_reinitialized_portfolio() {
     );
 }
 
+// A matcher grant signed for one LP portfolio incarnation must not be replayable after the account
+// is closed and reinitialized. Otherwise the retained grant can authorize fresh unsigned LP fills
+// against replacement collateral even though every new trade carries the replacement's public ID.
+#[test]
+fn v16_attack_presigned_matcher_config_rejects_reinitialized_portfolio() {
+    const MARK: u64 = 1_000_000;
+    const VICTIM_CAPITAL: u128 = 100_000;
+
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.update_liquidation_fee_policy_with_cu(10_000);
+    env.configure_auth_mark_with_cu(0, MARK);
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+
+    let victim_owner = Keypair::new();
+    let victim_account = Keypair::new();
+    let victim = victim_account.pubkey();
+    env.ensure_signer_account(victim_owner.pubkey());
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &victim_account,
+        env.portfolio_account_len,
+        env.program_id,
+    );
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    )
+    .expect("initialize incarnation A");
+    let original_id = env.portfolio_id(victim);
+
+    let matcher_context = Keypair::new();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::create_account(
+            &env.payer.pubkey(),
+            &matcher_context.pubkey(),
+            1_000_000_000,
+            MATCHER_CONTEXT_LEN as u64,
+            &matcher_program,
+        ),
+        &[&matcher_context],
+    )
+    .expect("System Program creates matcher context");
+    let delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &victim,
+        &victim_owner.pubkey(),
+        &matcher_program,
+        &matcher_context.pubkey(),
+    );
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        Instruction {
+            program_id: matcher_program,
+            accounts: vec![
+                AccountMeta::new_readonly(victim_owner.pubkey(), true),
+                AccountMeta::new_readonly(delegate, false),
+                AccountMeta::new(matcher_context.pubkey(), false),
+                AccountMeta::new_readonly(env.program_id, false),
+                AccountMeta::new_readonly(env.market, false),
+                AccountMeta::new_readonly(victim, false),
+            ],
+            data: vec![2],
+        },
+        &[&victim_owner],
+    )
+    .expect("LP owner publicly initializes matcher context for incarnation A");
+
+    let set_config_ix = |portfolio_id: u64, enabled: u8, incarnation_bound: bool| {
+        let mut data = vec![68u8];
+        if incarnation_bound {
+            data.extend_from_slice(&portfolio_id.to_le_bytes());
+        }
+        data.push(enabled);
+        Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(victim_owner.pubkey(), true),
+                AccountMeta::new_readonly(env.market, false),
+                AccountMeta::new(victim, false),
+                AccountMeta::new_readonly(matcher_program, false),
+                AccountMeta::new_readonly(matcher_context.pubkey(), false),
+                AccountMeta::new_readonly(delegate, false),
+            ],
+            data,
+        }
+    };
+
+    env.svm.expire_blockhash();
+    let incarnation_bound = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        set_config_ix(original_id, 1, true),
+        &[&victim_owner],
+    )
+    .is_ok();
+    if !incarnation_bound {
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            set_config_ix(original_id, 1, false),
+            &[&victim_owner],
+        )
+        .expect("legacy matcher grant is valid for incarnation A");
+    }
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        set_config_ix(original_id, 0, incarnation_bound),
+        &[&victim_owner],
+    )
+    .expect("incarnation A disables its matcher grant before closing");
+
+    env.svm.expire_blockhash();
+    let retained_config = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            set_config_ix(original_id, 1, incarnation_bound),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &victim, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio account");
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    )
+    .expect("initialize incarnation B");
+    let replacement_id = env.portfolio_id(victim);
+    assert!(replacement_id > original_id);
+    env.deposit(&victim_owner, victim, VICTIM_CAPITAL);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let matcher_before = env.svm.get_account(&matcher_context.pubkey()).unwrap();
+    let replay = env.svm.send_transaction(retained_config);
+    if let Err(rejected) = replay {
+        assert!(
+            format!("{rejected:?}").contains("Custom(16)"),
+            "the stale matcher grant must reject with EngineProvenanceMismatch: {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(
+            env.svm.get_account(&matcher_context.pubkey()).unwrap(),
+            matcher_before
+        );
+        assert_eq!(env.portfolio_matcher_config(victim).enabled, 0);
+        return;
+    }
+    assert_eq!(
+        env.portfolio_matcher_config(victim).enabled,
+        1,
+        "incarnation A's retained signature enabled its matcher on replacement B"
+    );
+
+    let attacker_owner = Keypair::new();
+    let attacker_trade = env.create_portfolio(&attacker_owner);
+    let attacker_reward = env.create_portfolio(&attacker_owner);
+    env.deposit(&attacker_owner, attacker_trade, 100_000_000);
+    env.deposit(&attacker_owner, attacker_reward, 1_000);
+    env.send(
+        ProgInstruction::TradeCpi {
+            account_a_portfolio_id: env.portfolio_id(attacker_trade),
+            account_b_portfolio_id: replacement_id,
+            asset_index: 0,
+            size_q: POS_SCALE as i128,
+            fee_bps: 0,
+            limit_price: 0,
+        },
+        vec![
+            AccountMeta::new(attacker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_trade, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(matcher_context.pubkey(), false),
+            AccountMeta::new_readonly(delegate, false),
+        ],
+        &[&attacker_owner],
+    )
+    .expect("fresh attacker trade uses B's current public ID and the replayed matcher grant");
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim), 0).side,
+        SideV16::Short
+    );
+
+    for slot in 1..=30u64 {
+        env.svm.warp_to_slot(slot);
+        let _ = env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim, false),
+            ],
+            &[],
+        );
+    }
+
+    let reward_before = env.portfolio_state(attacker_reward).capital.get();
+    env.svm.expire_blockhash();
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(attacker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new(attacker_reward, false),
+        ],
+        &[&attacker_owner],
+    )
+    .expect("the attacker liquidates replacement B");
+    let reward = env
+        .portfolio_state(attacker_reward)
+        .capital
+        .get()
+        .checked_sub(reward_before)
+        .expect("liquidation cannot debit the attacker reward portfolio");
+    assert!(reward > 0, "the replayed grant must fund a real reward");
+    let destination = env.withdraw(&attacker_owner, attacker_reward, reward);
+    assert_eq!(env.token_amount(destination), reward as u64);
+    panic!(
+        "incarnation-A matcher grant authorized a fresh trade against B and paid the attacker a {reward}-atom withdrawable liquidation reward"
+    );
+}
+
 #[test]
 fn v16_trade_entrypoints_bind_both_portfolio_ids_before_matcher_or_state_mutation() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
@@ -21312,7 +21584,10 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21377,7 +21652,10 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21748,7 +22026,10 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id: AUTO_PORTFOLIO_ID,
+                enabled: 1,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -21822,7 +22103,10 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     let lp_before_config = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -22082,7 +22366,10 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -31347,7 +31634,10 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: AUTO_PORTFOLIO_ID,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -557,6 +557,28 @@ fn kani_v16_tradecpi_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_set_matcher_config_decode_preserves_portfolio_id_and_enabled() {
+    let portfolio_id: u64 = kani::any();
+    let enabled: u8 = kani::any();
+
+    let mut data = [0u8; 10];
+    data[0] = 68;
+    data[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+    data[9] = enabled;
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::SetMatcherConfig {
+            portfolio_id: got_portfolio_id,
+            enabled: got_enabled,
+        } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_enabled, enabled);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
 fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
     // Audit fix: the ret's echoed fields and abi_version are drawn INDEPENDENTLY of the
     // expected (bound) params, and sizes are full-width i128, so both the accept path AND
@@ -1278,6 +1300,13 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
         },
         extra,
     );
+    assert_rejects_trailing_byte(
+        Instruction::SetMatcherConfig {
+            portfolio_id: 1,
+            enabled: 1,
+        },
+        extra,
+    );
     assert_rejects_trailing_byte(Instruction::SyncMaintenanceFee { now_slot: 1 }, extra);
 }
 
@@ -1567,6 +1596,9 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
 
     let trade_cpi = [10u8; 33];
     assert!(Instruction::decode(&trade_cpi).is_err());
+
+    let set_matcher_config = [68u8; 9];
+    assert!(Instruction::decode(&set_matcher_config).is_err());
 
     let top_up = [9u8; 16];
     assert!(Instruction::decode(&top_up).is_err());


### PR DESCRIPTION
## Classification

REAL LoF reachable through public instructions on a normally initialized live market.

## Root cause

`SetMatcherConfig` signed only the enabled byte. Its account tuple was bound to the LP account address and owner, but not to the market-owned monotonic portfolio ID. After a portfolio was closed and the same account address was initialized again for the same owner, a retained grant from incarnation A could enable the matcher on funded incarnation B.

The trade-entrypoint ID checks from #303 do not stop this: after replaying the stale grant, an attacker can submit a fresh `TradeCpi` naming B's public current ID.

## Reproduction

The LiteSVM regression uses only public protocol and matcher instructions:

1. an LP owner signs a matcher grant for empty portfolio incarnation A;
2. A disables the grant, closes, and the same account address is publicly reinitialized as funded incarnation B;
3. an unprivileged relayer replays A's retained grant;
4. the relayer submits a fresh matcher trade using B's current portfolio ID;
5. authenticated mark updates and permissionless cranks make B liquidatable;
6. the relayer liquidates B and withdraws a 524-atom victim-funded reward as SPL collateral.

On the exact parent, the test fails with:

`incarnation-A matcher grant authorized a fresh trade against B and paid the attacker a 524-atom withdrawable liquidation reward`

## Fix

- Add `portfolio_id: u64` to the tag 68 payload.
- Validate it against the portfolio's existing monotonic ID before matcher-config reallocation or mutation.
- Reject stale grants with `EngineProvenanceMismatch`.
- Reject the old unbound ABI.
- Update clients/tests and document the incarnation-bound grant.
- Add Kani coverage for field preservation, trailing bytes, and truncation.

This adds no signer, PDA, authority, admin, token-transfer, or custody surface.

## Validation

- Fixed SBF SHA-256: `1d0eb05d18c47eb1c35724ff9305408bc632b4d178decbcf28ab96f5f7364b99`
- 570/570 serial LiteSVM tests passed.
- 6/6 unit tests passed.
- 3/3 relevant Kani harnesses verified with zero failures:
  - `kani_v16_set_matcher_config_decode_preserves_portfolio_id_and_enabled`
  - `kani_v16_trade_and_crank_payloads_reject_trailing_byte`
  - `kani_v16_every_active_payload_rejects_one_byte_truncation`
- Stale replay asserts exact `Custom(16)` and byte-identical market, portfolio, and matcher-context rollback.

Stacked on #303 because the exploit regression intentionally exercises the current trade-incarnation ABI.