### PR TITLE
[HARDENING LoF] Bind rebalance consent to position episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,12 @@ This section describes intent and operational ordering, not argument-by-argument
   - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector;
-    the payload binds consent to the program-assigned `portfolio_id`
+    the payload binds consent to both the program-assigned `portfolio_id` and the portfolio's
+    `position_epoch`
+  - `position_epoch` advances after every successful exposure-changing trade, rebalance,
+    liquidation, recovery force-close, or recovery-leg forfeit; refresh-only cranks do not advance
+    it, so stale consent cannot target a replacement position and permissionless maintenance cannot
+    invalidate current consent
 - **ClaimResolvedPayoutTopup** (tag 46)
   - permissionless resolved-payout top-up claim; pays only the stored owner receipt token account
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -65,7 +65,10 @@ pub mod constants {
     pub const PORTFOLIO_MATCHER_CONFIG_LEN: usize = 104;
     pub const PORTFOLIO_ID_OFF: usize = PORTFOLIO_MATCHER_CONFIG_OFF + PORTFOLIO_MATCHER_CONFIG_LEN;
     pub const PORTFOLIO_ID_LEN: usize = 8;
-    pub const PORTFOLIO_ACCOUNT_LEN: usize = PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN;
+    pub const PORTFOLIO_POSITION_EPOCH_OFF: usize = PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN;
+    pub const PORTFOLIO_POSITION_EPOCH_LEN: usize = 8;
+    pub const PORTFOLIO_ACCOUNT_LEN: usize =
+        PORTFOLIO_POSITION_EPOCH_OFF + PORTFOLIO_POSITION_EPOCH_LEN;
     pub const MAX_MATCHER_TAIL_ACCOUNTS: usize = 32;
     pub const MATCHER_ABI_VERSION: u32 = 3;
     pub const MATCHER_CONTEXT_MIN_LEN: usize = 64;
@@ -161,7 +164,8 @@ pub mod state {
             ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
             ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
             PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
+            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF,
+            PORTFOLIO_POSITION_EPOCH_LEN, PORTFOLIO_POSITION_EPOCH_OFF, PORTFOLIO_STATE_LEN,
             VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
@@ -821,6 +825,27 @@ pub mod state {
             .checked_add(1)
             .ok_or(PercolatorError::EngineCounterOverflow)?;
         Ok((id, next))
+    }
+
+    #[inline]
+    pub fn read_portfolio_position_epoch(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        read_u64(data, PORTFOLIO_POSITION_EPOCH_OFF)
+    }
+
+    #[inline]
+    pub fn bump_portfolio_position_epoch(data: &mut [u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        let next = read_portfolio_position_epoch(data)?
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineCounterOverflow)?;
+        data.get_mut(
+            PORTFOLIO_POSITION_EPOCH_OFF
+                ..PORTFOLIO_POSITION_EPOCH_OFF + PORTFOLIO_POSITION_EPOCH_LEN,
+        )
+        .ok_or(PercolatorError::InvalidAccountLen)?
+        .copy_from_slice(&next.to_le_bytes());
+        Ok(next)
     }
 
     #[inline]
@@ -2656,6 +2681,7 @@ pub mod ix {
         },
         RebalanceReduce {
             portfolio_id: u64,
+            position_epoch: u64,
             asset_index: u16,
             reduce_q: u128,
         },
@@ -2930,6 +2956,7 @@ pub mod ix {
                 },
                 44 => Self::RebalanceReduce {
                     portfolio_id: read_u64(&mut rest)?,
+                    position_epoch: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     reduce_q: read_u128(&mut rest)?,
                 },
@@ -3324,11 +3351,13 @@ pub mod ix {
                 }
                 Self::RebalanceReduce {
                     portfolio_id,
+                    position_epoch,
                     asset_index,
                     reduce_q,
                 } => {
                     out.push(44);
                     push_u64(&mut out, portfolio_id);
+                    push_u64(&mut out, position_epoch);
                     push_u16(&mut out, asset_index);
                     push_u128(&mut out, reduce_q);
                 }
@@ -5464,9 +5493,17 @@ pub mod processor {
             } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
             Instruction::RebalanceReduce {
                 portfolio_id,
+                position_epoch,
                 asset_index,
                 reduce_q,
-            } => handle_rebalance_reduce(program_id, accounts, portfolio_id, asset_index, reduce_q),
+            } => handle_rebalance_reduce(
+                program_id,
+                accounts,
+                portfolio_id,
+                position_epoch,
+                asset_index,
+                reduce_q,
+            ),
             Instruction::FinalizeResetSide { asset_index, side } => {
                 handle_finalize_reset_side(program_id, accounts, asset_index, side)
             }
@@ -5945,6 +5982,10 @@ pub mod processor {
                 source_lien_before_b.as_ref(),
                 source_lien_after_b.as_ref(),
             )?;
+            drop(account_a);
+            drop(account_b);
+            state::bump_portfolio_position_epoch(&mut account_a_data)?;
+            state::bump_portfolio_position_epoch(&mut account_b_data)?;
         }
         if let Some(cfg) = cfg_after {
             state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)?;
