### PR TITLE
[BLOCKER LoF] Reject delayed authenticated mark intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ AuthMark and EwmaMark are authority-pushed pricing modes for markets that do not
 
 AuthMark is the direct authority-mark path:
 
-- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, now_slot, mark_e6 }`.
+- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, now_slot, mark_e6, observation_sequence }`. `PushEwmaMark` carries the same signer-chosen, strictly increasing `observation_sequence`. The program persists the last accepted sequence per asset across oracle-profile rewrites, so delayed same-incarnation reports cannot replace newer authenticated observations while gaps and out-of-order transaction landing remain supported.
 - **No EWMA configuration**: there is no halflife, mark-min-fee, feed id, confidence filter, invert flag, or unit-scale configuration in the AuthMark API.
 - **Authority boundary**: only the configured mark authority can push a new mark; public cranks can only consume the stored mark.
 - **Adapter-friendly**: a separate oracle adapter PDA can verify Pyth, Chainlink, Switchboard, or custom feed policy, then sign `PushAuthMark` with the resulting mark.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ AuthMark and EwmaMark are authority-pushed pricing modes for markets that do not
 
 AuthMark is the direct authority-mark path:
 
-- **Direct mark API**: `ConfigureAuthMark { asset_index, now_slot, initial_mark_e6 }` and `PushAuthMark { asset_index, now_slot, mark_e6, observation_sequence }`. `PushEwmaMark` carries the same signer-chosen, strictly increasing `observation_sequence`. The program persists the last accepted sequence per asset across oracle-profile rewrites, so delayed same-incarnation reports cannot replace newer authenticated observations while gaps and out-of-order transaction landing remain supported.
+- **Direct mark API**: `ConfigureAuthMark` and `PushAuthMark` both carry a signer-chosen, strictly increasing `observation_sequence`. `ConfigureEwmaMark`, `PushEwmaMark`, and `ConfigureHybridOracle` advance the same per-asset sequence, including across oracle-mode changes. The program persists the last accepted sequence across oracle-profile rewrites, so delayed same-incarnation mark intents cannot replace newer ones while sequence gaps and out-of-order transaction landing remain supported.
 - **No EWMA configuration**: there is no halflife, mark-min-fee, feed id, confidence filter, invert flag, or unit-scale configuration in the AuthMark API.
 - **Authority boundary**: only the configured mark authority can push a new mark; public cranks can only consume the stored mark.
 - **Adapter-friendly**: a separate oracle adapter PDA can verify Pyth, Chainlink, Switchboard, or custom feed policy, then sign `PushAuthMark` with the resulting mark.

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2617,6 +2617,7 @@ pub mod ix {
             unit_scale: u32,
             conf_filter_bps: u16,
             oracle_leg_feeds: [[u8; 32]; 3],
+            observation_sequence: u64,
         },
         ConfigureEwmaMark {
             asset_index: u16,
@@ -2624,6 +2625,7 @@ pub mod ix {
             initial_mark_e6: u64,
             mark_ewma_halflife_slots: u64,
             mark_min_fee: u64,
+            observation_sequence: u64,
         },
         PushEwmaMark {
             asset_index: u16,
@@ -2635,6 +2637,7 @@ pub mod ix {
             asset_index: u16,
             now_slot: u64,
             initial_mark_e6: u64,
+            observation_sequence: u64,
         },
         PushAuthMark {
             asset_index: u16,
@@ -2863,6 +2866,7 @@ pub mod ix {
                     asset_index: read_u16(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     initial_mark_e6: read_u64(&mut rest)?,
+                    observation_sequence: read_u64(&mut rest)?,
                 },
                 63 => Self::PushAuthMark {
                     asset_index: read_u16(&mut rest)?,
@@ -2913,6 +2917,7 @@ pub mod ix {
                         read_bytes32(&mut rest)?,
                         read_bytes32(&mut rest)?,
                     ],
+                    observation_sequence: read_u64(&mut rest)?,
                 },
                 35 => Self::ConfigureEwmaMark {
                     asset_index: read_u16(&mut rest)?,
@@ -2920,6 +2925,7 @@ pub mod ix {
                     initial_mark_e6: read_u64(&mut rest)?,
                     mark_ewma_halflife_slots: read_u64(&mut rest)?,
                     mark_min_fee: read_u64(&mut rest)?,
+                    observation_sequence: read_u64(&mut rest)?,
                 },
                 36 => Self::PushEwmaMark {
                     asset_index: read_u16(&mut rest)?,
@@ -3218,6 +3224,7 @@ pub mod ix {
                     unit_scale,
                     conf_filter_bps,
                     oracle_leg_feeds,
+                    observation_sequence,
                 } => {
                     out.push(34);
                     push_u16(&mut out, asset_index);
@@ -3235,6 +3242,7 @@ pub mod ix {
                     for feed in oracle_leg_feeds {
                         out.extend_from_slice(&feed);
                     }
+                    push_u64(&mut out, observation_sequence);
                 }
                 Self::ConfigureEwmaMark {
                     asset_index,
@@ -3242,6 +3250,7 @@ pub mod ix {
                     initial_mark_e6,
                     mark_ewma_halflife_slots,
                     mark_min_fee,
+                    observation_sequence,
                 } => {
                     out.push(35);
                     push_u16(&mut out, asset_index);
@@ -3249,6 +3258,7 @@ pub mod ix {
                     push_u64(&mut out, initial_mark_e6);
                     push_u64(&mut out, mark_ewma_halflife_slots);
                     push_u64(&mut out, mark_min_fee);
+                    push_u64(&mut out, observation_sequence);
                 }
                 Self::PushEwmaMark {
                     asset_index,
@@ -3266,11 +3276,13 @@ pub mod ix {
                     asset_index,
                     now_slot,
                     initial_mark_e6,
+                    observation_sequence,
                 } => {
                     out.push(62);
                     push_u16(&mut out, asset_index);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, initial_mark_e6);
+                    push_u64(&mut out, observation_sequence);
                 }
                 Self::PushAuthMark {
                     asset_index,
@@ -4682,6 +4694,16 @@ pub mod processor {
         profile
     }
 
+    fn advance_mark_observation_sequence(
+        profile: &mut state::AssetOracleProfileV16,
+        observation_sequence: u64,
+    ) -> ProgramResult {
+        if observation_sequence <= profile.mark_observation_sequence() {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        profile.set_mark_observation_sequence(observation_sequence)
+    }
+
     fn backing_fee_policy_count_from_profile(profile: &state::AssetOracleProfileV16) -> u16 {
         (profile.backing_trade_fee_bps_long != 0) as u16
             + (profile.backing_trade_fee_bps_short != 0) as u16
@@ -5377,6 +5399,7 @@ pub mod processor {
                 unit_scale,
                 conf_filter_bps,
                 oracle_leg_feeds,
+                observation_sequence,
             } => handle_configure_hybrid_oracle(
                 program_id,
                 accounts,
@@ -5393,6 +5416,7 @@ pub mod processor {
                 unit_scale,
                 conf_filter_bps,
                 oracle_leg_feeds,
+                observation_sequence,
             ),
             Instruction::ConfigureEwmaMark {
                 asset_index,
@@ -5400,6 +5424,7 @@ pub mod processor {
                 initial_mark_e6,
                 mark_ewma_halflife_slots,
                 mark_min_fee,
+                observation_sequence,
             } => handle_configure_ewma_mark(
                 program_id,
                 accounts,
@@ -5408,6 +5433,7 @@ pub mod processor {
                 initial_mark_e6,
                 mark_ewma_halflife_slots,
                 mark_min_fee,
+                observation_sequence,
             ),
             Instruction::PushEwmaMark {
                 asset_index,
@@ -5426,12 +5452,14 @@ pub mod processor {
                 asset_index,
                 now_slot,
                 initial_mark_e6,
+                observation_sequence,
             } => handle_configure_auth_mark(
                 program_id,
                 accounts,
                 asset_index,
                 now_slot,
                 initial_mark_e6,
+                observation_sequence,
             ),
             Instruction::PushAuthMark {
                 asset_index,
@@ -9837,6 +9865,7 @@ pub mod processor {
         unit_scale: u32,
         conf_filter_bps: u16,
         oracle_leg_feeds: [[u8; 32]; constants::ORACLE_LEG_CAP],
+        observation_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9919,6 +9948,7 @@ pub mod processor {
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
             };
+            advance_mark_observation_sequence(&mut profile, observation_sequence)?;
 
             let (price, publish_time, advanced) = oracle_v16::read_external_price_e6_profile(
                 &mut profile,
@@ -9976,6 +10006,7 @@ pub mod processor {
         initial_mark_e6: u64,
         mark_ewma_halflife_slots: u64,
         mark_min_fee: u64,
+        observation_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10013,7 +10044,7 @@ pub mod processor {
             // oracle_authority exactly like permissionless assets 1..N.
             expect_live_authority(&existing_profile.oracle_authority, admin.key)?;
 
-            let profile = state::AssetOracleProfileV16 {
+            let mut profile = state::AssetOracleProfileV16 {
                 oracle_mode: constants::ORACLE_MODE_EWMA_MARK,
                 oracle_leg_count: 0,
                 oracle_leg_flags: 0,
@@ -10045,6 +10076,7 @@ pub mod processor {
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
             };
+            advance_mark_observation_sequence(&mut profile, observation_sequence)?;
 
             reset_empty_asset_oracle_anchor_view(
                 &mut group,
@@ -10087,6 +10119,7 @@ pub mod processor {
         asset_index: u16,
         now_slot: u64,
         initial_mark_e6: u64,
+        observation_sequence: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10121,7 +10154,7 @@ pub mod processor {
             // oracle_authority exactly like permissionless assets 1..N.
             expect_live_authority(&existing_profile.oracle_authority, authority.key)?;
 
-            let profile = state::AssetOracleProfileV16 {
+            let mut profile = state::AssetOracleProfileV16 {
                 oracle_mode: constants::ORACLE_MODE_AUTH_MARK,
                 oracle_leg_count: 0,
                 oracle_leg_flags: 0,
@@ -10153,6 +10186,7 @@ pub mod processor {
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
             };
+            advance_mark_observation_sequence(&mut profile, observation_sequence)?;
 
             reset_empty_asset_oracle_anchor_view(
                 &mut group,
@@ -10230,12 +10264,7 @@ pub mod processor {
             }
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index_usize);
             expect_live_authority(&authorities.oracle_authority, authority.key)?;
-            if observation_sequence <= profile.mark_observation_sequence() {
-                return Err(PercolatorError::EngineStale.into());
-            }
-            if observation_sequence > state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE {
-                return Err(PercolatorError::EngineCounterOverflow.into());
-            }
+            advance_mark_observation_sequence(&mut profile, observation_sequence)?;
             if authenticated_slot < profile.mark_ewma_last_slot
                 || authenticated_slot < group.header.current_slot.get()
             {
@@ -10263,7 +10292,6 @@ pub mod processor {
             profile.oracle_target_price_e6 = next_mark;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
-            profile.set_mark_observation_sequence(observation_sequence)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =
@@ -10319,12 +10347,7 @@ pub mod processor {
             }
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index_usize);
             expect_live_authority(&authorities.oracle_authority, authority.key)?;
-            if observation_sequence <= profile.mark_observation_sequence() {
-                return Err(PercolatorError::EngineStale.into());
-            }
-            if observation_sequence > state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE {
-                return Err(PercolatorError::EngineCounterOverflow.into());
-            }
+            advance_mark_observation_sequence(&mut profile, observation_sequence)?;
             if authenticated_slot < profile.mark_ewma_last_slot
                 || authenticated_slot < group.header.current_slot.get()
             {
@@ -10335,7 +10358,6 @@ pub mod processor {
             profile.oracle_target_price_e6 = mark_e6;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
-            profile.set_mark_observation_sequence(observation_sequence)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -568,7 +568,7 @@ pub mod state {
         pub backing_trade_fee_bps_short: u16,
         pub backing_trade_fee_insurance_share_bps_long: u16,
         pub backing_trade_fee_insurance_share_bps_short: u16,
-        pub _padding0: [u8; 6],
+        pub(crate) mark_observation_sequence_le: [u8; 6],
         pub insurance_authority: [u8; 32],
         pub insurance_operator: [u8; 32],
         pub backing_bucket_authority: [u8; 32],
@@ -589,6 +589,27 @@ pub mod state {
         // (insurance/operator/backing/oracle) and itself, and can be burned (set to 0). Isolated:
         // it can never act on another asset. Set to the activator at creation.
         pub asset_admin: [u8; 32],
+    }
+
+    impl AssetOracleProfileV16 {
+        pub const MAX_MARK_OBSERVATION_SEQUENCE: u64 = (1u64 << 48) - 1;
+
+        #[inline]
+        pub fn mark_observation_sequence(&self) -> u64 {
+            let mut bytes = [0u8; 8];
+            bytes[..6].copy_from_slice(&self.mark_observation_sequence_le);
+            u64::from_le_bytes(bytes)
+        }
+
+        #[inline]
+        pub fn set_mark_observation_sequence(&mut self, sequence: u64) -> Result<(), ProgramError> {
+            if sequence > Self::MAX_MARK_OBSERVATION_SEQUENCE {
+                return Err(PercolatorError::EngineCounterOverflow.into());
+            }
+            self.mark_observation_sequence_le
+                .copy_from_slice(&sequence.to_le_bytes()[..6]);
+            Ok(())
+        }
     }
 
     /// Aggregate backing-domain accounting for an authority-controlled vault.
@@ -1123,7 +1144,6 @@ pub mod state {
                 profile.backing_trade_fee_insurance_share_bps_short,
             )
             || profile.invert > 1
-            || profile._padding0 != [0u8; 6]
             || profile.oracle_leg_count as usize > ORACLE_LEG_CAP
             || (profile.oracle_leg_flags & !ORACLE_LEG_FLAGS_MASK) != 0
         {
@@ -1214,7 +1234,7 @@ pub mod state {
             backing_trade_fee_bps_short: 0,
             backing_trade_fee_insurance_share_bps_long: 0,
             backing_trade_fee_insurance_share_bps_short: 0,
-            _padding0: [0u8; 6],
+            mark_observation_sequence_le: [0u8; 6],
             insurance_authority: [0u8; 32],
             insurance_operator: [0u8; 32],
             backing_bucket_authority: [0u8; 32],
@@ -1249,7 +1269,7 @@ pub mod state {
                 .backing_trade_fee_insurance_share_bps_long,
             backing_trade_fee_insurance_share_bps_short: config
                 .backing_trade_fee_insurance_share_bps_short,
-            _padding0: [0u8; 6],
+            mark_observation_sequence_le: [0u8; 6],
             // At InitMarket the market key bootstraps asset 0 exactly like an activator bootstraps a
             // permissionless asset 1..N: it is asset 0's cold-storage admin and all its sub-authorities.
             insurance_authority: config.marketauth,
@@ -2609,6 +2629,7 @@ pub mod ix {
             asset_index: u16,
             now_slot: u64,
             mark_e6: u64,
+            observation_sequence: u64,
         },
         ConfigureAuthMark {
             asset_index: u16,
@@ -2619,6 +2640,7 @@ pub mod ix {
             asset_index: u16,
             now_slot: u64,
             mark_e6: u64,
+            observation_sequence: u64,
         },
         ForceCloseAbandonedAsset {
             asset_index: u16,
@@ -2846,6 +2868,7 @@ pub mod ix {
                     asset_index: read_u16(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     mark_e6: read_u64(&mut rest)?,
+                    observation_sequence: read_u64(&mut rest)?,
                 },
                 64 => Self::ForceCloseAbandonedAsset {
                     asset_index: read_u16(&mut rest)?,
@@ -2902,6 +2925,7 @@ pub mod ix {
                     asset_index: read_u16(&mut rest)?,
                     now_slot: read_u64(&mut rest)?,
                     mark_e6: read_u64(&mut rest)?,
+                    observation_sequence: read_u64(&mut rest)?,
                 },
                 40 => Self::UpdateAssetLifecycle {
                     action: read_u8(&mut rest)?,
@@ -3230,11 +3254,13 @@ pub mod ix {
                     asset_index,
                     now_slot,
                     mark_e6,
+                    observation_sequence,
                 } => {
                     out.push(36);
                     push_u16(&mut out, asset_index);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, mark_e6);
+                    push_u64(&mut out, observation_sequence);
                 }
                 Self::ConfigureAuthMark {
                     asset_index,
@@ -3250,11 +3276,13 @@ pub mod ix {
                     asset_index,
                     now_slot,
                     mark_e6,
+                    observation_sequence,
                 } => {
                     out.push(63);
                     push_u16(&mut out, asset_index);
                     push_u64(&mut out, now_slot);
                     push_u64(&mut out, mark_e6);
+                    push_u64(&mut out, observation_sequence);
                 }
                 Self::ForceCloseAbandonedAsset {
                     asset_index,
@@ -4646,6 +4674,7 @@ pub mod processor {
             existing.backing_trade_fee_insurance_share_bps_long;
         profile.backing_trade_fee_insurance_share_bps_short =
             existing.backing_trade_fee_insurance_share_bps_short;
+        profile.mark_observation_sequence_le = existing.mark_observation_sequence_le;
         profile.insurance_authority = existing.insurance_authority;
         profile.insurance_operator = existing.insurance_operator;
         profile.backing_bucket_authority = existing.backing_bucket_authority;
@@ -5384,7 +5413,15 @@ pub mod processor {
                 asset_index,
                 now_slot,
                 mark_e6,
-            } => handle_push_ewma_mark(program_id, accounts, asset_index, now_slot, mark_e6),
+                observation_sequence,
+            } => handle_push_ewma_mark(
+                program_id,
+                accounts,
+                asset_index,
+                now_slot,
+                mark_e6,
+                observation_sequence,
+            ),
             Instruction::ConfigureAuthMark {
                 asset_index,
                 now_slot,
@@ -5400,7 +5437,15 @@ pub mod processor {
                 asset_index,
                 now_slot,
                 mark_e6,
-            } => handle_push_auth_mark(program_id, accounts, asset_index, now_slot, mark_e6),
+                observation_sequence,
+            } => handle_push_auth_mark(
+                program_id,
+                accounts,
+                asset_index,
+                now_slot,
+                mark_e6,
+                observation_sequence,
+            ),
             Instruction::ForceCloseAbandonedAsset {
                 asset_index,
                 now_slot,
@@ -9855,7 +9900,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                mark_observation_sequence_le: existing_profile.mark_observation_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -9981,7 +10026,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                mark_observation_sequence_le: existing_profile.mark_observation_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -10089,7 +10134,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                mark_observation_sequence_le: existing_profile.mark_observation_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -10152,6 +10197,7 @@ pub mod processor {
         asset_index: u16,
         now_slot: u64,
         mark_e6: u64,
+        observation_sequence: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10184,6 +10230,12 @@ pub mod processor {
             }
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index_usize);
             expect_live_authority(&authorities.oracle_authority, authority.key)?;
+            if observation_sequence <= profile.mark_observation_sequence() {
+                return Err(PercolatorError::EngineStale.into());
+            }
+            if observation_sequence > state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE {
+                return Err(PercolatorError::EngineCounterOverflow.into());
+            }
             if authenticated_slot < profile.mark_ewma_last_slot
                 || authenticated_slot < group.header.current_slot.get()
             {
@@ -10211,6 +10263,7 @@ pub mod processor {
             profile.oracle_target_price_e6 = next_mark;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
+            profile.set_mark_observation_sequence(observation_sequence)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =
@@ -10233,6 +10286,7 @@ pub mod processor {
         asset_index: u16,
         now_slot: u64,
         mark_e6: u64,
+        observation_sequence: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -10265,6 +10319,12 @@ pub mod processor {
             }
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index_usize);
             expect_live_authority(&authorities.oracle_authority, authority.key)?;
+            if observation_sequence <= profile.mark_observation_sequence() {
+                return Err(PercolatorError::EngineStale.into());
+            }
+            if observation_sequence > state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE {
+                return Err(PercolatorError::EngineCounterOverflow.into());
+            }
             if authenticated_slot < profile.mark_ewma_last_slot
                 || authenticated_slot < group.header.current_slot.get()
             {
@@ -10275,6 +10335,7 @@ pub mod processor {
             profile.oracle_target_price_e6 = mark_e6;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
+            profile.set_mark_observation_sequence(observation_sequence)?;
             write_oracle_profile_to_view(&mut group, asset_index_usize, &profile)?;
             if asset_index_usize == 0 {
                 cfg.last_good_oracle_slot =
@@ -12192,6 +12253,32 @@ pub mod processor {
                 core::mem::size_of::<state::WrapperConfigV16>(),
                 state::wrapper_config_len_for_test(),
                 "WRAPPER_CONFIG_LEN must equal size_of::<WrapperConfigV16>() for the zero-copy layout",
+            );
+        }
+
+        #[test]
+        fn mark_observation_sequence_uses_profile_padding_without_layout_growth() {
+            assert_eq!(
+                core::mem::size_of::<state::AssetOracleProfileV16>(),
+                constants::ASSET_ORACLE_PROFILE_LEN,
+            );
+
+            let mut profile = state::AssetOracleProfileV16::default();
+            assert_eq!(profile.mark_observation_sequence(), 0);
+            profile
+                .set_mark_observation_sequence(
+                    state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE,
+                )
+                .unwrap();
+            assert_eq!(
+                profile.mark_observation_sequence(),
+                state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE,
+            );
+            assert_eq!(
+                profile.set_mark_observation_sequence(
+                    state::AssetOracleProfileV16::MAX_MARK_OBSERVATION_SEQUENCE + 1,
+                ),
+                Err(PercolatorError::EngineCounterOverflow.into()),
             );
         }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -13111,6 +13111,145 @@ fn v16_attack_delayed_auth_mark_configuration_cannot_override_newer_intent() {
 }
 
 #[test]
+fn v16_attack_delayed_auth_mark_cannot_override_newer_observation() {
+    const OPEN_SIZE_Q: i128 = -((10_000 * POS_SCALE) as i128);
+    const ATTACKER_DEPOSIT: u128 = 2_000_000;
+    const LP_DEPOSIT: u128 = 4_000_000;
+    const STALE_MARK_PROFIT: u128 = 500_000;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+    let attacker = Keypair::new();
+    let lp_owner = Keypair::new();
+    let attacker_account = env.create_portfolio(&attacker);
+    let lp_account = env.create_portfolio(&lp_owner);
+    env.deposit(&attacker, attacker_account, ATTACKER_DEPOSIT);
+    env.deposit(&lp_owner, lp_account, LP_DEPOSIT);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp(&mut env, &lp_owner, lp_account);
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp_owner,
+        lp_account,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        OPEN_SIZE_Q,
+        0,
+    );
+
+    // The honest mark authority signs a transient low observation and then a correcting
+    // observation. Both remain valid under one recent blockhash, so an unprivileged relayer can
+    // choose their landing order. The older report must not become current after the newer one.
+    env.svm.expire_blockhash();
+    let recent_blockhash = env.svm.latest_blockhash();
+    let signed_push = |mark_e6| {
+        let push_ix = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::PushAuthMark {
+                asset_index: 0,
+                now_slot: 0,
+                mark_e6,
+            }
+            .encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), push_ix],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            recent_blockhash,
+        )
+    };
+    let delayed_low_mark = signed_push(50);
+    let newer_correct_mark = signed_push(100);
+    env.svm
+        .send_transaction(newer_correct_mark)
+        .expect("newer correcting mark lands first");
+    assert_eq!(env.market_state().0.mark_ewma_e6, 100);
+
+    let stale_push = env.svm.send_transaction(delayed_low_mark);
+    if stale_push.is_ok() {
+        assert_eq!(
+            env.market_state().0.mark_ewma_e6,
+            50,
+            "the delayed older observation replaced the newer mark"
+        );
+        env.svm.warp_to_slot(1);
+        env.svm.expire_blockhash();
+        for account in [attacker_account, lp_account] {
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.svm.expire_blockhash();
+        env.trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_account,
+            &lp_owner,
+            lp_account,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            -OPEN_SIZE_Q,
+            0,
+        );
+
+        let attacker_state = env.portfolio_state(attacker_account);
+        let lp_state = env.portfolio_state(lp_account);
+        assert_eq!(attacker_state.pnl.get(), STALE_MARK_PROFIT as i128);
+        assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_MARK_PROFIT);
+        env.convert_released_pnl_with_cu(&attacker, attacker_account, STALE_MARK_PROFIT);
+        let attacker_capital = env.portfolio_state(attacker_account).capital.get();
+        let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
+        let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
+        assert_eq!(
+            env.token_amount(attacker_dest) as u128,
+            ATTACKER_DEPOSIT + STALE_MARK_PROFIT
+        );
+        assert_eq!(
+            env.token_amount(lp_dest) as u128,
+            LP_DEPOSIT - STALE_MARK_PROFIT
+        );
+        panic!(
+            "delayed AuthMark overrode a newer observation and transferred \
+             {STALE_MARK_PROFIT} atoms from the independent LP"
+        );
+    }
+
+    assert_eq!(
+        env.market_state().0.mark_ewma_e6,
+        100,
+        "a rejected stale report must leave the newer mark current"
+    );
+    env.svm.expire_blockhash();
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp_owner,
+        lp_account,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        -OPEN_SIZE_Q,
+        0,
+    );
+    assert_eq!(env.portfolio_state(attacker_account).pnl.get(), 0);
+    assert_eq!(env.portfolio_state(lp_account).capital.get(), LP_DEPOSIT);
+}
+
+#[test]
 fn v16_bpf_auth_mark_target_effective_lag_counts_toward_liquidation_health() {
     const INITIAL_MARK: u64 = 100_000_000;
     const TARGET_MARK: u64 = 90_000_000;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2392,6 +2392,7 @@ impl V16CuEnv {
         now_slot: u64,
         now_unix_ts: i64,
     ) -> Result<u64, String> {
+        let observation_sequence = self.next_mark_observation_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2410,6 +2411,7 @@ impl V16CuEnv {
                 unit_scale: 0,
                 conf_filter_bps: 500,
                 oracle_leg_feeds: feeds,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2493,6 +2495,7 @@ impl V16CuEnv {
         hybrid_soft_stale_slots: u64,
         conf_filter_bps: u16,
     ) -> Result<u64, String> {
+        let observation_sequence = self.next_mark_observation_sequence(asset_index as usize);
         let mut accounts = vec![
             AccountMeta::new(self.admin.pubkey(), true),
             AccountMeta::new(self.market, false),
@@ -2522,6 +2525,7 @@ impl V16CuEnv {
                 unit_scale,
                 conf_filter_bps,
                 oracle_leg_feeds: feeds,
+                observation_sequence,
             },
             accounts,
             &[&self.admin],
@@ -2535,6 +2539,7 @@ impl V16CuEnv {
         halflife_slots: u64,
         mark_min_fee: u64,
     ) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2545,6 +2550,7 @@ impl V16CuEnv {
                 initial_mark_e6,
                 mark_ewma_halflife_slots: halflife_slots,
                 mark_min_fee,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2577,6 +2583,7 @@ impl V16CuEnv {
     }
 
     fn configure_auth_mark_with_cu(&mut self, now_slot: u64, initial_mark_e6: u64) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2585,6 +2592,7 @@ impl V16CuEnv {
                 asset_index: 0,
                 now_slot,
                 initial_mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2622,6 +2630,7 @@ impl V16CuEnv {
         now_slot: u64,
         initial_mark_e6: u64,
     ) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(asset_index as usize);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2630,6 +2639,7 @@ impl V16CuEnv {
                 asset_index,
                 now_slot,
                 initial_mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2674,6 +2684,7 @@ impl V16CuEnv {
         initial_mark_e6: u64,
     ) -> u64 {
         self.ensure_signer_account(authority.pubkey());
+        let observation_sequence = self.next_mark_observation_sequence(asset_index as usize);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2682,6 +2693,7 @@ impl V16CuEnv {
                 asset_index,
                 now_slot,
                 initial_mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
@@ -5218,6 +5230,7 @@ fn v16_attack_privileged_reactivate_rekeys_retired_slot_authorities() {
             asset_index: 1,
             now_slot: 5,
             initial_mark_e6: 300,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(old_creator.pubkey(), true),
@@ -5242,6 +5255,7 @@ fn v16_attack_privileged_reactivate_rekeys_retired_slot_authorities() {
             asset_index: 1,
             now_slot: 5,
             initial_mark_e6: 300,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(new_oracle.pubkey(), true),
@@ -6315,6 +6329,7 @@ fn v16_bpf_asset0_shutdown_force_closes_preserves_insurance_and_restarts() {
             asset_index: 0,
             now_slot: 8,
             initial_mark_e6: 250,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(marketauth.pubkey(), true),
@@ -13040,31 +13055,100 @@ fn v16_attack_delayed_auth_mark_configuration_cannot_override_newer_intent() {
         asset_index: 0,
         now_slot: 0,
         initial_mark_e6: 50,
+        observation_sequence: 1,
     });
     let newer_correct_config = signed_mark_instruction(ProgInstruction::ConfigureAuthMark {
         asset_index: 0,
         now_slot: 0,
         initial_mark_e6: 100,
+        observation_sequence: 2,
     });
     let next_honest_observation = signed_mark_instruction(ProgInstruction::PushAuthMark {
         asset_index: 0,
         now_slot: 0,
         mark_e6: 100,
+        observation_sequence: 3,
     });
 
     env.svm
         .send_transaction(newer_correct_config)
         .expect("newer correcting configuration lands first");
     assert_eq!(env.market_state().0.mark_ewma_e6, 100);
-    env.svm
-        .send_transaction(delayed_low_config)
-        .expect("pre-fix delayed configuration remains valid");
+    let stale_config = env.svm.send_transaction(delayed_low_config);
+    if stale_config.is_ok() {
+        assert_eq!(
+            env.market_state().0.mark_ewma_e6,
+            50,
+            "the delayed older configuration regressed the live mark"
+        );
+
+        env.trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_account,
+            &lp_owner,
+            lp_account,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            OPEN_SIZE_Q,
+            0,
+        );
+        env.svm
+            .send_transaction(next_honest_observation)
+            .expect("the next honest mark observation lands");
+        env.svm.warp_to_slot(1);
+        for account in [attacker_account, lp_account] {
+            env.svm.expire_blockhash();
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 1,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.svm.expire_blockhash();
+        env.trade_cpi_with_cu_on_asset(
+            &attacker,
+            attacker_account,
+            &lp_owner,
+            lp_account,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            0,
+            -OPEN_SIZE_Q,
+            0,
+        );
+
+        let attacker_state = env.portfolio_state(attacker_account);
+        let lp_state = env.portfolio_state(lp_account);
+        assert_eq!(attacker_state.pnl.get(), STALE_MARK_PROFIT as i128);
+        assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_MARK_PROFIT);
+        env.convert_released_pnl_with_cu(&attacker, attacker_account, STALE_MARK_PROFIT);
+        let attacker_capital = env.portfolio_state(attacker_account).capital.get();
+        let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
+        let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
+        assert_eq!(
+            env.token_amount(attacker_dest) as u128,
+            ATTACKER_DEPOSIT + STALE_MARK_PROFIT
+        );
+        assert_eq!(
+            env.token_amount(lp_dest) as u128,
+            LP_DEPOSIT - STALE_MARK_PROFIT
+        );
+        panic!(
+            "delayed AuthMark configuration transferred {STALE_MARK_PROFIT} atoms \
+             from an independent LP"
+        );
+    }
+
     assert_eq!(
         env.market_state().0.mark_ewma_e6,
-        50,
-        "the delayed older configuration regressed the live mark"
+        100,
+        "a rejected stale configuration leaves the newer mark current"
     );
-
     env.trade_cpi_with_cu_on_asset(
         &attacker,
         attacker_account,
@@ -13077,20 +13161,6 @@ fn v16_attack_delayed_auth_mark_configuration_cannot_override_newer_intent() {
         OPEN_SIZE_Q,
         0,
     );
-    env.svm
-        .send_transaction(next_honest_observation)
-        .expect("the next honest mark observation lands");
-    env.svm.warp_to_slot(1);
-    for account in [attacker_account, lp_account] {
-        env.svm.expire_blockhash();
-        env.crank(
-            account,
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 1,
-                observations: crank_observations(0),
-            },
-        );
-    }
     env.svm.expire_blockhash();
     env.trade_cpi_with_cu_on_asset(
         &attacker,
@@ -13104,26 +13174,164 @@ fn v16_attack_delayed_auth_mark_configuration_cannot_override_newer_intent() {
         -OPEN_SIZE_Q,
         0,
     );
+    assert_eq!(env.portfolio_state(attacker_account).pnl.get(), 0);
+    assert_eq!(env.portfolio_state(lp_account).capital.get(), LP_DEPOSIT);
+}
 
-    let attacker_state = env.portfolio_state(attacker_account);
-    let lp_state = env.portfolio_state(lp_account);
-    assert_eq!(attacker_state.pnl.get(), STALE_MARK_PROFIT as i128);
-    assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_MARK_PROFIT);
-    env.convert_released_pnl_with_cu(&attacker, attacker_account, STALE_MARK_PROFIT);
-    let attacker_capital = env.portfolio_state(attacker_account).capital.get();
-    let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
-    let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
-    assert_eq!(
-        env.token_amount(attacker_dest) as u128,
-        ATTACKER_DEPOSIT + STALE_MARK_PROFIT
+#[test]
+fn v16_mark_observation_sequence_orders_configuration_across_modes() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.svm.warp_to_slot(1);
+    let mut clock = env.svm.get_sysvar::<Clock>();
+    clock.unix_timestamp = 100;
+    env.svm.set_sysvar(&clock);
+    let feed_id = [0xabu8; 32];
+    let feed = env.set_pyth_price(&feed_id, 100_000_000, -6, 100);
+
+    let send_config = |env: &mut V16CuEnv,
+                       instruction: ProgInstruction,
+                       oracle_accounts: &[Pubkey]|
+     -> Result<u64, String> {
+        let mut accounts = vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ];
+        accounts.extend(
+            oracle_accounts
+                .iter()
+                .copied()
+                .map(|key| AccountMeta::new_readonly(key, false)),
+        );
+        env.svm.expire_blockhash();
+        env.send(instruction, accounts, &[&admin])
+    };
+
+    send_config(
+        &mut env,
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: 0,
+            now_slot: 1,
+            initial_mark_e6: 100,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            observation_sequence: 2,
+        },
+        &[],
+    )
+    .expect("a forward sequence gap is accepted");
+
+    let ewma_state = env.svm.get_account(&env.market).unwrap();
+    let stale_auth = send_config(
+        &mut env,
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            now_slot: 1,
+            initial_mark_e6: 50,
+            observation_sequence: 1,
+        },
+        &[],
+    );
+    assert!(
+        stale_auth.is_err(),
+        "an older AuthMark configuration cannot override a newer EWMA configuration"
     );
     assert_eq!(
-        env.token_amount(lp_dest) as u128,
-        LP_DEPOSIT - STALE_MARK_PROFIT
+        env.svm.get_account(&env.market).unwrap(),
+        ewma_state,
+        "rejected cross-mode configuration leaves the market byte-identical"
     );
-    panic!(
-        "delayed AuthMark configuration transferred {STALE_MARK_PROFIT} atoms \
-         from an independent LP"
+
+    send_config(
+        &mut env,
+        ProgInstruction::ConfigureAuthMark {
+            asset_index: 0,
+            now_slot: 1,
+            initial_mark_e6: 100,
+            observation_sequence: 3,
+        },
+        &[],
+    )
+    .expect("newer AuthMark configuration");
+    let auth_state = env.svm.get_account(&env.market).unwrap();
+    let stale_hybrid = send_config(
+        &mut env,
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 0,
+            now_slot: 1,
+            now_unix_ts: 100,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 3,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: [feed_id, [0u8; 32], [0u8; 32]],
+            observation_sequence: 2,
+        },
+        &[feed],
+    );
+    assert!(
+        stale_hybrid.is_err(),
+        "an older Hybrid configuration cannot override a newer AuthMark configuration"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        auth_state,
+        "rejected stale Hybrid configuration is atomic"
+    );
+
+    send_config(
+        &mut env,
+        ProgInstruction::ConfigureHybridOracle {
+            asset_index: 0,
+            now_slot: 1,
+            now_unix_ts: 100,
+            oracle_leg_count: 1,
+            oracle_leg_flags: 0,
+            max_staleness_secs: 60,
+            hybrid_soft_stale_slots: 3,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            invert: 0,
+            unit_scale: 0,
+            conf_filter_bps: 500,
+            oracle_leg_feeds: [feed_id, [0u8; 32], [0u8; 32]],
+            observation_sequence: 4,
+        },
+        &[feed],
+    )
+    .expect("newer Hybrid configuration");
+    let hybrid_state = env.svm.get_account(&env.market).unwrap();
+    let stale_ewma = send_config(
+        &mut env,
+        ProgInstruction::ConfigureEwmaMark {
+            asset_index: 0,
+            now_slot: 1,
+            initial_mark_e6: 50,
+            mark_ewma_halflife_slots: 1,
+            mark_min_fee: 0,
+            observation_sequence: 3,
+        },
+        &[],
+    );
+    assert!(
+        stale_ewma.is_err(),
+        "an older EWMA configuration cannot override a newer Hybrid configuration"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        hybrid_state,
+        "the stale EWMA attempt leaves the Hybrid state byte-identical"
+    );
+    let profile = state::read_asset_oracle_profile(&hybrid_state.data, 0).unwrap();
+    assert_eq!(profile.mark_observation_sequence(), 4);
+    assert_eq!(
+        profile.oracle_mode,
+        percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS
     );
 }
 
@@ -16103,6 +16311,7 @@ fn v16_attack_cross_margin_two_asset_conservation() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -16170,6 +16379,7 @@ fn v16_attack_cross_margin_divergent_moves_conserve() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
     );
     let la = Keypair::new();
@@ -16193,7 +16403,7 @@ fn v16_attack_cross_margin_divergent_moves_conserve() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 90,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
     ); // asset1 down -> la loses
        // crank both assets for both portfolios, two passes to converge §6.1/§6.2 warmup.
@@ -17269,6 +17479,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
     );
     let victim_owner = Keypair::new();
@@ -17310,7 +17521,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
                 asset_index: 1,
                 now_slot: slot,
                 mark_e6: mark,
-                observation_sequence: slot,
+                observation_sequence: slot + 1,
             },
         );
         for ai in [0u16, 1] {
@@ -17497,6 +17708,7 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
     );
     let victim_owner = Keypair::new();
@@ -17536,7 +17748,7 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
                 asset_index: 1,
                 now_slot: slot,
                 mark_e6: mark,
-                observation_sequence: slot,
+                observation_sequence: slot + 1,
             },
         );
         for ai in [0u16, 1] {
@@ -19919,6 +20131,7 @@ fn v16_attack_cross_margin_solvent_account_not_unfairly_liquidated() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
     );
     let victim_owner = Keypair::new();
@@ -19958,7 +20171,7 @@ fn v16_attack_cross_margin_solvent_account_not_unfairly_liquidated() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 110,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
     );
     for slot in [10u64, 11] {
@@ -22798,6 +23011,7 @@ fn v16_attack_non_admin_cannot_resolve_or_configure() {
             asset_index: 0,
             now_slot: 0,
             initial_mark_e6: 999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -29866,6 +30080,7 @@ fn v16_attack_cross_margin_divergent_close_conserves() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
     );
     let la = Keypair::new();
@@ -29887,7 +30102,7 @@ fn v16_attack_cross_margin_divergent_close_conserves() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 90,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
     );
     for slot in [10u64, 11] {
@@ -32683,6 +32898,7 @@ fn v16_attack_max_leg_multi_asset_conserves() {
                 asset_index: ai,
                 now_slot: 0,
                 initial_mark_e6: 100,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(env.admin.pubkey(), true),
@@ -32933,6 +33149,7 @@ fn v16_attack_ewma_mark_halflife_zero_safe() {
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 0,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -33291,6 +33508,7 @@ fn v16_attack_retire_asset_authority_gated() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -33405,6 +33623,7 @@ fn v16_attack_per_asset_crank_isolation() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -34451,6 +34670,7 @@ fn v16_attack_per_asset_funding_isolation() {
             initial_mark_e6: IP,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -34586,6 +34806,7 @@ fn v16_attack_fee_redirect_split_lands_correctly() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -35215,6 +35436,7 @@ fn v16_attack_fee_redirect_full_boundary() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -36864,6 +37086,7 @@ fn v16_attack_force_close_healthy_asset_rejected() {
             asset_index: 1,
             now_slot: 0,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -37186,6 +37409,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
             asset_index: 1,
             now_slot: 1,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -40753,7 +40977,7 @@ fn v16_attack_cross_margin_netting_conserves() {
             asset_index: 1,
             now_slot: 2,
             mark_e6: 110,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -42489,6 +42713,7 @@ fn v16_attack_hybrid_oracle_scalar_bounds_reject_atomically() {
                 unit_scale: 0,
                 conf_filter_bps,
                 oracle_leg_feeds: feeds,
+                observation_sequence: 1,
             },
             accounts.clone(),
             &[&admin],
@@ -42537,6 +42762,7 @@ fn v16_attack_hybrid_oracle_scalar_bounds_reject_atomically() {
             unit_scale: 0,
             conf_filter_bps: 500,
             oracle_leg_feeds: feeds,
+            observation_sequence: 1,
         },
         accounts,
         &[&admin],
@@ -44021,7 +44247,7 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44058,6 +44284,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
             initial_mark_e6: 200,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -44084,6 +44311,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 200,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -44124,6 +44352,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
             unit_scale: 0,
             conf_filter_bps: 500,
             oracle_leg_feeds: feeds,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -44154,6 +44383,7 @@ fn v16_attack_non_authority_cannot_reconfigure_oracle_modes() {
             initial_mark_e6: 200,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44205,6 +44435,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 0,
+            observation_sequence: 1,
         },
         "ConfigureAuthMark zero initial mark",
     );
@@ -44214,6 +44445,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: over_max,
+            observation_sequence: 1,
         },
         "ConfigureAuthMark over-max initial mark",
     );
@@ -44225,6 +44457,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             initial_mark_e6: 0,
             mark_ewma_halflife_slots: 4,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         "ConfigureEwmaMark zero initial mark",
     );
@@ -44236,6 +44469,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             initial_mark_e6: over_max,
             mark_ewma_halflife_slots: 4,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         "ConfigureEwmaMark over-max initial mark",
     );
@@ -44247,6 +44481,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 0,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         "ConfigureEwmaMark zero halflife",
     );
@@ -44262,6 +44497,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 4,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44312,7 +44548,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 120,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44336,6 +44572,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 3,
             initial_mark_e6: 200,
+            observation_sequence: 3,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44355,7 +44592,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: 0,
-            observation_sequence: 2,
+            observation_sequence: 4,
         },
         "PushAuthMark zero mark",
     );
@@ -44365,7 +44602,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: over_max,
-            observation_sequence: 2,
+            observation_sequence: 4,
         },
         "PushAuthMark over-max mark",
     );
@@ -44379,7 +44616,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: 220,
-            observation_sequence: 2,
+            observation_sequence: 4,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44439,6 +44676,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 500,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -44467,6 +44705,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
             initial_mark_e6: 500,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -44507,6 +44746,7 @@ fn v16_attack_oracle_reconfiguration_rejects_after_positions_enter_market() {
             unit_scale: 0,
             conf_filter_bps: 500,
             oracle_leg_feeds: feeds,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -44914,6 +45154,7 @@ fn v16_attack_market_exceeds_64_assets_position_holds_any_14_legs() {
                 asset_index: ai,
                 now_slot: TRADE_SLOT,
                 initial_mark_e6: PRICE,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(env.admin.pubkey(), true),
@@ -47679,6 +47920,7 @@ fn v16_attack_non_admin_activate_cannot_install_authorities() {
             asset_index: 1,
             now_slot: 1,
             initial_mark_e6: 1_000_000,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -47819,6 +48061,7 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
             initial_mark_e6: PRICE,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -47863,7 +48106,7 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
             asset_index: HIGH_ASSET as u16,
             now_slot: LIQUIDATION_SLOT,
             mark_e6: 300,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -57164,7 +57407,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -57208,6 +57451,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 10,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(a1.pubkey(), true),
@@ -57229,7 +57473,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             asset_index: 1,
             now_slot: 2,
             mark_e6: 150,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(a1.pubkey(), true),
@@ -57282,7 +57526,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -57337,6 +57581,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 asset_index: 0,
                 now_slot: 1,
                 initial_mark_e6: 250,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -57363,6 +57608,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 asset_index: 1,
                 now_slot: 1,
                 initial_mark_e6: 250,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -57398,6 +57644,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 initial_mark_e6: 250,
                 mark_ewma_halflife_slots: 10,
                 mark_min_fee: 0,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -57426,6 +57673,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 initial_mark_e6: 250,
                 mark_ewma_halflife_slots: 10,
                 mark_min_fee: 0,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -57474,6 +57722,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 unit_scale: 0,
                 conf_filter_bps: 500,
                 oracle_leg_feeds: feeds,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -57511,6 +57760,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_reconfigure_other_asset_modes(
                 unit_scale: 0,
                 conf_filter_bps: 500,
                 oracle_leg_feeds: feeds,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(a1.pubkey(), true),
@@ -58173,7 +58423,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 110,
-            observation_sequence: 1,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58217,7 +58467,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 3,
             mark_e6: 120,
-            observation_sequence: 2,
+            observation_sequence: 3,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58241,7 +58491,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 3,
             mark_e6: 120,
-            observation_sequence: 2,
+            observation_sequence: 3,
         },
         vec![
             AccountMeta::new(newauth.pubkey(), true),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -12981,6 +12981,136 @@ fn v16_bpf_configure_and_push_auth_mark_are_bounded_and_clock_authenticated() {
 }
 
 #[test]
+fn v16_attack_delayed_auth_mark_configuration_cannot_override_newer_intent() {
+    const OPEN_SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+    const ATTACKER_DEPOSIT: u128 = 2_000_000;
+    const LP_DEPOSIT: u128 = 4_000_000;
+    const STALE_MARK_PROFIT: u128 = 500_000;
+
+    let mut env = V16CuEnv::new();
+    let attacker = Keypair::new();
+    let lp_owner = Keypair::new();
+    let attacker_account = env.create_portfolio(&attacker);
+    let lp_account = env.create_portfolio(&lp_owner);
+    env.deposit(&attacker, attacker_account, ATTACKER_DEPOSIT);
+    env.deposit(&lp_owner, lp_account, LP_DEPOSIT);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp(&mut env, &lp_owner, lp_account);
+
+    // The honest oracle authority signs a low initial configuration, then corrects it before
+    // either transaction lands. A later ordinary observation at the corrected price is also
+    // pre-signed. All three transactions are valid under the same recent blockhash, so an
+    // unprivileged relayer can choose their landing order without possessing the oracle key.
+    env.svm.expire_blockhash();
+    let recent_blockhash = env.svm.latest_blockhash();
+    let signed_mark_instruction = |instruction: ProgInstruction| {
+        let ix = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: instruction.encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), ix],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            recent_blockhash,
+        )
+    };
+    let delayed_low_config = signed_mark_instruction(ProgInstruction::ConfigureAuthMark {
+        asset_index: 0,
+        now_slot: 0,
+        initial_mark_e6: 50,
+    });
+    let newer_correct_config = signed_mark_instruction(ProgInstruction::ConfigureAuthMark {
+        asset_index: 0,
+        now_slot: 0,
+        initial_mark_e6: 100,
+    });
+    let next_honest_observation = signed_mark_instruction(ProgInstruction::PushAuthMark {
+        asset_index: 0,
+        now_slot: 0,
+        mark_e6: 100,
+    });
+
+    env.svm
+        .send_transaction(newer_correct_config)
+        .expect("newer correcting configuration lands first");
+    assert_eq!(env.market_state().0.mark_ewma_e6, 100);
+    env.svm
+        .send_transaction(delayed_low_config)
+        .expect("pre-fix delayed configuration remains valid");
+    assert_eq!(
+        env.market_state().0.mark_ewma_e6,
+        50,
+        "the delayed older configuration regressed the live mark"
+    );
+
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp_owner,
+        lp_account,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        OPEN_SIZE_Q,
+        0,
+    );
+    env.svm
+        .send_transaction(next_honest_observation)
+        .expect("the next honest mark observation lands");
+    env.svm.warp_to_slot(1);
+    for account in [attacker_account, lp_account] {
+        env.svm.expire_blockhash();
+        env.crank(
+            account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 1,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.svm.expire_blockhash();
+    env.trade_cpi_with_cu_on_asset(
+        &attacker,
+        attacker_account,
+        &lp_owner,
+        lp_account,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        -OPEN_SIZE_Q,
+        0,
+    );
+
+    let attacker_state = env.portfolio_state(attacker_account);
+    let lp_state = env.portfolio_state(lp_account);
+    assert_eq!(attacker_state.pnl.get(), STALE_MARK_PROFIT as i128);
+    assert_eq!(lp_state.capital.get(), LP_DEPOSIT - STALE_MARK_PROFIT);
+    env.convert_released_pnl_with_cu(&attacker, attacker_account, STALE_MARK_PROFIT);
+    let attacker_capital = env.portfolio_state(attacker_account).capital.get();
+    let attacker_dest = env.withdraw(&attacker, attacker_account, attacker_capital);
+    let lp_dest = env.withdraw(&lp_owner, lp_account, lp_state.capital.get());
+    assert_eq!(
+        env.token_amount(attacker_dest) as u128,
+        ATTACKER_DEPOSIT + STALE_MARK_PROFIT
+    );
+    assert_eq!(
+        env.token_amount(lp_dest) as u128,
+        LP_DEPOSIT - STALE_MARK_PROFIT
+    );
+    panic!(
+        "delayed AuthMark configuration transferred {STALE_MARK_PROFIT} atoms \
+         from an independent LP"
+    );
+}
+
+#[test]
 fn v16_bpf_auth_mark_target_effective_lag_counts_toward_liquidation_health() {
     const INITIAL_MARK: u64 = 100_000_000;
     const TARGET_MARK: u64 = 90_000_000;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1255,6 +1255,15 @@ impl V16CuEnv {
         state::read_portfolio_id(&account.data).unwrap()
     }
 
+    fn next_mark_observation_sequence(&self, asset_index: usize) -> u64 {
+        let account = self.svm.get_account(&self.market).expect("market account");
+        state::read_asset_oracle_profile(&account.data, asset_index)
+            .unwrap()
+            .mark_observation_sequence()
+            .checked_add(1)
+            .expect("mark observation sequence")
+    }
+
     fn mutate_market<F>(&mut self, f: F)
     where
         F: FnOnce(&mut state::WrapperConfigV16, &mut MarketGroupV16),
@@ -2547,6 +2556,7 @@ impl V16CuEnv {
     }
 
     fn push_ewma_mark_with_cu(&mut self, now_slot: u64, mark_e6: u64) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2555,6 +2565,7 @@ impl V16CuEnv {
                 asset_index: 0,
                 now_slot,
                 mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2585,6 +2596,7 @@ impl V16CuEnv {
     }
 
     fn push_auth_mark_with_cu(&mut self, now_slot: u64, mark_e6: u64) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2593,6 +2605,7 @@ impl V16CuEnv {
                 asset_index: 0,
                 now_slot,
                 mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2633,6 +2646,7 @@ impl V16CuEnv {
         now_slot: u64,
         mark_e6: u64,
     ) -> u64 {
+        let observation_sequence = self.next_mark_observation_sequence(asset_index as usize);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2641,6 +2655,7 @@ impl V16CuEnv {
                 asset_index,
                 now_slot,
                 mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2685,6 +2700,7 @@ impl V16CuEnv {
         mark_e6: u64,
     ) -> u64 {
         self.ensure_signer_account(authority.pubkey());
+        let observation_sequence = self.next_mark_observation_sequence(asset_index as usize);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2693,6 +2709,7 @@ impl V16CuEnv {
                 asset_index,
                 now_slot,
                 mark_e6,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
@@ -13145,7 +13162,7 @@ fn v16_attack_delayed_auth_mark_cannot_override_newer_observation() {
     // choose their landing order. The older report must not become current after the newer one.
     env.svm.expire_blockhash();
     let recent_blockhash = env.svm.latest_blockhash();
-    let signed_push = |mark_e6| {
+    let signed_push = |mark_e6, observation_sequence| {
         let push_ix = Instruction {
             program_id: env.program_id,
             accounts: vec![
@@ -13156,6 +13173,7 @@ fn v16_attack_delayed_auth_mark_cannot_override_newer_observation() {
                 asset_index: 0,
                 now_slot: 0,
                 mark_e6,
+                observation_sequence,
             }
             .encode(),
         };
@@ -13166,8 +13184,8 @@ fn v16_attack_delayed_auth_mark_cannot_override_newer_observation() {
             recent_blockhash,
         )
     };
-    let delayed_low_mark = signed_push(50);
-    let newer_correct_mark = signed_push(100);
+    let delayed_low_mark = signed_push(50, 1);
+    let newer_correct_mark = signed_push(100, 2);
     env.svm
         .send_transaction(newer_correct_mark)
         .expect("newer correcting mark lands first");
@@ -13247,6 +13265,54 @@ fn v16_attack_delayed_auth_mark_cannot_override_newer_observation() {
     );
     assert_eq!(env.portfolio_state(attacker_account).pnl.get(), 0);
     assert_eq!(env.portfolio_state(lp_account).capital.get(), LP_DEPOSIT);
+}
+
+#[test]
+fn v16_attack_delayed_ewma_mark_cannot_override_newer_observation() {
+    let mut env = V16CuEnv::new();
+    env.configure_ewma_mark_with_cu(0, 100, 1, 0);
+    env.svm.warp_to_slot(1);
+    env.svm.expire_blockhash();
+    let recent_blockhash = env.svm.latest_blockhash();
+    let signed_push = |mark_e6, observation_sequence| {
+        let push_ix = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::PushEwmaMark {
+                asset_index: 0,
+                now_slot: 0,
+                mark_e6,
+                observation_sequence,
+            }
+            .encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), push_ix],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            recent_blockhash,
+        )
+    };
+    let delayed_old = signed_push(80, 1);
+    let newer = signed_push(120, 2);
+    env.svm
+        .send_transaction(newer)
+        .expect("newer EWMA observation lands first despite a sequence gap");
+    let newer_state = env.svm.get_account(&env.market).unwrap();
+
+    let stale = env.svm.send_transaction(delayed_old);
+    assert!(
+        stale.is_err(),
+        "a delayed older EWMA observation must reject after a newer sequence"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        newer_state,
+        "the rejected stale EWMA observation must leave the newer state byte-identical"
+    );
 }
 
 #[test]
@@ -16127,6 +16193,7 @@ fn v16_attack_cross_margin_divergent_moves_conserve() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 90,
+            observation_sequence: 1,
         },
     ); // asset1 down -> la loses
        // crank both assets for both portfolios, two passes to converge §6.1/§6.2 warmup.
@@ -17243,6 +17310,7 @@ fn v16_regression_cross_margin_insolvency_no_value_extraction() {
                 asset_index: 1,
                 now_slot: slot,
                 mark_e6: mark,
+                observation_sequence: slot,
             },
         );
         for ai in [0u16, 1] {
@@ -17468,6 +17536,7 @@ fn v16_attack_resolved_cross_margin_deep_insolvency_winds_down_publicly() {
                 asset_index: 1,
                 now_slot: slot,
                 mark_e6: mark,
+                observation_sequence: slot,
             },
         );
         for ai in [0u16, 1] {
@@ -18947,6 +19016,7 @@ fn v16_attack_extreme_auth_mark_push_rejected_or_safe() {
     env.svm.warp_to_slot(5);
     // push extreme marks; each must reject or be clamped — never panic, never corrupt state.
     for mark in [0u64, 1, u64::MAX, u64::MAX / 2] {
+        let observation_sequence = env.next_mark_observation_sequence(0);
         env.svm.expire_blockhash();
         let _ = send_tx(
             &mut env.svm,
@@ -18956,6 +19026,7 @@ fn v16_attack_extreme_auth_mark_push_rejected_or_safe() {
                 asset_index: 0,
                 now_slot: 5,
                 mark_e6: mark,
+                observation_sequence,
             },
             vec![
                 AccountMeta::new(env.admin.pubkey(), true),
@@ -19887,6 +19958,7 @@ fn v16_attack_cross_margin_solvent_account_not_unfairly_liquidated() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 110,
+            observation_sequence: 1,
         },
     );
     for slot in [10u64, 11] {
@@ -23008,6 +23080,7 @@ fn v16_attack_out_of_range_asset_index_rejected() {
                 asset_index: bad,
                 now_slot: 1,
                 mark_e6: 100,
+                observation_sequence: 1,
             },
             vec![
                 AccountMeta::new(env.admin.pubkey(), true),
@@ -27329,6 +27402,7 @@ fn v16_attack_permissionless_asset_oracle_cannot_block_base_resolve_matured() {
             asset_index: 1,
             now_slot: 40,
             mark_e6: 102,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(creator.pubkey(), true),
@@ -29813,6 +29887,7 @@ fn v16_attack_cross_margin_divergent_close_conserves() {
             asset_index: 1,
             now_slot: 10,
             mark_e6: 90,
+            observation_sequence: 1,
         },
     );
     for slot in [10u64, 11] {
@@ -40678,6 +40753,7 @@ fn v16_attack_cross_margin_netting_conserves() {
             asset_index: 1,
             now_slot: 2,
             mark_e6: 110,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -42561,6 +42637,7 @@ fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 9_999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -42584,6 +42661,7 @@ fn v16_attack_pushed_mark_cannot_override_external_oracle_asset() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 9_999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -43914,6 +43992,7 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 9_999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -43942,6 +44021,7 @@ fn v16_attack_non_authority_cannot_push_auth_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44208,6 +44288,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 0,
+            observation_sequence: 1,
         },
         "PushEwmaMark zero mark",
     );
@@ -44217,6 +44298,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: over_max,
+            observation_sequence: 1,
         },
         "PushEwmaMark over-max mark",
     );
@@ -44230,6 +44312,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 120,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -44272,6 +44355,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: 0,
+            observation_sequence: 2,
         },
         "PushAuthMark zero mark",
     );
@@ -44281,6 +44365,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: over_max,
+            observation_sequence: 2,
         },
         "PushAuthMark over-max mark",
     );
@@ -44294,6 +44379,7 @@ fn v16_attack_mark_input_bounds_reject_atomically() {
             asset_index: 0,
             now_slot: 4,
             mark_e6: 220,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -47777,6 +47863,7 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
             asset_index: HIGH_ASSET as u16,
             now_slot: LIQUIDATION_SLOT,
             mark_e6: 300,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -57047,6 +57134,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 9_999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(a1.pubkey(), true),
@@ -57076,6 +57164,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -57140,6 +57229,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             asset_index: 1,
             now_slot: 2,
             mark_e6: 150,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(a1.pubkey(), true),
@@ -57163,6 +57253,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 9_999_999,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(a1.pubkey(), true),
@@ -57191,6 +57282,7 @@ fn v16_attack_cross_asset_oracle_authority_cannot_push_other_asset_ewma_mark() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 150,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58081,6 +58173,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 110,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58124,6 +58217,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 3,
             mark_e6: 120,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58147,6 +58241,7 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
             asset_index: 0,
             now_slot: 3,
             mark_e6: 120,
+            observation_sequence: 2,
         },
         vec![
             AccountMeta::new(newauth.pubkey(), true),
@@ -59782,6 +59877,7 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_default_runtime_authorities
             asset_index: 0,
             now_slot: 2,
             mark_e6: 777,
+            observation_sequence: 1,
         },
         vec![
             AccountMeta::new(old_marketauth.pubkey(), true),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -943,6 +943,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
     let mark_ewma_halflife_slots: u64 = kani::any();
     let mark_min_fee: u64 = kani::any();
     let unit_scale: u32 = kani::any();
+    let observation_sequence: u64 = kani::any();
     let mut feeds = [[0u8; 32]; 3];
     let mut i = 0;
     while i < 3 {
@@ -954,7 +955,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 156];
+    let mut data = [0u8; 164];
     data[0] = 34;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
     data[3..11].copy_from_slice(&now_slot.to_le_bytes());
@@ -971,6 +972,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
     data[60..92].copy_from_slice(&feeds[0]);
     data[92..124].copy_from_slice(&feeds[1]);
     data[124..156].copy_from_slice(&feeds[2]);
+    data[156..164].copy_from_slice(&observation_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::ConfigureHybridOracle {
@@ -987,6 +989,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
             unit_scale: got_unit_scale,
             conf_filter_bps: got_conf,
             oracle_leg_feeds: got_feeds,
+            observation_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_now_slot, now_slot);
@@ -1001,6 +1004,7 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
             assert_eq!(got_unit_scale, unit_scale);
             assert_eq!(got_conf, conf_filter_bps);
             assert_eq!(got_feeds, feeds);
+            assert_eq!(got_sequence, observation_sequence);
         }
         _ => unreachable!(),
     }
@@ -1017,13 +1021,14 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
     let push_mark_e6: u64 = kani::any();
     let observation_sequence: u64 = kani::any();
 
-    let mut configure = [0u8; 35];
+    let mut configure = [0u8; 43];
     configure[0] = 35;
     configure[1..3].copy_from_slice(&asset_index.to_le_bytes());
     configure[3..11].copy_from_slice(&now_slot.to_le_bytes());
     configure[11..19].copy_from_slice(&initial_mark_e6.to_le_bytes());
     configure[19..27].copy_from_slice(&mark_ewma_halflife_slots.to_le_bytes());
     configure[27..35].copy_from_slice(&mark_min_fee.to_le_bytes());
+    configure[35..43].copy_from_slice(&observation_sequence.to_le_bytes());
     match Instruction::decode(&configure).unwrap() {
         Instruction::ConfigureEwmaMark {
             asset_index: got_asset_index,
@@ -1031,12 +1036,14 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
             initial_mark_e6: got_mark,
             mark_ewma_halflife_slots: got_halflife,
             mark_min_fee: got_min_fee,
+            observation_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, initial_mark_e6);
             assert_eq!(got_halflife, mark_ewma_halflife_slots);
             assert_eq!(got_min_fee, mark_min_fee);
+            assert_eq!(got_sequence, observation_sequence);
         }
         _ => unreachable!(),
     }
@@ -1062,20 +1069,23 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut configure_auth = [0u8; 19];
+    let mut configure_auth = [0u8; 27];
     configure_auth[0] = 62;
     configure_auth[1..3].copy_from_slice(&asset_index.to_le_bytes());
     configure_auth[3..11].copy_from_slice(&now_slot.to_le_bytes());
     configure_auth[11..19].copy_from_slice(&initial_mark_e6.to_le_bytes());
+    configure_auth[19..27].copy_from_slice(&observation_sequence.to_le_bytes());
     match Instruction::decode(&configure_auth).unwrap() {
         Instruction::ConfigureAuthMark {
             asset_index: got_asset_index,
             now_slot: got_now,
             initial_mark_e6: got_mark,
+            observation_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, initial_mark_e6);
+            assert_eq!(got_sequence, observation_sequence);
         }
         _ => unreachable!(),
     }
@@ -1103,8 +1113,22 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
-fn kani_v16_authenticated_mark_push_payloads_require_exact_length() {
+fn kani_v16_authenticated_mark_payloads_require_exact_length() {
     let extra: u8 = kani::any();
+
+    let hybrid = [34u8; 164];
+    assert!(Instruction::decode(&hybrid).is_ok());
+    assert!(Instruction::decode(&hybrid[..163]).is_err());
+    let mut hybrid_trailing = [34u8; 165];
+    hybrid_trailing[164] = extra;
+    assert!(Instruction::decode(&hybrid_trailing).is_err());
+
+    let configure_ewma = [35u8; 43];
+    assert!(Instruction::decode(&configure_ewma).is_ok());
+    assert!(Instruction::decode(&configure_ewma[..42]).is_err());
+    let mut configure_ewma_trailing = [35u8; 44];
+    configure_ewma_trailing[43] = extra;
+    assert!(Instruction::decode(&configure_ewma_trailing).is_err());
 
     let ewma = [36u8; 27];
     assert!(Instruction::decode(&ewma).is_ok());
@@ -1112,6 +1136,13 @@ fn kani_v16_authenticated_mark_push_payloads_require_exact_length() {
     let mut ewma_trailing = [36u8; 28];
     ewma_trailing[27] = extra;
     assert!(Instruction::decode(&ewma_trailing).is_err());
+
+    let configure_auth = [62u8; 27];
+    assert!(Instruction::decode(&configure_auth).is_ok());
+    assert!(Instruction::decode(&configure_auth[..26]).is_err());
+    let mut configure_auth_trailing = [62u8; 28];
+    configure_auth_trailing[27] = extra;
+    assert!(Instruction::decode(&configure_auth_trailing).is_err());
 
     let auth = [63u8; 27];
     assert!(Instruction::decode(&auth).is_ok());
@@ -1328,6 +1359,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             unit_scale: 0,
             conf_filter_bps: 500,
             oracle_leg_feeds: [[1u8; 32], [0u8; 32], [0u8; 32]],
+            observation_sequence: 1,
         },
         extra,
     );
@@ -1338,6 +1370,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             initial_mark_e6: 100,
             mark_ewma_halflife_slots: 1,
             mark_min_fee: 0,
+            observation_sequence: 1,
         },
         extra,
     );
@@ -1355,6 +1388,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             asset_index: 0,
             now_slot: 1,
             initial_mark_e6: 100,
+            observation_sequence: 1,
         },
         extra,
     );

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -1015,6 +1015,7 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
     let mark_ewma_halflife_slots: u64 = kani::any();
     let mark_min_fee: u64 = kani::any();
     let push_mark_e6: u64 = kani::any();
+    let observation_sequence: u64 = kani::any();
 
     let mut configure = [0u8; 35];
     configure[0] = 35;
@@ -1040,20 +1041,23 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut push = [0u8; 19];
+    let mut push = [0u8; 27];
     push[0] = 36;
     push[1..3].copy_from_slice(&asset_index.to_le_bytes());
     push[3..11].copy_from_slice(&now_slot.to_le_bytes());
     push[11..19].copy_from_slice(&push_mark_e6.to_le_bytes());
+    push[19..27].copy_from_slice(&observation_sequence.to_le_bytes());
     match Instruction::decode(&push).unwrap() {
         Instruction::PushEwmaMark {
             asset_index: got_asset_index,
             now_slot: got_now,
             mark_e6: got_mark,
+            observation_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, push_mark_e6);
+            assert_eq!(got_sequence, observation_sequence);
         }
         _ => unreachable!(),
     }
@@ -1076,23 +1080,45 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut push_auth = [0u8; 19];
+    let mut push_auth = [0u8; 27];
     push_auth[0] = 63;
     push_auth[1..3].copy_from_slice(&asset_index.to_le_bytes());
     push_auth[3..11].copy_from_slice(&now_slot.to_le_bytes());
     push_auth[11..19].copy_from_slice(&push_mark_e6.to_le_bytes());
+    push_auth[19..27].copy_from_slice(&observation_sequence.to_le_bytes());
     match Instruction::decode(&push_auth).unwrap() {
         Instruction::PushAuthMark {
             asset_index: got_asset_index,
             now_slot: got_now,
             mark_e6: got_mark,
+            observation_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_now, now_slot);
             assert_eq!(got_mark, push_mark_e6);
+            assert_eq!(got_sequence, observation_sequence);
         }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_authenticated_mark_push_payloads_require_exact_length() {
+    let extra: u8 = kani::any();
+
+    let ewma = [36u8; 27];
+    assert!(Instruction::decode(&ewma).is_ok());
+    assert!(Instruction::decode(&ewma[..26]).is_err());
+    let mut ewma_trailing = [36u8; 28];
+    ewma_trailing[27] = extra;
+    assert!(Instruction::decode(&ewma_trailing).is_err());
+
+    let auth = [63u8; 27];
+    assert!(Instruction::decode(&auth).is_ok());
+    assert!(Instruction::decode(&auth[..26]).is_err());
+    let mut auth_trailing = [63u8; 28];
+    auth_trailing[27] = extra;
+    assert!(Instruction::decode(&auth_trailing).is_err());
 }
 
 #[kani::proof]
@@ -1320,6 +1346,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 101,
+            observation_sequence: 1,
         },
         extra,
     );
@@ -1336,6 +1363,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
             asset_index: 0,
             now_slot: 2,
             mark_e6: 101,
+            observation_sequence: 1,
         },
         extra,
     );
@@ -1526,13 +1554,13 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let configure_ewma_mark = [35u8; 34];
     assert!(Instruction::decode(&configure_ewma_mark).is_err());
 
-    let push_ewma_mark = [36u8; 18];
+    let push_ewma_mark = [36u8; 26];
     assert!(Instruction::decode(&push_ewma_mark).is_err());
 
     let configure_auth_mark = [62u8; 18];
     assert!(Instruction::decode(&configure_auth_mark).is_err());
 
-    let push_auth_mark = [63u8; 18];
+    let push_auth_mark = [63u8; 26];
     assert!(Instruction::decode(&push_auth_mark).is_err());
 
     let update_liquidation = [37u8; 2];


### PR DESCRIPTION
## Summary

An unprivileged relayer can reorder honest, fully signed authenticated-mark transactions that share a still-valid recent blockhash. Before this change, landing-slot freshness did not order either mark pushes or oracle-mode configuration. A withheld older intent could therefore replace a newer correction and create a false mark that an attacker trades against through the public CPI path.

Two exact-parent public LiteSVM RED tests demonstrate the same missing per-asset ordering invariant:

- Delayed `PushAuthMark`: land honest sequence 2 (mark 100) before withheld sequence 1 (mark 50), then settle and withdraw 500,000 collateral atoms from an independent LP.
- Delayed `ConfigureAuthMark`: land honest configuration sequence 2 (mark 100) before withheld configuration sequence 1 (mark 50), open through the official matcher, apply honest future sequence 3, then settle and withdraw 500,000 atoms from the LP.

Neither exploit uses state injection, a dishonest oracle value, a compromised key, or a victim signature.

## Fix

- Add signer-chosen `observation_sequence` to `ConfigureHybridOracle`, `ConfigureEwmaMark`, `ConfigureAuthMark`, `PushEwmaMark`, and `PushAuthMark`.
- Make all five instructions advance one shared per-asset watermark, including across mode changes.
- Persist the watermark in six bytes of existing oracle-profile padding, preserving the 400-byte zero-copy layout.
- Require strict monotonicity while allowing gaps and out-of-order transaction landing.
- Preserve the sequence across oracle-profile and asset-lifecycle rewrites.
- Reject values outside the persisted 48-bit range.
- Update direct API documentation, decoder tests, and Kani wire contracts.

Asset-generation binding remains a separate concern from PR #275.

## TDD evidence

- Exact pre-fix parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- Configuration RED: `23a6e800`
- Push RED: `0ae218da` (same test as original `393ea841`)
- Push fix: `abf2198f`
- Comprehensive shared-sequence fix: `d5f21527`

Fixed-head controls cover stale AuthMark and EWMA pushes, cross-mode stale configurations, accepted sequence gaps, byte-identical rollback on rejection, and ordinary positive configuration/push paths.

## Verification

- Pinned v1.52 program, authenticated matcher, and hostile matcher SBF builds: PASS
- `cargo test --test v16_cu -- --test-threads=1`: 569/569 PASS, including all max-shape CU gates
- `cargo test --lib -- --test-threads=1`: 7/7 PASS
- `cargo check --all-targets`: PASS
- `cargo fmt --all -- --check`: PASS
- `git diff --check`: PASS

The updated Kani sources compile. The 164-byte hybrid field-preservation query was stopped after 10 minutes because the existing whole-enum decoder also symbolically explored unrelated variable-length crank/batch branches (unwind 94); no Kani pass is claimed for that final query.