### PR TITLE
[BLOCKER LoF] Bind market resolution to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,8 +855,10 @@ These are governance powers, not bugs:
 3. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
-4. `ResolveMarket`
+4. `ResolveMarket { market_id }`
    - transition market to resolved mode using stored authority price.
+   - the signed terminal action is bound to asset 0's current generation; retained resolves from a
+     shutdown/restart generation reject before changing market state.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
 5. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can withdraw resolved-market insurance.

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2568,7 +2568,9 @@ pub mod ix {
             amount: u128,
         },
         CloseSlab,
-        ResolveMarket,
+        ResolveMarket {
+            market_id: u64,
+        },
         TopUpBackingBucket {
             domain: u16,
             amount: u128,
@@ -2842,7 +2844,9 @@ pub mod ix {
                     amount: read_u128(&mut rest)?,
                 },
                 13 => Self::CloseSlab,
-                19 => Self::ResolveMarket,
+                19 => Self::ResolveMarket {
+                    market_id: read_u64(&mut rest)?,
+                },
                 24 => Self::TopUpBackingBucket {
                     domain: read_u16(&mut rest)?,
                     amount: read_u128(&mut rest)?,
@@ -3142,7 +3146,10 @@ pub mod ix {
                     push_u128(&mut out, amount);
                 }
                 Self::CloseSlab => out.push(13),
-                Self::ResolveMarket => out.push(19),
+                Self::ResolveMarket { market_id } => {
+                    out.push(19);
+                    push_u64(&mut out, market_id);
+                }
                 Self::TopUpBackingBucket {
                     domain,
                     amount,
@@ -5304,7 +5311,9 @@ pub mod processor {
                 handle_top_up_insurance_domain(program_id, accounts, domain, amount)
             }
             Instruction::CloseSlab => handle_close_slab(program_id, accounts),
-            Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
+            Instruction::ResolveMarket { market_id } => {
+                handle_resolve_market(program_id, accounts, market_id)
+            }
             Instruction::TopUpBackingBucket {
                 domain,
                 amount,
@@ -8754,6 +8763,7 @@ pub mod processor {
     fn handle_resolve_market<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -8762,6 +8772,11 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         let mut market_data = market_ai.try_borrow_mut_data()?;
         let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
+        if group.markets.is_empty()
+            || group.markets[0].engine.asset.market_id.get() != expected_market_id
+        {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
         if group.header.mode != 0 {
             return Err(PercolatorError::EngineLockActive.into());
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2254,11 +2254,12 @@ impl V16CuEnv {
     }
 
     fn resolve(&mut self) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::ResolveMarket,
+            ProgInstruction::ResolveMarket { market_id },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -6502,11 +6503,12 @@ fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
             attacker.pubkey().to_bytes(),
             "the retained old rotation seized the fresh market"
         );
+        let market_id = env.asset_market_id(0);
         let forced_resolve = send_tx(
             &mut env.svm,
             env.program_id,
             &env.payer,
-            ProgInstruction::ResolveMarket,
+            ProgInstruction::ResolveMarket { market_id },
             vec![
                 AccountMeta::new(attacker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -23322,11 +23324,12 @@ fn v16_attack_non_admin_cannot_resolve_or_configure() {
 
     // non-admin ResolveMarket -> reject; market stays Live.
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let r_res = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket { market_id },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24783,7 +24786,9 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: first_generation_market_id(0),
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24919,7 +24924,9 @@ fn v16_attack_terminal_withdraw_insurance_rejects_portfolio_as_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: first_generation_market_id(0),
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -28561,11 +28568,12 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
     );
 
     env.svm.expire_blockhash();
+    let market_id = env.asset_market_id(0);
     let resolve = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket { market_id },
         vec![
             AccountMeta::new(new_admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -28782,7 +28790,9 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: first_generation_market_id(0),
+        },
         vec![
             AccountMeta::new(market.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -31672,7 +31682,9 @@ fn v16_attack_close_resolved_rejects_cross_market_portfolio_payout() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: first_generation_market_id(0),
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6555,6 +6555,161 @@ fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
     .expect("the same rotation remains live when signed for the current market generation");
 }
 
+// ResolveMarket is a signed terminal action, so it must identify the asset-0 generation whose
+// positions the administrator intended to settle. Otherwise a transaction retained while an empty
+// generation A was live can be submitted after an ordinary shutdown/restart, crystallizing a
+// replacement user's temporary generation-B loss and making it withdrawable by the opposing trader.
+#[test]
+fn v16_attack_presigned_resolve_rejects_restarted_asset_generation() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 110;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(1_000_000, 1);
+    let old_market_id = env.asset_market_id(0);
+    let program_id = env.program_id;
+    let market = env.market;
+    let resolve_ix = |market_id: u64, generation_bound: bool| {
+        let mut data = vec![19u8];
+        if generation_bound {
+            data.extend_from_slice(&market_id.to_le_bytes());
+        }
+        Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(market, false),
+            ],
+            data,
+        }
+    };
+
+    // Keep the RED source compatible with both the legacy tag-only wire and the fixed wire. A
+    // wrong generation distinguishes a decoder that knows the witness without mutating the market.
+    env.svm.expire_blockhash();
+    let generation_probe = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        resolve_ix(old_market_id.checked_add(10_000).unwrap(), true),
+        &[&admin],
+    );
+    let generation_bound = format!("{generation_probe:?}").contains(&format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    ));
+
+    env.svm.expire_blockhash();
+    let stale_resolve = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            resolve_ix(old_market_id, generation_bound),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("empty generation A shuts down through the public lifecycle");
+    env.svm.warp_to_slot(3);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 3, PRICE)
+        .expect("asset 0 restarts into generation B");
+    env.configure_auth_mark_with_cu(3, PRICE);
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+
+    let winner_owner = Keypair::new();
+    let victim_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&winner_owner, winner, DEPOSIT);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &victim_owner,
+        victim,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(10);
+    env.push_auth_mark_with_cu(10, ADVERSE_PRICE);
+    for slot in [10u64, 11] {
+        env.svm.warp_to_slot(slot);
+        for portfolio in [victim, winner] {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                &[],
+            );
+        }
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        ADVERSE_PRICE
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let winner_before = env.svm.get_account(&winner).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(stale_resolve);
+    if let Err(rejected) = replay {
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::AssetGenerationMismatch as u32
+        );
+        assert!(
+            format!("{rejected:?}").contains(&expected_error),
+            "the stale resolve must reject with {expected_error}: {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&winner).unwrap(), winner_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+        env.svm.expire_blockhash();
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            resolve_ix(new_market_id, true),
+            &[&admin],
+        )
+        .expect("a resolve signed for generation B remains available");
+        return;
+    }
+
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+    env.svm.warp_to_slot(12);
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let winner_dest = env.close_resolved(&winner_owner, winner);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let winner_payout = env.token_amount(winner_dest) as u128;
+    assert_eq!(victim_payout, 900_000);
+    assert_eq!(winner_payout, 1_100_000);
+    panic!(
+        "a generation-A resolve crystallized generation B and paid the opposing trader {} atoms of the replacement victim's capital",
+        winner_payout - DEPOSIT
+    );
+}
+
 #[test]
 fn v16_attack_prefunded_market_generation_pda_cannot_block_init() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -628,6 +628,30 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_resolve_market_decode_preserves_generation() {
+    let market_id: u64 = kani::any();
+    let trailing: u8 = kani::any();
+    let mut data = [0u8; 9];
+    data[0] = 19;
+    data[1..].copy_from_slice(&market_id.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::ResolveMarket {
+            market_id: got_market_id,
+        } => assert_eq!(got_market_id, market_id),
+        _ => unreachable!(),
+    }
+
+    assert!(Instruction::decode(&[19]).is_err());
+    assert!(Instruction::decode(&data[..8]).is_err());
+
+    let mut oversized = [0u8; 10];
+    oversized[..9].copy_from_slice(&data);
+    oversized[9] = trailing;
+    assert!(Instruction::decode(&oversized).is_err());
+}
+
+#[kani::proof]
 fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let market_id: u64 = kani::any();
@@ -1232,7 +1256,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
     assert_rejects_trailing_byte(Instruction::CloseSlab, extra);
-    assert_rejects_trailing_byte(Instruction::ResolveMarket, extra);
+    assert_rejects_trailing_byte(Instruction::ResolveMarket { market_id: 1 }, extra);
     assert_rejects_trailing_byte(
         Instruction::UpdateAuthority {
             market_id: 1,
@@ -1502,6 +1526,9 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
 
     let crank = [5u8; 59];
     assert!(Instruction::decode(&crank).is_err());
+
+    let resolve_market = [19u8; 8];
+    assert!(Instruction::decode(&resolve_market).is_err());
 
     let asset_lifecycle = [40u8; 147];
     assert!(Instruction::decode(&asset_lifecycle).is_err());


### PR DESCRIPTION
## Classification

REAL loss of funds reachable through the public interface.

An unprivileged submitter can retain an administrator-signed `ResolveMarket` transaction from empty asset-0 generation A, wait for an ordinary public shutdown/restart into generation B, and submit the stale transaction after replacement users fund and trade. Resolution crystallizes temporary generation-B PnL and makes the opposing portfolio's gain withdrawable.

## Reproduction

- Exact parent: `4c5753f0bfe91cce2116ce2434fdce34537423de`
- RED commit: `6d60b89`
- Fix commit: `9f408ac`
- No direct account-state injection is used.
- Public lifecycle: empty shutdown at slot 2, restart at slot 3, replacement deposits/trade, authenticated mark move, retained resolve submission.
- Exact RED loss: victim deposit `1,000,000` pays out `900,000`; opposing deposit `1,000,000` pays out `1,100,000`. The stale signature transfers `100,000` SPL atoms of replacement victim capital.

## Fix

`ResolveMarket { market_id }` now carries the intended asset-0 generation. The processor compares it with the active generation before reading time or mutating resolution state. Legacy tag-only, truncated, mismatched-generation, and trailing-byte payloads fail closed. A current-generation resolve remains available.

This adds no authority, custody, withdrawal, or administrator fund-moving surface.

## Verification

- Focused exact-parent RED fails with the 100,000-atom transfer.
- Focused fixed real-SBF LiteSVM regression passes.
- Full serial real-SBF LiteSVM: `569 passed; 0 failed` in 227.89s.
- Resolution-filtered LiteSVM: `66` paths exercised; `65` initially passed and one fixture-missing case passed after building the hostile matcher.
- Library tests: `5 passed; 0 failed`.
- `cargo check --all-targets` passes.
- Focused Kani wire proof: `0 of 845 failed`.
- `rustfmt --check` and `git diff --check` pass.
- Fixed SBF SHA-256: `2900cac88a42411594e60e93934de584f80aeb585967953370c3a058e788a598`.