### PR TITLE
[BLOCKER LoF] Recover terminal bankruptcy double charge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=76a86f483dd1dd3d3fffa51bea1bba67a8168411#76a86f483dd1dd3d3fffa51bea1bba67a8168411"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "76a86f483dd1dd3d3fffa51bea1bba67a8168411" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "76a86f483dd1dd3d3fffa51bea1bba67a8168411" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8173,6 +8173,9 @@ pub mod processor {
                 if !live_authority_matches(&authorities.insurance_authority, operator.key) {
                     return Err(PercolatorError::Unauthorized.into());
                 }
+                group
+                    .recredit_terminal_claim_free_residual_for_asset_not_atomic(asset_index)
+                    .map_err(map_v16_error)?;
                 authorities.insurance_authority
             };
             let available = market_insurance_withdraw_capacity_view(&group, asset_index)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -17322,6 +17322,7 @@ fn v16_public_bankruptcy_recredits_claim_free_residual_to_provider() {
     const POSITION_Q: i128 = 1_000_000_000_000;
     const INITIAL_MARK: u64 = 100;
     const FINAL_MARK: u64 = 130;
+    const MAX_MARKET_SLOTS: usize = 5_834;
 
     let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
         maintenance_margin_bps: 1_000,
@@ -17543,31 +17544,66 @@ fn v16_public_bankruptcy_recredits_claim_free_residual_to_provider() {
     assert_eq!(after_users.materialized_portfolio_count, 0);
     assert_eq!(after_users.c_tot, 0);
     assert_eq!(
-        after_users.insurance, 200_000_000,
-        "the last portfolio close must return the 20M claim-free duplicate charge to insurance"
+        after_users.insurance, 180_000_000,
+        "the duplicate 20M remains residual until its asset provider asks to withdraw"
     );
     assert_eq!(
         after_users.insurance_domain_budget_remaining_total, after_users.insurance,
-        "all terminal insurance is again provider-withdrawable"
+        "all currently classified terminal insurance remains provider-withdrawable"
     );
 
+    // Preserve the publicly reached accounting state while expanding only the
+    // disabled tail to the largest market shape that fits Solana's account cap.
+    // The provider recovery below must remain asset-local rather than scanning
+    // every configured domain.
+    let max_market_len =
+        state::market_account_len_for_capacity(MAX_MARKET_SLOTS).expect("max market length");
+    let asset0_profile = {
+        let account = env.svm.get_account(&env.market).unwrap();
+        state::read_asset_oracle_profile(&account.data, 0).unwrap()
+    };
+    {
+        let mut account = env.svm.get_account(&env.market).unwrap();
+        account.data.resize(max_market_len, 0);
+        account.lamports = account.lamports.max(max_market_len as u64 * 10);
+        env.svm.set_account(env.market, account).unwrap();
+    }
+    env.mutate_market(|_cfg, group| {
+        group.config.max_market_slots = MAX_MARKET_SLOTS as u32;
+        group.next_market_id = (MAX_MARKET_SLOTS as u64) + 1;
+    });
+    {
+        let mut account = env.svm.get_account(&env.market).unwrap();
+        state::write_asset_oracle_profile(&mut account.data, 0, &asset0_profile).unwrap();
+        env.svm.set_account(env.market, account).unwrap();
+    }
+
     let provider_destination = env.token_account(provider.pubkey(), 0);
-    env.send(
-        ProgInstruction::WithdrawInsuranceAsset {
-            asset_index: 0,
-            amount: after_users.insurance,
-        },
-        vec![
-            AccountMeta::new(provider.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(provider_destination, false),
-            AccountMeta::new(env.vault, false),
-            AccountMeta::new_readonly(env.vault_authority, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-        ],
-        &[&provider],
-    )
-    .expect("provider recovers terminal insurance");
+    let insurance_withdraw_cu = env
+        .send(
+            ProgInstruction::WithdrawInsuranceAsset {
+                asset_index: 0,
+                amount: 2 * DOMAIN_TRANCHE,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_destination, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&provider],
+        )
+        .expect("provider recovers terminal insurance");
+    println!(
+        "terminal overlap recredit + withdrawal: assets={MAX_MARKET_SLOTS}, CU={insurance_withdraw_cu}"
+    );
+    assert_cu_within(
+        "asset-local terminal overlap recredit and withdrawal",
+        insurance_withdraw_cu,
+        CUSTODY_CU_LIMIT,
+    );
     for domain in [0u16, 1] {
         let backing = env.market_state().1.source_backing_buckets[domain as usize]
             .fresh_unliened_backing_num

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -17309,6 +17309,298 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
     );
 }
 
+// Issue #289 / BLOCKER LoF + terminal DoS: a public bankruptcy first spends
+// same-domain insurance, while the winner's source claim later consumes
+// counterparty backing. Once every portfolio exits, the insurance spend must be
+// recredited from the now-claim-free residual. Otherwise the provider bears the
+// same deficit twice and the duplicate charge remains ownerless in the vault.
+#[test]
+fn v16_public_bankruptcy_recredits_claim_free_residual_to_provider() {
+    const DOMAIN_TRANCHE: u128 = 100_000_000;
+    const PROVIDER_PRINCIPAL: u128 = 4 * DOMAIN_TRANCHE;
+    const TRADER_CAPITAL: u128 = 10_000_000;
+    const POSITION_Q: i128 = 1_000_000_000_000;
+    const INITIAL_MARK: u64 = 100;
+    const FINAL_MARK: u64 = 130;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        maintenance_margin_bps: 1_000,
+        initial_margin_bps: 1_000,
+        max_price_move_bps_per_slot: 500,
+        ..V16CuMarketParams::default()
+    });
+    let provider = Keypair::new();
+    let oracle = Keypair::new();
+    env.ensure_signer_account(provider.pubkey());
+    env.ensure_signer_account(oracle.pubkey());
+
+    let admin = env.admin.insecure_clone();
+    for (kind, incoming) in [
+        (processor::ASSET_AUTH_INSURANCE, &provider),
+        (processor::ASSET_AUTH_INSURANCE_OPERATOR, &provider),
+        (processor::ASSET_AUTH_BACKING_BUCKET, &provider),
+        (processor::ASSET_AUTH_ORACLE, &oracle),
+    ] {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::UpdateAssetAuthority {
+                asset_index: 0,
+                kind,
+                new_pubkey: incoming.pubkey().to_bytes(),
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new_readonly(incoming.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&admin, incoming],
+        )
+        .expect("cold admin delegates the funded domains and oracle");
+    }
+
+    env.configure_auth_mark_for_asset_with_authority(0, &oracle, 100, INITIAL_MARK);
+    for domain in [0u16, 1] {
+        env.top_up_insurance_domain_with_authority(&provider, domain, DOMAIN_TRANCHE);
+        env.top_up_backing_bucket_with_authority(&provider, domain, DOMAIN_TRANCHE, 10_000);
+    }
+    assert_eq!(
+        env.market_state().1.vault,
+        PROVIDER_PRINCIPAL,
+        "independent provider funds real insurance and backing"
+    );
+
+    let observer = Keypair::new();
+    let observer_portfolio = env.create_portfolio(&observer);
+    let long = Keypair::new();
+    let long_portfolio = env.create_portfolio(&long);
+    let short = Keypair::new();
+    let short_portfolio = env.create_portfolio(&short);
+    env.deposit(&long, long_portfolio, TRADER_CAPITAL);
+    env.deposit(&short, short_portfolio, TRADER_CAPITAL);
+    env.trade_asset_with_cu(
+        0,
+        &long,
+        long_portfolio,
+        &short,
+        short_portfolio,
+        POSITION_Q,
+        INITIAL_MARK,
+        0,
+    );
+
+    let public_crank = |env: &mut V16CuEnv, portfolio: Pubkey, now_slot: u64, observe: bool| {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot,
+                observations: if observe {
+                    crank_observations(0)
+                } else {
+                    vec![]
+                },
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        )
+    };
+
+    let mut slot = 101u64;
+    env.svm.warp_to_slot(slot);
+    env.push_auth_mark_for_asset_with_authority(0, &oracle, slot, FINAL_MARK);
+    for _ in 0..64 {
+        env.svm.warp_to_slot(slot);
+        public_crank(&mut env, observer_portfolio, slot, true)
+            .expect("permissionless observation advances the bounded honest mark");
+        if env.market_state().1.assets[0].effective_price == FINAL_MARK {
+            break;
+        }
+        slot = slot.checked_add(1).unwrap();
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        FINAL_MARK,
+        "the authenticated mark reaches the ordinary market move"
+    );
+
+    public_crank(&mut env, short_portfolio, slot, true)
+        .expect("settle the losing account at the reached mark");
+    for _ in 0..4 {
+        public_crank(&mut env, short_portfolio, slot, false)
+            .expect("permissionless liquidation makes bounded progress");
+    }
+    assert!(
+        percolator::active_bitmap_is_empty(
+            env.portfolio_state(short_portfolio)
+                .active_bitmap
+                .map(|word| word.get())
+        ),
+        "the bankrupt short is fully closed"
+    );
+
+    public_crank(&mut env, long_portfolio, slot, false).expect("refresh the reset winner");
+    env.send(
+        ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: 0,
+            b_delta_budget: percolator::MAX_VAULT_TVL,
+        },
+        vec![
+            AccountMeta::new(long.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long_portfolio, false),
+        ],
+        &[&long],
+    )
+    .expect("winner clears the stale recovery leg");
+    for side in [0u8, 1] {
+        env.send(
+            ProgInstruction::FinalizeResetSide {
+                asset_index: 0,
+                side,
+            },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .expect("permissionless side reset completes");
+    }
+    assert!(
+        percolator::active_bitmap_is_empty(
+            env.portfolio_state(long_portfolio)
+                .active_bitmap
+                .map(|word| word.get())
+        ),
+        "the winner has no live leg before resolution"
+    );
+
+    env.resolve();
+    let owners = [&observer, &long, &short];
+    let portfolios = [observer_portfolio, long_portfolio, short_portfolio];
+    let destinations = owners.map(|owner| env.token_account(owner.pubkey(), 0));
+    for _ in 0..512 {
+        let mut open = 0usize;
+        for index in 0..portfolios.len() {
+            if env
+                .svm
+                .get_account(&portfolios[index])
+                .map_or(true, |account| account.lamports == 0)
+            {
+                continue;
+            }
+            open += 1;
+            let payout_accounts = vec![
+                AccountMeta::new_readonly(owners[index].pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolios[index], false),
+                AccountMeta::new(destinations[index], false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ];
+            let _ = env.send(
+                ProgInstruction::CloseResolved {
+                    fee_rate_per_slot: 0,
+                },
+                payout_accounts.clone(),
+                &[owners[index]],
+            );
+            let _ = env.send(
+                ProgInstruction::ClaimResolvedPayoutTopup,
+                payout_accounts,
+                &[owners[index]],
+            );
+            let _ = env.send(
+                ProgInstruction::ClosePortfolio,
+                vec![
+                    AccountMeta::new(owners[index].pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolios[index], false),
+                ],
+                &[owners[index]],
+            );
+        }
+        if open == 0 {
+            break;
+        }
+    }
+    assert!(
+        portfolios.iter().all(|portfolio| env
+            .svm
+            .get_account(portfolio)
+            .map_or(true, |account| account.lamports == 0)),
+        "every public portfolio reaches terminal dematerialization"
+    );
+    let trader_payouts = destinations.map(|destination| env.token_amount(destination) as u128);
+    assert_eq!(
+        trader_payouts,
+        [0, 40_000_000, 0],
+        "the public bankruptcy pays the winner exactly once"
+    );
+
+    let after_users = env.market_state().1;
+    assert_eq!(after_users.materialized_portfolio_count, 0);
+    assert_eq!(after_users.c_tot, 0);
+    assert_eq!(
+        after_users.insurance, 200_000_000,
+        "the last portfolio close must return the 20M claim-free duplicate charge to insurance"
+    );
+    assert_eq!(
+        after_users.insurance_domain_budget_remaining_total, after_users.insurance,
+        "all terminal insurance is again provider-withdrawable"
+    );
+
+    let provider_destination = env.token_account(provider.pubkey(), 0);
+    env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            amount: after_users.insurance,
+        },
+        vec![
+            AccountMeta::new(provider.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(provider_destination, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&provider],
+    )
+    .expect("provider recovers terminal insurance");
+    for domain in [0u16, 1] {
+        let backing = env.market_state().1.source_backing_buckets[domain as usize]
+            .fresh_unliened_backing_num
+            / BOUND_SCALE;
+        if backing == 0 {
+            continue;
+        }
+        env.send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain,
+                amount: backing,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_destination, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&provider],
+        )
+        .expect("provider recovers remaining source backing");
+    }
+    assert_eq!(
+        env.token_amount(provider_destination) as u128,
+        380_000_000,
+        "provider bears the traders' 20M net gain exactly once"
+    );
+    assert_eq!(env.market_state().1.vault, 0);
+    env.close_slab_with_cu();
+}
+
 // security.md sweep — resolved wind-down LoF / over-claim (#22/#30/#48): a market can be resolved
 // with OPEN positions (handle_resolve_market does not require flat). After resolution a long and a
 // short must each recover their FAIR value via CloseResolved — neither stuck (LoF) nor able to


