### PR TITLE
[PRIVILEGED LoF] Bind bilateral trades to live base-fee consent

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6003,10 +6003,18 @@ pub mod processor {
         for leg in legs {
             ensure_valid_reported_trade_price(leg.exec_price)?;
         }
-        let (_cfg_pre, mode_pre, max_market_slots, _) =
+        let (cfg_pre, mode_pre, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         if mode_pre != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
+        }
+        // Both owners sign every leg, so each fee is also their consent ceiling for a mutable
+        // base-fee policy that may have changed since this transaction was built.
+        if legs
+            .iter()
+            .any(|leg| cfg_pre.trade_fee_base_bps > leg.fee_bps)
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
         }
         handle_batch_execute_zero_copy(
             program_id,
@@ -6224,10 +6232,14 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         ensure_valid_reported_trade_price(exec_price)?;
-        let (_cfg_pre, mode_pre, max_market_slots, _) =
+        let (cfg_pre, mode_pre, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         if mode_pre != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
+        }
+        // Both owners sign `fee_bps`; do not let a later policy update increase their charge.
+        if cfg_pre.trade_fee_base_bps > fee_bps {
+            return Err(PercolatorError::InvalidInstruction.into());
         }
         handle_trade_nocpi_zero_copy(
             program_id,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -34646,9 +34646,9 @@ fn v16_attack_trade_fee_policy_follows_asset0_insurance_authority() {
         short,
         POS_SCALE as i128,
         100,
-        0,
+        500,
     )
-    .expect("trade succeeds with caller fee_bps=0 after the insurance authority sets the floor");
+    .expect("trade succeeds after both owners consent to the authority-set fee floor");
     let (_, group) = env.market_state();
     assert!(
         group.insurance > insurance_before,
@@ -37540,7 +37540,7 @@ fn ewma_no_cpi_fee_and_mark_for_reported_price(
         account_b,
         size_q,
         reported_price,
-        0,
+        100,
     )
     .unwrap_or_else(|err| {
         panic!("{path:?}: no-CPI EWMA trade with reported_price={reported_price} failed: {err}")
@@ -54152,13 +54152,11 @@ fn v16_attack_switchboard_owner_and_key_binding_reject_spoofed_feed() {
     );
 }
 
-// Fee-RATE evasion: execute_trade floors the caller-supplied fee_bps to the config base
-// (hybrid_trade_fee_bps_view: base = max(caller_fee_bps, cfg.trade_fee_base_bps), src/v16_program.rs).
-// A trader passing fee_bps=0 must still pay the config trade_fee_base_bps -- complements the exec_price
-// BASIS-evasion guard (v16_attack_tradenocpi_fee_cannot_be_evaded_via_exec_price). The default market is
-// manual-priced (no dynamic mark-externality fee), so the only fee source is the base via the floor.
+// A bilateral trade's signed fee must consent to the current mutable base-fee policy. Rejecting a
+// lower value prevents fee evasion without letting a post-sign policy update increase either
+// owner's charge. The default market is manual-priced, so only the configured base fee applies.
 #[test]
-fn v16_attack_trade_caller_fee_bps_floored_to_config_base() {
+fn v16_attack_trade_requires_signed_base_fee_consent() {
     let mut env = V16CuEnv::new();
     env.update_trade_fee_policy_with_cu(500); // config base fee = 5%
     let la = Keypair::new();
@@ -54169,18 +54167,27 @@ fn v16_attack_trade_caller_fee_bps_floored_to_config_base() {
     env.deposit(&lb, pb, 1_000_000);
     let ins0 = env.market_state().1.insurance;
 
-    // Trader passes fee_bps = 0 trying to evade the fee.
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let a_before = env.svm.get_account(&pa).unwrap();
+    let b_before = env.svm.get_account(&pb).unwrap();
+
     env.svm.expire_blockhash();
     let r = env.try_trade_asset_with_cu(0, &la, pa, &lb, pb, POS_SCALE as i128, 100, 0);
     assert!(
-        r.is_ok(),
-        "fee_bps=0 must be FLOORED to the config base (not rejected): {r:?}"
+        r.is_err(),
+        "fee_bps below the live base must reject rather than evade or silently increase: {r:?}"
     );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&pa).unwrap(), a_before);
+    assert_eq!(env.svm.get_account(&pb).unwrap(), b_before);
+
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(0, &la, pa, &lb, pb, POS_SCALE as i128, 100, 500);
 
     let (_, g1) = env.market_state();
     assert!(
         g1.insurance > ins0,
-        "caller fee_bps=0 must be floored to trade_fee_base_bps (config base fee charged), not evaded; \
+        "a trade that signs the configured base must pay it; \
          insurance {ins0} -> {}",
         g1.insurance
     );
@@ -59719,7 +59726,7 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 #[test]
-fn probe_presigned_trade_nocpi_cannot_be_rugged_by_base_fee_update() {
+fn v16_attack_presigned_nocpi_trade_cannot_be_rugged_by_base_fee_update() {
     const FEE_BPS: u64 = 500;
     const DEPOSIT: u128 = 1_000_000;
     const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
@@ -59762,6 +59769,34 @@ fn probe_presigned_trade_nocpi_cannot_be_rugged_by_base_fee_update() {
     };
     let retained_open = retained_trade(SIZE_Q);
     let retained_close = retained_trade(-SIZE_Q);
+    let retained_batch = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(attacker.pubkey(), true),
+                    AccountMeta::new(victim.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(attacker_portfolio, false),
+                    AccountMeta::new(victim_portfolio, false),
+                ],
+                data: ProgInstruction::BatchTradeNoCpi {
+                    legs: vec![BatchTradeLeg {
+                        asset_index: 0,
+                        size_q: SIZE_Q,
+                        exec_price: 100,
+                        fee_bps: 0,
+                    }],
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &attacker, &victim],
+        env.svm.latest_blockhash(),
+    );
 
     env.update_trade_fee_policy_with_cu(FEE_BPS);
     let market_after_policy = env.svm.get_account(&env.market).unwrap();
@@ -59807,6 +59842,24 @@ fn probe_presigned_trade_nocpi_cannot_be_rugged_by_base_fee_update() {
     );
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_after_policy);
 
+    assert!(
+        env.svm.send_transaction(retained_batch).is_err(),
+        "a retained batch must reject the same post-sign base-fee increase"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_after_policy
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_portfolio).unwrap(),
+        attacker_after_policy
+    );
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_after_policy
+    );
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_after_policy);
+
     env.svm.expire_blockhash();
     env.trade_asset_with_cu(
         0,
@@ -59834,4 +59887,33 @@ fn probe_presigned_trade_nocpi_cannot_be_rugged_by_base_fee_update() {
     );
     assert_eq!(env.portfolio_state(victim_portfolio).capital.get(), 990_000);
     assert_eq!(env.market_state().1.insurance, 20_000);
+
+    for size_q in [SIZE_Q, -SIZE_Q] {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::BatchTradeNoCpi {
+                legs: vec![BatchTradeLeg {
+                    asset_index: 0,
+                    size_q,
+                    exec_price: 100,
+                    fee_bps: FEE_BPS,
+                }],
+            },
+            vec![
+                AccountMeta::new(attacker.pubkey(), true),
+                AccountMeta::new(victim.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker_portfolio, false),
+                AccountMeta::new(victim_portfolio, false),
+            ],
+            &[&attacker, &victim],
+        )
+        .expect("freshly consented batch trade");
+    }
+    assert_eq!(
+        env.portfolio_state(attacker_portfolio).capital.get(),
+        980_000
+    );
+    assert_eq!(env.portfolio_state(victim_portfolio).capital.get(), 980_000);
+    assert_eq!(env.market_state().1.insurance, 40_000);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,121 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn probe_presigned_trade_nocpi_cannot_be_rugged_by_base_fee_update() {
+    const FEE_BPS: u64 = 500;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        max_trading_fee_bps: FEE_BPS,
+        ..V16CuMarketParams::default()
+    });
+    let attacker = env.admin.insecure_clone();
+    let victim = Keypair::new();
+    let attacker_portfolio = env.create_portfolio(&attacker);
+    let victim_portfolio = env.create_portfolio(&victim);
+    env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+
+    let retained_trade = |size_q: i128| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(attacker.pubkey(), true),
+                AccountMeta::new(victim.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker_portfolio, false),
+                AccountMeta::new(victim_portfolio, false),
+            ],
+            data: ProgInstruction::TradeNoCpi {
+                asset_index: 0,
+                size_q,
+                exec_price: 100,
+                fee_bps: 0,
+            }
+            .encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &attacker, &victim],
+            env.svm.latest_blockhash(),
+        )
+    };
+    let retained_open = retained_trade(SIZE_Q);
+    let retained_close = retained_trade(-SIZE_Q);
+
+    env.update_trade_fee_policy_with_cu(FEE_BPS);
+    let market_after_policy = env.svm.get_account(&env.market).unwrap();
+    let attacker_after_policy = env.svm.get_account(&attacker_portfolio).unwrap();
+    let victim_after_policy = env.svm.get_account(&victim_portfolio).unwrap();
+    let vault_after_policy = env.svm.get_account(&env.vault).unwrap();
+
+    if env.svm.send_transaction(retained_open).is_ok() {
+        env.svm
+            .send_transaction(retained_close)
+            .expect("the paired retained close must land on the vulnerable parent");
+        let attacker_state = env.portfolio_state(attacker_portfolio);
+        let victim_state = env.portfolio_state(victim_portfolio);
+        let (_, group) = env.market_state();
+        assert_eq!(attacker_state.capital.get(), 990_000);
+        assert_eq!(victim_state.capital.get(), 990_000);
+        assert_eq!(group.insurance, 20_000);
+
+        let (insurance_dest, _) = env.withdraw_insurance_with_cu(group.insurance);
+        let attacker_dest =
+            env.withdraw(&attacker, attacker_portfolio, attacker_state.capital.get());
+        let victim_dest = env.withdraw(&victim, victim_portfolio, victim_state.capital.get());
+        assert_eq!(
+            env.token_amount(attacker_dest) + env.token_amount(insurance_dest),
+            1_010_000,
+            "the fee authority recovers its own fees and extracts the victim's fee"
+        );
+        assert_eq!(env.token_amount(victim_dest), 990_000);
+        panic!("a retained zero-fee trade accepted a post-sign base-fee increase");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_after_policy
+    );
+    assert_eq!(
+        env.svm.get_account(&attacker_portfolio).unwrap(),
+        attacker_after_policy
+    );
+    assert_eq!(
+        env.svm.get_account(&victim_portfolio).unwrap(),
+        victim_after_policy
+    );
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_after_policy);
+
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &attacker,
+        attacker_portfolio,
+        &victim,
+        victim_portfolio,
+        SIZE_Q,
+        100,
+        FEE_BPS,
+    );
+    env.trade_asset_with_cu(
+        0,
+        &attacker,
+        attacker_portfolio,
+        &victim,
+        victim_portfolio,
+        -SIZE_Q,
+        100,
+        FEE_BPS,
+    );
+    assert_eq!(
+        env.portfolio_state(attacker_portfolio).capital.get(),
+        990_000
+    );
+    assert_eq!(env.portfolio_state(victim_portfolio).capital.get(), 990_000);
+    assert_eq!(env.market_state().1.insurance, 20_000);
+}


