### PR TITLE
[BLOCKER LoF] Bind resolve policy to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ current_fee_bps >= trade_fee_base_bps
 
 The `max_price_move_bps_per_slot` floor applies only during stale hybrid fallback. It lets consenting counterparties keep trading at any execution price while charging for the next honest external-oracle step even when the EWMA mark itself does not move.
 
-The hard `permissionless_resolve_stale_slots` timer remains independent. If that hard timer matures, live price-taking paths stop and the market exits through permissionless resolution.
+The hard `permissionless_resolve_stale_slots` timer remains independent. If that hard timer matures, live price-taking paths stop and the market exits through permissionless resolution. The signed `ConfigurePermissionlessResolve { market_id, .. }` policy update is bound to asset 0's current generation, so a retained update from before an asset-0 shutdown/restart cannot shorten or extend the replacement generation's terminal window.
 
 ---
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2629,6 +2629,7 @@ pub mod ix {
         },
         SyncInsuranceLedger,
         ConfigurePermissionlessResolve {
+            market_id: u64,
             stale_slots: u64,
             force_close_delay_slots: u64,
         },
@@ -2924,6 +2925,7 @@ pub mod ix {
                 },
                 54 => Self::SyncInsuranceLedger,
                 38 => Self::ConfigurePermissionlessResolve {
+                    market_id: read_u64(&mut rest)?,
                     stale_slots: read_u64(&mut rest)?,
                     force_close_delay_slots: read_u64(&mut rest)?,
                 },
@@ -3239,10 +3241,12 @@ pub mod ix {
                 }
                 Self::SyncInsuranceLedger => out.push(54),
                 Self::ConfigurePermissionlessResolve {
+                    market_id,
                     stale_slots,
                     force_close_delay_slots,
                 } => {
                     out.push(38);
+                    push_u64(&mut out, market_id);
                     push_u64(&mut out, stale_slots);
                     push_u64(&mut out, force_close_delay_slots);
                 }
@@ -5370,11 +5374,13 @@ pub mod processor {
             }
             Instruction::SyncInsuranceLedger => handle_sync_insurance_ledger(program_id, accounts),
             Instruction::ConfigurePermissionlessResolve {
+                market_id,
                 stale_slots,
                 force_close_delay_slots,
             } => handle_configure_permissionless_resolve(
                 program_id,
                 accounts,
+                market_id,
                 stale_slots,
                 force_close_delay_slots,
             ),
@@ -9817,6 +9823,7 @@ pub mod processor {
     fn handle_configure_permissionless_resolve<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> ProgramResult {
@@ -9832,18 +9839,26 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, mode, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
-        expect_live_authority(&cfg.marketauth, admin.key)?;
-        if mode != MarketModeV16::Live {
-            return Err(PercolatorError::EngineLockActive.into());
-        }
-        if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
-            return Err(PercolatorError::OracleStale.into());
-        }
-        cfg.permissionless_resolve_stale_slots = stale_slots;
-        cfg.force_close_delay_slots = force_close_delay_slots;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        let mut market_data = market_ai.try_borrow_mut_data()?;
+        let cfg_after = {
+            let (mut cfg, group) = state::market_view_mut(&mut market_data)?;
+            if group.markets.is_empty()
+                || group.markets[0].engine.asset.market_id.get() != expected_market_id
+            {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
+            }
+            expect_live_authority(&cfg.marketauth, admin.key)?;
+            if group.header.mode != 0 {
+                return Err(PercolatorError::EngineLockActive.into());
+            }
+            if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
+                return Err(PercolatorError::OracleStale.into());
+            }
+            cfg.permissionless_resolve_stale_slots = stale_slots;
+            cfg.force_close_delay_slots = force_close_delay_slots;
+            cfg
+        };
+        state::write_wrapper_config(&mut market_data, &cfg_after)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2307,11 +2307,13 @@ impl V16CuEnv {
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigurePermissionlessResolve {
+                market_id,
                 stale_slots,
                 force_close_delay_slots,
             },
@@ -26735,6 +26737,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
         "test setup rotates marketauth away from the old key"
     );
     let cfg_after_rotation = env.market_state().0;
