### PR TITLE
[BLOCKER LoF] Reject delayed liquidation-fee policy replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - candidate accounts are untrusted hints, not a liveness precondition; honest keepers should include the worst known stale/bankrupt/liquidatable accounts, but the engine also makes cursored progress
   - may perform bounded catchup/recovery, liquidation, touch-only settlement, round-robin lifecycle progress, and empty-account reclaim
   - liquidation rewards are optional: when `liquidation_cranker_fee_share_bps > 0`, a keeper may append its writable Percolator portfolio account as the final account in the instruction. Oracle accounts remain immediately after the target portfolio account; the reward portfolio, if present, is last. If no reward portfolio is supplied, the full retained liquidation penalty stays in insurance.
+- **UpdateLiquidationFeePolicy** (tag 37)
+  - sets the optional cranker share and carries a market-authority-chosen `policy_sequence`
+  - the sequence must strictly exceed the last accepted liquidation-policy sequence; gaps are allowed, while delayed, duplicate, zero, and lower intents reject
+  - tag 37's payload is exactly `u16 cranker_share_bps || u64 policy_sequence`; legacy unsequenced payloads reject
 - **SyncMaintenanceFee** (tag 48)
   - permissionless per-portfolio maintenance-fee realization for the supplied portfolio account
   - charges `maintenance_fee_per_slot * elapsed_slots`, capped by remaining capital, into insurance after engine-side loss settlement

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -512,7 +512,13 @@ pub mod state {
         pub collateral_mint: [u8; 32],
         pub secondary_collateral_mint: [u8; 32],
         pub maintenance_fee_per_slot: u128,
-        pub permissionless_market_init_fee: u128,
+        /// The public asset-init fee is token-denominated and therefore bounded to `u64`.
+        /// This occupies the low word of the former `u128` field, preserving the zero-copy ABI.
+        pub permissionless_market_init_fee: u64,
+        /// Last accepted market-authority liquidation-policy intent. The high word of the former
+        /// `permissionless_market_init_fee` was always zero because every public setter enforced
+        /// `u64`, so legacy accounts begin at sequence zero without migration.
+        pub liquidation_fee_policy_sequence: u64,
         pub trade_fee_base_bps: u64,
         pub permissionless_resolve_stale_slots: u64,
         pub force_close_delay_slots: u64,
@@ -2550,6 +2556,7 @@ pub mod ix {
         },
         UpdateLiquidationFeePolicy {
             cranker_share_bps: u16,
+            policy_sequence: u64,
         },
         UpdateMaintenanceFeePolicy {
             cranker_share_bps: u16,
@@ -2812,6 +2819,7 @@ pub mod ix {
                 },
                 37 => Self::UpdateLiquidationFeePolicy {
                     cranker_share_bps: read_u16(&mut rest)?,
+                    policy_sequence: read_u64(&mut rest)?,
                 },
                 49 => Self::UpdateMaintenanceFeePolicy {
                     cranker_share_bps: read_u16(&mut rest)?,
@@ -3116,9 +3124,13 @@ pub mod ix {
                     out.push(kind);
                     out.extend_from_slice(&new_pubkey);
                 }
-                Self::UpdateLiquidationFeePolicy { cranker_share_bps } => {
+                Self::UpdateLiquidationFeePolicy {
+                    cranker_share_bps,
+                    policy_sequence,
+                } => {
                     out.push(37);
                     push_u16(&mut out, cranker_share_bps);
+                    push_u64(&mut out, policy_sequence);
                 }
                 Self::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
                     out.push(49);
@@ -5289,9 +5301,15 @@ pub mod processor {
                 kind,
                 new_pubkey,
             } => handle_update_asset_authority(program_id, accounts, asset_index, kind, new_pubkey),
-            Instruction::UpdateLiquidationFeePolicy { cranker_share_bps } => {
-                handle_update_liquidation_fee_policy(program_id, accounts, cranker_share_bps)
-            }
+            Instruction::UpdateLiquidationFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            } => handle_update_liquidation_fee_policy(
+                program_id,
+                accounts,
+                cranker_share_bps,
+                policy_sequence,
+            ),
             Instruction::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
                 handle_update_maintenance_fee_policy(program_id, accounts, cranker_share_bps)
             }
@@ -5550,6 +5568,7 @@ pub mod processor {
             secondary_collateral_mint: [0u8; 32],
             maintenance_fee_per_slot,
             permissionless_market_init_fee: 0,
+            liquidation_fee_policy_sequence: 0,
             trade_fee_base_bps,
             permissionless_resolve_stale_slots: 0,
             force_close_delay_slots: 0,
@@ -9107,7 +9126,7 @@ pub mod processor {
                 0
             } else {
                 let fee = permissionless_market_init_fee_for_asset(
-                    cfg_pre.permissionless_market_init_fee,
+                    u128::from(cfg_pre.permissionless_market_init_fee),
                     asset_index,
                 )?;
                 if fee == 0 {
@@ -9146,7 +9165,7 @@ pub mod processor {
                         cfg.marketauth != [0u8; 32] && cfg.marketauth == authority.key.to_bytes();
                     if !still_asset_authority {
                         let expected_fee = permissionless_market_init_fee_for_asset(
-                            cfg.permissionless_market_init_fee,
+                            u128::from(cfg.permissionless_market_init_fee),
                             asset_index,
                         )?;
                         if expected_fee == 0 || expected_fee != init_fee {
@@ -9505,6 +9524,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         cranker_share_bps: u16,
+        policy_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9517,7 +9537,11 @@ pub mod processor {
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
+        if policy_sequence <= cfg.liquidation_fee_policy_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
         cfg.liquidation_cranker_fee_share_bps = cranker_share_bps;
+        cfg.liquidation_fee_policy_sequence = policy_sequence;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
     }
 
@@ -9706,7 +9730,7 @@ pub mod processor {
         expect_signer(admin)?;
         expect_writable(market_ai)?;
         expect_owner(market_ai, program_id)?;
-        let _ = amount_to_u64(min_init_fee)?;
+        let min_init_fee = amount_to_u64(min_init_fee)?;
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -57610,6 +57610,132 @@ fn v16_attack_sync_maintenance_full_cranker_share_conserves_no_insurance_underfl
     assert_domain_budget_remaining_total_consistent(&group, "100% maintenance cranker share");
 }
 
+#[test]
+fn v16_attack_delayed_liquidation_policy_cannot_redirect_fee_to_cranker() {
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+
+    // The honest admin signs an older 100% cranker-share policy and then a
+    // correcting 0% policy under one still-live blockhash. Relayers may land
+    // those already-authorized bytes, but an older intent must not replace the
+    // correction after users enter under the visible zero-share policy.
+    let blockhash = env.svm.latest_blockhash();
+    let make_policy_tx = |cranker_share_bps| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::UpdateLiquidationFeePolicy { cranker_share_bps }.encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            blockhash,
+        )
+    };
+    let delayed_high_share = make_policy_tx(10_000);
+    let correcting_zero_share = make_policy_tx(0);
+    env.svm
+        .send_transaction(correcting_zero_share)
+        .expect("newer zero-share policy lands first");
+    assert_eq!(env.market_state().0.liquidation_cranker_fee_share_bps, 0);
+
+    let long_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short_owner = Keypair::new();
+    let short = env.create_portfolio(&short_owner);
+    let cranker_owner = Keypair::new();
+    let cranker = env.create_portfolio(&cranker_owner);
+    env.deposit(&long_owner, long, 100_000_000);
+    env.deposit(&short_owner, short, 100_000);
+    env.deposit(&cranker_owner, cranker, 1_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+
+    let delayed_accepted = env.svm.send_transaction(delayed_high_share).is_ok();
+    for slot in 1..=30u64 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, 2_000_000);
+        env.svm.expire_blockhash();
+        let _ = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        );
+    }
+
+    let cranker_capital_before = env.portfolio_state(cranker).capital.get();
+    let insurance_before = env.market_state().1.insurance;
+    env.svm.expire_blockhash();
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(cranker_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(short, false),
+            AccountMeta::new(cranker, false),
+        ],
+        &[&cranker_owner],
+    )
+    .expect("the liquidation itself remains live");
+    let cranker_reward = env
+        .portfolio_state(cranker)
+        .capital
+        .get()
+        .saturating_sub(cranker_capital_before);
+    let insurance_credit = env
+        .market_state()
+        .1
+        .insurance
+        .saturating_sub(insurance_before);
+    assert!(
+        cranker_reward + insurance_credit > 0,
+        "the liquidation must charge a nonzero fee"
+    );
+    let extracted = if cranker_reward == 0 {
+        0
+    } else {
+        let destination = env.withdraw(&cranker_owner, cranker, cranker_reward);
+        env.token_amount(destination)
+    };
+
+    assert!(
+        !delayed_accepted,
+        "older high-share intent landed after the correction and redirected \
+         {cranker_reward} fee atoms from canonical insurance; {extracted} atoms \
+         were publicly withdrawn by the relayer/cranker"
+    );
+    assert_eq!(
+        (cranker_reward, extracted),
+        (0, 0),
+        "the corrected zero-share policy must leave no extractable cranker reward"
+    );
+}
+
 // [from pr125]
 // LoF/safety sweep — RebalanceReduce is reduce-ONLY: an over-sized reduce_q cannot flip a position into
 // opposite-side risk. The engine clamps `reduce_q = reduce_q.min(leg.basis_pos_q.unsigned_abs())`, so a

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -969,11 +969,20 @@ impl V16CuEnv {
     }
 
     fn update_liquidation_fee_policy_with_cu(&mut self, cranker_share_bps: u16) -> u64 {
+        let policy_sequence = self
+            .market_state()
+            .0
+            .liquidation_fee_policy_sequence
+            .checked_add(1)
+            .expect("liquidation policy sequence");
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateLiquidationFeePolicy { cranker_share_bps },
+            ProgInstruction::UpdateLiquidationFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -13119,6 +13128,7 @@ fn v16_bpf_policy_authority_and_base_unit_tags_are_bounded_and_persist() {
     );
     let (cfg, _) = env.market_state();
     assert_eq!(cfg.liquidation_cranker_fee_share_bps, 1_234);
+    assert_eq!(cfg.liquidation_fee_policy_sequence, 1);
 
     let maintenance_cu = env.update_maintenance_fee_policy_with_cu(2_345);
     assert_cu_within(
@@ -13193,6 +13203,63 @@ fn v16_bpf_policy_authority_and_base_unit_tags_are_bounded_and_persist() {
     assert_cu_within("UpdateAuthority", authority_cu, CUSTODY_CU_LIMIT);
     let (cfg, _) = env.market_state();
     assert_eq!(cfg.marketauth, new_asset_authority.pubkey().to_bytes());
+}
+
+#[test]
+fn v16_bpf_liquidation_policy_sequence_accepts_gaps_and_rejects_replays() {
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(77);
+
+    let update = |env: &mut V16CuEnv, sequence: u64, share_bps: u16| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateLiquidationFeePolicy {
+                cranker_share_bps: share_bps,
+                policy_sequence: sequence,
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin],
+        )
+    };
+
+    let first_cu = update(&mut env, 17, 1_234).expect("first sequence with a forward gap");
+    assert_cu_within(
+        "UpdateLiquidationFeePolicy sequenced",
+        first_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let accepted = env.svm.get_account(&env.market).unwrap();
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.liquidation_cranker_fee_share_bps, 1_234);
+    assert_eq!(cfg.liquidation_fee_policy_sequence, 17);
+    assert_eq!(
+        cfg.permissionless_market_init_fee, 77,
+        "the ABI-compatible sequence word must not corrupt the adjacent init fee"
+    );
+
+    for stale_sequence in [0, 16, 17] {
+        assert!(
+            update(&mut env, stale_sequence, 9_999).is_err(),
+            "zero, lower, and equal policy sequences must reject"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            accepted,
+            "a rejected policy replay must leave the complete market byte-identical"
+        );
+    }
+
+    update(&mut env, 1_000_000, 4_321).expect("large forward sequence gaps remain valid");
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.liquidation_cranker_fee_share_bps, 4_321);
+    assert_eq!(cfg.liquidation_fee_policy_sequence, 1_000_000);
+    assert_eq!(cfg.permissionless_market_init_fee, 77);
 }
 
 #[test]
@@ -25873,6 +25940,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     old_attempt(
         ProgInstruction::UpdateLiquidationFeePolicy {
             cranker_share_bps: 5_000,
+            policy_sequence: 1,
         },
         "liquidation policy replay",
     );
@@ -25919,6 +25987,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     new_update(
         ProgInstruction::UpdateLiquidationFeePolicy {
             cranker_share_bps: 5_000,
+            policy_sequence: 1,
         },
         "liquidation policy update",
     );
@@ -34493,6 +34562,7 @@ fn v16_attack_global_policy_bounds_reject_grief_values() {
         &mut env,
         ProgInstruction::UpdateLiquidationFeePolicy {
             cranker_share_bps: 10_001,
+            policy_sequence: 2,
         },
         "liquidation cranker share above 100%",
     );
@@ -34729,7 +34799,8 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
     );
     assert!(
         attempt(ProgInstruction::UpdateLiquidationFeePolicy {
-            cranker_share_bps: 2_500
+            cranker_share_bps: 2_500,
+            policy_sequence: 1,
         })
         .is_err(),
         "asset-1 authority must not control global liquidation-fee policy"
@@ -57620,14 +57691,18 @@ fn v16_attack_delayed_liquidation_policy_cannot_redirect_fee_to_cranker() {
     // those already-authorized bytes, but an older intent must not replace the
     // correction after users enter under the visible zero-share policy.
     let blockhash = env.svm.latest_blockhash();
-    let make_policy_tx = |cranker_share_bps| {
+    let make_policy_tx = |cranker_share_bps, policy_sequence| {
         let instruction = Instruction {
             program_id: env.program_id,
             accounts: vec![
                 AccountMeta::new(env.admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
             ],
-            data: ProgInstruction::UpdateLiquidationFeePolicy { cranker_share_bps }.encode(),
+            data: ProgInstruction::UpdateLiquidationFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            }
+            .encode(),
         };
         Transaction::new_signed_with_payer(
             &[heap_ix(), cu_ix(), instruction],
@@ -57636,8 +57711,8 @@ fn v16_attack_delayed_liquidation_policy_cannot_redirect_fee_to_cranker() {
             blockhash,
         )
     };
-    let delayed_high_share = make_policy_tx(10_000);
-    let correcting_zero_share = make_policy_tx(0);
+    let delayed_high_share = make_policy_tx(10_000, 1);
+    let correcting_zero_share = make_policy_tx(0, 2);
     env.svm
         .send_transaction(correcting_zero_share)
         .expect("newer zero-share policy lands first");
@@ -57685,22 +57760,38 @@ fn v16_attack_delayed_liquidation_policy_cannot_redirect_fee_to_cranker() {
     let cranker_capital_before = env.portfolio_state(cranker).capital.get();
     let insurance_before = env.market_state().1.insurance;
     env.svm.expire_blockhash();
-    send_tx(
-        &mut env.svm,
-        env.program_id,
-        &env.payer,
-        ProgInstruction::PermissionlessCrank {
-            now_slot: 30,
-            observations: crank_observations(0),
-        },
-        vec![
-            AccountMeta::new(cranker_owner.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(short, false),
-            AccountMeta::new(cranker, false),
-        ],
-        &[&cranker_owner],
-    )
+    let liquidation = ProgInstruction::PermissionlessCrank {
+        now_slot: 30,
+        observations: crank_observations(0),
+    };
+    if delayed_accepted {
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            liquidation,
+            vec![
+                AccountMeta::new(cranker_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+                AccountMeta::new(cranker, false),
+            ],
+            &[&cranker_owner],
+        )
+    } else {
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            liquidation,
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        )
+    }
     .expect("the liquidation itself remains live");
     let cranker_reward = env
         .portfolio_state(cranker)

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -766,15 +766,21 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
 #[kani::proof]
 fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
+    let policy_sequence: u64 = kani::any();
 
-    let mut data = [0u8; 3];
+    let mut data = [0u8; 11];
     data[0] = 37;
     data[1..3].copy_from_slice(&cranker_share_bps.to_le_bytes());
+    data[3..11].copy_from_slice(&policy_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateLiquidationFeePolicy {
             cranker_share_bps: got,
-        } => assert_eq!(got, cranker_share_bps),
+            policy_sequence: got_sequence,
+        } => {
+            assert_eq!(got, cranker_share_bps);
+            assert_eq!(got_sequence, policy_sequence);
+        }
         _ => unreachable!(),
     }
 }
@@ -1232,6 +1238,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::UpdateLiquidationFeePolicy {
             cranker_share_bps: 4_000,
+            policy_sequence: 1,
         },
         extra,
     );

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -786,6 +786,24 @@ fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_update_liquidation_fee_policy_requires_exact_framing() {
+    let instruction = Instruction::UpdateLiquidationFeePolicy {
+        cranker_share_bps: kani::any(),
+        policy_sequence: kani::any(),
+    };
+    let mut data = instruction.encode();
+    assert_eq!(data.len(), 11);
+    assert!(Instruction::decode(&data).is_ok());
+
+    data.pop();
+    assert!(Instruction::decode(&data).is_err());
+
+    data.push(0);
+    data.push(kani::any());
+    assert!(Instruction::decode(&data).is_err());
+}
+
+#[kani::proof]
 fn kani_v16_update_maintenance_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
 


### PR DESCRIPTION
## Root cause

`UpdateLiquidationFeePolicy` authenticated the market authority but carried no intent ordering. Two honestly signed policy transactions could remain valid under the same recent blockhash and land in reverse order. An unprivileged relayer/cranker could therefore land a newer 0% correction first, wait for independent users to trade, then land the older 100% cranker-share intent immediately before liquidating a victim.

The exact-parent public LiteSVM RED test redirected 524 liquidation-fee atoms away from canonical insurance and then withdrew all 524 atoms through the public cranker portfolio path. It uses no protocol-state injection, dishonest oracle, initialization mistake, or compromised authority.

## Fix

- Add a signer-chosen `u64 policy_sequence` to tag 37.
- Require strict advancement over the last accepted liquidation-policy sequence; gaps are allowed, while zero, duplicate, and lower values reject without mutation.
- Reject legacy unsequenced and trailing-byte payloads through exact instruction framing.
- Preserve the 448-byte zero-copy market ABI by narrowing `permissionless_market_init_fee` to its already-enforced `u64` domain and using the former high 64-bit word for the sequence. Every publicly reachable legacy account has that word zero.
- Keep liquidation live after a rejected replay; the fee remains in canonical insurance when the accepted share is 0%.

## TDD history

- `7af894cf`: exact-parent RED reproduction against `36fa587e` / engine `143e68c`; 524 atoms publicly extracted.
- `32848fa2`: production fix and GREEN public-interface tests.
- `9f55856b`: dedicated exact-framing Kani proof.

## Verification

- Solana SBF build, tools v1.52
- 567/567 `v16_cu` LiteSVM/CU tests green
- 6/6 library tests green, including fixed `WrapperConfigV16` size
- Focused Kani field-preservation proof: 817 checks, 0 failures
- Focused Kani exact/short/trailing framing proof: 1,533 checks, 0 failures
- `cargo check --all-targets`
- `cargo fmt --check`
- `git diff --check`

Engine pin remains `143e68c4917ed0400a27b952f036a5677047cd84`; no engine change is required.