### PR TITLE
[BLOCKER LoF] Bind backing top-ups to asset generations

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2572,6 +2572,7 @@ pub mod ix {
         ResolveMarket,
         TopUpBackingBucket {
             domain: u16,
+            market_id: u64,
             amount: u128,
             expiry_slot: u64,
         },
@@ -2850,6 +2851,7 @@ pub mod ix {
                 19 => Self::ResolveMarket,
                 24 => Self::TopUpBackingBucket {
                     domain: read_u16(&mut rest)?,
+                    market_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                     expiry_slot: read_u64(&mut rest)?,
                 },
@@ -3158,11 +3160,13 @@ pub mod ix {
                 Self::ResolveMarket => out.push(19),
                 Self::TopUpBackingBucket {
                     domain,
+                    market_id,
                     amount,
                     expiry_slot,
                 } => {
                     out.push(24);
                     push_u16(&mut out, domain);
+                    push_u64(&mut out, market_id);
                     push_u128(&mut out, amount);
                     push_u64(&mut out, expiry_slot);
                 }
@@ -5332,9 +5336,17 @@ pub mod processor {
             Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
             Instruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
-            } => handle_top_up_backing_bucket(program_id, accounts, domain, amount, expiry_slot),
+            } => handle_top_up_backing_bucket(
+                program_id,
+                accounts,
+                domain,
+                market_id,
+                amount,
+                expiry_slot,
+            ),
             Instruction::WithdrawBackingBucket { domain, amount } => {
                 handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
             }
@@ -7667,6 +7679,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         domain: u16,
+        expected_market_id: u64,
         amount: u128,
         expiry_slot: u64,
     ) -> ProgramResult {
@@ -7697,6 +7710,9 @@ pub mod processor {
                 || asset_index >= configured_slots
             {
                 return Err(PercolatorError::EngineLockActive.into());
+            }
+            if group.markets[asset_index].engine.asset.market_id.get() != expected_market_id {
+                return Err(PercolatorError::AssetGenerationMismatch.into());
             }
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
             let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2838,12 +2838,14 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> u64 {
+        let market_id = self.asset_market_id(domain / 2);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3022,6 +3024,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3041,6 +3044,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3064,6 +3068,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let market_id = self.asset_market_id(domain / 2);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3083,6 +3088,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3108,6 +3114,7 @@ impl V16CuEnv {
         expiry_slot: u64,
     ) -> Pubkey {
         self.ensure_signer_account(authority.pubkey());
+        let market_id = self.asset_market_id(domain / 2);
         let source = self.token_account(authority.pubkey(), amount as u64);
         send_tx(
             &mut self.svm,
@@ -3115,6 +3122,7 @@ impl V16CuEnv {
             &self.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain,
+                market_id,
                 amount,
                 expiry_slot,
             },
@@ -3983,6 +3991,7 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
         &payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 77,
             expiry_slot: 10,
         },
@@ -4286,6 +4295,11 @@ fn top_up_backing_bucket_to_market(
     amount: u128,
     expiry_slot: u64,
 ) -> Pubkey {
+    let market_id = state::read_market(&env.svm.get_account(&market).unwrap().data)
+        .unwrap()
+        .1
+        .assets[(domain / 2) as usize]
+        .market_id;
     let source = env.token_account(env.admin.pubkey(), amount as u64);
     env.svm.expire_blockhash();
     send_tx(
@@ -4294,6 +4308,7 @@ fn top_up_backing_bucket_to_market(
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain,
+            market_id,
             amount,
             expiry_slot,
         },
@@ -4642,6 +4657,7 @@ fn v16_bpf_failed_backing_topup_transfer_rolls_back_bucket_and_ledger() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 100,
             expiry_slot: 10,
         },
@@ -6730,6 +6746,7 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
     let backing_topup = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 2,
+            market_id: first_generation_market_id(1),
             amount: 88,
             expiry_slot: 10,
         },
@@ -23716,6 +23733,7 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 100,
             expiry_slot: 10,
         },
@@ -24410,6 +24428,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 40,
             expiry_slot: 10,
         },
@@ -24507,6 +24526,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 40,
             expiry_slot: 10,
         },
@@ -25198,6 +25218,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 30,
             expiry_slot: 10,
         },
@@ -25408,6 +25429,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 30,
             expiry_slot: 10,
         },
@@ -25646,6 +25668,7 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
         &mut env,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 500,
             expiry_slot,
         },
@@ -26065,6 +26088,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 700,
             expiry_slot: 10_000,
         },