+    let market_id = env.asset_market_id(0);
 
     let mut old_attempt = |ix: ProgInstruction, label: &str| {
         env.svm.expire_blockhash();
@@ -26805,6 +26808,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     old_attempt(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -26851,6 +26855,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     new_update(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -37819,6 +37824,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id: first_generation_market_id(0),
             stale_slots: 100,
             force_close_delay_slots: DELAY,
         },
@@ -55402,6 +55408,7 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
 fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     let mut env = V16CuEnv::new();
     let admin = env.admin.insecure_clone();
+    let market_id = env.asset_market_id(0);
     let market = env.market;
     let metas = |signer: Pubkey| {
         vec![
@@ -55417,6 +55424,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -55437,6 +55445,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 0,
             force_close_delay_slots: 1_000,
         },
@@ -55452,6 +55461,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: percolator_prog::constants::MAX_PERMISSIONLESS_RESOLVE_STALE_SLOTS + 1,
             force_close_delay_slots: 1_000,
         },
@@ -55470,6 +55480,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 1_000,
             force_close_delay_slots: 0,
         },
@@ -55488,6 +55499,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 1_000,
             force_close_delay_slots: percolator_prog::constants::MAX_FORCE_CLOSE_DELAY_SLOTS + 1,
         },
@@ -55508,6 +55520,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_ok = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -55537,6 +55550,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
 fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     let mut env = V16CuEnv::new();
     let admin = env.admin.insecure_clone();
+    let market_id = env.asset_market_id(0);
     env.configure_permissionless_resolve_with_cu(5, 5);
     env.configure_auth_mark_with_cu(0, 100);
 
@@ -55548,6 +55562,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let fresh = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 6,
             force_close_delay_slots: 6,
         },
@@ -55575,6 +55590,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let stale = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            market_id,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6555,6 +6555,168 @@ fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
     .expect("the same rotation remains live when signed for the current market generation");
 }
 
+// ConfigurePermissionlessResolve changes when anyone may irreversibly settle the market. A signed
+// policy must identify the asset-0 generation whose liveness window the administrator intended to
+// change. Otherwise a transaction retained while empty generation A was live can be submitted after
+// an ordinary shutdown/restart and used to crystallize replacement users' generation-B PnL.
+#[test]
+fn v16_attack_presigned_resolve_policy_rejects_restarted_asset_generation() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 110;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new();
+    env.configure_permissionless_resolve_with_cu(1_000_000, 1);
+    let admin = env.admin.insecure_clone();
+    let old_market_id = env.asset_market_id(0);
+    let program_id = env.program_id;
+    let market = env.market;
+    let configure_ix = |market_id: u64, generation_bound: bool| {
+        let mut data = vec![38u8];
+        if generation_bound {
+            data.extend_from_slice(&market_id.to_le_bytes());
+        }
+        data.extend_from_slice(&1u64.to_le_bytes());
+        data.extend_from_slice(&1u64.to_le_bytes());
+        Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(market, false),
+            ],
+            data,
+        }
+    };
+
+    // Keep the RED source compatible with both wire versions. A wrong generation identifies a
+    // decoder that knows the witness without changing the policy.
+    env.svm.expire_blockhash();
+    let generation_probe = send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        configure_ix(old_market_id.checked_add(10_000).unwrap(), true),
+        &[&admin],
+    );
+    let generation_bound = format!("{generation_probe:?}").contains(&format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    ));
+
+    env.svm.expire_blockhash();
+    let stale_configure = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            configure_ix(old_market_id, generation_bound),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("empty generation A shuts down through the public lifecycle");
+    env.svm.warp_to_slot(3);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 3, PRICE)
+        .expect("asset 0 restarts into generation B");
+    env.configure_auth_mark_with_cu(3, PRICE);
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+
+    let winner_owner = Keypair::new();
+    let victim_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&winner_owner, winner, DEPOSIT);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &victim_owner,
+        victim,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(10);
+    env.push_auth_mark_with_cu(10, ADVERSE_PRICE);
+    for portfolio in [victim, winner] {
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 10,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        );
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        ADVERSE_PRICE
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let winner_before = env.svm.get_account(&winner).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(stale_configure);
+    if let Err(rejected) = replay {
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::AssetGenerationMismatch as u32
+        );
+        assert!(
+            format!("{rejected:?}").contains(&expected_error),
+            "the stale policy must reject with {expected_error}: {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&winner).unwrap(), winner_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+        env.svm.expire_blockhash();
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            configure_ix(new_market_id, true),
+            &[&admin],
+        )
+        .expect("a resolve policy signed for generation B remains available");
+        return;
+    }
+
+    env.svm.warp_to_slot(11);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ResolveStalePermissionless { now_slot: 0 },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    )
+    .expect("the stale policy lets anyone resolve replacement generation B");
+
+    env.svm.warp_to_slot(12);
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let winner_dest = env.close_resolved(&winner_owner, winner);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let winner_payout = env.token_amount(winner_dest) as u128;
+    assert_eq!(victim_payout, 900_000);
+    assert_eq!(winner_payout, 1_100_000);
+    panic!(
+        "a generation-A resolve policy paid the opposing trader {} atoms of replacement victim capital",
+        winner_payout - DEPOSIT
+    );
+}
+
 #[test]
 fn v16_attack_prefunded_market_generation_pda_cannot_block_init() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -909,24 +909,40 @@ fn kani_v16_base_unit_payloads_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