@@ -6196,6 +6237,10 @@ pub mod processor {
                 source_lien_before_b.as_ref(),
                 source_lien_after_b.as_ref(),
             )?;
+            drop(account_a);
+            drop(account_b);
+            state::bump_portfolio_position_epoch(&mut account_a_data)?;
+            state::bump_portfolio_position_epoch(&mut account_b_data)?;
         }
         if let Some(cfg) = cfg_after {
             state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)?;
@@ -6472,7 +6517,12 @@ pub mod processor {
             .map_err(map_v16_error)?;
         account_b
             .validate_with_market(&group.as_view())
-            .map_err(map_v16_error)
+            .map_err(map_v16_error)?;
+        drop(account_a);
+        drop(account_b);
+        state::bump_portfolio_position_epoch(&mut account_a_data)?;
+        state::bump_portfolio_position_epoch(&mut account_b_data)?;
+        Ok(())
     }
 
     fn matcher_tail_start_or_verify_lp_config<'a>(
@@ -8478,6 +8528,7 @@ pub mod processor {
         if b_delta_budget == 0 {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        let portfolio_ai = account(accounts, 2)?;
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
@@ -8485,7 +8536,9 @@ pub mod processor {
             group
                 .forfeit_recovery_leg_not_atomic(portfolio, asset_index as usize, b_delta_budget)
                 .map(|_| ())
-        })
+        })?;
+        state::bump_portfolio_position_epoch(&mut portfolio_ai.try_borrow_mut_data()?)?;
+        Ok(())
     }
 
     #[inline(never)]
@@ -8493,6 +8546,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         expected_portfolio_id: u64,
+        expected_position_epoch: u64,
         asset_index: u16,
         reduce_q: u128,
     ) -> ProgramResult {
@@ -8502,6 +8556,11 @@ pub mod processor {
         let portfolio_ai = account(accounts, 2)?;
         expect_owner(portfolio_ai, program_id)?;
         if state::read_portfolio_id(&portfolio_ai.try_borrow_data()?)? != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        if state::read_portfolio_position_epoch(&portfolio_ai.try_borrow_data()?)?
+            != expected_position_epoch
+        {
             return Err(PercolatorError::EngineProvenanceMismatch.into());
         }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
@@ -8517,7 +8576,9 @@ pub mod processor {
                     },
                 )
                 .map(|_| ())
-        })
+        })?;
+        state::bump_portfolio_position_epoch(&mut portfolio_ai.try_borrow_mut_data()?)?;
+        Ok(())
     }
 
     #[inline(never)]
@@ -10757,6 +10818,8 @@ pub mod processor {
             )?;
             if selected_liquidation {
                 group.validate_shape().map_err(map_v16_error)?;
+                drop(portfolio);
+                state::bump_portfolio_position_epoch(&mut portfolio_data)?;
             }
             cfg_after = cfg;
         }
@@ -12214,6 +12277,33 @@ pub mod processor {
                 state::allocate_portfolio_id(u64::MAX),
                 Err(PercolatorError::EngineCounterOverflow.into())
             );
