### PR TITLE
[HARDENING LoF] Bind portfolio close to its incarnation

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,9 @@ This section describes intent and operational ordering, not argument-by-argument
 - **Withdraw** (tag 4)
   - performs oracle-read + engine checks; withdraws from vault via PDA signer; debits engine
 - **ClosePortfolio** (tag 8)
+  - carries the current portfolio ID; stale incarnations reject before deregistration or lamport movement
   - closes a flat, empty portfolio account and sweeps its rent to the market slab
+  - legacy tag-only closes are accepted only for pre-ID portfolios whose stored ID is zero
 - **CloseResolved** (tag 30)
   - resolved-market payout/finalization path for a supplied portfolio; pays only the stored owner token account
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -792,12 +792,20 @@ pub mod state {
 
     #[inline]
     pub fn read_portfolio_id(data: &[u8]) -> Result<u64, ProgramError> {
-        check_header(data, KIND_PORTFOLIO)?;
-        let id = read_u64(data, PORTFOLIO_ID_OFF)?;
+        let id = read_portfolio_id_or_legacy(data)?;
         if id == 0 {
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(id)
+    }
+
+    #[inline]
+    pub fn read_portfolio_id_or_legacy(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        if data.len() == PORTFOLIO_ENGINE_ACCOUNT_LEN || data.len() == PORTFOLIO_ID_OFF {
+            return Ok(0);
+        }
+        read_u64(data, PORTFOLIO_ID_OFF)
     }
 
     #[inline]
@@ -2510,7 +2518,9 @@ pub mod ix {
         SetMatcherConfig {
             enabled: u8,
         },
-        ClosePortfolio,
+        ClosePortfolio {
+            portfolio_id: u64,
+        },
         TopUpInsurance {
             amount: u128,
         },
@@ -2777,7 +2787,15 @@ pub mod ix {
                 68 => Self::SetMatcherConfig {
                     enabled: read_u8(&mut rest)?,
                 },
-                8 => Self::ClosePortfolio,
+                8 => Self::ClosePortfolio {
+                    // Legacy tag-only closes are valid only for pre-ID portfolios, whose stored ID
+                    // is zero. Current portfolios must carry and match their nonzero incarnation.
+                    portfolio_id: if rest.is_empty() {
+                        0
+                    } else {
+                        read_u64(&mut rest)?
+                    },
+                },
                 9 => Self::TopUpInsurance {
                     amount: read_u128(&mut rest)?,
                 },
@@ -3067,7 +3085,10 @@ pub mod ix {
                     out.push(68);
                     out.push(enabled);
                 }
-                Self::ClosePortfolio => out.push(8),
+                Self::ClosePortfolio { portfolio_id } => {
+                    out.push(8);
+                    push_u64(&mut out, portfolio_id);
+                }
                 Self::TopUpInsurance { amount } => {
                     out.push(9);
                     push_u128(&mut out, amount);
@@ -5258,7 +5279,9 @@ pub mod processor {
             Instruction::SetMatcherConfig { enabled } => {
                 handle_set_matcher_config(program_id, accounts, enabled)
             }
-            Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
+            Instruction::ClosePortfolio { portfolio_id } => {
+                handle_close_portfolio(program_id, accounts, portfolio_id)
+            }
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
             }
@@ -7078,6 +7101,7 @@ pub mod processor {
     fn handle_close_portfolio<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
     ) -> ProgramResult {
         let closer = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -7087,6 +7111,11 @@ pub mod processor {
         expect_writable(portfolio_ai)?;
         expect_owner(market_ai, program_id)?;
         expect_owner(portfolio_ai, program_id)?;
+        let current_portfolio_id =
+            state::read_portfolio_id_or_legacy(&portfolio_ai.try_borrow_data()?)?;
+        if current_portfolio_id != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
         let (_, _, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         ensure_portfolio_storage_for_market_slots(portfolio_ai, max_market_slots)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -9,6 +9,7 @@ use percolator_prog::{
         ASSET_ORACLE_WRAPPER_LEN, MARKET_GROUP_OFF, MATCHER_ABI_VERSION, MATCHER_CONTEXT_MIN_LEN,
         ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, PORTFOLIO_ENGINE_ACCOUNT_LEN,
     },
+    error::PercolatorError,
     ix::{BatchTradeCpiLeg, BatchTradeLeg, CrankObservationHint, Instruction as ProgInstruction},
     oracle_v16, processor, state,
     state::{MarketGroupV16, PortfolioAccountV16},
@@ -19248,6 +19249,143 @@ fn v16_portfolio_incarnation_id_separates_close_and_reuse() {
     assert_eq!(replacement.residual_crystallized_loss_atoms_total.get(), 0);
     assert_eq!(replacement.residual_spent_principal_atoms_total.get(), 0);
     assert_eq!(replacement.residual_received_atoms_total.get(), 0);
+}
+
+// A close signed for one portfolio incarnation must not be replayable after the account is closed,
+// re-funded, and initialized again. ClosePortfolio transfers the account's lamports into the market
+// slab, so an old signature can otherwise destroy a replacement account funded by the same owner.
+#[test]
+fn v16_attack_presigned_close_rejects_reinitialized_portfolio() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio_account = Keypair::new();
+    let portfolio = portfolio_account.pubkey();
+    env.ensure_signer_account(owner.pubkey());
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &portfolio_account,
+        env.portfolio_account_len,
+        env.program_id,
+    );
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    )
+    .expect("initialize incarnation A");
+    let original_id = env.portfolio_id(portfolio);
+    let close_ix = |portfolio_id: u64, incarnation_bound: bool| {
+        let mut data = vec![8u8];
+        if incarnation_bound {
+            data.extend_from_slice(&portfolio_id.to_le_bytes());
+        }
+        Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            data,
+        }
+    };
+
+    let market_before_probe = env.svm.get_account(&env.market).unwrap();
+    let portfolio_before_probe = env.svm.get_account(&portfolio).unwrap();
+    env.svm.expire_blockhash();
+    let probe = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        close_ix(original_id + 10_000, true),
+        &[&owner],
+    );
+    let incarnation_bound = match probe {
+        Err(ref rejected)
+            if format!("{rejected:?}").contains(&format!(
+                "Custom({})",
+                PercolatorError::EngineProvenanceMismatch as u32
+            )) =>
+        {
+            true
+        }
+        Err(_) => false,
+        Ok(_) => panic!("a close carrying the wrong portfolio incarnation must reject"),
+    };
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_probe);
+    assert_eq!(
+        env.svm.get_account(&portfolio).unwrap(),
+        portfolio_before_probe
+    );
+
+    env.svm.expire_blockhash();
+    let retained_close = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            close_ix(original_id, incarnation_bound),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.close_portfolio_with_cu(&owner, portfolio);
+    env.svm.expire_blockhash();
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        system_instruction::transfer(&env.payer.pubkey(), &portfolio, 1_000_000_000),
+        &[],
+    )
+    .expect("re-fund the closed portfolio account through the System Program");
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[&owner],
+    )
+    .expect("initialize incarnation B");
+    let replacement_id = env.portfolio_id(portfolio);
+    assert!(replacement_id > original_id);
+
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let replacement_before_replay = env.svm.get_account(&portfolio).unwrap();
+    let replay = env.svm.send_transaction(retained_close);
+    if let Err(rejected) = replay {
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::EngineProvenanceMismatch as u32
+        );
+        assert!(
+            format!("{rejected:?}").contains(&expected_error),
+            "the stale close must reject with {expected_error}: {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_replay);
+        assert_eq!(
+            env.svm.get_account(&portfolio).unwrap(),
+            replacement_before_replay
+        );
+        return;
+    }
+
+    assert_eq!(env.svm.get_account(&portfolio).unwrap().lamports, 0);
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap().lamports,
+        market_before_replay.lamports + replacement_before_replay.lamports
+    );
+    panic!(
+        "a close signed for portfolio incarnation {original_id} drained replacement incarnation {replacement_id}"
+    );
 }
 
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2177,8 +2177,11 @@ impl V16CuEnv {
     }
 
     fn close_portfolio_with_cu(&mut self, owner: &Keypair, portfolio: Pubkey) -> u64 {
+        let portfolio_id =
+            state::read_portfolio_id_or_legacy(&self.svm.get_account(&portfolio).unwrap().data)
+                .unwrap();
         self.send(
-            ProgInstruction::ClosePortfolio,
+            ProgInstruction::ClosePortfolio { portfolio_id },
             vec![
                 AccountMeta::new(owner.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -8814,7 +8817,9 @@ fn v16_attack_non_owner_cannot_close_flat_portfolio() {
 
     env.svm.expire_blockhash();
     let bad_close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -8876,7 +8881,7 @@ fn v16_attack_non_owner_close_rolls_back_legacy_realloc() {
 
     env.svm.expire_blockhash();
     let bad_close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio { portfolio_id: 0 },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -8954,7 +8959,9 @@ fn v16_attack_close_portfolio_rejects_occupied_source_domain_without_claim_bound
 
     env.svm.expire_blockhash();
     let close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -16183,7 +16190,7 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
 
     env.svm.expire_blockhash();
     let close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio { portfolio_id: 0 },
         vec![
             AccountMeta::new(long_owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -19316,11 +19323,39 @@ fn v16_attack_presigned_close_rejects_reinitialized_portfolio() {
         Err(_) => false,
         Ok(_) => panic!("a close carrying the wrong portfolio incarnation must reject"),
     };
-    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_probe);
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_probe
+    );
     assert_eq!(
         env.svm.get_account(&portfolio).unwrap(),
         portfolio_before_probe
     );
+    if incarnation_bound {
+        env.svm.expire_blockhash();
+        let legacy = send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            close_ix(original_id, false),
+            &[&owner],
+        );
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::EngineProvenanceMismatch as u32
+        );
+        assert!(
+            format!("{legacy:?}").contains(&expected_error),
+            "legacy tag-only close must reject a current nonzero incarnation: {legacy:?}"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_probe
+        );
+        assert_eq!(
+            env.svm.get_account(&portfolio).unwrap(),
+            portfolio_before_probe
+        );
+    }
 
     env.svm.expire_blockhash();
     let retained_close = Transaction::new_signed_with_payer(
@@ -19370,7 +19405,10 @@ fn v16_attack_presigned_close_rejects_reinitialized_portfolio() {
             format!("{rejected:?}").contains(&expected_error),
             "the stale close must reject with {expected_error}: {rejected:?}"
         );
-        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before_replay);
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_replay
+        );
         assert_eq!(
             env.svm.get_account(&portfolio).unwrap(),
             replacement_before_replay
@@ -19386,6 +19424,52 @@ fn v16_attack_presigned_close_rejects_reinitialized_portfolio() {
     panic!(
         "a close signed for portfolio incarnation {original_id} drained replacement incarnation {replacement_id}"
     );
+}
+
+#[test]
+fn v16_legacy_tag_only_close_remains_available_to_zero_id_portfolios() {
+    let mut env = V16CuEnv::new();
+    for legacy_len in [
+        PORTFOLIO_ENGINE_ACCOUNT_LEN,
+        percolator_prog::constants::PORTFOLIO_ID_OFF,
+        percolator_prog::constants::PORTFOLIO_ACCOUNT_LEN,
+    ] {
+        let owner = Keypair::new();
+        let portfolio = env.create_portfolio(&owner);
+        let mut legacy = env.svm.get_account(&portfolio).unwrap();
+        if legacy_len < legacy.data.len() {
+            legacy.data.truncate(legacy_len);
+        } else {
+            let id_offset = percolator_prog::constants::PORTFOLIO_ID_OFF;
+            legacy.data[id_offset..id_offset + 8].fill(0);
+        }
+        env.svm.set_account(portfolio, legacy).unwrap();
+
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let portfolio_before = env.svm.get_account(&portfolio).unwrap();
+        env.svm.expire_blockhash();
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                data: vec![8],
+            },
+            &[&owner],
+        )
+        .unwrap_or_else(|err| panic!("legacy length {legacy_len} must remain closable: {err}"));
+
+        assert_eq!(env.svm.get_account(&portfolio).unwrap().lamports, 0);
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap().lamports,
+            market_before.lamports + portfolio_before.lamports
+        );
+    }
 }
 
 // security.md sweep — rounding asymmetry (#37 dust): trade fees must round UP (ceil, protocol favor)
@@ -30326,12 +30410,15 @@ fn v16_attack_cross_market_portfolio_cannot_drain_foreign_vault() {
     );
     let pa_before_close = env.svm.get_account(&pa).unwrap();
     let market_b_before_close = env.svm.get_account(&market_b).unwrap();
+    let pa_id = env.portfolio_id(pa);
     env.svm.expire_blockhash();
     let close_foreign = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: pa_id,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -33298,7 +33385,9 @@ fn v16_attack_close_portfolio_with_pnl_rejected() {
     // ClosePortfolio must reject (PnL != 0).
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(p),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -43121,7 +43210,7 @@ fn v16_attack_close_uninitialized_portfolio_rejects_without_counter_change() {
 
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio { portfolio_id: 0 },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53169,7 +53258,9 @@ fn v16_attack_empty_portfolio_reinit_cannot_inflate_materialized_count() {
 
     env.svm.expire_blockhash();
     env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53203,7 +53294,9 @@ fn v16_attack_close_portfolio_with_capital_rejected_no_strand() {
     assert!(cap > 0 && vault0 >= 400_000);
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(p),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53277,7 +53370,9 @@ fn v16_attack_abandoned_empty_portfolio_cannot_block_slab_close() {
     let abandoned_lamports = env.svm.get_account(&abandoned).unwrap().lamports;
     env.svm.expire_blockhash();
     let cleanup = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(abandoned),
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53330,7 +53425,9 @@ fn v16_attack_marketauth_terminal_close_cannot_skip_resolved_payout() {
     let vault_before = env.svm.get_account(&env.vault).unwrap();
     env.svm.expire_blockhash();
     let terminal_close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53376,7 +53473,9 @@ fn v16_attack_marketauth_terminal_close_cannot_skip_resolved_payout() {
 
     env.svm.expire_blockhash();
     env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53443,7 +53542,9 @@ fn v16_attack_marketauth_terminal_close_cannot_burn_pending_payout_topup() {
     let vault_before = env.svm.get_account(&env.vault).unwrap();
     env.svm.expire_blockhash();
     let terminal_close = env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -53476,7 +53577,9 @@ fn v16_attack_marketauth_terminal_close_cannot_burn_pending_payout_topup() {
 
     env.svm.expire_blockhash();
     env.send(
-        ProgInstruction::ClosePortfolio,
+        ProgInstruction::ClosePortfolio {
+            portfolio_id: env.portfolio_id(portfolio),
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -230,6 +230,23 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_close_portfolio_decode_preserves_incarnation_and_legacy_zero() {
+    let portfolio_id: u64 = kani::any();
+    let mut data = [0u8; 9];
+    data[0] = 8;
+    data[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::ClosePortfolio { portfolio_id: got } => assert_eq!(got, portfolio_id),
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        Instruction::decode(&[8]).unwrap(),
+        Instruction::ClosePortfolio { portfolio_id: 0 }
+    );
+}
+
+#[kani::proof]
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
@@ -1401,7 +1418,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
         extra,
     );
     assert_rejects_trailing_byte(Instruction::ClaimResolvedPayoutTopup, extra);
-    assert_rejects_trailing_byte(Instruction::ClosePortfolio, extra);
+    assert_rejects_trailing_byte(Instruction::ClosePortfolio { portfolio_id: 1 }, extra);
 }
 
 #[kani::proof]
@@ -1477,6 +1494,9 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
 
     let withdraw = [4u8; 16];
     assert!(Instruction::decode(&withdraw).is_err());
+
+    let close_portfolio = [8u8; 8];
+    assert!(Instruction::decode(&close_portfolio).is_err());
 
     let crank = [5u8; 59];
     assert!(Instruction::decode(&crank).is_err());


### PR DESCRIPTION
## Classification

**REAL LoF** reachable through the public `ClosePortfolio` interface on a normally initialized live market.

A portfolio address can be closed and later reinitialized with a new monotonic portfolio ID. A close transaction signed for the old incarnation previously carried no incarnation witness, so it remained valid against the replacement account. The exact-parent real-SBF LiteSVM RED replay swept all **1,000,000,000 lamports** owned by replacement incarnation 2 into the market slab.

This is the upstream fix for the existing Meta DAO RED coverage in aeyakovenko/percolator-meta#351.

## TDD history

- Exact parent: `da64be6`
- RED commit: `18501cf`
- Fix commit: `184d27d`

## Fix

- Carry the expected portfolio ID in `ClosePortfolio`.
- Compare it with the account's current ID before resize, deregistration, mutation, or lamport movement.
- Preserve tag-only compatibility only for recognized pre-ID layouts whose stored ID is zero.
- Reject partial and trailing payloads canonically.
- Document the wire/lifecycle rule and add decoder proofs.

This adds no signer, authority, custody, admin, or fund-moving surface.

## Verification

- Real-SBF serial LiteSVM: **567 passed, 0 failed**
- Library tests: **6 passed, 0 failed**
- Focused stale-close, legacy-layout, and legacy-realloc tests: passed
- Kani:
  - close decode preserves the incarnation and legacy zero
  - resolved recovery payloads reject trailing bytes
  - active payloads reject one-byte truncation
- `cargo check --all-targets`: passed
- `rustfmt --check`: passed
- `git diff --check`: passed
- Rebuilt SBF SHA-256: `9ae56ff9522d0ceba5b3643b2c879e5b011beab877adfff4de64f7f87bed6faf`
