### PR TITLE
[BLOCKER LoF] Reject delayed maintenance-fee policy replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - optional final account: a writable Percolator cranker portfolio can receive `maintenance_cranker_fee_share_bps` of the fee as internal account capital. If omitted, or if the configured share is zero, the full fee remains in insurance. If the cranker portfolio is the same key as the fee payer, the unsplit insurance share is still collected.
   - live nonflat accounts are anchored to the loss-accrued market slot, so fees cannot run ahead of settled losses
   - the rate is configured at `InitMarket` in collateral atoms per slot; a "$0.50 per 24h" anti-dust policy is an operator/client conversion from collateral atoms per day to atoms per expected slot
+- **UpdateMaintenanceFeePolicy** (tag 49)
+  - sets the optional maintenance cranker share and carries a market-authority-chosen `policy_sequence`
+  - the sequence must strictly exceed the last accepted maintenance-policy sequence; gaps are allowed, while delayed, duplicate, zero, and lower intents reject
+  - tag 49's payload is exactly `u16 cranker_share_bps || u64 policy_sequence`; legacy unsequenced payloads reject
 - **FinalizeResetSide** (tag 45)
   - permissionless side-reset finalization for engine-ready asset sides
   - validates side encoding and engine readiness; it is not an admin override

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -517,7 +517,13 @@ pub mod state {
         pub permissionless_resolve_stale_slots: u64,
         pub force_close_delay_slots: u64,
         pub last_good_oracle_slot: u64,
-        pub insurance_withdraw_deposit_remaining: u128,
+        /// Deposits-only insurance principal is bounded by `MAX_VAULT_TVL` and therefore `u64`.
+        /// This occupies the low word of the former `u128` field, preserving the zero-copy ABI.
+        pub insurance_withdraw_deposit_remaining: u64,
+        /// Last accepted market-authority maintenance-policy intent. The high word of the former
+        /// deposits-only principal was always zero in publicly reachable states, so legacy accounts
+        /// begin at sequence zero without migration.
+        pub maintenance_fee_policy_sequence: u64,
         pub insurance_withdraw_max_bps: u16,
         pub liquidation_cranker_fee_share_bps: u16,
         pub maintenance_cranker_fee_share_bps: u16,
@@ -2553,6 +2559,7 @@ pub mod ix {
         },
         UpdateMaintenanceFeePolicy {
             cranker_share_bps: u16,
+            policy_sequence: u64,
         },
         UpdateBackingFeePolicy {
             domain: u16,
@@ -2815,6 +2822,7 @@ pub mod ix {
                 },
                 49 => Self::UpdateMaintenanceFeePolicy {
                     cranker_share_bps: read_u16(&mut rest)?,
+                    policy_sequence: read_u64(&mut rest)?,
                 },
                 51 => Self::UpdateBackingFeePolicy {
                     domain: read_u16(&mut rest)?,
@@ -3120,9 +3128,13 @@ pub mod ix {
                     out.push(37);
                     push_u16(&mut out, cranker_share_bps);
                 }
-                Self::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
+                Self::UpdateMaintenanceFeePolicy {
+                    cranker_share_bps,
+                    policy_sequence,
+                } => {
                     out.push(49);
                     push_u16(&mut out, cranker_share_bps);
+                    push_u64(&mut out, policy_sequence);
                 }
                 Self::UpdateBackingFeePolicy {
                     domain,
@@ -5292,9 +5304,15 @@ pub mod processor {
             Instruction::UpdateLiquidationFeePolicy { cranker_share_bps } => {
                 handle_update_liquidation_fee_policy(program_id, accounts, cranker_share_bps)
             }
-            Instruction::UpdateMaintenanceFeePolicy { cranker_share_bps } => {
-                handle_update_maintenance_fee_policy(program_id, accounts, cranker_share_bps)
-            }
+            Instruction::UpdateMaintenanceFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            } => handle_update_maintenance_fee_policy(
+                program_id,
+                accounts,
+                cranker_share_bps,
+                policy_sequence,
+            ),
             Instruction::UpdateBackingFeePolicy {
                 domain,
                 fee_bps,
@@ -5555,6 +5573,7 @@ pub mod processor {
             force_close_delay_slots: 0,
             last_good_oracle_slot: init_slot,
             insurance_withdraw_deposit_remaining: 0,
+            maintenance_fee_policy_sequence: 0,
             insurance_withdraw_max_bps: 0,
             liquidation_cranker_fee_share_bps: 0,
             maintenance_cranker_fee_share_bps: 0,
@@ -7198,7 +7217,7 @@ pub mod processor {
             if cfg.insurance_withdraw_deposits_only != 0 {
                 cfg.insurance_withdraw_deposit_remaining = cfg
                     .insurance_withdraw_deposit_remaining
-                    .checked_add(amount)
+                    .checked_add(amount_u64)
                     .ok_or(PercolatorError::EngineArithmeticOverflow)?;
                 cfg_after = Some(cfg);
             }
@@ -9526,6 +9545,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         cranker_share_bps: u16,
+        policy_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9538,7 +9558,11 @@ pub mod processor {
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
+        if policy_sequence <= cfg.maintenance_fee_policy_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
         cfg.maintenance_cranker_fee_share_bps = cranker_share_bps;
+        cfg.maintenance_fee_policy_sequence = policy_sequence;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
     }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -57610,6 +57610,95 @@ fn v16_attack_sync_maintenance_full_cranker_share_conserves_no_insurance_underfl
     assert_domain_budget_remaining_total_consistent(&group, "100% maintenance cranker share");
 }
 
+#[test]
+fn v16_attack_delayed_maintenance_policy_cannot_redirect_fee_to_cranker() {
+    let mut env = V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(
+        1, 10_000, 10_000, 10_000, 58,
+    );
+
+    // The honest market authority signs an older 100% cranker-share policy and
+    // then a correcting 0% policy under one still-live blockhash. A relayer may
+    // submit the signed bytes, but must not be able to restore the superseded
+    // split after an independent user enters under the visible correction.
+    let blockhash = env.svm.latest_blockhash();
+    let make_policy_tx = |cranker_share_bps| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::UpdateMaintenanceFeePolicy { cranker_share_bps }.encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            blockhash,
+        )
+    };
+    let delayed_high_share = make_policy_tx(10_000);
+    let correcting_zero_share = make_policy_tx(0);
+    env.svm
+        .send_transaction(correcting_zero_share)
+        .expect("newer zero-share policy lands first");
+    assert_eq!(env.market_state().0.maintenance_cranker_fee_share_bps, 0);
+
+    let payer_owner = Keypair::new();
+    let payer_portfolio = env.create_portfolio(&payer_owner);
+    let cranker_owner = Keypair::new();
+    let cranker_portfolio = env.create_portfolio(&cranker_owner);
+    env.deposit(&payer_owner, payer_portfolio, 100_000_000);
+
+    let delayed_accepted = env.svm.send_transaction(delayed_high_share).is_ok();
+    let insurance_before = env.market_state().1.insurance;
+    let payer_before = env.portfolio_state(payer_portfolio).capital.get();
+    let cranker_before = env.portfolio_state(cranker_portfolio).capital.get();
+    env.svm.warp_to_slot(10);
+    if delayed_accepted {
+        env.sync_maintenance_fee_with_cu(payer_portfolio, Some(cranker_portfolio), 10);
+    } else {
+        env.sync_maintenance_fee_with_cu(payer_portfolio, None, 10);
+    }
+
+    let payer_after = env.portfolio_state(payer_portfolio).capital.get();
+    let cranker_reward = env
+        .portfolio_state(cranker_portfolio)
+        .capital
+        .get()
+        .saturating_sub(cranker_before);
+    let insurance_credit = env
+        .market_state()
+        .1
+        .insurance
+        .saturating_sub(insurance_before);
+    let charged = payer_before.saturating_sub(payer_after);
+    assert_eq!(charged, 580, "the independent user owes the same fee");
+    assert_eq!(
+        cranker_reward + insurance_credit,
+        charged,
+        "the charged maintenance fee remains conserved"
+    );
+    let extracted = if cranker_reward == 0 {
+        0
+    } else {
+        let destination = env.withdraw(&cranker_owner, cranker_portfolio, cranker_reward);
+        env.token_amount(destination)
+    };
+
+    assert!(
+        !delayed_accepted,
+        "older high-share intent landed after the correction and redirected \
+         {cranker_reward} fee atoms from canonical insurance; {extracted} atoms \
+         were publicly withdrawn by the relayer/cranker"
+    );
+    assert_eq!(
+        (cranker_reward, extracted, insurance_credit),
+        (0, 0, charged),
+        "the corrected zero-share policy must retain the complete fee in canonical insurance"
+    );
+}
+
 // [from pr125]
 // LoF/safety sweep — RebalanceReduce is reduce-ONLY: an over-sized reduce_q cannot flip a position into
 // opposite-side risk. The engine clamps `reduce_q = reduce_q.min(leg.basis_pos_q.unsigned_abs())`, so a

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1499,11 +1499,20 @@ impl V16CuEnv {
     }
 
     fn update_maintenance_fee_policy_with_cu(&mut self, cranker_share_bps: u16) -> u64 {
+        let policy_sequence = self
+            .market_state()
+            .0
+            .maintenance_fee_policy_sequence
+            .checked_add(1)
+            .expect("maintenance policy sequence");
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateMaintenanceFeePolicy { cranker_share_bps },
+            ProgInstruction::UpdateMaintenanceFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -13128,6 +13137,7 @@ fn v16_bpf_policy_authority_and_base_unit_tags_are_bounded_and_persist() {
     );
     let (cfg, _) = env.market_state();
     assert_eq!(cfg.maintenance_cranker_fee_share_bps, 2_345);
+    assert_eq!(cfg.maintenance_fee_policy_sequence, 1);
 
     let backing_cu = env.update_backing_fee_policy_with_cu(0, 77, 5_000);
     assert_cu_within("UpdateBackingFeePolicy", backing_cu, CUSTODY_CU_LIMIT);
@@ -13193,6 +13203,61 @@ fn v16_bpf_policy_authority_and_base_unit_tags_are_bounded_and_persist() {
     assert_cu_within("UpdateAuthority", authority_cu, CUSTODY_CU_LIMIT);
     let (cfg, _) = env.market_state();
     assert_eq!(cfg.marketauth, new_asset_authority.pubkey().to_bytes());
+}
+
+#[test]
+fn v16_bpf_maintenance_policy_sequence_accepts_gaps_and_rejects_replays() {
+    let mut env = V16CuEnv::new();
+    let update = |env: &mut V16CuEnv, sequence: u64, share_bps: u16| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateMaintenanceFeePolicy {
+                cranker_share_bps: share_bps,
+                policy_sequence: sequence,
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin],
+        )
+    };
+
+    let first_cu = update(&mut env, 17, 1_234).expect("first sequence with a forward gap");
+    assert_cu_within(
+        "UpdateMaintenanceFeePolicy sequenced",
+        first_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let accepted = env.svm.get_account(&env.market).unwrap();
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.maintenance_cranker_fee_share_bps, 1_234);
+    assert_eq!(cfg.maintenance_fee_policy_sequence, 17);
+    assert_eq!(
+        cfg.insurance_withdraw_deposit_remaining, 0,
+        "the ABI-compatible sequence word must not corrupt adjacent insurance accounting"
+    );
+
+    for stale_sequence in [0, 16, 17] {
+        assert!(
+            update(&mut env, stale_sequence, 9_999).is_err(),
+            "zero, lower, and equal policy sequences must reject"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            accepted,
+            "a rejected policy replay must leave the complete market byte-identical"
+        );
+    }
+
+    update(&mut env, 1_000_000, 4_321).expect("large forward sequence gaps remain valid");
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.maintenance_cranker_fee_share_bps, 4_321);
+    assert_eq!(cfg.maintenance_fee_policy_sequence, 1_000_000);
+    assert_eq!(cfg.insurance_withdraw_deposit_remaining, 0);
 }
 
 #[test]
@@ -25879,6 +25944,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     old_attempt(
         ProgInstruction::UpdateMaintenanceFeePolicy {
             cranker_share_bps: 4_000,
+            policy_sequence: 1,
         },
         "maintenance policy replay",
     );
@@ -25925,6 +25991,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     new_update(
         ProgInstruction::UpdateMaintenanceFeePolicy {
             cranker_share_bps: 4_000,
+            policy_sequence: 1,
         },
         "maintenance policy update",
     );
@@ -34500,6 +34567,7 @@ fn v16_attack_global_policy_bounds_reject_grief_values() {
         &mut env,
         ProgInstruction::UpdateMaintenanceFeePolicy {
             cranker_share_bps: 10_001,
+            policy_sequence: 2,
         },
         "maintenance cranker share above 100%",
     );
@@ -34736,7 +34804,8 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
     );
     assert!(
         attempt(ProgInstruction::UpdateMaintenanceFeePolicy {
-            cranker_share_bps: 2_500
+            cranker_share_bps: 2_500,
+            policy_sequence: 1,
         })
         .is_err(),
         "asset-1 authority must not control global maintenance-fee policy"
@@ -57621,14 +57690,18 @@ fn v16_attack_delayed_maintenance_policy_cannot_redirect_fee_to_cranker() {
     // submit the signed bytes, but must not be able to restore the superseded
     // split after an independent user enters under the visible correction.
     let blockhash = env.svm.latest_blockhash();
-    let make_policy_tx = |cranker_share_bps| {
+    let make_policy_tx = |cranker_share_bps, policy_sequence| {
         let instruction = Instruction {
             program_id: env.program_id,
             accounts: vec![
                 AccountMeta::new(env.admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
             ],
-            data: ProgInstruction::UpdateMaintenanceFeePolicy { cranker_share_bps }.encode(),
+            data: ProgInstruction::UpdateMaintenanceFeePolicy {
+                cranker_share_bps,
+                policy_sequence,
+            }
+            .encode(),
         };
         Transaction::new_signed_with_payer(
             &[heap_ix(), cu_ix(), instruction],
@@ -57637,8 +57710,8 @@ fn v16_attack_delayed_maintenance_policy_cannot_redirect_fee_to_cranker() {
             blockhash,
         )
     };
-    let delayed_high_share = make_policy_tx(10_000);
-    let correcting_zero_share = make_policy_tx(0);
+    let delayed_high_share = make_policy_tx(10_000, 1);
+    let correcting_zero_share = make_policy_tx(0, 2);
     env.svm
         .send_transaction(correcting_zero_share)
         .expect("newer zero-share policy lands first");

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -782,17 +782,41 @@ fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_update_maintenance_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
+    let policy_sequence: u64 = kani::any();
 
-    let mut data = [0u8; 3];
+    let mut data = [0u8; 11];
     data[0] = 49;
     data[1..3].copy_from_slice(&cranker_share_bps.to_le_bytes());
+    data[3..11].copy_from_slice(&policy_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateMaintenanceFeePolicy {
             cranker_share_bps: got,
-        } => assert_eq!(got, cranker_share_bps),
+            policy_sequence: got_sequence,
+        } => {
+            assert_eq!(got, cranker_share_bps);
+            assert_eq!(got_sequence, policy_sequence);
+        }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_update_maintenance_fee_policy_requires_exact_framing() {
+    let instruction = Instruction::UpdateMaintenanceFeePolicy {
+        cranker_share_bps: kani::any(),
+        policy_sequence: kani::any(),
+    };
+    let mut data = instruction.encode();
+    assert_eq!(data.len(), 11);
+    assert!(Instruction::decode(&data).is_ok());
+
+    data.pop();
+    assert!(Instruction::decode(&data).is_err());
+
+    data.push(0);
+    data.push(kani::any());
+    assert!(Instruction::decode(&data).is_err());
 }
 
 #[kani::proof]
@@ -1238,6 +1262,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::UpdateMaintenanceFeePolicy {
             cranker_share_bps: 4_000,
+            policy_sequence: 1,
         },
         extra,
     );


### PR DESCRIPTION
## What changed

- add an exact-parent public LiteSVM RED proving that a delayed, still-valid market-authority maintenance-fee policy can overwrite a newer correction
- sequence `UpdateMaintenanceFeePolicy` intents and reject zero, duplicate, lower, and delayed sequences while accepting forward gaps
- preserve the 448-byte zero-copy market config ABI by splitting the former deposits-only `u128` principal counter into its reachable `u64` value and a new `u64` sequence word
- add public boundary/rollback coverage and focused Kani wire-field and exact-framing proofs

## Impact and root cause

The instruction authenticated the market authority but had no intent ordering. An untrusted relayer could hold an older signed 100% cranker-share update, land the authority's newer 0% correction first, wait for an independent user to accrue maintenance fees, then land the old update. The exact-parent RED charges 580 atoms, diverts all 580 from canonical insurance to the relayer's cranker portfolio, and publicly withdraws them.

The fix requires `policy_sequence` to strictly exceed the last accepted value. Gaps remain valid so dropped transactions do not stall administration. Legacy three-byte payloads fail exact decoding.

## TDD history

- RED: `05dcf8eec135255235f2d154836d7fae553cf07b`
- GREEN: `eab4443a992190bea780184e18d400c66fc4bada`
- exact parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- pinned engine: `143e68c4917ed0400a27b952f036a5677047cd84`

## Verification

- `cargo build-sbf --tools-version v1.52`
- public LiteSVM/CU suite: 567/567 passed
- library tests: 6/6 passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- Kani field preservation: 817 checks, 0 failures
- Kani exact/short/trailing framing: 1,533 checks, 0 failures