### PR TITLE
[BLOCKER LoF] Sequence-bind matcher config intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,14 +352,17 @@ This makes it a "pure identity signer" and prevents it from becoming an attack s
 ### LP matcher config (TradeCpi / BatchTradeCpi)
 Unsigned LP matcher fills require an enabled matcher config stored directly on the LP portfolio.
 
-`SetMatcherConfig` (tag 68) is signed by the LP owner and writes:
+`SetMatcherConfig` (tag 68) is signed by the LP owner, supplies the current portfolio incarnation
+ID and matcher-config sequence, and writes:
 
-`matcher_program, matcher_context, matcher_delegate, enabled`
+`matcher_program, matcher_context, matcher_delegate, enabled, next_sequence`
 
 During `TradeCpi` / `BatchTradeCpi`, Percolator reads this LP-account config and requires the
 instruction's matcher program, matcher context, and matcher delegate PDA to match it byte-for-byte.
 Extra matcher CPI tail accounts begin immediately after the matcher delegate. Disabled configs,
 wrong matcher program/context/delegate, wrong LP owner, or wrong LP portfolio all reject.
+Every successful config update advances the sequence, so delayed signed grants cannot override a
+newer revocation. The portfolio ID also rejects an intent signed for a closed account incarnation.
 
 ### Matcher context (TradeCpi)
 - account owned by matcher program
