### PR TITLE
[BLOCKER LoF] Bind asset shutdown to market generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   `WrapperConfigV16.marketauth` key (it replaced the former separate `admin` / `asset_authority` /
   `base_unit_authority`). `marketauth` is the only key that can: **create market 0** (`InitMarket`),
   **create/retire assets 1..N and set the permissionless-create-fee policy**, **safely force-shutdown
-  any asset including asset 0** (`ASSET_ACTION_SHUTDOWN` → RECOVERY with the `force_close_delay_slots`
-  exit window so traders can exit), **resolve/close the market** (`ResolveMarket { market_id }`/`CloseSlab`),
+  any asset including asset 0** (`ShutdownAsset { asset_index, market_id, now_slot }` → RECOVERY
+  with the `force_close_delay_slots` exit window so traders can exit), **resolve/close the market**
+  (`ResolveMarket { market_id }`/`CloseSlab`),
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
   `UpdateAuthority { market_id, new_pubkey }` (current `marketauth` signs, the non-zero replacement
   co-signs, and `market_id` must match the current base-asset generation; burn-to-zero is rejected).
@@ -183,10 +184,11 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   value, and only **succeeds + zeroes (reclaims) the account** once users are made whole and the slab
   is fully drained; the abandoned-market path is the permissionless-resolve fallback
   (`v16_bpf_permissionless_stale_resolve_is_bounded_and_oracle_free`, bounded + oracle-free).
-- **The `marketauth` key can force-shutdown assets 0..N without rugging traders** — `ASSET_ACTION_SHUTDOWN`
+- **The `marketauth` key can force-shutdown assets 0..N without rugging traders** — `ShutdownAsset`
   accepts either `marketauth` (global liveness) or that asset's `asset_admin` (local shutdown); any
-  other signer is rejected. It moves the asset to RECOVERY with a frozen mark, and the wind-down
-  force-close is gated behind `force_close_delay_slots` so there is an **exit window**. **✅**
+  other signer is rejected, and `market_id` must match the current asset generation. It moves the
+  asset to RECOVERY with a frozen mark, and the wind-down force-close is gated behind
+  `force_close_delay_slots` so there is an **exit window**. **✅**
   `v16_attack_force_shutdown_timeout_lets_traders_exit_before_close` asserts shutdown → RECOVERY,
   force-close **rejects before** the delay and **succeeds after**; plus
   `v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot` and
@@ -401,9 +403,13 @@ This section describes intent and operational ordering, not argument-by-argument
 - **UpdateAssetLifecycle** (tag 40)
   - appends/reactivates/retires assets 1..N, including permissionless create/reuse when the configured
     create fee is nonzero
-  - `ASSET_ACTION_SHUTDOWN` moves any asset 0..N to RECOVERY at a frozen mark, with force-close blocked
-    until `force_close_delay_slots` elapses; signer is `marketauth` or that asset's `asset_admin`
   - ordinary `RETIRE` rejects `asset_index = 0`; asset 0 is restarted, not reused
+- **ShutdownAsset** (tag 70)
+  - `ShutdownAsset { asset_index, market_id, now_slot }` moves any asset 0..N to RECOVERY at a
+    frozen mark
+  - requires the current asset generation plus `marketauth` or that asset's `asset_admin`; the legacy
+    generation-free shutdown action is rejected
+  - force-close remains blocked until `force_close_delay_slots` elapses
 - **RestartAssetOracle** (tag 69)
   - `RestartAssetOracle { asset_index, now_slot, initial_price }`, signed by that asset's `asset_admin`
   - after the target asset is already RECOVERY and empty of positions/loss plus value-bearing

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2697,6 +2697,11 @@ pub mod ix {
             now_slot: u64,
             initial_price: u64,
         },