@@ -26163,6 +26187,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: BAD_DOMAIN,
+            market_id: 0,
             amount: 456,
             expiry_slot: 10_000,
         },
@@ -32621,6 +32646,7 @@ fn v16_attack_topup_backing_bucket_authority_gated() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 0,
+            market_id: first_generation_market_id(0),
             amount: 500,
             expiry_slot: 10_000,
         },
@@ -32786,6 +32812,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_earnings
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 2,
+            market_id: first_generation_market_id(1),
             amount: 300,
             expiry_slot: 10_000,
         },
@@ -34493,6 +34520,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         let result = env.send(
             ProgInstruction::TopUpBackingBucket {
                 domain: 1,
+                market_id: first_generation_market_id(0),
                 amount: 2,
                 expiry_slot: 10_000,
             },
@@ -36166,6 +36194,7 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
             &env.payer,
             ProgInstruction::TopUpBackingBucket {
                 domain: 0,
+                market_id: first_generation_market_id(0),
                 amount,
                 expiry_slot: expiry,
             },
@@ -51458,6 +51487,7 @@ fn v16_attack_backing_fee_policy_cannot_replay_across_asset_reuse() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: WINNING_DOMAIN,
+            market_id: new_market_id,
             amount: BACKING_PRINCIPAL,
             expiry_slot: 100,
         },
@@ -56898,6 +56928,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let stale_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 30,
             expiry_slot: 100,
         },
@@ -59655,6 +59686,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
+            market_id: first_generation_market_id(0),
             amount: 13,
             expiry_slot: 10_000,
         },
@@ -61213,6 +61245,7 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
         env.send(
             ProgInstruction::TopUpBackingBucket {
                 domain: 1,
+                market_id: first_generation_market_id(0),
                 amount: 50,
                 expiry_slot: expiry,
             },

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -50971,6 +50971,280 @@ fn v16_attack_retired_reused_asset_backing_fee_policy_cannot_stick_batch_gate() 
     );
 }
 
+// A backing top-up signed for a retired asset must not fund a replacement asset at the same index.
+// A replacement creator can reuse the old backing authority, relay the old transfer, and consume
+// the victim's principal through a real self-matched position while its own combined capital stays
+// whole.
+#[test]
+fn v16_attack_backing_topup_cannot_replay_across_asset_reuse() {
+    const DOMAIN: u16 = 3;
+    const TOPUP: u128 = 150;
+    const EXPIRY_SLOT: u64 = 8;
+    const INITIAL_PRICE: u64 = 100;
+    const WIN_MARK: u64 = 120;
+    const SIZE_Q: i128 = 20 * POS_SCALE as i128;
+    const WINNER_DEPOSIT: u128 = 2_000;
+    const LOSER_DEPOSIT: u128 = 250;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(4, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(20, 5);
+    env.update_market_init_fee_policy_with_cu(1);
+    let admin = env.admin.insecure_clone();
+    let old_provider = Keypair::new();
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&old_provider),
+        1,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        old_provider.pubkey().to_bytes(),
+    )
+    .expect("generation-A backing authority accepts the role");
+    let old_market_id = env.asset_market_id(1);
+    let source = env.token_account(old_provider.pubkey(), TOPUP as u64);
+
+    let mut legacy_topup_data = vec![24u8];
+    legacy_topup_data.extend_from_slice(&DOMAIN.to_le_bytes());
+    legacy_topup_data.extend_from_slice(&TOPUP.to_le_bytes());
+    legacy_topup_data.extend_from_slice(&EXPIRY_SLOT.to_le_bytes());
+    let uses_market_id_wire = ProgInstruction::decode(&legacy_topup_data).is_err();
+    let mut bound_topup_data = vec![24u8];
+    bound_topup_data.extend_from_slice(&DOMAIN.to_le_bytes());
+    bound_topup_data.extend_from_slice(&old_market_id.to_le_bytes());
+    bound_topup_data.extend_from_slice(&TOPUP.to_le_bytes());
+    bound_topup_data.extend_from_slice(&EXPIRY_SLOT.to_le_bytes());
+    let topup_accounts = vec![
+        AccountMeta::new(old_provider.pubkey(), true),
+        AccountMeta::new(env.market, false),
+        AccountMeta::new(source, false),
+        AccountMeta::new(env.vault, false),
+        AccountMeta::new_readonly(spl_token::ID, false),
+    ];
+    let stale_topup_ix = Instruction {
+        program_id: env.program_id,
+        accounts: topup_accounts.clone(),
+        data: if uses_market_id_wire {
+            bound_topup_data
+        } else {
+            legacy_topup_data
+        },
+    };
+    let stale_topup = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_topup_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &old_provider],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        2,
+        0,
+    );
+    let attacker = Keypair::new();
+    env.svm.warp_to_slot(3);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        3,
+        INITIAL_PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        old_provider.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+    let new_market_id = env.asset_market_id(1);
+    assert_ne!(new_market_id, old_market_id);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let source_before = env.svm.get_account(&source).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(stale_topup);
+    if uses_market_id_wire {
+        let replay_error = format!(
+            "{:?}",
+            replay.expect_err("stale backing top-up must reject")
+        );
+        let expected_error = format!(
+            "Custom({})",
+            PercolatorError::AssetGenerationMismatch as u32
+        );
+        assert!(
+            replay_error.contains(&expected_error),
+            "stale backing top-up must fail with {expected_error}, got {replay_error}"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&source).unwrap(), source_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+
+        let mut current_topup_data = vec![24u8];
+        current_topup_data.extend_from_slice(&DOMAIN.to_le_bytes());
+        current_topup_data.extend_from_slice(&new_market_id.to_le_bytes());
+        current_topup_data.extend_from_slice(&TOPUP.to_le_bytes());
+        current_topup_data.extend_from_slice(&EXPIRY_SLOT.to_le_bytes());
+        send_raw_ixs(
+            &mut env.svm,
+            &env.payer,
+            vec![
+                heap_ix(),
+                cu_ix(),
+                Instruction {
+                    program_id: env.program_id,
+                    accounts: topup_accounts,
+                    data: current_topup_data,
+                },
+            ],
+            &[&old_provider],
+        )
+        .expect("current-generation backing top-up remains usable");
+        assert_eq!(env.token_amount(source), 0);
+        return;
+    }
+
+    replay.expect("retained old-asset backing top-up lands on the replacement asset");
+    assert_eq!(env.token_amount(source), 0);
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[DOMAIN as usize].fresh_unliened_backing_num,
+        TOPUP * BOUND_SCALE
+    );
+
+    env.configure_auth_mark_for_asset_with_authority(1, &attacker, 3, INITIAL_PRICE);
+    let winner = Keypair::new();
+    let loser = Keypair::new();
+    let winner_account = env.create_portfolio(&winner);
+    let loser_account = env.create_portfolio(&loser);
+    env.deposit(&winner, winner_account, WINNER_DEPOSIT);
+    env.deposit(&loser, loser_account, LOSER_DEPOSIT);
+    env.trade_asset_with_cu(
+        1,
+        &winner,
+        winner_account,
+        &loser,
+        loser_account,
+        SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    );
+    for (slot, mark) in [(4, 105), (5, 110), (6, 115), (7, WIN_MARK)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_with_authority(1, &attacker, slot, mark);
+        env.crank(
+            winner_account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+        );
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(1),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(loser_account, false),
+            ],
+            &[],
+        );
+    }
+    assert_eq!(
+        env.portfolio_state(winner_account).pnl.get(),
+        400,
+        "the replacement asset creates a real source-backed winner"
+    );
+    assert_eq!(env.portfolio_state(loser_account).capital.get(), 0);
+    assert!(env.portfolio_state(loser_account).pnl.get() < 0);
+    env.resolve_stale_permissionless_with_cu(30);
+    env.svm.warp_to_slot(36);
+    let first_winner_dest = env.close_resolved(&winner, winner_account);
+    let mut attacker_payout = env.token_amount(first_winner_dest) as u128;
+    for _ in 0..16 {
+        let state = env.portfolio_state(loser_account);
+        if state.pnl.get() == 0 && percolator::active_bitmap_is_empty(active_bitmap(&state)) {
+            break;
+        }
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 36,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new_readonly(loser.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(loser_account, false),
+            ],
+            &[],
+        )
+        .expect("resolved loser makes bounded public progress");
+    }
+    let loser_after = env.portfolio_state(loser_account);
+    assert_eq!(loser_after.capital.get(), 0);
+    assert_eq!(loser_after.pnl.get(), 0);
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &loser_after
+    )));
+    env.close_portfolio_with_cu(&loser, loser_account);
+
+    for _ in 0..3 {
+        let dest = env.close_resolved(&winner, winner_account);
+        attacker_payout += env.token_amount(dest) as u128;
+    }
+    assert!(
+        attacker_payout > WINNER_DEPOSIT + LOSER_DEPOSIT,
+        "replacement-market winner must extract independent backing, got {attacker_payout}"
+    );
+    env.close_portfolio_with_cu(&winner, winner_account);
+
+    let provider_dest = env.token_account(old_provider.pubkey(), 0);
+    let withdraw_provider = |env: &mut V16CuEnv, amount: u128| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::WithdrawBackingBucket {
+                domain: DOMAIN,
+                amount,
+            },
+            vec![
+                AccountMeta::new(old_provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&old_provider],
+        )
+    };
+    assert!(
+        withdraw_provider(&mut env, TOPUP).is_err(),
+        "the provider cannot recover consumed replayed principal"
+    );
+    let recoverable = env.market_state().1.source_backing_buckets[DOMAIN as usize]
+        .fresh_unliened_backing_num
+        / BOUND_SCALE;
+    let provider_loss = TOPUP - recoverable;
+    assert_eq!(
+        attacker_payout - WINNER_DEPOSIT - LOSER_DEPOSIT,
+        provider_loss,
+        "the attacker's net terminal gain is the independent provider's unavailable principal"
+    );
+    if recoverable != 0 {
+        withdraw_provider(&mut env, recoverable)
+            .expect("the provider recovers only unconsumed principal");
+    }
+    assert_eq!(env.token_amount(provider_dest) as u128, recoverable);
+    panic!(
+        "retained old-asset top-up transferred {provider_loss} atoms of independent backing to the replacement-market winner"
+    );
+}
+
 // An insurance top-up signed for a retired asset must not fund a replacement asset at the same
 // index. A replacement creator can deliberately reuse the old insurance authority while installing
 // itself as insurance operator, then relay the old transfer and withdraw the victim's deposit.

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -308,22 +308,26 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
+    let market_id: u64 = kani::any();
     let amount: u128 = kani::any();
     let expiry_slot: u64 = kani::any();
 
-    let mut data = [0u8; 27];
+    let mut data = [0u8; 35];
     data[0] = 24;
     data[1..3].copy_from_slice(&domain.to_le_bytes());
-    data[3..19].copy_from_slice(&amount.to_le_bytes());
-    data[19..27].copy_from_slice(&expiry_slot.to_le_bytes());
+    data[3..11].copy_from_slice(&market_id.to_le_bytes());
+    data[11..27].copy_from_slice(&amount.to_le_bytes());
+    data[27..35].copy_from_slice(&expiry_slot.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TopUpBackingBucket {
             domain: got_domain,
+            market_id: got_market_id,
             amount: got_amount,
             expiry_slot: got_expiry,
         } => {
             assert_eq!(got_domain, domain);
+            assert_eq!(got_market_id, market_id);
             assert_eq!(got_amount, amount);
             assert_eq!(got_expiry, expiry_slot);
         }
@@ -1229,6 +1233,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::TopUpBackingBucket {
             domain: 1,
+            market_id: 1,
             amount: 1,
             expiry_slot: 10,
         },


### PR DESCRIPTION
## Impact

A signed `TopUpBackingBucket` capability was bound only to a domain index. After that asset generation retired, a permissionless replacement creator could assign the old backing authority to the reused slot and relay a retained generation-A top-up into generation B.

The LiteSVM exploit uses only public post-reuse actions: it opens a real self-matched position, advances the replacement oracle, lets the signed backing expire, invokes permissionless resolution, and orders terminal closes so the replacement-market winner receives all 150 atoms of the independent provider's backing.

## Root cause

Tag 24 did not carry the asset's monotonic `market_id`, so authorization survived slot retirement and reuse.

## Fix

- Add `market_id` to the tag-24 wire format.
- Reject a generation mismatch before accounting changes or the SPL transfer.
- Update all callers and the Kani wire-format proof.
- Keep a current-generation positive control in the adaptive LiteSVM regression.

## TDD and validation

- RED commit: `27e0b0fe` against exact parent `96b332d6`.
- Exact-parent SBF SHA-256: `a04f9ef2644acef23a7714f3fdd14dfbdc5ac1da1aada1086c09cb7cb9e4d92e`.
- Fixed commit: `8d7b32e8`.
- Fixed SBF SHA-256: `ea93ff175732f82f72abedea5446f9067ce137fae660dbb4648ec4f38e2493c5`.
- Targeted exploit: pass.
- Full LiteSVM suite: 573 passed.
- Library tests: 5 passed.
- Kani test target: compiles.