@@ -447,8 +450,9 @@ This section describes intent and operational ordering, not argument-by-argument
     anti-spoof binding as `TradeCpi`, then all fills apply through the batch path. Bounded to 16
     legs (the matcher's return-data cap).
 - **SetMatcherConfig** (tag 68)
-  - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
-    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.
+  - LP-owner-signed, incarnation- and sequence-bound opt-in/out for unsigned LP matcher fills. This
+    writes the matcher config tail on the LP portfolio: matcher program, matcher context, matcher
+    delegate, enabled flag, and next sequence.
 
 ### Oracle / mark management
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
@@ -761,7 +765,8 @@ Call `InitMarket` with:
   - deploy or choose matcher program
   - create matcher context account owned by matcher program
   - create a portfolio with `InitPortfolio`
-  - call `SetMatcherConfig` with the LP owner signing the exact matcher program/context/delegate tuple
+  - call `SetMatcherConfig` with the LP owner signing the portfolio ID, current config sequence, and
+    exact matcher program/context/delegate tuple
   - deposit collateral with `Deposit`
 - User:
   - create a portfolio with `InitPortfolio`

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -658,7 +658,29 @@ pub mod state {
         pub matcher_program: [u8; 32],
         pub matcher_context: [u8; 32],
         pub matcher_delegate: [u8; 32],
-        pub enabled: u64,
+        pub enabled: u8,
+        sequence_le: [u8; 7],
+    }
+
+    impl PortfolioMatcherConfigV16 {
+        pub const MAX_SEQUENCE: u64 = (1u64 << 56) - 1;
+
+        #[inline]
+        pub fn sequence(&self) -> u64 {
+            let mut bytes = [0u8; 8];
+            bytes[..7].copy_from_slice(&self.sequence_le);
+            u64::from_le_bytes(bytes)
+        }
+
+        #[inline]
+        pub fn set_sequence(&mut self, sequence: u64) -> Result<(), ProgramError> {
+            if sequence > Self::MAX_SEQUENCE {
+                return Err(PercolatorError::EngineCounterOverflow.into());
+            }
+            self.sequence_le
+                .copy_from_slice(&sequence.to_le_bytes()[..7]);
+            Ok(())
+        }
     }
 
     pub type AssetOracleStorageV16 = [u8; ASSET_ORACLE_WRAPPER_LEN];
@@ -792,12 +814,17 @@ pub mod state {
 
     #[inline]
     pub fn read_portfolio_id(data: &[u8]) -> Result<u64, ProgramError> {
-        check_header(data, KIND_PORTFOLIO)?;
-        let id = read_u64(data, PORTFOLIO_ID_OFF)?;
+        let id = read_portfolio_id_allow_legacy_zero(data)?;
         if id == 0 {
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(id)
+    }
+
+    #[inline]
+    pub fn read_portfolio_id_allow_legacy_zero(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        read_u64(data, PORTFOLIO_ID_OFF)
     }
 
     #[inline]
@@ -2508,6 +2535,8 @@ pub mod ix {
             legs: Vec<BatchTradeCpiLeg>,
         },
         SetMatcherConfig {
+            portfolio_id: u64,
+            expected_sequence: u64,
             enabled: u8,
         },
         ClosePortfolio,
@@ -2775,6 +2804,8 @@ pub mod ix {
                     Self::BatchTradeCpi { legs }
                 }
                 68 => Self::SetMatcherConfig {
+                    portfolio_id: read_u64(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                     enabled: read_u8(&mut rest)?,
                 },
                 8 => Self::ClosePortfolio,
@@ -3063,8 +3094,14 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    portfolio_id,
+                    expected_sequence,
+                    enabled,
+                } => {
                     out.push(68);
+                    push_u64(&mut out, portfolio_id);
+                    push_u64(&mut out, expected_sequence);
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
@@ -5255,9 +5292,17 @@ pub mod processor {
             Instruction::BatchTradeCpi { legs } => {
                 handle_batch_trade_cpi(program_id, accounts, &legs)
             }
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                portfolio_id,
+                expected_sequence,
+                enabled,
+            } => handle_set_matcher_config(
+                program_id,
+                accounts,
+                portfolio_id,
+                expected_sequence,
+                enabled,
+            ),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6710,6 +6755,8 @@ pub mod processor {
     fn handle_set_matcher_config<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_id: u64,
+        expected_sequence: u64,
         enabled: u8,
     ) -> ProgramResult {
         if enabled > 1 {
@@ -6734,7 +6781,17 @@ pub mod processor {
         if lp_portfolio_ai.data_len() < required_len {
             lp_portfolio_ai.realloc(required_len, true)?;
         }
-        let cfg = if enabled == 0 {
+        let current = state::read_portfolio_matcher_config(&lp_portfolio_ai.try_borrow_data()?)?;
+        let current_portfolio_id =
+            state::read_portfolio_id_allow_legacy_zero(&lp_portfolio_ai.try_borrow_data()?)?;
+        if portfolio_id != current_portfolio_id || expected_sequence != current.sequence() {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let next_sequence = expected_sequence
+            .checked_add(1)
+            .filter(|sequence| *sequence <= state::PortfolioMatcherConfigV16::MAX_SEQUENCE)
+            .ok_or(PercolatorError::EngineCounterOverflow)?;
+        let mut cfg = if enabled == 0 {
             state::PortfolioMatcherConfigV16::default()
         } else {
             let matcher_prog = account(accounts, 3)?;
@@ -6757,13 +6814,14 @@ pub mod processor {
                 matcher_ctx.key,
             );
             expect_key(matcher_delegate, &delegate)?;
-            state::PortfolioMatcherConfigV16 {
-                matcher_program: matcher_prog.key.to_bytes(),
-                matcher_context: matcher_ctx.key.to_bytes(),
-                matcher_delegate: matcher_delegate.key.to_bytes(),
-                enabled: 1,
-            }
+            let mut config = state::PortfolioMatcherConfigV16::default();
+            config.matcher_program = matcher_prog.key.to_bytes();
+            config.matcher_context = matcher_ctx.key.to_bytes();
+            config.matcher_delegate = matcher_delegate.key.to_bytes();
+            config.enabled = 1;
+            config
         };
+        cfg.set_sequence(next_sequence)?;
         state::write_portfolio_matcher_config(&mut lp_portfolio_ai.try_borrow_mut_data()?, &cfg)
     }
 
@@ -12201,6 +12259,28 @@ pub mod processor {
             assert_eq!(state::allocate_portfolio_id(41).unwrap(), (41, 42));
             assert_eq!(
                 state::allocate_portfolio_id(u64::MAX),
+                Err(PercolatorError::EngineCounterOverflow.into())
+            );
+        }
+
+        #[test]
+        fn matcher_config_sequence_preserves_tail_layout_and_bounds() {
+            assert_eq!(
+                core::mem::size_of::<state::PortfolioMatcherConfigV16>(),
+                constants::PORTFOLIO_MATCHER_CONFIG_LEN
+            );
+            let mut config = state::PortfolioMatcherConfigV16::default();
+            assert_eq!(config.enabled, 0);
+            assert_eq!(config.sequence(), 0);
+            config
+                .set_sequence(state::PortfolioMatcherConfigV16::MAX_SEQUENCE)
+                .unwrap();
+            assert_eq!(
+                config.sequence(),
+                state::PortfolioMatcherConfigV16::MAX_SEQUENCE
+            );
+            assert_eq!(
+                config.set_sequence(state::PortfolioMatcherConfigV16::MAX_SEQUENCE + 1),
                 Err(PercolatorError::EngineCounterOverflow.into())
             );
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -20553,6 +20553,164 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
 }
 
 #[test]
+fn v16_attack_delayed_matcher_enable_cannot_override_newer_revoke() {
+    const OPEN_SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+    const ATTACKER_DEPOSIT: u128 = 2_000_000;
+    const LP_DEPOSIT: u128 = 4_000_000;
+    const STALE_GRANT_PROFIT: u128 = 1_000_000;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+    let attacker = Keypair::new();
+    let lp_owner = Keypair::new();
+    let attacker_account = env.create_portfolio(&attacker);
+    let lp_account = env.create_portfolio(&lp_owner);
+    env.deposit(&attacker, attacker_account, ATTACKER_DEPOSIT);
+    env.deposit(&lp_owner, lp_account, LP_DEPOSIT);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp(&mut env, &lp_owner, lp_account);
+
+    // Model two independently signed intents that can land out of order under one still-valid
+    // recent blockhash. The owner first signs an enable, then decides to revoke it. Landing the
+    // newer revoke must make the older transaction stale rather than let it restore unsigned fills.
+    env.svm.expire_blockhash();
+    let recent_blockhash = env.svm.latest_blockhash();
+    let enable_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(lp_owner.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(lp_account, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new_readonly(matcher_context, false),
+            AccountMeta::new_readonly(matcher_delegate, false),
+        ],
+        data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+    };
+    let revoke_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(lp_owner.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(lp_account, false),
+        ],
+        data: ProgInstruction::SetMatcherConfig { enabled: 0 }.encode(),
+    };
+    let delayed_enable = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), enable_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &lp_owner],
+        recent_blockhash,
+    );
+    let newer_revoke = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), revoke_ix],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &lp_owner],
+        recent_blockhash,
+    );
+    env.svm
+        .send_transaction(newer_revoke)
+        .expect("newer matcher revoke lands first");
+    assert_eq!(env.portfolio_matcher_config(lp_account).enabled, 0);
+
+    let stale_enable = env.svm.send_transaction(delayed_enable);
+    if stale_enable.is_ok() {
+        assert_eq!(
+            env.portfolio_matcher_config(lp_account).enabled,
+            1,
+            "the delayed transaction restored the revoked matcher grant"
+        );
+
+        env.svm.expire_blockhash();
+        env.trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_account,
+            &lp_owner,
+            lp_account,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            OPEN_SIZE_Q,
+            0,
+        );
+        env.svm.warp_to_slot(1);
+        env.svm.expire_blockhash();
+        env.push_auth_mark_with_cu(1, 200);
+        for account in [attacker_account, lp_account] {
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.svm.expire_blockhash();
+        env.trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_account,
+            &lp_owner,
+            lp_account,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            -OPEN_SIZE_Q,
+            0,
+        );
+
+        let attacker_state = env.portfolio_state(attacker_account);
+        let lp_state = env.portfolio_state(lp_account);
+        assert_eq!(attacker_state.pnl.get(), STALE_GRANT_PROFIT as i128);
+        assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_GRANT_PROFIT);
+        env.convert_released_pnl_with_cu(
+            &attacker,
+            attacker_account,
+            STALE_GRANT_PROFIT,
+        );
+        let attacker_capital = env.portfolio_state(attacker_account).capital.get();
+        let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
+        let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
+        assert_eq!(
+            env.token_amount(attacker_dest) as u128,
+            ATTACKER_DEPOSIT + STALE_GRANT_PROFIT
+        );
+        assert_eq!(
+            env.token_amount(lp_dest) as u128,
+            LP_DEPOSIT - STALE_GRANT_PROFIT
+        );
+        panic!(
+            "delayed matcher enable overrode a newer revoke and transferred \
+             {STALE_GRANT_PROFIT} atoms from the independent LP"
+        );
+    }
+
+    assert_eq!(
+        env.portfolio_matcher_config(lp_account).enabled,
+        0,
+        "a rejected stale enable must leave the newer revoke in force"
+    );
+    env.svm.expire_blockhash();
+    let blocked_fill = env.try_trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp_owner,
+        lp_account,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        OPEN_SIZE_Q,
+        0,
+    );
+    assert!(
+        blocked_fill.is_err(),
+        "the revoked matcher must remain unable to fill the LP"
+    );
+}
+
+#[test]
 fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
     let mut env = V16CuEnv::new();
     let matcher_program = Pubkey::new_unique();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2009,6 +2009,14 @@ impl V16CuEnv {
         matcher_delegate: Pubkey,
         enabled: u8,
     ) -> Result<Pubkey, String> {
+        let portfolio = self
+            .svm
+            .get_account(&maker_account)
+            .expect("portfolio account");
+        let portfolio_id = state::read_portfolio_id_allow_legacy_zero(&portfolio.data).unwrap_or(0);
+        let expected_sequence = state::read_portfolio_matcher_config(&portfolio.data)
+            .map(|config| config.sequence())
+            .unwrap_or(0);
         self.svm.expire_blockhash();
         let mut accounts = vec![
             AccountMeta::new(maker_owner.pubkey(), true),
@@ -2023,7 +2031,11 @@ impl V16CuEnv {
             ]);
         }
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id,
+                expected_sequence,
+                enabled,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -20575,6 +20587,8 @@ fn v16_attack_delayed_matcher_enable_cannot_override_newer_revoke() {
     // newer revoke must make the older transaction stale rather than let it restore unsigned fills.
     env.svm.expire_blockhash();
     let recent_blockhash = env.svm.latest_blockhash();
+    let portfolio_id = env.portfolio_id(lp_account);
+    let expected_sequence = env.portfolio_matcher_config(lp_account).sequence();
     let enable_ix = Instruction {
         program_id: env.program_id,
         accounts: vec![
@@ -20585,7 +20599,12 @@ fn v16_attack_delayed_matcher_enable_cannot_override_newer_revoke() {
             AccountMeta::new_readonly(matcher_context, false),
             AccountMeta::new_readonly(matcher_delegate, false),
         ],
-        data: ProgInstruction::SetMatcherConfig { enabled: 1 }.encode(),
+        data: ProgInstruction::SetMatcherConfig {
+            portfolio_id,
+            expected_sequence,
+            enabled: 1,
+        }
+        .encode(),
     };
     let revoke_ix = Instruction {
         program_id: env.program_id,
@@ -20594,7 +20613,12 @@ fn v16_attack_delayed_matcher_enable_cannot_override_newer_revoke() {
             AccountMeta::new_readonly(env.market, false),
             AccountMeta::new(lp_account, false),
         ],
-        data: ProgInstruction::SetMatcherConfig { enabled: 0 }.encode(),
+        data: ProgInstruction::SetMatcherConfig {
+            portfolio_id,
+            expected_sequence,
+            enabled: 0,
+        }
+        .encode(),
     };
     let delayed_enable = Transaction::new_signed_with_payer(
         &[heap_ix(), cu_ix(), enable_ix],
@@ -20664,11 +20688,7 @@ fn v16_attack_delayed_matcher_enable_cannot_override_newer_revoke() {
         let lp_state = env.portfolio_state(lp_account);
         assert_eq!(attacker_state.pnl.get(), STALE_GRANT_PROFIT as i128);
         assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_GRANT_PROFIT);
-        env.convert_released_pnl_with_cu(
-            &attacker,
-            attacker_account,
-            STALE_GRANT_PROFIT,
-        );
+        env.convert_released_pnl_with_cu(&attacker, attacker_account, STALE_GRANT_PROFIT);
         let attacker_capital = env.portfolio_state(attacker_account).capital.get();
         let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
         let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
@@ -20728,10 +20748,16 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
     let market_before = env.svm.get_account(&env.market).unwrap();
     let lp_before = env.svm.get_account(&lp).unwrap();
     let ctx_before = env.svm.get_account(&ctx).unwrap();
+    let portfolio_id = env.portfolio_id(lp);
+    let expected_sequence = env.portfolio_matcher_config(lp).sequence();
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id,
+            expected_sequence,
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20793,10 +20819,16 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
     let market_before = env.svm.get_account(&env.market).unwrap();
     let victim_before = env.svm.get_account(&victim_lp).unwrap();
     let attacker_before = env.svm.get_account(&attacker_lp).unwrap();
+    let portfolio_id = env.portfolio_id(victim_lp);
+    let expected_sequence = env.portfolio_matcher_config(victim_lp).sequence();
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id,
+            expected_sequence,
+            enabled: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21157,11 +21189,17 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     );
     env.try_init_auth_matcher_context_with_delegate(matcher_program, &lp_owner, lp, ctx, delegate)
         .expect("init auth matcher context without setting percolator auth");
+    let portfolio_id = env.portfolio_id(lp);
+    let expected_sequence = env.portfolio_matcher_config(lp).sequence();
 
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                portfolio_id,
+                expected_sequence,
+                enabled: 1,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -21233,9 +21271,15 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
 
     let market_before_config = env.svm.get_account(&env.market).unwrap();
     let lp_before_config = env.svm.get_account(&lp).unwrap();
+    let portfolio_id = env.portfolio_id(lp);
+    let expected_sequence = env.portfolio_matcher_config(lp).sequence();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id,
+            expected_sequence,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21262,16 +21306,13 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     );
 
     let mut corrupt_lp = env.svm.get_account(&lp).unwrap();
-    state::write_portfolio_matcher_config(
-        &mut corrupt_lp.data,
-        &state::PortfolioMatcherConfigV16 {
-            matcher_program: env.program_id.to_bytes(),
-            matcher_context: env.market.to_bytes(),
-            matcher_delegate: self_delegate.to_bytes(),
-            enabled: 1,
-        },
-    )
-    .expect("inject stale self-matcher config for fill-time guard");
+    let mut corrupt_config = state::PortfolioMatcherConfigV16::default();
+    corrupt_config.matcher_program = env.program_id.to_bytes();
+    corrupt_config.matcher_context = env.market.to_bytes();
+    corrupt_config.matcher_delegate = self_delegate.to_bytes();
+    corrupt_config.enabled = 1;
+    state::write_portfolio_matcher_config(&mut corrupt_lp.data, &corrupt_config)
+        .expect("inject stale self-matcher config for fill-time guard");
     env.svm.set_account(lp, corrupt_lp).unwrap();
 
     let market_before_fill = env.svm.get_account(&env.market).unwrap();
@@ -21491,7 +21532,11 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: 0,
+            expected_sequence: 0,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -30694,11 +30739,17 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
             },
         )
         .unwrap();