+        ShutdownAsset {
+            asset_index: u16,
+            market_id: u64,
+            now_slot: u64,
+        },
         UpdateAssetLifecycle {
             action: u8,
             asset_index: u16,
@@ -2940,6 +2945,11 @@ pub mod ix {
                     asset_index: read_u16(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     initial_price: read_u64(&mut rest)?,
+                },
+                70 => Self::ShutdownAsset {
+                    asset_index: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
+                    now_slot: read_u64(&mut rest)?,
                 },
                 52 => Self::WithdrawBackingBucketEarnings {
                     domain: read_u16(&mut rest)?,
@@ -3415,6 +3425,16 @@ pub mod ix {
                     push_u16(&mut out, asset_index);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, initial_price);
+                }
+                Self::ShutdownAsset {
+                    asset_index,
+                    market_id,
+                    now_slot,
+                } => {
+                    out.push(70);
+                    push_u16(&mut out, asset_index);
+                    push_u64(&mut out, market_id);
+                    push_u64(&mut out, now_slot);
                 }
                 Self::UpdateAssetLifecycle {
                     action,
@@ -5594,6 +5614,23 @@ pub mod processor {
                 now_slot,
                 initial_price,
             ),
+            Instruction::ShutdownAsset {
+                asset_index,
+                market_id,
+                now_slot,
+            } => handle_update_asset_lifecycle(
+                program_id,
+                accounts,
+                ASSET_ACTION_SHUTDOWN,
+                asset_index,
+                now_slot,
+                0,
+                [0u8; 32],
+                [0u8; 32],
+                [0u8; 32],
+                [0u8; 32],
+                Some(market_id),
+            ),
             Instruction::UpdateAssetLifecycle {
                 action,
                 asset_index,
@@ -5614,6 +5651,7 @@ pub mod processor {
                 insurance_operator,
                 backing_bucket_authority,
                 oracle_authority,
+                None,
             ),
             Instruction::WithdrawInsurance { amount } => {
                 handle_withdraw_insurance(program_id, accounts, amount)
@@ -9310,6 +9348,7 @@ pub mod processor {
         insurance_operator: [u8; 32],
         backing_bucket_authority: [u8; 32],
         oracle_authority: [u8; 32],
+        expected_market_id: Option<u64>,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9499,6 +9538,8 @@ pub mod processor {
             return Ok(());
         }
         if action == ASSET_ACTION_SHUTDOWN {
+            let expected_market_id =
+                expected_market_id.ok_or(PercolatorError::InvalidInstruction)?;
             if now_slot == 0 || initial_price != 0 || cfg_pre.force_close_delay_slots == 0 {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
@@ -9515,6 +9556,9 @@ pub mod processor {
                 let configured_slots = group.header.config.max_market_slots.get() as usize;
                 if asset_index >= configured_slots || asset_index >= group.markets.len() {
                     return Err(PercolatorError::InvalidInstruction.into());
+                }
+                if group.markets[asset_index].engine.asset.market_id.get() != expected_market_id {
+                    return Err(PercolatorError::AssetGenerationMismatch.into());
                 }
                 let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
                 let marketauth_authorized = live_authority_matches(&cfg.marketauth, authority.key);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6628,6 +6628,148 @@ fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
     .expect("the same rotation remains live when signed for the current market generation");
 }
 
+// UpdateAssetLifecycle(SHUTDOWN) is a signed terminal action. It must identify the asset
+// generation the local administrator intended to freeze; otherwise a relayer can retain an empty
+// generation-A shutdown and submit it after an ordinary restart, locking generation B at an
+// attacker-favorable mark and making the replacement victim's temporary loss withdrawable.
+#[test]
+fn v16_attack_presigned_shutdown_rejects_restarted_asset_generation() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 110;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(1_000_000, 1);
+    let old_market_id = env.asset_market_id(0);
+
+    env.svm.expire_blockhash();
+    let stale_shutdown = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(admin.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                data: ProgInstruction::UpdateAssetLifecycle {
+                    action: processor::ASSET_ACTION_SHUTDOWN,
+                    asset_index: 0,
+                    now_slot: 12,
+                    initial_price: 0,
+                    insurance_authority: admin.pubkey().to_bytes(),
+                    insurance_operator: admin.pubkey().to_bytes(),
+                    backing_bucket_authority: admin.pubkey().to_bytes(),
+                    oracle_authority: admin.pubkey().to_bytes(),
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(2);
+    env.try_shutdown_asset_with_authority(&admin, 0, 2)
+        .expect("empty generation A shuts down through the public lifecycle");
+    env.svm.warp_to_slot(3);
+    env.try_restart_asset_oracle_with_authority(&admin, 0, 3, PRICE)
+        .expect("asset 0 restarts into generation B");
+    env.configure_auth_mark_with_cu(3, PRICE);
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+
+    let winner_owner = Keypair::new();
+    let victim_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&winner_owner, winner, DEPOSIT);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &victim_owner,
+        victim,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(10);
+    env.push_auth_mark_with_cu(10, ADVERSE_PRICE);
+    for slot in [10u64, 11] {
+        env.svm.warp_to_slot(slot);
+        for portfolio in [victim, winner] {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                &[],
+            );
+        }
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        ADVERSE_PRICE
+    );
+
+    env.svm.warp_to_slot(12);
+    env.svm
+        .send_transaction(stale_shutdown)
+        .expect("RED: generation-A shutdown freezes generation B");
+    assert_eq!(
+        env.market_state().1.assets[0].lifecycle,
+        AssetLifecycleV16::Recovery
+    );
+
+    let relayer = Keypair::new();
+    env.svm.warp_to_slot(13);
+    env.force_close_abandoned_asset_with_cu(&relayer, winner, victim, 0, 13, SIZE_Q.unsigned_abs());
+    let winner_after_force_close = env.portfolio_state(winner);
+    let victim_after_force_close = env.portfolio_state(victim);
+    assert_eq!(
+        victim_after_force_close.capital.get() as i128 + victim_after_force_close.pnl.get(),
+        900_000
+    );
+    assert_eq!(
+        winner_after_force_close.capital.get() as i128 + winner_after_force_close.pnl.get(),
+        1_100_000
+    );
+
+    env.send(
+        ProgInstruction::ResolveMarket {
+            market_id: new_market_id,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    )
+    .expect("the current administrator completes ordinary terminal resolution");
+    env.svm.warp_to_slot(14);
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let winner_dest = env.close_resolved(&winner_owner, winner);
+    assert_eq!(env.token_amount(victim_dest), 900_000);
+    assert_eq!(env.token_amount(winner_dest), 1_100_000);
+    panic!(
+        "a retained generation-A shutdown froze generation B and made {} atoms of replacement victim capital withdrawable by the opposing trader",
+        100_000
+    );
+}
+
 #[test]
 fn v16_attack_prefunded_market_generation_pda_cannot_block_init() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -908,10 +908,13 @@ impl V16CuEnv {
         now_slot: u64,
         initial_price: u64,
     ) -> u64 {
-        send_tx(
-            &mut self.svm,
-            self.program_id,
-            &self.payer,
+        let instruction = if action == percolator_prog::processor::ASSET_ACTION_SHUTDOWN {
+            ProgInstruction::ShutdownAsset {
+                asset_index,
+                market_id: self.asset_market_id(asset_index),
+                now_slot,
+            }
+        } else {
             ProgInstruction::UpdateAssetLifecycle {
                 action,
                 asset_index,
@@ -921,7 +924,13 @@ impl V16CuEnv {
                 insurance_operator: self.admin.pubkey().to_bytes(),
                 backing_bucket_authority: self.admin.pubkey().to_bytes(),
                 oracle_authority: self.admin.pubkey().to_bytes(),
-            },
+            }
+        };
+        send_tx(
+            &mut self.svm,
+            self.program_id,
+            &self.payer,
+            instruction,
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -937,19 +946,15 @@ impl V16CuEnv {
         asset_index: u16,
         now_slot: u64,
     ) -> Result<u64, String> {
+        let market_id = self.asset_market_id(asset_index);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateAssetLifecycle {
-                action: percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+            ProgInstruction::ShutdownAsset {
                 asset_index,
+                market_id,
                 now_slot,
-                initial_price: 0,
-                insurance_authority: authority.pubkey().to_bytes(),
-                insurance_operator: authority.pubkey().to_bytes(),
-                backing_bucket_authority: authority.pubkey().to_bytes(),
-                oracle_authority: authority.pubkey().to_bytes(),
             },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
@@ -6655,15 +6660,10 @@ fn v16_attack_presigned_shutdown_rejects_restarted_asset_generation() {
                     AccountMeta::new(admin.pubkey(), true),
                     AccountMeta::new(env.market, false),
                 ],
-                data: ProgInstruction::UpdateAssetLifecycle {
-                    action: processor::ASSET_ACTION_SHUTDOWN,
+                data: ProgInstruction::ShutdownAsset {
                     asset_index: 0,
+                    market_id: old_market_id,
                     now_slot: 12,
-                    initial_price: 0,
-                    insurance_authority: admin.pubkey().to_bytes(),
-                    insurance_operator: admin.pubkey().to_bytes(),
-                    backing_bucket_authority: admin.pubkey().to_bytes(),
-                    oracle_authority: admin.pubkey().to_bytes(),
                 }
                 .encode(),
             },
@@ -6726,9 +6726,62 @@ fn v16_attack_presigned_shutdown_rejects_restarted_asset_generation() {
     );
 
     env.svm.warp_to_slot(12);
-    env.svm
-        .send_transaction(stale_shutdown)
-        .expect("RED: generation-A shutdown freezes generation B");
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let winner_before = env.svm.get_account(&winner).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let replay = env.svm.send_transaction(stale_shutdown);
+    if let Err(rejected) = replay {
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::AssetGenerationMismatch as u32
+        );
+        assert!(
+            format!("{rejected:?}").contains(&expected_error),
+            "the stale shutdown must reject with {expected_error}: {rejected:?}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&winner).unwrap(), winner_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(
+            env.market_state().1.assets[0].lifecycle,
+            AssetLifecycleV16::Active
+        );
+
+        env.send(
+            ProgInstruction::UpdateAssetLifecycle {
+                action: processor::ASSET_ACTION_SHUTDOWN,
+                asset_index: 0,
+                now_slot: 12,
+                initial_price: 0,
+                insurance_authority: admin.pubkey().to_bytes(),
+                insurance_operator: admin.pubkey().to_bytes(),
+                backing_bucket_authority: admin.pubkey().to_bytes(),
+                oracle_authority: admin.pubkey().to_bytes(),
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&admin],
+        )
+        .expect_err("the legacy generation-free shutdown wire must stay disabled");
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+
+        env.send(
+            ProgInstruction::ShutdownAsset {
+                asset_index: 0,
+                market_id: new_market_id,
+                now_slot: 12,
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&admin],
+        )
+        .expect("a shutdown signed for generation B remains available");
+        return;
+    }
     assert_eq!(
         env.market_state().1.assets[0].lifecycle,
         AssetLifecycleV16::Recovery
@@ -7111,15 +7164,10 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::UpdateAssetLifecycle {
-            action: processor::ASSET_ACTION_SHUTDOWN,
+        ProgInstruction::ShutdownAsset {
             asset_index: 0,
+            market_id: old_market_id,
             now_slot: 2,
-            initial_price: 0,
-            insurance_authority: stranger.pubkey().to_bytes(),
-            insurance_operator: stranger.pubkey().to_bytes(),
-            backing_bucket_authority: stranger.pubkey().to_bytes(),
-            oracle_authority: stranger.pubkey().to_bytes(),
         },
         vec![
             AccountMeta::new(stranger.pubkey(), true),
@@ -38064,15 +38112,10 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::UpdateAssetLifecycle {
-            action: percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        ProgInstruction::ShutdownAsset {
             asset_index: 1,
+            market_id: market_b_open.assets[1].market_id,
             now_slot: SHUT,
-            initial_price: 0,
-            insurance_authority: env.admin.pubkey().to_bytes(),
-            insurance_operator: env.admin.pubkey().to_bytes(),
-            backing_bucket_authority: env.admin.pubkey().to_bytes(),
-            oracle_authority: env.admin.pubkey().to_bytes(),
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -46436,19 +46479,15 @@ fn v16_attack_force_shutdown_timeout_lets_traders_exit_before_close() {
     env.svm.expire_blockhash();
     let mallory = Keypair::new();
     env.ensure_signer_account(mallory.pubkey());
+    let asset_market_id = env.asset_market_id(1);
     let stranger = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::UpdateAssetLifecycle {
-            action: percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        ProgInstruction::ShutdownAsset {
             asset_index: 1,
+            market_id: asset_market_id,
             now_slot: SHUT,
-            initial_price: 0,
-            insurance_authority: mallory.pubkey().to_bytes(),
-            insurance_operator: mallory.pubkey().to_bytes(),
-            backing_bucket_authority: mallory.pubkey().to_bytes(),
-            oracle_authority: mallory.pubkey().to_bytes(),
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -61592,21 +61631,17 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_lifecycle_admin() {
     );
 
     let market_before = env.svm.get_account(&env.market).unwrap();
+    let market_id = env.asset_market_id(0);
     env.svm.warp_to_slot(2);
     env.svm.expire_blockhash();
     let stale_shutdown = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::UpdateAssetLifecycle {
-            action: percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        ProgInstruction::ShutdownAsset {
             asset_index: 0,
+            market_id,
             now_slot: 2,
-            initial_price: 0,
-            insurance_authority: old_marketauth.pubkey().to_bytes(),
-            insurance_operator: old_marketauth.pubkey().to_bytes(),
-            backing_bucket_authority: old_marketauth.pubkey().to_bytes(),
-            oracle_authority: old_marketauth.pubkey().to_bytes(),
         },
         vec![
             AccountMeta::new(old_marketauth.pubkey(), true),
@@ -61634,15 +61669,10 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_lifecycle_admin() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::UpdateAssetLifecycle {
-            action: percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        ProgInstruction::ShutdownAsset {
             asset_index: 0,
+            market_id,
             now_slot: 2,
-            initial_price: 0,
-            insurance_authority: new_marketauth.pubkey().to_bytes(),
-            insurance_operator: new_marketauth.pubkey().to_bytes(),
-            backing_bucket_authority: new_marketauth.pubkey().to_bytes(),
-            oracle_authority: new_marketauth.pubkey().to_bytes(),
         },
         vec![
             AccountMeta::new(new_marketauth.pubkey(), true),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -402,6 +402,38 @@ fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_shutdown_asset_decode_preserves_generation_witness() {
+    let asset_index: u16 = kani::any();
+    let market_id: u64 = kani::any();
+    let now_slot: u64 = kani::any();
+
+    let data = Instruction::ShutdownAsset {
+        asset_index,
+        market_id,
+        now_slot,
+    }
+    .encode();
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::ShutdownAsset {
+            asset_index: got_asset_index,
+            market_id: got_market_id,
+            now_slot: got_now_slot,
+        } => {
+            assert_eq!(got_asset_index, asset_index);
+            assert_eq!(got_market_id, market_id);
+            assert_eq!(got_now_slot, now_slot);
+        }
+        _ => unreachable!(),
+    }
+
+    let trailing_byte: u8 = kani::any();
+    let mut with_trailing = data;
+    with_trailing.push(trailing_byte);
+    assert!(Instruction::decode(&with_trailing).is_err());
+}
+
+#[kani::proof]
 fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let market_id: u64 = kani::any();
@@ -1620,6 +1652,9 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
 
     let asset_lifecycle = [40u8; 147];
     assert!(Instruction::decode(&asset_lifecycle).is_err());
+
+    let shutdown_asset = [70u8; 18];
+    assert!(Instruction::decode(&shutdown_asset).is_err());
 
     let trade = [6u8; 42];
     assert!(Instruction::decode(&trade).is_err());


### PR DESCRIPTION
## Impact

A retained `UpdateAssetLifecycle(SHUTDOWN)` authorization from empty asset generation A remains valid after the same slot is normally shut down and restarted as generation B. An opposing trader can relay it after generation-B users open matched positions, freeze settlement at a favorable committed mark, permissionlessly force-close, and withdraw capital that could not be realized unilaterally in the live market.

The exact-parent LiteSVM RED path funds two independent generation-B portfolios with 1,000,000 atoms each. After stale shutdown and public wind-down, the victim withdraws 900,000 while the opposing trader withdraws 1,100,000. This is a public, extractable 100,000-atom loss against a normally initialized live asset.

## Root cause

Legacy tag 40 authenticated `marketauth` or `asset_admin` but carried no asset-generation witness, so a signed terminal capability survived shutdown and restart of the same slot.

## Fix

- Add `ShutdownAsset { asset_index, market_id, now_slot }` as tag 70.
- Require `market_id` to match the current engine asset generation before mutation.
- Reject generation-free shutdown through legacy `UpdateAssetLifecycle`.
- Preserve the existing authority check, trader exit window, and force-close path.
- Add wire round-trip, trailing-byte, and truncation proofs.
- Add no authority or fund-moving surface.

## TDD evidence

- Exact parent: `32f9b381`
- Exact-parent SBF SHA-256: `8c267d12effff796ff560a44ecd38fee0304b4fde3a5fdb59090d9b79888369f`
- RED commit: `5a529176`
- Fix commit: `4973cc41`
- Fixed SBF SHA-256: `d613a1507def1d21f66da0c70fdbc4b97eeeb5669786ed64789453a575e96331`

The adaptive regression fails on the exact parent only after proving the 900,000 / 1,100,000 withdrawals. It passes on the fix by proving stale rejection is byte-atomic and a shutdown signed for generation B remains reachable.

## Validation

- `cargo test --test v16_cu --quiet`: 579 passed
- `cargo test --lib --quiet`: 5 passed
- `cargo kani --tests --only-codegen`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed