### PR TITLE
[BLOCKER DoS] Bind market resolution to its generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   `base_unit_authority`). `marketauth` is the only key that can: **create market 0** (`InitMarket`),
   **create/retire assets 1..N and set the permissionless-create-fee policy**, **safely force-shutdown
   any asset including asset 0** (`ASSET_ACTION_SHUTDOWN` → RECOVERY with the `force_close_delay_slots`
-  exit window so traders can exit), **resolve/close the market** (`ResolveMarket`/`CloseSlab`),
+  exit window so traders can exit), **resolve/close the market** (`ResolveMarket { market_id }`/`CloseSlab`),
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
   `UpdateAuthority { market_id, new_pubkey }` (current `marketauth` signs, the non-zero replacement
   co-signs, and `market_id` must match the current base-asset generation; burn-to-zero is rejected).
@@ -856,7 +856,7 @@ These are governance powers, not bugs:
 3. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
-4. `ResolveMarket`
+4. `ResolveMarket { market_id }`
    - transition market to resolved mode using stored authority price.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
 5. `UpdateAssetAuthority { asset_index = 0, market_id, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2569,7 +2569,9 @@ pub mod ix {
             amount: u128,
         },
         CloseSlab,
-        ResolveMarket,
+        ResolveMarket {
+            market_id: u64,
+        },
         TopUpBackingBucket {
             domain: u16,
             market_id: u64,
@@ -2853,7 +2855,9 @@ pub mod ix {
                     amount: read_u128(&mut rest)?,
                 },
                 13 => Self::CloseSlab,
-                19 => Self::ResolveMarket,
+                19 => Self::ResolveMarket {
+                    market_id: read_u64(&mut rest)?,
+                },
                 24 => Self::TopUpBackingBucket {
                     domain: read_u16(&mut rest)?,
                     market_id: read_u64(&mut rest)?,
@@ -3167,7 +3171,10 @@ pub mod ix {
                     push_u128(&mut out, amount);
                 }
                 Self::CloseSlab => out.push(13),
-                Self::ResolveMarket => out.push(19),
+                Self::ResolveMarket { market_id } => {
+                    out.push(19);
+                    push_u64(&mut out, market_id);
+                }
                 Self::TopUpBackingBucket {
                     domain,
                     market_id,
@@ -5353,7 +5360,9 @@ pub mod processor {
                 amount,
             } => handle_top_up_insurance_domain(program_id, accounts, domain, market_id, amount),
             Instruction::CloseSlab => handle_close_slab(program_id, accounts),
-            Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
+            Instruction::ResolveMarket { market_id } => {
+                handle_resolve_market(program_id, accounts, market_id)
+            }
             Instruction::TopUpBackingBucket {
                 domain,
                 market_id,
@@ -8847,6 +8856,7 @@ pub mod processor {
     fn handle_resolve_market<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -8855,6 +8865,11 @@ pub mod processor {
         expect_owner(market_ai, program_id)?;
         let mut market_data = market_ai.try_borrow_mut_data()?;
         let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
+        if group.markets.is_empty()
+            || group.markets[0].engine.asset.market_id.get() != expected_market_id
+        {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
         if group.header.mode != 0 {
             return Err(PercolatorError::EngineLockActive.into());
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2264,11 +2264,12 @@ impl V16CuEnv {
     }
 
     fn resolve(&mut self) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::ResolveMarket,
+            ProgInstruction::ResolveMarket { market_id },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -6563,11 +6564,12 @@ fn v16_attack_signed_authority_rotation_cannot_replay_across_market_reinit() {
             attacker.pubkey().to_bytes(),
             "the retained old rotation seized the fresh market"
         );
+        let market_id = env.asset_market_id(0);
         let forced_resolve = send_tx(
             &mut env.svm,
             env.program_id,
             &env.payer,
-            ProgInstruction::ResolveMarket,
+            ProgInstruction::ResolveMarket { market_id },
             vec![
                 AccountMeta::new(attacker.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -23240,12 +23242,13 @@ fn v16_attack_non_admin_cannot_resolve_or_configure() {
     env.deposit(&la, pa, 1_000_000);
 
     // non-admin ResolveMarket -> reject; market stays Live.
+    let market_id = env.asset_market_id(0);
     env.svm.expire_blockhash();
     let r_res = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket { market_id },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24705,12 +24708,19 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
         &[&admin],
     )
     .expect("fund market B insurance");
+    let market_b_id = state::read_market(&env.svm.get_account(&market_b).unwrap().data)
+        .unwrap()
+        .1
+        .assets[0]
+        .market_id;
     env.svm.expire_blockhash();
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: market_b_id,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24841,12 +24851,19 @@ fn v16_attack_terminal_withdraw_insurance_rejects_portfolio_as_ledger() {
         &[&admin],
     )
     .expect("fund market B terminal insurance");
+    let market_b_id = state::read_market(&env.svm.get_account(&market_b).unwrap().data)
+        .unwrap()
+        .1
+        .assets[0]
+        .market_id;
     env.svm.expire_blockhash();
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: market_b_id,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -28502,12 +28519,13 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
         "test setup rotates marketauth away from the old key"
     );
 
+    let market_id = env.asset_market_id(0);
     env.svm.expire_blockhash();
     let resolve = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket { market_id },
         vec![
             AccountMeta::new(new_admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -28724,7 +28742,9 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: first_generation_market_id(0),
+        },
         vec![
             AccountMeta::new(market.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -31616,12 +31636,19 @@ fn v16_attack_close_resolved_rejects_cross_market_portfolio_payout() {
         "market B vault funded"
     );
 
+    let market_b_id = state::read_market(&env.svm.get_account(&market_b).unwrap().data)
+        .unwrap()
+        .1
+        .assets[0]
+        .market_id;
     env.svm.expire_blockhash();
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            market_id: market_b_id,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -61636,6 +61636,216 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
     );
 }
 
+// A resolve signed for a closed market must not acquire authority over a live replacement at the
+// same address. ResolveMarket is terminal, so replaying that retained capability after reinit would
+// permanently halt a generation-B market even when independent users already have open positions.
+#[test]
+fn v16_attack_resolve_market_cannot_replay_across_market_reinit() {
+    const PRICE: u64 = 100;
+    const DEPOSIT: u128 = 1_000;
+    const SIZE_Q: i128 = 5 * POS_SCALE as i128;
+
+    let params = V16CuMarketParams::default();
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    let admin = env.admin.insecure_clone();
+    let old_market_id = env.asset_market_id(0);
+
+    let legacy_resolve_data = vec![19u8];
+    let uses_market_id_wire = ProgInstruction::decode(&legacy_resolve_data).is_err();
+    let mut bound_resolve_data = vec![19u8];
+    bound_resolve_data.extend_from_slice(&old_market_id.to_le_bytes());
+    let stale_resolve_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: if uses_market_id_wire {
+            bound_resolve_data
+        } else {
+            legacy_resolve_data
+        },
+    };
+    let reinit_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: init_market_instruction(&reinit_params).encode(),
+    };
+    let retained_blockhash = env.svm.latest_blockhash();
+    let stale_resolve = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_resolve_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+    let presigned_reinit = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), reinit_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+
+    // The legitimate generation-A resolve has a different message from the retained probe, so its
+    // signature does not consume the stale transaction in LiteSVM replay protection.
+    env.resolve();
+    env.close_slab_with_cu();
+    assert_eq!(env.svm.get_account(&env.market).unwrap().lamports, 0);
+
+    env.svm.warp_to_slot(10);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .send_transaction(presigned_reinit)
+        .expect("the same market address is publicly reinitialized from a retained signed init");
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+    let victim = Keypair::new();
+    let counterparty = Keypair::new();
+    let victim_account = env.create_portfolio(&victim);
+    let counterparty_account = env.create_portfolio(&counterparty);
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&counterparty, counterparty_account, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &counterparty,
+        counterparty_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim_account), 0).basis_pos_q,
+        SIZE_Q
+    );
+
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let replay = env.svm.send_transaction(stale_resolve);
+    if !uses_market_id_wire {
+        replay.expect("retained generation-A resolve lands on the live replacement market");
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+        let close_after_replay = env.try_trade_asset_with_cu(
+            0,
+            &victim,
+            victim_account,
+            &counterparty,
+            counterparty_account,
+            -SIZE_Q,
+            PRICE,
+            0,
+        );
+        assert!(
+            close_after_replay.is_err(),
+            "terminal replay must demonstrably stop ordinary trade progress"
+        );
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(victim_account), 0).basis_pos_q,
+            SIZE_Q,
+            "the independent users remain in the terminally resolved generation"
+        );
+        panic!("a retained old-market resolve permanently halted a live replacement market");
+    }
+
+    let replay_error = format!(
+        "{:?}",
+        replay.expect_err("stale market resolve must reject")
+    );
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale market resolve must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_replay,
+        "generation mismatch leaves the live replacement byte-identical"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &counterparty,
+        counterparty_account,
+        -SIZE_Q,
+        PRICE,
+        0,
+    );
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(
+        &env.portfolio_state(victim_account)
+    )));
+
+    let mut current_resolve_data = vec![19u8];
+    current_resolve_data.extend_from_slice(&new_market_id.to_le_bytes());
+    let current_resolve = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(admin.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                data: current_resolve_data,
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+    env.svm
+        .send_transaction(current_resolve)
+        .expect("current-generation resolve remains usable");
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+}
+
 // A fee policy signed for a retired market must not acquire authority over a replacement market at
 // the same address. Otherwise it can land while the replacement is empty (bypassing the funded-live
 // fee guard), then tax an already-signed zero-fee trade and route the proceeds to a permissionless

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -1318,7 +1318,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
     assert_rejects_trailing_byte(Instruction::CloseSlab, extra);
-    assert_rejects_trailing_byte(Instruction::ResolveMarket, extra);
+    assert_rejects_trailing_byte(Instruction::ResolveMarket { market_id: 1 }, extra);
     assert_rejects_trailing_byte(
         Instruction::UpdateAuthority {
             market_id: 1,


### PR DESCRIPTION
## Root cause

`ResolveMarket` was an unscoped signed capability: tag 19 carried no market generation. After the market account closed and was reinitialized at the same address under a new base-asset `market_id`, any retained generation-A resolve transaction still authenticated against the reused `marketauth` key and could irreversibly resolve generation B.

## Public DoS proof

The adaptive LiteSVM regression pre-signs both reinitialization and the stale resolve before generation A closes. The transactions are relayed without the admin private key. Generation B is then live, independently funded, and has a real open position before the stale A resolve lands. The market enters terminal resolved mode, a normal position-closing trade fails, and no instruction can transition that generation back to live.

RED commit: `026c9d99`
Exact-parent commit: `8d3b4636`
Exact-parent SBF SHA-256: `f7c2823f8b2bf65a5c09a263af9a7c2160b9232b578affd199f2cd4927252f4a`

## Fix

- Change the wire to `ResolveMarket { market_id }`.
- Reject `AssetGenerationMismatch` before the terminal state transition.
- Update every caller and the README authority-surface documentation.
- Preserve current-generation resolution behavior.

Production fix commit: `5ce20455`
Formal payload migration: `b8e439e1`

This adds no admin authority, recovery override, or fund-moving path.

## Validation

- Adaptive exploit: RED on exact parent, GREEN on fixed SBF.
- Fixed SBF SHA-256: `686fa3afe3248a3b48c652eff616e076e5c8b87877d714cb0a4799fe419a397e`.
- `cargo test --test v16_cu --quiet`: 575 passed.
- `cargo test --lib --quiet`: 5 passed.
- `cargo kani --tests --only-codegen`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.