### PR TITLE
[PRIVILEGED LoF] Require LP consent for CPI base fees

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -654,8 +654,15 @@ pub mod state {
         pub matcher_program: [u8; 32],
         pub matcher_context: [u8; 32],
         pub matcher_delegate: [u8; 32],
-        pub enabled: u64,
+        pub enabled: u8,
+        pub reserved0: u8,
+        /// LP-signed cap for the authority-mutable base fee component.
+        pub trade_fee_cap_bps: u16,
+        pub reserved1: [u8; 4],
     }
+
+    const _: [(); PORTFOLIO_MATCHER_CONFIG_LEN] =
+        [(); core::mem::size_of::<PortfolioMatcherConfigV16>()];
 
     pub type AssetOracleStorageV16 = [u8; ASSET_ORACLE_WRAPPER_LEN];
     pub type MarketViewMutV16<'a> = MarketGroupV16ViewMut<'a, AssetOracleStorageV16>;
@@ -759,7 +766,11 @@ pub mod state {
                 .get(..config_len)
                 .ok_or(PercolatorError::InvalidAccountLen)?,
         );
-        if cfg.enabled > 1 {
+        if cfg.enabled > 1
+            || cfg.reserved0 != 0
+            || cfg.trade_fee_cap_bps > 10_000
+            || cfg.reserved1 != [0; 4]
+        {
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(cfg)
@@ -771,7 +782,11 @@ pub mod state {
         cfg: &PortfolioMatcherConfigV16,
     ) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
-        if cfg.enabled > 1 {
+        if cfg.enabled > 1
+            || cfg.reserved0 != 0
+            || cfg.trade_fee_cap_bps > 10_000
+            || cfg.reserved1 != [0; 4]
+        {
             return Err(ProgramError::InvalidAccountData);
         }
         let bytes = matcher_config_bytes_mut(data)?;
@@ -2472,6 +2487,7 @@ pub mod ix {
         },
         SetMatcherConfig {
             enabled: u8,
+            trade_fee_cap_bps: u16,
         },
         ClosePortfolio,
         TopUpInsurance {
@@ -2737,9 +2753,20 @@ pub mod ix {
                     }
                     Self::BatchTradeCpi { legs }
                 }
-                68 => Self::SetMatcherConfig {
-                    enabled: read_u8(&mut rest)?,
-                },
+                68 => {
+                    let enabled = read_u8(&mut rest)?;
+                    // Legacy authorizations had no fee-consent field. Decode them as cap zero so
+                    // they remain valid only while the mutable market base fee is also zero.
+                    let trade_fee_cap_bps = if rest.is_empty() {
+                        0
+                    } else {
+                        read_u16(&mut rest)?
+                    };
+                    Self::SetMatcherConfig {
+                        enabled,
+                        trade_fee_cap_bps,
+                    }
+                }
                 8 => Self::ClosePortfolio,
                 9 => Self::TopUpInsurance {
                     amount: read_u128(&mut rest)?,
@@ -3026,9 +3053,13 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    enabled,
+                    trade_fee_cap_bps,
+                } => {
                     out.push(68);
                     out.push(enabled);
+                    push_u16(&mut out, trade_fee_cap_bps);
                 }
                 Self::ClosePortfolio => out.push(8),
                 Self::TopUpInsurance { amount } => {
@@ -5182,9 +5213,10 @@ pub mod processor {
             Instruction::BatchTradeCpi { legs } => {
                 handle_batch_trade_cpi(program_id, accounts, &legs)
             }
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                enabled,
+                trade_fee_cap_bps,
+            } => handle_set_matcher_config(program_id, accounts, enabled, trade_fee_cap_bps),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6387,7 +6419,7 @@ pub mod processor {
         matcher_prog_key: &Pubkey,
         matcher_ctx_key: &Pubkey,
         matcher_delegate_key: &Pubkey,
-    ) -> Result<usize, ProgramError> {
+    ) -> Result<(usize, u16), ProgramError> {
         let cfg = state::read_portfolio_matcher_config(&account_b_ai.try_borrow_data()?)?;
         if cfg.enabled != 1
             || cfg.matcher_program != matcher_prog_key.to_bytes()
@@ -6396,7 +6428,7 @@ pub mod processor {
         {
             return Err(PercolatorError::Unauthorized.into());
         }
-        Ok(7)
+        Ok((7, cfg.trade_fee_cap_bps))
     }
 
     fn validate_matcher_tail<'a>(
@@ -6513,12 +6545,15 @@ pub mod processor {
             matcher_ctx.key,
         );
         expect_key(matcher_delegate, &delegate)?;
-        let tail_start = matcher_tail_start_or_verify_lp_config(
+        let (tail_start, lp_trade_fee_cap_bps) = matcher_tail_start_or_verify_lp_config(
             account_b_ai,
             matcher_prog.key,
             matcher_ctx.key,
             matcher_delegate.key,
         )?;
+        if cfg_pre.trade_fee_base_bps > u64::from(lp_trade_fee_cap_bps) {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
         let tail = accounts
             .get(tail_start..)
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
@@ -6613,9 +6648,8 @@ pub mod processor {
             asset_index,
             ret.exec_size,
             ret.exec_price_e6,
-            // Only the taker signs this fill, and the matcher ABI does not carry a fee for the LP
-            // to approve. Start CPI fee derivation at the market-configured base; hybrid/EWMA
-            // movement may still raise it deterministically inside the shared trade path.
+            // The LP's signed matcher config caps the mutable base above. Hybrid/EWMA movement may
+            // still raise the final fee deterministically inside the shared trade path.
             cfg_pre.trade_fee_base_bps,
             max_market_slots,
         )
@@ -6626,8 +6660,9 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         enabled: u8,
+        trade_fee_cap_bps: u16,
     ) -> ProgramResult {
-        if enabled > 1 {
+        if enabled > 1 || trade_fee_cap_bps > 10_000 || (enabled == 0 && trade_fee_cap_bps != 0) {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let lp_owner = account(accounts, 0)?;
@@ -6677,6 +6712,9 @@ pub mod processor {
                 matcher_context: matcher_ctx.key.to_bytes(),
                 matcher_delegate: matcher_delegate.key.to_bytes(),
                 enabled: 1,
+                reserved0: 0,
+                trade_fee_cap_bps,
+                reserved1: [0; 4],
             }
         };
         state::write_portfolio_matcher_config(&mut lp_portfolio_ai.try_borrow_mut_data()?, &cfg)
@@ -6866,12 +6904,15 @@ pub mod processor {
             matcher_ctx.key,
         );
         expect_key(matcher_delegate, &delegate)?;
-        let tail_start = matcher_tail_start_or_verify_lp_config(
+        let (tail_start, lp_trade_fee_cap_bps) = matcher_tail_start_or_verify_lp_config(
             account_b_ai,
             matcher_prog.key,
             matcher_ctx.key,
             matcher_delegate.key,
         )?;
+        if cpi_fee_bps > u64::from(lp_trade_fee_cap_bps) {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
         let tail = accounts
             .get(tail_start..)
             .ok_or(ProgramError::NotEnoughAccountKeys)?;
@@ -6975,8 +7016,8 @@ pub mod processor {
                 asset_index: leg.asset_index,
                 size_q: ret.exec_size,
                 exec_price: ret.exec_price_e6,
-                // Batch LPs are unsigned too. Caller fee fields are validated above but cannot
-                // increase their charge without matcher-side fee consent in the ABI.
+                // Batch LPs are unsigned too. Their signed matcher config caps this mutable base;
+                // caller fee fields cannot increase the LP charge.
                 fee_bps: cpi_fee_bps,
             });
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -50391,6 +50391,112 @@ fn v16_attack_cpi_taker_cannot_siphon_unsigned_lp_with_caller_fee() {
     }
 }
 
+#[test]
+fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (1_000 * POS_SCALE) as i128;
+    const BASE_FEE_BPS: u64 = 500;
+
+    let mut exploited_routes = Vec::new();
+    for batch in [false, true] {
+        let mut env = V16CuEnv::new();
+        let matcher_program = Pubkey::new_unique();
+        let matcher_bytes =
+            std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+        env.svm.add_program(matcher_program, &matcher_bytes);
+        let attacker = env.admin.insecure_clone();
+        let lp = Keypair::new();
+        let attacker_account = env.create_portfolio(&attacker);
+        let lp_account = env.create_portfolio(&lp);
+        env.deposit(&attacker, attacker_account, DEPOSIT);
+        env.deposit(&lp, lp_account, DEPOSIT);
+        let (ctx, delegate, _) = env.init_auth_matcher_context(matcher_program, &lp, lp_account);
+
+        // The LP authorizes its matcher while the market base is zero. The authority then raises
+        // the execution-time fee, but neither matcher request nor return carries LP consent to it.
+        env.update_trade_fee_policy_with_cu(BASE_FEE_BPS);
+        let market_after_policy = env.svm.get_account(&env.market).unwrap();
+        let attacker_after_policy = env.svm.get_account(&attacker_account).unwrap();
+        let lp_after_policy = env.svm.get_account(&lp_account).unwrap();
+        let ctx_after_policy = env.svm.get_account(&ctx).unwrap();
+
+        let send_fill = |env: &mut V16CuEnv, size_q: i128| {
+            env.svm.expire_blockhash();
+            if batch {
+                env.send(
+                    ProgInstruction::BatchTradeCpi {
+                        legs: vec![BatchTradeCpiLeg {
+                            asset_index: 0,
+                            size_q,
+                            fee_bps: 0,
+                            limit_price: 0,
+                        }],
+                    },
+                    vec![
+                        AccountMeta::new(attacker.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(attacker_account, false),
+                        AccountMeta::new(lp_account, false),
+                        AccountMeta::new_readonly(matcher_program, false),
+                        AccountMeta::new(ctx, false),
+                        AccountMeta::new_readonly(delegate, false),
+                    ],
+                    &[&attacker],
+                )
+            } else {
+                env.try_trade_cpi_with_cu_on_asset(
+                    &attacker,
+                    attacker_account,
+                    &lp,
+                    lp_account,
+                    matcher_program,
+                    ctx,
+                    delegate,
+                    0,
+                    size_q,
+                    0,
+                )
+            }
+        };
+
+        if send_fill(&mut env, SIZE_Q).is_ok() {
+            send_fill(&mut env, -SIZE_Q).expect("vulnerable paired CPI close");
+            let attacker_state = env.portfolio_state(attacker_account);
+            let lp_state = env.portfolio_state(lp_account);
+            let (_, group) = env.market_state();
+            assert_eq!(attacker_state.capital.get(), 990_000);
+            assert_eq!(lp_state.capital.get(), 990_000);
+            assert_eq!(group.insurance, 20_000);
+            let (insurance_dest, _) = env.withdraw_insurance_with_cu(group.insurance);
+            let attacker_dest =
+                env.withdraw(&attacker, attacker_account, attacker_state.capital.get());
+            let lp_dest = env.withdraw(&lp, lp_account, lp_state.capital.get());
+            assert_eq!(
+                env.token_amount(attacker_dest) + env.token_amount(insurance_dest),
+                1_010_000
+            );
+            assert_eq!(env.token_amount(lp_dest), 990_000);
+            exploited_routes.push(if batch { "batch" } else { "single" });
+            continue;
+        }
+
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_after_policy
+        );
+        assert_eq!(
+            env.svm.get_account(&attacker_account).unwrap(),
+            attacker_after_policy
+        );
+        assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_after_policy);
+        assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_after_policy);
+    }
+    assert!(
+        exploited_routes.is_empty(),
+        "CPI matchers accepted authority-controlled base fees without LP consent on {exploited_routes:?}"
+    );
+}
+
 // BatchTradeCpi 14-leg fan-out through one batched matcher CPI, under the tx CU budget.
 #[test]
 fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1888,6 +1888,21 @@ impl V16CuEnv {
         maker_owner: &Keypair,
         maker_account: Pubkey,
     ) -> (Pubkey, Pubkey, u64) {
+        self.init_auth_matcher_context_with_trade_fee_cap(
+            matcher_program,
+            maker_owner,
+            maker_account,
+            10_000,
+        )
+    }
+
+    fn init_auth_matcher_context_with_trade_fee_cap(
+        &mut self,
+        matcher_program: Pubkey,
+        maker_owner: &Keypair,
+        maker_account: Pubkey,
+        trade_fee_cap_bps: u16,
+    ) -> (Pubkey, Pubkey, u64) {
         let ctx = Pubkey::new_unique();
         let delegate = matcher_delegate_key(
             &self.program_id,
@@ -1906,13 +1921,14 @@ impl V16CuEnv {
                 delegate,
             )
             .expect("init auth matcher context");
-        self.set_matcher_config(
+        self.set_matcher_config_with_trade_fee_cap(
             matcher_program,
             maker_owner,
             maker_account,
             ctx,
             delegate,
             1,
+            trade_fee_cap_bps,
         );
         (ctx, delegate, cu)
     }
@@ -1984,18 +2000,19 @@ impl V16CuEnv {
         matcher_delegate: Pubkey,
         enabled: u8,
     ) -> Pubkey {
-        self.try_set_matcher_config(
+        self.set_matcher_config_with_trade_fee_cap(
             matcher_program,
             maker_owner,
             maker_account,
             matcher_context,
             matcher_delegate,
             enabled,
+            if enabled == 0 { 0 } else { 10_000 },
         )
-        .expect("set matcher config")
     }
 
-    fn try_set_matcher_config(
+    #[allow(clippy::too_many_arguments)]
+    fn set_matcher_config_with_trade_fee_cap(
         &mut self,
         matcher_program: Pubkey,
         maker_owner: &Keypair,
@@ -2003,6 +2020,30 @@ impl V16CuEnv {
         matcher_context: Pubkey,
         matcher_delegate: Pubkey,
         enabled: u8,
+        trade_fee_cap_bps: u16,
+    ) -> Pubkey {
+        self.try_set_matcher_config_with_trade_fee_cap(
+            matcher_program,
+            maker_owner,
+            maker_account,
+            matcher_context,
+            matcher_delegate,
+            enabled,
+            trade_fee_cap_bps,
+        )
+        .expect("set matcher config")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_set_matcher_config_with_trade_fee_cap(
+        &mut self,
+        matcher_program: Pubkey,
+        maker_owner: &Keypair,
+        maker_account: Pubkey,
+        matcher_context: Pubkey,
+        matcher_delegate: Pubkey,
+        enabled: u8,
+        trade_fee_cap_bps: u16,
     ) -> Result<Pubkey, String> {
         self.svm.expire_blockhash();
         let mut accounts = vec![
@@ -2018,7 +2059,10 @@ impl V16CuEnv {
             ]);
         }
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                enabled,
+                trade_fee_cap_bps,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -20449,7 +20493,10 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 0,
+            trade_fee_cap_bps: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20514,7 +20561,10 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 0,
+            trade_fee_cap_bps: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20879,7 +20929,10 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                enabled: 1,
+                trade_fee_cap_bps: 10_000,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -20953,7 +21006,10 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     let lp_before_config = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            trade_fee_cap_bps: 10_000,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20987,6 +21043,9 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
             matcher_context: env.market.to_bytes(),
             matcher_delegate: self_delegate.to_bytes(),
             enabled: 1,
+            reserved0: 0,
+            trade_fee_cap_bps: 10_000,
+            reserved1: [0; 4],
         },
     )
     .expect("inject stale self-matcher config for fill-time guard");
@@ -21209,7 +21268,10 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            trade_fee_cap_bps: 10_000,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -30416,7 +30478,10 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            trade_fee_cap_bps: 10_000,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),
@@ -50392,10 +50457,11 @@ fn v16_attack_cpi_taker_cannot_siphon_unsigned_lp_with_caller_fee() {
 }
 
 #[test]
-fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
+fn v16_attack_cpi_lp_must_consent_to_mutable_market_base_fee() {
     const DEPOSIT: u128 = 1_000_000;
     const SIZE_Q: i128 = (1_000 * POS_SCALE) as i128;
     const BASE_FEE_BPS: u64 = 500;
+    const REJECTING_CAP_BPS: u16 = 499;
 
     let mut exploited_routes = Vec::new();
     for batch in [false, true] {
@@ -50410,17 +50476,45 @@ fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
         let lp_account = env.create_portfolio(&lp);
         env.deposit(&attacker, attacker_account, DEPOSIT);
         env.deposit(&lp, lp_account, DEPOSIT);
-        let (ctx, delegate, _) = env.init_auth_matcher_context(matcher_program, &lp, lp_account);
+        let (ctx, delegate, _) = env.init_auth_matcher_context_with_trade_fee_cap(
+            matcher_program,
+            &lp,
+            lp_account,
+            REJECTING_CAP_BPS,
+        );
+        assert_eq!(
+            env.portfolio_matcher_config(lp_account).trade_fee_cap_bps,
+            REJECTING_CAP_BPS
+        );
+        let lp_before_invalid_cap = env.svm.get_account(&lp_account).unwrap();
+        let invalid_cap = env.try_set_matcher_config_with_trade_fee_cap(
+            matcher_program,
+            &lp,
+            lp_account,
+            ctx,
+            delegate,
+            1,
+            10_001,
+        );
+        assert!(invalid_cap.is_err(), "fee consent must be bounded to 100%");
+        assert_eq!(
+            env.svm.get_account(&lp_account).unwrap(),
+            lp_before_invalid_cap,
+            "a rejected cap update must leave the prior LP consent intact"
+        );
 
-        // The LP authorizes its matcher while the market base is zero. The authority then raises
-        // the execution-time fee, but neither matcher request nor return carries LP consent to it.
+        // The LP authorizes its matcher with a retained 499 bps base-fee cap. The authority then
+        // raises the execution-time fee above that signed bound.
         env.update_trade_fee_policy_with_cu(BASE_FEE_BPS);
         let market_after_policy = env.svm.get_account(&env.market).unwrap();
         let attacker_after_policy = env.svm.get_account(&attacker_account).unwrap();
         let lp_after_policy = env.svm.get_account(&lp_account).unwrap();
         let ctx_after_policy = env.svm.get_account(&ctx).unwrap();
 
-        let send_fill = |env: &mut V16CuEnv, size_q: i128| {
+        let send_fill = |env: &mut V16CuEnv,
+                         size_q: i128,
+                         matcher_context: Pubkey,
+                         matcher_delegate: Pubkey| {
             env.svm.expire_blockhash();
             if batch {
                 env.send(
@@ -50438,8 +50532,8 @@ fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
                         AccountMeta::new(attacker_account, false),
                         AccountMeta::new(lp_account, false),
                         AccountMeta::new_readonly(matcher_program, false),
-                        AccountMeta::new(ctx, false),
-                        AccountMeta::new_readonly(delegate, false),
+                        AccountMeta::new(matcher_context, false),
+                        AccountMeta::new_readonly(matcher_delegate, false),
                     ],
                     &[&attacker],
                 )
@@ -50450,8 +50544,8 @@ fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
                     &lp,
                     lp_account,
                     matcher_program,
-                    ctx,
-                    delegate,
+                    matcher_context,
+                    matcher_delegate,
                     0,
                     size_q,
                     0,
@@ -50459,8 +50553,8 @@ fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
             }
         };
 
-        if send_fill(&mut env, SIZE_Q).is_ok() {
-            send_fill(&mut env, -SIZE_Q).expect("vulnerable paired CPI close");
+        if send_fill(&mut env, SIZE_Q, ctx, delegate).is_ok() {
+            send_fill(&mut env, -SIZE_Q, ctx, delegate).expect("vulnerable paired CPI close");
             let attacker_state = env.portfolio_state(attacker_account);
             let lp_state = env.portfolio_state(lp_account);
             let (_, group) = env.market_state();
@@ -50490,6 +50584,25 @@ fn probe_cpi_lp_must_consent_to_mutable_market_base_fee() {
         );
         assert_eq!(env.svm.get_account(&lp_account).unwrap(), lp_after_policy);
         assert_eq!(env.svm.get_account(&ctx).unwrap(), ctx_after_policy);
+
+        let (consenting_ctx, consenting_delegate, _) = env
+            .init_auth_matcher_context_with_trade_fee_cap(
+                matcher_program,
+                &lp,
+                lp_account,
+                BASE_FEE_BPS as u16,
+            );
+        assert_eq!(
+            env.portfolio_matcher_config(lp_account).trade_fee_cap_bps,
+            BASE_FEE_BPS as u16
+        );
+        send_fill(&mut env, SIZE_Q, consenting_ctx, consenting_delegate)
+            .expect("LP-consented CPI open");
+        send_fill(&mut env, -SIZE_Q, consenting_ctx, consenting_delegate)
+            .expect("LP-consented CPI close");
+        assert_eq!(env.portfolio_state(attacker_account).capital.get(), 990_000);
+        assert_eq!(env.portfolio_state(lp_account).capital.get(), 990_000);
+        assert_eq!(env.market_state().1.insurance, 20_000);
     }
     assert!(
         exploited_routes.is_empty(),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -443,6 +443,40 @@ fn kani_v16_tradecpi_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_set_matcher_config_decode_preserves_fee_consent() {
+    let enabled: u8 = kani::any();
+    let trade_fee_cap_bps: u16 = kani::any();
+    let data = Instruction::SetMatcherConfig {
+        enabled,
+        trade_fee_cap_bps,
+    }
+    .encode();
+    match Instruction::decode(&data).unwrap() {
+        Instruction::SetMatcherConfig {
+            enabled: decoded_enabled,
+            trade_fee_cap_bps: decoded_cap,
+        } => {
+            assert_eq!(decoded_enabled, enabled);
+            assert_eq!(decoded_cap, trade_fee_cap_bps);
+        }
+        _ => unreachable!(),
+    }
+
+    // Existing two-byte authorizations remain decodable, but cannot silently consent to a fee.
+    let legacy = [68, enabled];
+    match Instruction::decode(&legacy).unwrap() {
+        Instruction::SetMatcherConfig {
+            enabled: decoded_enabled,
+            trade_fee_cap_bps: decoded_cap,
+        } => {
+            assert_eq!(decoded_enabled, enabled);
+            assert_eq!(decoded_cap, 0);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
 fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
     // Audit fix: the ret's echoed fields and abi_version are drawn INDEPENDENTLY of the
     // expected (bound) params, and sizes are full-width i128, so both the accept path AND


### PR DESCRIPTION
## Root cause

PR #224 correctly removes the taker's unsigned caller fee from CPI fills, but the replacement still charges the live market `trade_fee_base_bps`. The asset-0 insurance authority can raise that mutable base after an LP authorizes a matcher. A taker controlled by that authority can then execute a retained single or batch CPI open/close, charge the unsigned LP, withdraw the resulting insurance, and realize the LP's loss.

The exact-parent RED commit `834a2a15` proves both public routes with LiteSVM: two 1,000,000-atom deposits, a post-authorization increase to 500 bps, paired open/close fills, a 10,000-atom independent LP loss, and authority withdrawal of the 20,000-atom insurance charge.

## Fix

- Extend the owner-signed `SetMatcherConfig` payload with a cap for the authority-mutable base fee.
- Store the cap in previously reserved bytes of the existing 104-byte zero-copy portfolio matcher tail; account size is unchanged and compile-time asserted.
- Decode legacy two-byte matcher authorizations as cap zero, so they fail closed at nonzero base fees until the LP reauthorizes.
- Reject single and batch CPI before matcher invocation when the live base exceeds the retained LP cap.
- Keep the matcher ABI unchanged. Deterministic hybrid/EWMA externality fees remain outside this mutable-base cap.
- Bound caps to 10,000 bps and preserve rollback on invalid updates.

The fix commit is `2c33c88c`. The regression exercises the exact 499/500 bps reject/accept boundary for both CPI routes and verifies a freshly signed consent still trades normally.

## Validation

- `cargo build-sbf --tools-version v1.52` (program, auth matcher, hostile matcher)
- `cargo test --all-targets -- --test-threads=1`: 5 unit + 565 LiteSVM/CU tests passed
- `cargo kani --tests --harness kani_v16_set_matcher_config_decode_preserves_fee_consent`: 1/1 harness, 1,494 checks passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

This PR is intentionally stacked on #224 because the exploit exists after #224's caller-fee fix.