+        }
+
+        #[test]
+        fn portfolio_position_epoch_is_zero_initialized_checked_and_monotonic() {
+            let mut data = vec![
+                0u8;
+                state::portfolio_account_len_for_market_slots(1)
+                    .expect("portfolio account length")
+            ];
+            state::init_portfolio_account_zero_copy(
+                &mut data, [1u8; 32], [2u8; 32], [3u8; 32], 0, 1, 7,
+            )
+            .expect("initialize portfolio");
+            assert_eq!(state::read_portfolio_position_epoch(&data).unwrap(), 0);
+            assert_eq!(state::bump_portfolio_position_epoch(&mut data).unwrap(), 1);
+            assert_eq!(state::read_portfolio_position_epoch(&data).unwrap(), 1);
+
+            data[constants::PORTFOLIO_POSITION_EPOCH_OFF
+                ..constants::PORTFOLIO_POSITION_EPOCH_OFF
+                    + constants::PORTFOLIO_POSITION_EPOCH_LEN]
+                .copy_from_slice(&u64::MAX.to_le_bytes());
+            let before = data.clone();
+            assert_eq!(
+                state::bump_portfolio_position_epoch(&mut data),
+                Err(PercolatorError::EngineCounterOverflow.into())
+            );
+            assert_eq!(data, before, "overflow must not mutate the epoch tail");
         }
 
         fn test_wrapper_config(price: u64) -> state::WrapperConfigV16 {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1255,6 +1255,11 @@ impl V16CuEnv {
         state::read_portfolio_id(&account.data).unwrap()
     }
 
+    fn portfolio_position_epoch(&self, portfolio: Pubkey) -> u64 {
+        let account = self.svm.get_account(&portfolio).expect("portfolio account");
+        state::read_portfolio_position_epoch(&account.data).unwrap()
+    }
+
     fn mutate_market<F>(&mut self, f: F)
     where
         F: FnOnce(&mut state::WrapperConfigV16, &mut MarketGroupV16),
@@ -3428,9 +3433,11 @@ impl V16CuEnv {
         reduce_q: u128,
     ) -> u64 {
         let portfolio_id = self.portfolio_id(portfolio);
+        let position_epoch = self.portfolio_position_epoch(portfolio);
         self.send(
             ProgInstruction::RebalanceReduce {
                 portfolio_id,
+                position_epoch,
                 asset_index,
                 reduce_q,
             },
@@ -7765,7 +7772,6 @@ fn v16_bpf_stale_asset_does_not_block_current_unrelated_trade() {
         100,
         0,
     );
-
     let cranker_owner = Keypair::new();
     let cranker_portfolio = env.create_portfolio(&cranker_owner);
     env.svm.warp_to_slot(3);
@@ -9742,6 +9748,7 @@ fn v16_attack_auto_crank_current_solvent_partial_liquidation_makes_progress() {
         100,
         0,
     );
+    let position_epoch_after_trade = env.portfolio_position_epoch(short_account);
 
     env.svm.warp_to_slot(2);
     env.push_auth_mark_with_cu(2, 300);
@@ -9764,6 +9771,11 @@ fn v16_attack_auto_crank_current_solvent_partial_liquidation_makes_progress() {
     let before_group = env.market_state().1;
     let before_short = env.portfolio_state(short_account);
     let before_cert = health_cert(&before_short);
+    assert_eq!(
+        env.portfolio_position_epoch(short_account),
+        position_epoch_after_trade,
+        "refresh-only cranks must not invalidate signed position consent"
+    );
     assert!(
         before_cert.certified_liq_deficit != 0 && before_cert.certified_equity > 0,
         "setup must be solvent but liquidatable before partial liquidation: {before_cert:?}"
@@ -9792,6 +9804,11 @@ fn v16_attack_auto_crank_current_solvent_partial_liquidation_makes_progress() {
     let after_short = env.portfolio_state(short_account);
     let closed = oi_pre.saturating_sub(after_group.assets[0].oi_eff_short_q);
     assert!(closed > 0, "partial liquidation must reduce open interest");
+    assert_eq!(
+        env.portfolio_position_epoch(short_account),
+        position_epoch_after_trade + 1,
+        "a successful liquidation must advance the position episode"
+    );
     assert!(
         closed < oi_pre,
         "solvent liquidation should preserve the engine-selected remaining position: closed={closed}"
@@ -13489,6 +13506,8 @@ fn run_account_residual_counter_credit_case(
     assert_eq!(lp_initial.residual_received_atoms_total.get(), 0);
 
     env.set_residual_reward_counters_for_test(taker_account, crystallized_loss_atoms, 0, 0);
+    let taker_position_epoch = env.portfolio_position_epoch(taker_account);
+    let lp_position_epoch = env.portfolio_position_epoch(lp_account);
     let cu = execute_account_residual_counter_trade_path(
         &mut env,
         path,
@@ -13503,6 +13522,16 @@ fn run_account_residual_counter_credit_case(
         &format!("{path:?} account residual-counter trade"),
         cu,
         MULTI_ASSET_OPEN_TRADE_CU_LIMIT,
+    );
+    assert_eq!(
+        env.portfolio_position_epoch(taker_account),
+        taker_position_epoch + 1,
+        "{path:?}: a successful trade advances the taker's position episode"
+    );
+    assert_eq!(
+        env.portfolio_position_epoch(lp_account),
+        lp_position_epoch + 1,
+        "{path:?}: a successful trade advances the LP's position episode"
     );
 
     let taker_after = env.portfolio_state(taker_account);
@@ -16148,6 +16177,7 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     let reduce = env.send(
         ProgInstruction::RebalanceReduce {
             portfolio_id: 1,
+            position_epoch: 0,
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28473,6 +28503,7 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     let r_grief = env.send(
         ProgInstruction::RebalanceReduce {
             portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28503,6 +28534,7 @@ fn v16_attack_rebalance_reduce_owner_gated() {
     let r_owner = env.send(
         ProgInstruction::RebalanceReduce {
             portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             reduce_q: POS_SCALE,
         },
@@ -28619,6 +28651,8 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
     let vault_b_before = env.svm.get_account(&vault_b).unwrap();
     let foreign_portfolio_id = env.portfolio_id(foreign);
     let local_portfolio_id = env.portfolio_id(local);
+    let foreign_position_epoch = env.portfolio_position_epoch(foreign);
+    let local_position_epoch = env.portfolio_position_epoch(local);
     let reduce_q = POS_SCALE / 2;
     env.svm.expire_blockhash();
     let rejected = send_tx(
@@ -28627,6 +28661,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::RebalanceReduce {
             portfolio_id: foreign_portfolio_id,
+            position_epoch: foreign_position_epoch,
             asset_index: 0,
             reduce_q,
         },
@@ -28662,6 +28697,7 @@ fn v16_attack_rebalance_reduce_rejects_cross_market_portfolio_substitution() {
         &env.payer,
         ProgInstruction::RebalanceReduce {
             portfolio_id: local_portfolio_id,
+            position_epoch: local_position_epoch,
             asset_index: 0,
             reduce_q,
         },
@@ -56333,6 +56369,7 @@ fn v16_attack_rebalance_reduce_rejects_when_resolve_matured() {
     let rejected = env.send(
         ProgInstruction::RebalanceReduce {
             portfolio_id: env.portfolio_id(long),
+            position_epoch: env.portfolio_position_epoch(long),
             asset_index: 0,
             reduce_q: remaining,
         },
@@ -57649,6 +57686,7 @@ fn v16_attack_rebalance_reduce_overshoot_clamps_to_flat_no_flip() {
     let r = env.send(
         ProgInstruction::RebalanceReduce {
             portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             reduce_q: 3 * POS_SCALE,
         },
@@ -59774,6 +59812,7 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
                 ],
                 data: ProgInstruction::RebalanceReduce {
                     portfolio_id: old_portfolio_id,
+                    position_epoch: env.portfolio_position_epoch(victim),
                     asset_index: 0,
                     reduce_q: NEW_SIZE_Q as u128,
                 }
@@ -59864,12 +59903,17 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
 
     let replay = env.svm.send_transaction(retained_reduce);
     let replayed = replay.is_ok();
-    if replayed {
+    if !replayed {
         assert!(
-            !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
-            "control: stale reduction closed the replacement position"
+            has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+            "rejected stale consent must leave the replacement exposure intact"
         );
+        return;
     }
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+        "control: stale reduction closed the replacement position"
+    );
 
     env.svm.expire_blockhash();
     env.svm.warp_to_slot(2);
@@ -59883,18 +59927,6 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
             },
         );
     }
-    if !replayed {
-        env.trade_with_cu(
-            &victim_owner,
-            victim,
-            &attacker_owner,
-            attacker,
-            -NEW_SIZE_Q,
-            100,
-            0,
-        );
-    }
-
     env.resolve();
     let victim_dest = env.close_resolved(&victim_owner, victim);
     let attacker_dest = env.close_resolved(&attacker_owner, attacker);
@@ -59936,6 +59968,7 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
         100,
         0,
     );
+    let signed_position_epoch = env.portfolio_position_epoch(victim);
 
     env.svm.expire_blockhash();
     let retained_reduce = Transaction::new_signed_with_payer(
@@ -59951,6 +59984,7 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
                 ],
                 data: ProgInstruction::RebalanceReduce {
                     portfolio_id,
+                    position_epoch: signed_position_epoch,
                     asset_index: 0,
                     reduce_q: NEW_SIZE_Q as u128,
                 }
@@ -59982,6 +60016,10 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
         0,
     );
     assert_eq!(env.portfolio_id(victim), portfolio_id);
+    assert!(
+        env.portfolio_position_epoch(victim) > signed_position_epoch,
+        "replacement exposure must advance the position episode"
+    );
 
     env.svm.warp_to_slot(1);
     env.push_auth_mark_with_cu(1, 50);
@@ -60002,12 +60040,17 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
 
     let replay = env.svm.send_transaction(retained_reduce);
     let replayed = replay.is_ok();
-    if replayed {
+    if !replayed {
         assert!(
-            !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
-            "control: stale reduction closed the replacement position"
+            has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+            "rejected stale consent must leave the replacement exposure intact"
         );
+        return;
     }
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+        "control: stale reduction closed the replacement position"
+    );
 
     env.svm.expire_blockhash();
     env.svm.warp_to_slot(2);
@@ -60021,26 +60064,14 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
             },
         );
     }
-    if !replayed {
-        env.trade_with_cu(
-            &victim_owner,
-            victim,
-            &attacker_owner,
-            attacker,
-            -NEW_SIZE_Q,
-            100,
-            0,
-        );
-    }
-
     env.resolve();
     let victim_dest = env.close_resolved(&victim_owner, victim);
     let attacker_dest = env.close_resolved(&attacker_owner, attacker);
     let victim_payout = env.token_amount(victim_dest) as u128;
     let attacker_payout = env.token_amount(attacker_dest) as u128;
-    assert!(
-        !replayed && victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
+    panic!(
         "rebalance consent for an old position episode replayed onto its replacement: victim \
-         recovered {victim_payout}, attacker extracted {attacker_payout}",
+         recovered {}, attacker extracted {}",
+        victim_payout, attacker_payout,
     );
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59907,3 +59907,140 @@ fn v16_attack_rebalance_reduce_replay_cannot_cross_portfolio_incarnation() {
         env.portfolio_id(victim),
     );
 }
+
+// Portfolio/market/asset incarnation binding is not enough: a live portfolio can flatten and
+// reopen the same asset without changing any of those IDs. Retained reduction consent must bind
+// the position episode that existed when the owner signed it.
+#[test]
+fn v16_attack_rebalance_reduce_replay_cannot_cross_position_episode() {
+    const DEPOSIT: u128 = 1_000_000;
+    const OLD_SIZE_Q: i128 = 2_000 * POS_SCALE as i128;
+    const NEW_SIZE_Q: i128 = 1_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let victim_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    let portfolio_id = env.portfolio_id(victim);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        OLD_SIZE_Q,
+        100,
+        0,
+    );
+
+    env.svm.expire_blockhash();
+    let retained_reduce = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::RebalanceReduce {
+                    portfolio_id,
+                    asset_index: 0,
+                    reduce_q: NEW_SIZE_Q as u128,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        -OLD_SIZE_Q,
+        100,
+        0,
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(victim), 0));
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &attacker_owner,
+        attacker,
+        NEW_SIZE_Q,
+        100,
+        0,
+    );
+    assert_eq!(env.portfolio_id(victim), portfolio_id);
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 50);
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[],
+    )
+    .expect("refresh replacement at the adverse mark");
+    assert!(env.portfolio_state(victim).capital.get() < DEPOSIT);
+
+    let replay = env.svm.send_transaction(retained_reduce);
+    let replayed = replay.is_ok();
+    if replayed {
+        assert!(
+            !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+            "control: stale reduction closed the replacement position"
+        );
+    }
+
+    env.svm.expire_blockhash();
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 100);
+    for portfolio in [victim, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    if !replayed {
+        env.trade_with_cu(
+            &victim_owner,
+            victim,
+            &attacker_owner,
+            attacker,
+            -NEW_SIZE_Q,
+            100,
+            0,
+        );
+    }
+
+    env.resolve();
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let attacker_dest = env.close_resolved(&attacker_owner, attacker);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let attacker_payout = env.token_amount(attacker_dest) as u128;
+    assert!(
+        !replayed && victim_payout >= DEPOSIT && attacker_payout <= DEPOSIT,
+        "rebalance consent for an old position episode replayed onto its replacement: victim \
+         recovered {victim_payout}, attacker extracted {attacker_payout}",
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -269,6 +269,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let portfolio_id: u64 = kani::any();
+    let position_epoch: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let side: u8 = kani::any();
     let b_delta_budget: u128 = kani::any();
@@ -294,6 +295,7 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 
     let rebalance = Instruction::RebalanceReduce {
         portfolio_id,
+        position_epoch,
         asset_index,
         reduce_q,
     }
@@ -301,10 +303,12 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     match Instruction::decode(&rebalance).unwrap() {
         Instruction::RebalanceReduce {
             portfolio_id: got_portfolio_id,
+            position_epoch: got_position_epoch,
             asset_index: got_asset,
             reduce_q: got_reduce,
         } => {
             assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_position_epoch, position_epoch);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_reduce, reduce_q);
         }
@@ -356,6 +360,7 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_legacy_unbound_rebalance_payload_is_rejected() {
+    let portfolio_id: u64 = kani::any();
     let asset_index: u16 = kani::any();
     let reduce_q: u128 = kani::any();
     let mut legacy = [0u8; 19];
@@ -363,6 +368,13 @@ fn kani_v16_legacy_unbound_rebalance_payload_is_rejected() {
     legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
     legacy[3..19].copy_from_slice(&reduce_q.to_le_bytes());
     assert!(Instruction::decode(&legacy).is_err());
+
+    let mut incarnation_only = [0u8; 27];
+    incarnation_only[0] = 44;
+    incarnation_only[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+    incarnation_only[9..11].copy_from_slice(&asset_index.to_le_bytes());
+    incarnation_only[11..27].copy_from_slice(&reduce_q.to_le_bytes());
+    assert!(Instruction::decode(&incarnation_only).is_err());
 }
 
 #[kani::proof]
@@ -1396,6 +1408,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::RebalanceReduce {
             portfolio_id: 1,
+            position_epoch: 0,
             asset_index: 0,
             reduce_q: 1,
         },


### PR DESCRIPTION
## What changed

- add a wrapper-owned, checked `position_epoch` to each portfolio
- bind owner-signed `RebalanceReduce` payloads to both `portfolio_id` and `position_epoch`
- advance the epoch after successful exposure-changing single/batch trades, rebalance, liquidation, recovery force-close, and recovery-leg forfeit
- leave refresh-only cranks unchanged so permissionless maintenance cannot invalidate valid consent
- reject both pre-incarnation and portfolio-only legacy tag-44 payloads

## Root cause and impact

PR #292 binds reduction consent to a portfolio incarnation, but a still-live portfolio can flatten and reopen the same asset without changing its market, account address, portfolio ID, or asset identity. A retained owner-signed reduction for the old position therefore applied to the replacement position.

The exact-parent public LiteSVM reproduction uses only normal instructions and no state injection:

1. victim opens a 2,000-unit long and signs a 1,000-unit reduction
2. victim publicly closes that position and later opens a replacement 1,000-unit long in the same portfolio
3. the authenticated mark moves from 100 to 50
4. the retained old reduction lands and closes the replacement at the adverse mark
5. settlement pays the victim 950,000 and the counterparty 1,050,000

The same RED reproduced on #292 head `791ff0c9`, so this is distinct from account-incarnation replay.

## Validation

- exact-parent public LiteSVM RED: victim 950,000 / attacker 1,050,000
- fixed wrapper and all matcher SBFs rebuilt from clean worktrees
- `cargo test --all-targets --no-default-features`: 7 unit + 567 LiteSVM/CU tests passed
- all four public trade APIs explicitly advance both portfolio epochs
- refresh-only crank preserves epoch; successful partial liquidation advances it exactly once
- Kani tag-44 round trip: 1,507 checks, 0 failures
- Kani legacy payload rejection: 829 checks, 0 failures
- `cargo fmt --all -- --check`
- `git diff --check`

This PR intentionally targets #292's branch so the account-incarnation and position-episode bindings remain reviewable as two separate roots. Engine pin remains `143e68c4917ed0400a27b952f036a5677047cd84`.