+    let market_id: u64 = kani::any();
     let stale_slots: u64 = kani::any();
     let force_close_delay_slots: u64 = kani::any();
     let now_slot: u64 = kani::any();
+    let trailing: u8 = kani::any();
 
-    let mut configure = [0u8; 17];
+    let mut configure = [0u8; 25];
     configure[0] = 38;
-    configure[1..9].copy_from_slice(&stale_slots.to_le_bytes());
-    configure[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    configure[1..9].copy_from_slice(&market_id.to_le_bytes());
+    configure[9..17].copy_from_slice(&stale_slots.to_le_bytes());
+    configure[17..25].copy_from_slice(&force_close_delay_slots.to_le_bytes());
     match Instruction::decode(&configure).unwrap() {
         Instruction::ConfigurePermissionlessResolve {
+            market_id: got_market_id,
             stale_slots: got_stale,
             force_close_delay_slots: got_delay,
         } => {
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_stale, stale_slots);
             assert_eq!(got_delay, force_close_delay_slots);
         }
         _ => unreachable!(),
     }
+
+    let mut legacy = [0u8; 17];
+    legacy[0] = 38;
+    legacy[1..9].copy_from_slice(&stale_slots.to_le_bytes());
+    legacy[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
+
+    let mut oversized = [0u8; 26];
+    oversized[..25].copy_from_slice(&configure);
+    oversized[25] = trailing;
+    assert!(Instruction::decode(&oversized).is_err());
 
     let mut resolve = [0u8; 9];
     resolve[0] = 39;
@@ -1292,6 +1308,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::ConfigurePermissionlessResolve {
+            market_id: 1,
             stale_slots: 5,
             force_close_delay_slots: 1,
         },
@@ -1569,7 +1586,7 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let swap_base_units = [61u8; 16];
     assert!(Instruction::decode(&swap_base_units).is_err());
 
-    let configure_permissionless = [38u8; 16];
+    let configure_permissionless = [38u8; 24];
     assert!(Instruction::decode(&configure_permissionless).is_err());
 
     let resolve_permissionless = [39u8; 8];


### PR DESCRIPTION
## Classification

REAL loss of funds reachable through the public interface.

An unprivileged submitter can retain an administrator-signed `ConfigurePermissionlessResolve` transaction from empty asset-0 generation A, wait for an ordinary shutdown/restart into generation B, and submit it after replacement users fund and trade. The retained policy shortens the stale window to one slot; anyone can then resolve generation B and make the opposing portfolio's crystallized gain withdrawable.

## Reproduction

- Exact parent: `4c5753f0bfe91cce2116ce2434fdce34537423de`
- RED commit: `e621a99`
- Fix commit: `3180d97`
- No direct account-state injection is used.
- Public lifecycle: long resolve policy in generation A, retained signed one-slot policy, empty shutdown at slot 2, restart at slot 3, replacement deposits/trade, authenticated mark move, retained policy submission, permissionless resolve at slot 11.
- Exact RED loss: victim deposit `1,000,000` pays out `900,000`; opposing deposit `1,000,000` pays out `1,100,000`. The retained policy transfers `100,000` SPL atoms of replacement victim capital.

## Fix

`ConfigurePermissionlessResolve { market_id, .. }` now carries the intended asset-0 generation. The processor compares it with the active generation before consulting the clock or writing policy. Legacy, truncated, mismatched-generation, and trailing-byte payloads fail closed. A current-generation policy update remains available.

This adds no authority, custody, withdrawal, or administrator fund-moving surface.

## Verification

- Focused exact-parent RED fails with the 100,000-atom transfer.
- Focused fixed real-SBF LiteSVM regression passes.
- Full serial real-SBF LiteSVM: `569 passed; 0 failed` in 226.31s.
- Permissionless-resolve subset: `4 passed; 0 failed`.
- Rotated-authority and independent-market force-close controls pass.
- Library tests: `5 passed; 0 failed`.
- `cargo check --all-targets` passes.
- Focused Kani wire proof: `0 of 846 failed`.
- `rustfmt --check` and `git diff --check` pass.
- Fixed SBF SHA-256: `0835f580280158cfc15c42d6e6e3b8dd8ffba40fb6880da378cd45976b26d702`.