### PR DESCRIPTION
## Impact

The asset-0 insurance authority could raise `trade_fee_base_bps` after both owners signed a `TradeNoCpi` transaction. Landing the unchanged signed open and close then silently charged the new fee to both portfolios, credited the authority-controlled insurance budget, and made the independent victim's fee publicly withdrawable.

The exact-parent public LiteSVM reproduction starts both sides at 1,000,000 atoms. A post-sign 500 bps policy update charges each side 10,000 atoms; the authority withdraws 20,000 and ends at 1,010,000 while the victim ends at 990,000. It uses ordinary initialization, deposits, retained owner-signed transactions, a policy update, trades, insurance withdrawal, and owner withdrawals without protocol-state injection.

## Root cause

Both owners sign `fee_bps`, but bilateral execution used `max(fee_bps, trade_fee_base_bps)`. The mutable execution-time floor therefore was not bounded by either retained signature.

## Fix

- Treat each jointly signed `fee_bps` as consent to at most that live base fee.
- Reject single and batch no-CPI trades when the current base exceeds the signed value.
- Preserve dynamic EWMA fee calculation and all risk-reducing trade behavior once the live base is consented.
- Leave CPI semantics unchanged; unsigned-LP base-fee consent is handled separately by stacked PR #313 after #224.

The regression covers retained single and batch transactions, byte-identical rollback, freshly signed positive controls, exact fee collection, and withdrawal of the pre-fix victim-funded amount before the RED assertion.

## TDD evidence

- `623edff8` is the exact-parent RED on `da64be639168b496833dd4c701607a94fcb06b6c`.
- `197782a5` implements the bilateral single/batch fix.

## Verification

- `cargo build-sbf --tools-version v1.52`
- authenticated and hostile matcher fixture SBF builds
- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 public LiteSVM/CU tests passed
- focused RED/GREEN and positive controls passed
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo kani --tests`: the exhaustive one-byte truncation harness passed; the unchanged aggregate unknown/truncated-tag harness reached its existing decoder-symbolic-execution wall and was stopped. This PR changes no instruction encoding or decoding.