### PR TITLE
[BLOCKER LoF] Round composite oracle prices once

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -3658,22 +3658,6 @@ pub mod oracle_v16 {
         feeds[2] != [0u8; 32] && feeds[2] != feeds[0] && feeds[2] != feeds[1]
     }
 
-    fn leg_divides(config: &WrapperConfigV16, idx: usize) -> bool {
-        match idx {
-            1 => (config.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
-            2 => (config.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
-            _ => false,
-        }
-    }
-
-    fn profile_leg_divides(profile: &AssetOracleProfileV16, idx: usize) -> bool {
-        match idx {
-            1 => (profile.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
-            2 => (profile.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
-            _ => false,
-        }
-    }
-
     pub fn read_pyth_price_e6(
         price_ai: &AccountInfo,
         expected_feed_id: &[u8; 32],
@@ -3914,48 +3898,81 @@ pub mod oracle_v16 {
         }
     }
 
-    fn apply_transform(raw_price: u64, invert: u8, unit_scale: u32) -> Result<u64, ProgramError> {
-        let mut price = raw_price;
-        // Guard zero BEFORE the invert divide: a multi-leg `compose` with a divide leg can floor the
-        // accumulator to 0, and `1e12 / 0` would panic. A zero price is always OracleInvalid anyway
-        // (the post-transform check below already rejects it), so this only converts the panic into
-        // the same graceful error — no valid behavior changes (valid oracle prices are nonzero).
-        if price == 0 {
+    fn compose_price_e6(
+        prices_e6: &[u64],
+        flags: u8,
+        invert: u8,
+        unit_scale: u32,
+    ) -> Result<u64, ProgramError> {
+        if prices_e6.is_empty()
+            || prices_e6.len() > ORACLE_LEG_CAP
+            || invert > 1
+            || (flags & !ORACLE_LEG_FLAGS_MASK) != 0
+            || (prices_e6.len() == 1 && flags != 0)
+            || (prices_e6.len() == 2 && (flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0)
+        {
+            return Err(PercolatorError::EngineInvalidConfig.into());
+        }
+        if prices_e6
+            .iter()
+            .any(|price| *price == 0 || *price > percolator::MAX_ORACLE_PRICE)
+        {
             return Err(PercolatorError::OracleInvalid.into());
         }
-        if invert != 0 {
-            price = (1_000_000_000_000u128 / price as u128)
-                .try_into()
-                .map_err(|_| PercolatorError::OracleInvalid)?;
-        }
-        if unit_scale > 1 {
-            price /= unit_scale as u64;
-        }
-        if price == 0 || price > percolator::MAX_ORACLE_PRICE {
-            return Err(PercolatorError::OracleInvalid.into());
-        }
-        Ok(price)
-    }
 
-    fn compose(acc_e6: u64, leg_e6: u64, divide: bool) -> Result<u64, ProgramError> {
-        if leg_e6 == 0 {
+        // Keep the exact rational across all legs. With at most three E6 prices bounded by
+        // MAX_ORACLE_PRICE, both products are at most 1e36 and fit in u128.
+        let mut numerator = prices_e6[0] as u128;
+        let mut denominator = 1u128;
+        let mut i = 1usize;
+        while i < prices_e6.len() {
+            let divide = match i {
+                1 => (flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
+                2 => (flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
+                _ => false,
+            };
+            if divide {
+                numerator = numerator
+                    .checked_mul(1_000_000)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                denominator = denominator
+                    .checked_mul(prices_e6[i] as u128)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            } else {
+                numerator = numerator
+                    .checked_mul(prices_e6[i] as u128)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                denominator = denominator
+                    .checked_mul(1_000_000)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            }
+
+            // Preserve the old per-leg range gate, but do not feed this rounded quotient into the
+            // next leg. A later divide must see the remainder discarded by this check.
+            let intermediate = numerator / denominator;
+            if intermediate == 0 || intermediate > percolator::MAX_ORACLE_PRICE as u128 {
+                return Err(PercolatorError::OracleInvalid.into());
+            }
+            i += 1;
+        }
+
+        // Invert the retained fraction, not an already-rounded E6 integer. Dividing the final
+        // quotient by an integer unit_scale is equivalent to one combined floor.
+        if invert != 0 {
+            let inverted_numerator = denominator
+                .checked_mul(1_000_000_000_000)
+                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            denominator = numerator;
+            numerator = inverted_numerator;
+        }
+        let mut price = numerator / denominator;
+        if unit_scale > 1 {
+            price /= unit_scale as u128;
+        }
+        if price == 0 || price > percolator::MAX_ORACLE_PRICE as u128 {
             return Err(PercolatorError::OracleInvalid.into());
         }
-        let next = if divide {
-            (acc_e6 as u128)
-                .checked_mul(1_000_000)
-                .ok_or(PercolatorError::EngineArithmeticOverflow)?
-                / leg_e6 as u128
-        } else {
-            (acc_e6 as u128)
-                .checked_mul(leg_e6 as u128)
-                .ok_or(PercolatorError::EngineArithmeticOverflow)?
-                / 1_000_000
-        };
-        if next == 0 || next > percolator::MAX_ORACLE_PRICE as u128 {
-            return Err(PercolatorError::OracleInvalid.into());
-        }
-        Ok(next as u64)
+        Ok(price as u64)
     }
 
     pub fn read_external_price_e6(
@@ -3977,7 +3994,7 @@ pub mod oracle_v16 {
         ) {
             return Err(PercolatorError::EngineInvalidConfig.into());
         }
-        let mut acc = 0u64;
+        let mut prices = [0u64; ORACLE_LEG_CAP];
         let mut advanced = false;
         let mut max_publish_time = i64::MIN;
         let mut i = 0usize;
@@ -4005,15 +4022,16 @@ pub mod oracle_v16 {
                 advanced = true;
             }
             max_publish_time = core::cmp::max(max_publish_time, publish_time);
-            acc = if i == 0 {
-                price
-            } else {
-                compose(acc, price, leg_divides(config, i))?
-            };
+            prices[i] = price;
             i += 1;
         }
         Ok((
-            apply_transform(acc, config.invert, config.unit_scale)?,
+            compose_price_e6(
+                &prices[..count],
+                config.oracle_leg_flags,
+                config.invert,
+                config.unit_scale,
+            )?,
             max_publish_time,
             advanced,
         ))
@@ -4038,7 +4056,7 @@ pub mod oracle_v16 {
         ) {
             return Err(PercolatorError::EngineInvalidConfig.into());
         }
-        let mut acc = 0u64;
+        let mut prices = [0u64; ORACLE_LEG_CAP];
         let mut advanced = false;
         let mut max_publish_time = i64::MIN;
         let mut i = 0usize;
@@ -4066,15 +4084,16 @@ pub mod oracle_v16 {
                 advanced = true;
             }
             max_publish_time = core::cmp::max(max_publish_time, publish_time);
-            acc = if i == 0 {
-                price
-            } else {
-                compose(acc, price, profile_leg_divides(profile, i))?
-            };
+            prices[i] = price;
             i += 1;
         }
         Ok((
-            apply_transform(acc, profile.invert, profile.unit_scale)?,
+            compose_price_e6(
+                &prices[..count],
+                profile.oracle_leg_flags,
+                profile.invert,
+                profile.unit_scale,
+            )?,
             max_publish_time,
             advanced,
         ))

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -54276,20 +54276,26 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
         env.set_pyth_price_with_conf(&feeds[1], 1_000_000, -6, 0, 100),
         env.set_pyth_price_with_conf(&feeds[2], 2, -6, 0, 100),
     ];
-    env.try_configure_hybrid_asset_with_conf_filter_cu(
-        0,
-        3,
-        ORACLE_LEG_FLAG_DIVIDE_LEG2 | ORACLE_LEG_FLAG_DIVIDE_LEG3,
-        feeds,
-        &initial,
-        1,
-        100,
-        0,
-        0,
-        1_000,
-        0,
-    )
-    .expect("configure exact 1.5 three-leg cross-rate");
+    let configure_cu = env
+        .try_configure_hybrid_asset_with_conf_filter_cu(
+            0,
+            3,
+            ORACLE_LEG_FLAG_DIVIDE_LEG2 | ORACLE_LEG_FLAG_DIVIDE_LEG3,
+            feeds,
+            &initial,
+            1,
+            100,
+            0,
+            0,
+            1_000,
+            0,
+        )
+        .expect("configure exact 1.5 three-leg cross-rate");
+    assert_cu_within(
+        "single-round composite configure",
+        configure_cu,
+        CUSTODY_CU_LIMIT,
+    );
     assert_eq!(env.market_state().0.oracle_target_price_e6, 1_500_000);
 
     let victim_owner = Keypair::new();
@@ -54324,10 +54330,11 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
     // On the affected implementation the target is 1.0 and the mark eventually reaches it; with
     // one final rational round, the target remains 1.5 and every call is harmless.
     let mut slot = 1u64;
+    let mut max_crank_cu = 0u64;
     for _ in 0..12 {
         slot += production_risk_params().max_accrual_dt_slots;
         set_test_clock(&mut env, slot, 101);
-        env.crank_with_oracle_tail(
+        let cu = env.crank_with_oracle_tail(
             cranker,
             ProgInstruction::PermissionlessCrank {
                 now_slot: slot,
@@ -54335,11 +54342,12 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
             },
             &changed,
         );
+        max_crank_cu = max_crank_cu.max(cu);
     }
 
     // Refresh the victim first, then let an unprivileged cranker try the now-current liquidation
     // route with its own reward portfolio.
-    env.crank_with_oracle_tail(
+    let refresh_cu = env.crank_with_oracle_tail(
         victim,
         ProgInstruction::PermissionlessCrank {
             now_slot: slot,
@@ -54347,7 +54355,9 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
         },
         &changed,
     );
+    max_crank_cu = max_crank_cu.max(refresh_cu);
     let victim_capital_before = env.portfolio_state(victim).capital.get();
+    let victim_cert_before = health_cert(&env.portfolio_state(victim));
     let cranker_capital_before = env.portfolio_state(cranker).capital.get();
     let oi_before = env.market_state().1.assets[0].oi_eff_long_q;
 
@@ -54367,6 +54377,14 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
             AccountMeta::new(cranker, false),
         ],
         &[&cranker_owner],
+    );
+    if let Ok(cu) = liquidation_attempt.as_ref() {
+        max_crank_cu = max_crank_cu.max(*cu);
+    }
+    assert_cu_within(
+        "single-round composite public crank",
+        max_crank_cu,
+        CRANK_CU_LIMIT,
     );
 
     let (cfg_after, group_after) = env.market_state();
@@ -54392,15 +54410,20 @@ fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
             && group_after.assets[0].effective_price == 1_500_000
             && group_after.assets[0].oi_eff_long_q == oi_before
             && victim_after.capital.get() == victim_capital_before
+            && victim_cert_before.certified_liq_deficit == 0
             && extracted_reward == 0,
         "constant exact cross-rate changed: target={}, mark={}, long_oi={}->{}, \
-         victim_capital={}->{}, cranker_reward={}, extracted_reward={}, liquidation={:?}",
+         victim_capital={}->{}, equity={}, maintenance={}, deficit={}, cranker_reward={}, \
+         extracted_reward={}, liquidation={:?}",
         cfg_after.oracle_target_price_e6,
         group_after.assets[0].effective_price,
         oi_before,
         group_after.assets[0].oi_eff_long_q,
         victim_capital_before,
         victim_after.capital.get(),
+        victim_cert_before.certified_equity,
+        victim_cert_before.certified_maintenance_req,
+        victim_cert_before.certified_liq_deficit,
         cranker_reward,
         extracted_reward,
         liquidation_attempt,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -54260,6 +54260,153 @@ fn v16_bpf_oracle_composite_divide_legs_produce_correct_cross_rate() {
     );
 }
 
+// A composite must retain its rational remainder until the final E6 result. These two fully
+// authenticated feed tuples encode the same exact rate, 1.5, but sequential E6 flooring turns the
+// second tuple into 1.0. That wrong mark makes a healthy long liquidatable and pays an attacker a
+// real, withdrawable cranker reward.
+#[test]
+fn v16_attack_composite_intermediate_rounding_cannot_false_liquidate() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.update_liquidation_fee_policy_with_cu(5_000);
+    set_test_clock(&mut env, 1, 100);
+
+    let feeds = [[0xe1u8; 32], [0xe2u8; 32], [0xe3u8; 32]];
+    let initial = [
+        env.set_pyth_price_with_conf(&feeds[0], 3, -6, 0, 100),
+        env.set_pyth_price_with_conf(&feeds[1], 1_000_000, -6, 0, 100),
+        env.set_pyth_price_with_conf(&feeds[2], 2, -6, 0, 100),
+    ];
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        3,
+        ORACLE_LEG_FLAG_DIVIDE_LEG2 | ORACLE_LEG_FLAG_DIVIDE_LEG3,
+        feeds,
+        &initial,
+        1,
+        100,
+        0,
+        0,
+        1_000,
+        0,
+    )
+    .expect("configure exact 1.5 three-leg cross-rate");
+    assert_eq!(env.market_state().0.oracle_target_price_e6, 1_500_000);
+
+    let victim_owner = Keypair::new();
+    let counterparty_owner = Keypair::new();
+    let cranker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let counterparty = env.create_portfolio(&counterparty_owner);
+    let cranker = env.create_portfolio(&cranker_owner);
+    env.deposit(&victim_owner, victim, 540_000);
+    env.deposit(&counterparty_owner, counterparty, 540_000);
+    env.deposit(&cranker_owner, cranker, 1_000);
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &counterparty_owner,
+        counterparty,
+        POS_SCALE as i128,
+        1_500_000,
+        0,
+    );
+
+    // 3 / 2_000_000 / 1 has the same exact E6 value as 3 / 1_000_000 / 2:
+    // floor(3 * 1e6 * 1e6 / (2_000_000 * 1)) == 1_500_000.
+    let changed = [
+        env.set_pyth_price_with_conf(&feeds[0], 3, -6, 0, 101),
+        env.set_pyth_price_with_conf(&feeds[1], 2_000_000, -6, 0, 101),
+        env.set_pyth_price_with_conf(&feeds[2], 1, -6, 0, 101),
+    ];
+
+    // Drive the production 24-bps/slot clamp through bounded public cranks on a neutral account.
+    // On the affected implementation the target is 1.0 and the mark eventually reaches it; with
+    // one final rational round, the target remains 1.5 and every call is harmless.
+    let mut slot = 1u64;
+    for _ in 0..12 {
+        slot += production_risk_params().max_accrual_dt_slots;
+        set_test_clock(&mut env, slot, 101);
+        env.crank_with_oracle_tail(
+            cranker,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            &changed,
+        );
+    }
+
+    // Refresh the victim first, then let an unprivileged cranker try the now-current liquidation
+    // route with its own reward portfolio.
+    env.crank_with_oracle_tail(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: slot,
+            observations: crank_observations(0),
+        },
+        &changed,
+    );
+    let victim_capital_before = env.portfolio_state(victim).capital.get();
+    let cranker_capital_before = env.portfolio_state(cranker).capital.get();
+    let oi_before = env.market_state().1.assets[0].oi_eff_long_q;
+
+    env.svm.expire_blockhash();
+    let liquidation_attempt = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: slot,
+            observations: crank_observations_with_accounts(0, 3),
+        },
+        vec![
+            AccountMeta::new(cranker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new_readonly(changed[0], false),
+            AccountMeta::new_readonly(changed[1], false),
+            AccountMeta::new_readonly(changed[2], false),
+            AccountMeta::new(cranker, false),
+        ],
+        &[&cranker_owner],
+    );
+
+    let (cfg_after, group_after) = env.market_state();
+    let victim_after = env.portfolio_state(victim);
+    let cranker_reward = env
+        .portfolio_state(cranker)
+        .capital
+        .get()
+        .saturating_sub(cranker_capital_before);
+    let extracted_reward = if cranker_reward == 0 {
+        0
+    } else {
+        assert!(
+            liquidation_attempt.is_ok(),
+            "a credited reward must come from a committed liquidation"
+        );
+        let dest = env.withdraw(&cranker_owner, cranker, cranker_reward);
+        env.token_amount(dest)
+    };
+
+    assert!(
+        cfg_after.oracle_target_price_e6 == 1_500_000
+            && group_after.assets[0].effective_price == 1_500_000
+            && group_after.assets[0].oi_eff_long_q == oi_before
+            && victim_after.capital.get() == victim_capital_before
+            && extracted_reward == 0,
+        "constant exact cross-rate changed: target={}, mark={}, long_oi={}->{}, \
+         victim_capital={}->{}, cranker_reward={}, extracted_reward={}, liquidation={:?}",
+        cfg_after.oracle_target_price_e6,
+        group_after.assets[0].effective_price,
+        oi_before,
+        group_after.assets[0].oi_eff_long_q,
+        victim_capital_before,
+        victim_after.capital.get(),
+        cranker_reward,
+        extracted_reward,
+        liquidation_attempt,
+    );
+}
+
 // ForfeitRecoveryLeg owner-gating + input guard (sibling of v16_attack_rebalance_reduce_owner_gated, which
 // was tested while ForfeitRecoveryLeg was not). handle_forfeit_recovery_leg uses with_one_portfolio_view
 // (owner_must_sign=true), so a non-owner forfeiting a victim's recovery leg -- which would force the victim


### PR DESCRIPTION
## What changed

- Replace sequential per-leg E6 flooring with one checked rational numerator/denominator carried across all configured oracle legs.
- Apply inversion to the retained fraction and round only the final transformed E6 output.
- Preserve the existing per-leg zero and maximum-price gates without feeding their rounded quotient into the next leg.
- Add a public LiteSVM TDD regression with production risk parameters, authenticated three-leg Pyth observations, the real dt clamp, permissionless liquidation, cranker reward credit, and SPL withdrawal.

## Root cause and impact

For divide composites the wrapper evaluated `floor(floor(A*1e6/B)*1e6/C)`. A later small divisor can amplify the fraction discarded by the first divide. Two authenticated feed tuples with the same exact cross-rate of 1,500,000 therefore moved the stored target and mark to 1,000,000.

The exact-parent RED at `ccba79ed` opened an independent victim long and then used only permissionless cranks. The bad mark reduced long OI from 1,000,000 to 797,979, charged victim capital from 40,000 to 39,898, credited 51 atoms to the cranker, and allowed all 51 atoms to be withdrawn. The committed liquidation used 290,371 CU. Neither trader signed an oracle update or liquidation, and the oracle values themselves preserved the configured mathematical rate.

The fixed head keeps target and effective mark at 1,500,000, leaves the health certificate non-liquidatable, and preserves OI, victim capital, and cranker balance. Valid three-leg products are bounded by 1e36, below `u128::MAX`; checked arithmetic remains in place.

This is wrapper-specific oracle arithmetic. The engine pin remains `143e68c4917ed0400a27b952f036a5677047cd84`.

Fixes #327.

## Verification

- Exact-parent public SBF RED at `ccba79ed` with committed false liquidation and extracted SPL reward
- Fixed public SBF GREEN at `9cbfcda1`
- `cargo build-sbf --tools-version v1.52`
- Built `tests/fixtures/auth_matcher` and `tests/fixtures/hostile_matcher` with platform tools v1.52
- `cargo test --all-targets`: 6/6 unit and 566/566 public LiteSVM/CU tests passed
- New configuration and crank paths remain below `CUSTODY_CU_LIMIT` and `CRANK_CU_LIMIT`
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`