+    let cpi_lp_portfolio_id = env.portfolio_id(p_cpi_lp);
+    let cpi_lp_matcher_sequence = env.portfolio_matcher_config(p_cpi_lp).sequence();
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            portfolio_id: cpi_lp_portfolio_id,
+            expected_sequence: cpi_lp_matcher_sequence,
+            enabled: 1,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -230,6 +230,31 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_set_matcher_config_decode_preserves_intent_binding() {
+    let portfolio_id: u64 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let enabled: u8 = kani::any();
+    let mut data = [0u8; 18];
+    data[0] = 68;
+    data[1..9].copy_from_slice(&portfolio_id.to_le_bytes());
+    data[9..17].copy_from_slice(&expected_sequence.to_le_bytes());
+    data[17] = enabled;
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::SetMatcherConfig {
+            portfolio_id: got_portfolio_id,
+            expected_sequence: got_sequence,
+            enabled: got_enabled,
+        } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_sequence, expected_sequence);
+            assert_eq!(got_enabled, enabled);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
@@ -1489,6 +1514,9 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
 
     let trade_cpi = [10u8; 33];
     assert!(Instruction::decode(&trade_cpi).is_err());
+
+    let set_matcher_config = [68u8; 17];
+    assert!(Instruction::decode(&set_matcher_config).is_err());
 
     let top_up = [9u8; 16];
     assert!(Instruction::decode(&top_up).is_err());


