### PR TITLE
[BLOCKER LoF] Bind maintenance fee policy to market generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - resolved-market payout/finalization path for a supplied portfolio; pays only the stored owner token account
 
 ### Risk / maintenance
+- **UpdateMaintenanceFeePolicy** (tag 49)
+  - `UpdateMaintenanceFeePolicy { market_id, cranker_share_bps }` is signed by `marketauth`;
+    `market_id` must match the current base-asset generation so a retired slab's fee split cannot
+    redirect replacement-market user fees into a public cranker portfolio
 - **PermissionlessCrank** (tag 5)
   - permissionless maintenance entrypoint for a supplied asset/account path
   - authenticates clock/oracle state in the wrapper, then delegates bounded public progress to the engine

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2608,6 +2608,7 @@ pub mod ix {
             cranker_share_bps: u16,
         },
         UpdateMaintenanceFeePolicy {
+            market_id: u64,
             cranker_share_bps: u16,
         },
         UpdateBackingFeePolicy {
@@ -2889,6 +2890,7 @@ pub mod ix {
                     cranker_share_bps: read_u16(&mut rest)?,
                 },
                 49 => Self::UpdateMaintenanceFeePolicy {
+                    market_id: read_u64(&mut rest)?,
                     cranker_share_bps: read_u16(&mut rest)?,
                 },
                 51 => Self::UpdateBackingFeePolicy {
@@ -3226,8 +3228,12 @@ pub mod ix {
                     out.push(37);
                     push_u16(&mut out, cranker_share_bps);
                 }
-                Self::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
+                Self::UpdateMaintenanceFeePolicy {
+                    market_id,
+                    cranker_share_bps,
+                } => {
                     out.push(49);
+                    push_u64(&mut out, market_id);
                     push_u16(&mut out, cranker_share_bps);
                 }
                 Self::UpdateBackingFeePolicy {
@@ -5409,9 +5415,15 @@ pub mod processor {
             Instruction::UpdateLiquidationFeePolicy { cranker_share_bps } => {
                 handle_update_liquidation_fee_policy(program_id, accounts, cranker_share_bps)
             }
-            Instruction::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
-                handle_update_maintenance_fee_policy(program_id, accounts, cranker_share_bps)
-            }
+            Instruction::UpdateMaintenanceFeePolicy {
+                market_id,
+                cranker_share_bps,
+            } => handle_update_maintenance_fee_policy(
+                program_id,
+                accounts,
+                market_id,
+                cranker_share_bps,
+            ),
             Instruction::UpdateBackingFeePolicy {
                 domain,
                 market_id,
@@ -9738,6 +9750,7 @@ pub mod processor {
     fn handle_update_maintenance_fee_policy<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_market_id: u64,
         cranker_share_bps: u16,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
@@ -9748,8 +9761,11 @@ pub mod processor {
         if cranker_share_bps > 10_000 {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, _, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
+        let (mut cfg, _, _, market_id, _, _) =
+            state::read_market_trade_preflight(&market_ai.try_borrow_data()?, 0)?;
+        if market_id != expected_market_id {
+            return Err(PercolatorError::AssetGenerationMismatch.into());
+        }
         expect_live_authority(&cfg.marketauth, admin.key)?;
         cfg.maintenance_cranker_fee_share_bps = cranker_share_bps;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1535,11 +1535,15 @@ impl V16CuEnv {
     }
 
     fn update_maintenance_fee_policy_with_cu(&mut self, cranker_share_bps: u16) -> u64 {
+        let market_id = self.asset_market_id(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateMaintenanceFeePolicy { cranker_share_bps },
+            ProgInstruction::UpdateMaintenanceFeePolicy {
+                market_id,
+                cranker_share_bps,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -26740,6 +26744,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     old_attempt(
         ProgInstruction::UpdateMaintenanceFeePolicy {
+            market_id,
             cranker_share_bps: 4_000,
         },
         "maintenance policy replay",
@@ -26788,6 +26793,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     new_update(
         ProgInstruction::UpdateMaintenanceFeePolicy {
+            market_id,
             cranker_share_bps: 4_000,
         },
         "maintenance policy update",
@@ -35444,6 +35450,7 @@ fn v16_attack_global_policy_bounds_reject_grief_values() {
     reject_unchanged(
         &mut env,
         ProgInstruction::UpdateMaintenanceFeePolicy {
+            market_id,
             cranker_share_bps: 10_001,
         },
         "maintenance cranker share above 100%",
@@ -35690,6 +35697,7 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
     );
     assert!(
         attempt(ProgInstruction::UpdateMaintenanceFeePolicy {
+            market_id,
             cranker_share_bps: 2_500
         })
         .is_err(),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -62130,6 +62130,269 @@ fn v16_attack_permissionless_resolve_policy_cannot_replay_across_market_reinit()
     assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
 }
 
+// A maintenance-fee split signed for a closed market must not redirect fees from users of a live
+// replacement at the same address. A retained 100% cranker split otherwise lets any relay turn a
+// generation-B user fee into immediately withdrawable attacker capital without the current admin key.
+#[test]
+fn v16_attack_maintenance_fee_policy_cannot_replay_across_market_reinit() {
+    const DEPOSIT: u128 = 100_000;
+    const MAINTENANCE_FEE_PER_SLOT: u128 = 58;
+    const CRANKER_SHARE_BPS: u16 = 10_000;
+    const PRICE: u64 = 100;
+    const SIZE_Q: i128 = POS_SCALE as i128;
+
+    let params = V16CuMarketParams {
+        maintenance_fee_per_slot: MAINTENANCE_FEE_PER_SLOT,
+        ..V16CuMarketParams::default()
+    };
+    let reinit_params = V16CuMarketParams {
+        max_bankrupt_close_lifetime_slots: params.max_bankrupt_close_lifetime_slots + 1,
+        ..params
+    };
+    let mut env = V16CuEnv::new_with_init_params(params);
+    let admin = env.admin.insecure_clone();
+    let old_market_id = env.asset_market_id(0);
+
+    let mut legacy_policy_data = vec![49u8];
+    legacy_policy_data.extend_from_slice(&CRANKER_SHARE_BPS.to_le_bytes());
+    let uses_market_id_wire = ProgInstruction::decode(&legacy_policy_data).is_err();
+    let mut bound_policy_data = vec![49u8];
+    bound_policy_data.extend_from_slice(&old_market_id.to_le_bytes());
+    bound_policy_data.extend_from_slice(&CRANKER_SHARE_BPS.to_le_bytes());
+    let stale_policy_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: if uses_market_id_wire {
+            bound_policy_data
+        } else {
+            legacy_policy_data
+        },
+    };
+    let reinit_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new_readonly(env.mint, false),
+            AccountMeta::new(env.market_generation, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: init_market_instruction(&reinit_params).encode(),
+    };
+    let retained_blockhash = env.svm.latest_blockhash();
+    let stale_policy = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), stale_policy_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+    let presigned_reinit = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), reinit_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+
+    env.resolve();
+    env.close_slab_with_cu();
+    assert_eq!(env.svm.get_account(&env.market).unwrap().lamports, 0);
+
+    env.svm.warp_to_slot(10);
+    env.svm
+        .set_account(
+            env.market,
+            Account {
+                lamports: 1_000_000_000,
+                data: vec![
+                    0u8;
+                    state::market_account_len_for_capacity(
+                        params.max_portfolio_assets as usize,
+                    )
+                    .unwrap()
+                ],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .set_account(
+            env.vault,
+            Account {
+                lamports: 1_000_000_000,
+                data: make_token_data(env.mint, env.vault_authority, 0),
+                owner: spl_token::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.svm
+        .send_transaction(presigned_reinit)
+        .expect("the same market address is publicly reinitialized from a retained signed init");
+    let new_market_id = env.asset_market_id(0);
+    assert_ne!(new_market_id, old_market_id);
+    assert_eq!(env.market_state().0.maintenance_cranker_fee_share_bps, 0);
+    assert_eq!(
+        env.market_state().0.maintenance_fee_per_slot,
+        MAINTENANCE_FEE_PER_SLOT
+    );
+
+    let victim = Keypair::new();
+    let counterparty = Keypair::new();
+    let fee_payer = Keypair::new();
+    let victim_account = env.create_portfolio(&victim);
+    let counterparty_account = env.create_portfolio(&counterparty);
+    let fee_payer_account = env.create_portfolio(&fee_payer);
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&counterparty, counterparty_account, DEPOSIT);
+    env.deposit(&fee_payer, fee_payer_account, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &counterparty,
+        counterparty_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim_account), 0).basis_pos_q,
+        SIZE_Q
+    );
+
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let replay = env.svm.send_transaction(stale_policy);
+    if !uses_market_id_wire {
+        replay.expect("retained generation-A maintenance policy lands on generation B");
+        assert_eq!(
+            env.market_state().0.maintenance_cranker_fee_share_bps,
+            CRANKER_SHARE_BPS
+        );
+
+        env.svm.warp_to_slot(20);
+        let attacker = Keypair::new();
+        let attacker_account = env.create_portfolio(&attacker);
+        let victim_before = env.portfolio_state(fee_payer_account);
+        let victim_equity_before = victim_before.capital.get() as i128 + victim_before.pnl.get();
+        env.sync_maintenance_fee_with_cu(fee_payer_account, Some(attacker_account), 20);
+        let victim_after = env.portfolio_state(fee_payer_account);
+        let charged = (victim_equity_before
+            - (victim_after.capital.get() as i128 + victim_after.pnl.get()))
+            as u128;
+        assert_eq!(charged, MAINTENANCE_FEE_PER_SLOT * 10);
+        assert!(
+            charged > 0,
+            "the independent user paid a real maintenance fee"
+        );
+        assert_eq!(
+            env.portfolio_state(attacker_account).capital.get(),
+            charged,
+            "the stale split turns the entire victim fee into attacker capital"
+        );
+        assert_eq!(
+            env.market_state().1.insurance,
+            0,
+            "the stale 100% split leaves no victim fee in canonical insurance"
+        );
+        let destination = env.withdraw(&attacker, attacker_account, charged);
+        assert_eq!(
+            env.token_amount(destination),
+            charged as u64,
+            "the public cranker extracts the victim-paid fee from canonical custody"
+        );
+        panic!("a retained maintenance-fee policy let a public cranker withdraw generation-B user funds");
+    }
+
+    let replay_error = format!(
+        "{:?}",
+        replay.expect_err("stale maintenance-fee policy must reject")
+    );
+    let expected_error = format!(
+        "Custom({})",
+        PercolatorError::AssetGenerationMismatch as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale maintenance policy must fail with {expected_error}, got {replay_error}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_replay,
+        "generation mismatch leaves the replacement market byte-identical"
+    );
+    assert_eq!(env.market_state().0.maintenance_cranker_fee_share_bps, 0);
+
+    env.svm.warp_to_slot(20);
+    let stale_cranker = Keypair::new();
+    let stale_cranker_account = env.create_portfolio(&stale_cranker);
+    let victim_before = env.portfolio_state(fee_payer_account);
+    let victim_equity_before = victim_before.capital.get() as i128 + victim_before.pnl.get();
+    env.sync_maintenance_fee_with_cu(fee_payer_account, Some(stale_cranker_account), 20);
+    let victim_after = env.portfolio_state(fee_payer_account);
+    let charged = (victim_equity_before
+        - (victim_after.capital.get() as i128 + victim_after.pnl.get())) as u128;
+    assert!(charged > 0);
+    assert_eq!(env.portfolio_state(stale_cranker_account).capital.get(), 0);
+    assert_eq!(
+        env.market_state().1.insurance,
+        charged,
+        "with the stale policy rejected, the current zero-share policy retains the user fee"
+    );
+
+    let mut current_policy_data = vec![49u8];
+    current_policy_data.extend_from_slice(&new_market_id.to_le_bytes());
+    current_policy_data.extend_from_slice(&CRANKER_SHARE_BPS.to_le_bytes());
+    let current_policy = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(admin.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                data: current_policy_data,
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+    env.svm
+        .send_transaction(current_policy)
+        .expect("current-generation maintenance policy remains usable");
+    assert_eq!(
+        env.market_state().0.maintenance_cranker_fee_share_bps,
+        CRANKER_SHARE_BPS
+    );
+
+    env.svm.warp_to_slot(30);
+    let current_cranker = Keypair::new();
+    let current_cranker_account = env.create_portfolio(&current_cranker);
+    let victim_before_current = env.portfolio_state(fee_payer_account);
+    let victim_equity_before_current =
+        victim_before_current.capital.get() as i128 + victim_before_current.pnl.get();
+    env.sync_maintenance_fee_with_cu(fee_payer_account, Some(current_cranker_account), 30);
+    let victim_after_current = env.portfolio_state(fee_payer_account);
+    let current_reward = (victim_equity_before_current
+        - (victim_after_current.capital.get() as i128 + victim_after_current.pnl.get()))
+        as u128;
+    assert!(current_reward > 0);
+    assert_eq!(
+        env.portfolio_state(current_cranker_account).capital.get(),
+        current_reward
+    );
+    let destination = env.withdraw(&current_cranker, current_cranker_account, current_reward);
+    assert_eq!(env.token_amount(destination), current_reward as u64);
+}
+
 // A fee policy signed for a retired market must not acquire authority over a replacement market at
 // the same address. Otherwise it can land while the replacement is empty (bypassing the funded-live
 // fee guard), then tax an already-signed zero-fee trade and route the proceeds to a permissionless

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -810,16 +810,22 @@ fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_update_maintenance_fee_policy_decode_preserves_wire_fields() {
+    let market_id: u64 = kani::any();
     let cranker_share_bps: u16 = kani::any();
 
-    let mut data = [0u8; 3];
+    let mut data = [0u8; 11];
     data[0] = 49;
-    data[1..3].copy_from_slice(&cranker_share_bps.to_le_bytes());
+    data[1..9].copy_from_slice(&market_id.to_le_bytes());
+    data[9..11].copy_from_slice(&cranker_share_bps.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateMaintenanceFeePolicy {
+            market_id: got_market_id,
             cranker_share_bps: got,
-        } => assert_eq!(got, cranker_share_bps),
+        } => {
+            assert_eq!(got_market_id, market_id);
+            assert_eq!(got, cranker_share_bps);
+        }
         _ => unreachable!(),
     }
 }
@@ -1347,6 +1353,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::UpdateMaintenanceFeePolicy {
+            market_id: 9,
             cranker_share_bps: 4_000,
         },
         extra,


### PR DESCRIPTION
## Classification

REAL public loss of funds: a retained generation-A fee split lets an unprivileged cranker extract generation-B user-paid collateral from the canonical vault.

## Exploit

1. Retain a valid generation-A `UpdateMaintenanceFeePolicy` transaction setting the cranker share to 100%, plus a valid transaction that can reinitialize the slab after closure.
2. Resolve and close generation A through its legitimate lifecycle.
3. A public relay reinitializes generation B at the same address. Its intended cranker share is zero.
4. Independent users fund the market and open real matched OI; a separate independent depositor remains eligible for the account maintenance fee.
5. A public relay submits the retained generation-A policy without the current admin key.
6. At the next fee sync, the depositor pays 580 collateral atoms. Instead of remaining in canonical insurance, all 580 become attacker cranker capital.
7. The attacker withdraws all 580 atoms from the canonical token vault in the same slot.

This is an actual custody withdrawal, not points inflation, an opportunity-only change, or rollback griefing.

## TDD

- Exact parent: `e23031fa`
- Exact-parent SBF SHA-256: `e8a75bcaf13ea889cff991163786accf2ad050526dbb4423230fdf1381629b05`
- RED commit: `752a02f2`
- RED result: stale policy lands, a user pays 580 atoms, the attacker receives 580 internal capital and withdraws 580 vault tokens.
- Fix commit: `731463ba`
- Fixed SBF SHA-256: `cbfad08ac369f35f64b8f4e0b2395d230edb844e0d3bf66b3b3e734062ed11b0`
- GREEN result: stale policy rejects with `AssetGenerationMismatch`; the first 580 atoms remain in insurance, while a correctly bound current-generation policy still routes the next fee as configured.

## Fix

Tag 49 now carries the current base-asset `market_id`. The handler checks it before authority validation or fee-policy mutation. All callers, README documentation, and symbolic wire-layout checks are migrated. No authority, recovery override, or new fund-moving path is added.

## Verification

- `cargo test --test v16_cu --quiet`: 577 passed
- `cargo test --lib --quiet`: 5 passed
- `cargo kani --tests --only-codegen`: passed
- `cargo fmt --all`: passed
- `git diff --check`: passed