### PR DESCRIPTION
## Finding

Closes #289.

An exact-parent public LiteSVM lifecycle demonstrates a provider loss and terminal market lock:

1. An independent provider funds both insurance and backing domains.
2. Two users trade through the public interface.
3. An authenticated mark move makes the short bankrupt.
4. Permissionless liquidation spends `20M` insurance.
5. Resolution realizes the winner source-backed claim against counterparty backing for the same loss.
6. Before the fix, the provider recovers `360M` from `400M`; `20M` remains ownerless in the vault and `CloseSlab` fails.

The provider should bear the traders `20M` net gain once, recovering `380M`, with no residual vault balance.

## Fix

- Pin engine PR aeyakovenko/percolator#157.
- Before a resolved `WithdrawInsuranceAsset`, invoke the engine claim-free sweep for that asset.
- Keep recovery lazy and asset-local: the instruction touches two source domains, so maximal sparse markets cannot turn final portfolio close into an O(N) CU failure.

## TDD proof

`v16_public_bankruptcy_recredits_claim_free_residual_to_provider` uses only public instructions and real SPL custody for the exploit lifecycle. It is RED at exact parent `36fa587e` and GREEN here: every portfolio dematerializes, the winner is paid once, the provider recovers `380M`, custody reaches zero, and `CloseSlab` succeeds.

The same reached terminal state is then expanded only with canonical disabled slots to the maximal 5,834-slot fixture. The real SBF recredit plus provider withdrawal succeeds at `126,863 CU`, proving the fix remains bounded.

## Verification

- `cargo build-sbf --tools-version v1.52`: green.
- Wrapper unit + public LiteSVM/CU matrix: `6 + 566` green.
- Engine matrix: `50 + 11 + 15 + 2 + 9 + 1 + 72` green.
- Kani pure cap proof: `0/25` failed, `3/3` cap branches covered.
- Kani whole mutation proof: `0/3579` failed, required nonzero mutation covered.