### PR DESCRIPTION
## Summary

- bind `SetMatcherConfig` to the current portfolio incarnation and matcher-config sequence
- advance the sequence on every successful enable or revoke while preserving the existing 104-byte zero-copy tail
- document the ABI change and prove its decoder fields with targeted Kani harnesses

## Root cause

`SetMatcherConfig` authenticated the LP owner but carried no freshness value. Two honest transactions signed under the same live recent blockhash could land out of order: a newer revoke could land first, then an unprivileged relayer could submit the older enable and restore permissionless matcher access.

The exact-parent public LiteSVM reproduction uses normal initialized accounts and signed transactions, with no protocol-state injection. After replaying the stale enable, an unsigned attacker trades against the independent LP, moves the honest AuthMark from 100 to 200, closes, converts PnL, and withdraws 1,000,000 collateral atoms taken from the LP.

## Fix

Tag 68 now carries `portfolio_id`, `expected_sequence`, and `enabled`. The program verifies both freshness fields and increments the sequence before committing the config. The sequence occupies seven bytes adjacent to the one-byte enabled flag, so `PortfolioMatcherConfigV16` remains exactly 104 bytes. Legacy zero tails begin at sequence zero; the incarnation binding rejects intents from closed/recreated portfolios.

## TDD evidence

- exact-parent RED commit: `12f1fa08` (`v16_attack_delayed_matcher_enable_cannot_override_newer_revoke` loses 1,000,000 LP atoms)
- fixed GREEN commit: `93f7225c`
- `cargo build-sbf --tools-version v1.52`
- `cargo test --test v16_cu -- --test-threads=1`: 566/566 passed, including max-shape CU tests
- `cargo test --lib -- --test-threads=1`: 7/7 passed
- `cargo kani --tests --harness kani_v16_set_matcher_config_decode_preserves_intent_binding`: passed
- `cargo kani --tests --harness kani_v16_every_active_payload_rejects_one_byte_truncation`: passed