### PR TITLE
[BLOCKER LoF] Reject delayed trade-fee policy replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,13 @@ This section describes intent and operational ordering, not argument-by-argument
   - transfers collateral into vault; credits insurance fund in engine
 
 ### Trading
+- **UpdateTradeFeePolicy** (tag 55)
+  - sets the market-wide minimum trade fee and carries an asset-0 insurance-authority-chosen
+    `policy_sequence`
+  - the sequence must strictly exceed the last accepted trade-fee sequence; gaps are allowed, while
+    delayed, duplicate, zero, and lower intents reject
+  - tag 55's payload is exactly `u64 trade_fee_base_bps || u64 policy_sequence`; legacy
+    unsequenced payloads reject
 - **TradeNoCpi**
   - trade without external matcher (used for testing / deterministic scenarios)
 - **TradeCpi**

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -512,7 +512,13 @@ pub mod state {
         pub collateral_mint: [u8; 32],
         pub secondary_collateral_mint: [u8; 32],
         pub maintenance_fee_per_slot: u128,
-        pub permissionless_market_init_fee: u128,
+        /// The public setter and SPL transfer path require this fee to fit in `u64`.
+        /// This occupies the low word of the former `u128` field, preserving the zero-copy ABI.
+        pub permissionless_market_init_fee: u64,
+        /// Last accepted asset-0 insurance-authority trade-fee intent. The high word of the former
+        /// init-fee field was always zero in publicly reachable states, so legacy accounts begin at
+        /// sequence zero without migration.
+        pub trade_fee_policy_sequence: u64,
         pub trade_fee_base_bps: u64,
         pub permissionless_resolve_stale_slots: u64,
         pub force_close_delay_slots: u64,
@@ -2561,6 +2567,7 @@ pub mod ix {
         },
         UpdateTradeFeePolicy {
             trade_fee_base_bps: u64,
+            policy_sequence: u64,
         },
         UpdateFeeRedirectPolicy {
             redirect_bps: u16,
@@ -2823,6 +2830,7 @@ pub mod ix {
                 },
                 55 => Self::UpdateTradeFeePolicy {
                     trade_fee_base_bps: read_u64(&mut rest)?,
+                    policy_sequence: read_u64(&mut rest)?,
                 },
                 58 => Self::UpdateFeeRedirectPolicy {
                     redirect_bps: read_u16(&mut rest)?,
@@ -3134,9 +3142,13 @@ pub mod ix {
                     push_u16(&mut out, fee_bps);
                     push_u16(&mut out, insurance_share_bps);
                 }
-                Self::UpdateTradeFeePolicy { trade_fee_base_bps } => {
+                Self::UpdateTradeFeePolicy {
+                    trade_fee_base_bps,
+                    policy_sequence,
+                } => {
                     out.push(55);
                     push_u64(&mut out, trade_fee_base_bps);
+                    push_u64(&mut out, policy_sequence);
                 }
                 Self::UpdateFeeRedirectPolicy { redirect_bps } => {
                     out.push(58);
@@ -4353,10 +4365,10 @@ pub mod processor {
 
     #[inline(always)]
     fn permissionless_market_init_fee_for_asset(
-        base_fee: u128,
+        base_fee: u64,
         asset_index: usize,
     ) -> Result<u128, ProgramError> {
-        let mut fee = base_fee;
+        let mut fee = u128::from(base_fee);
         if fee == 0 {
             return Ok(0);
         }
@@ -5306,9 +5318,15 @@ pub mod processor {
                 fee_bps,
                 insurance_share_bps,
             ),
-            Instruction::UpdateTradeFeePolicy { trade_fee_base_bps } => {
-                handle_update_trade_fee_policy(program_id, accounts, trade_fee_base_bps)
-            }
+            Instruction::UpdateTradeFeePolicy {
+                trade_fee_base_bps,
+                policy_sequence,
+            } => handle_update_trade_fee_policy(
+                program_id,
+                accounts,
+                trade_fee_base_bps,
+                policy_sequence,
+            ),
             Instruction::UpdateFeeRedirectPolicy { redirect_bps } => {
                 handle_update_fee_redirect_policy(program_id, accounts, redirect_bps)
             }
@@ -5550,6 +5568,7 @@ pub mod processor {
             secondary_collateral_mint: [0u8; 32],
             maintenance_fee_per_slot,
             permissionless_market_init_fee: 0,
+            trade_fee_policy_sequence: 0,
             trade_fee_base_bps,
             permissionless_resolve_stale_slots: 0,
             force_close_delay_slots: 0,
@@ -9651,6 +9670,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         trade_fee_base_bps: u64,
+        policy_sequence: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9670,7 +9690,11 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        if policy_sequence <= cfg.trade_fee_policy_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
         cfg.trade_fee_base_bps = trade_fee_base_bps;
+        cfg.trade_fee_policy_sequence = policy_sequence;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
     }
 
@@ -9706,7 +9730,7 @@ pub mod processor {
         expect_signer(admin)?;
         expect_writable(market_ai)?;
         expect_owner(market_ai, program_id)?;
-        let _ = amount_to_u64(min_init_fee)?;
+        let min_init_fee = amount_to_u64(min_init_fee)?;
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,127 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_attack_delayed_trade_fee_policy_cannot_tax_presigned_trade() {
+    const PRICE: u64 = 100;
+    const DEPOSIT: u128 = 10_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const FORCED_FEE_BPS: u64 = 10_000;
+    const FORCED_FEE_PER_SIDE: u128 = 1_000;
+
+    let mut env = V16CuEnv::new();
+    let attacker = Keypair::new();
+    env.update_market_init_fee_policy_with_cu(1);
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        1,
+        PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let attacker_portfolio = env.create_portfolio(&attacker);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+
+    // The honest asset-0 insurance authority signs a high fee and then a
+    // correcting zero fee under one still-live blockhash. Once the correction
+    // lands, the independent victim signs a zero-fee trade on that visible
+    // policy. An untrusted relayer must not be able to restore the older fee
+    // immediately before submitting the already-signed trade.
+    let blockhash = env.svm.latest_blockhash();
+    let make_policy_tx = |trade_fee_base_bps| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::UpdateTradeFeePolicy { trade_fee_base_bps }.encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            blockhash,
+        )
+    };
+    let delayed_high_fee = make_policy_tx(FORCED_FEE_BPS);
+    let correcting_zero_fee = make_policy_tx(0);
+    env.svm
+        .send_transaction(correcting_zero_fee)
+        .expect("newer zero-fee policy lands first");
+    assert_eq!(env.market_state().0.trade_fee_base_bps, 0);
+
+    let trade_instruction = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new(attacker_portfolio, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 1,
+            size_q: SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let presigned_zero_fee_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), trade_instruction],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim, &attacker],
+        blockhash,
+    );
+
+    let delayed_accepted = env.svm.send_transaction(delayed_high_fee).is_ok();
+    env.svm
+        .send_transaction(presigned_zero_fee_trade)
+        .expect("the independently signed trade remains executable");
+
+    let (_, group) = env.market_state();
+    let victim_capital = env.portfolio_state(victim_portfolio).capital.get();
+    let attacker_capital = env.portfolio_state(attacker_portfolio).capital.get();
+    let charged_fees = group.insurance_domain_budget[2] + group.insurance_domain_budget[3];
+    let extracted = if charged_fees == 0 {
+        0
+    } else {
+        let (destination, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker, 1, charged_fees)
+            .expect("permissionless asset operator withdraws the forced trade fees");
+        env.token_amount(destination) as u128
+    };
+
+    if delayed_accepted {
+        assert_eq!(group.insurance_domain_budget[2], FORCED_FEE_PER_SIDE);
+        assert_eq!(group.insurance_domain_budget[3], FORCED_FEE_PER_SIDE);
+        assert_eq!(victim_capital, DEPOSIT - FORCED_FEE_PER_SIDE);
+        assert_eq!(attacker_capital, DEPOSIT - FORCED_FEE_PER_SIDE);
+        assert_eq!(extracted, FORCED_FEE_PER_SIDE * 2);
+        assert_eq!(
+            attacker_capital + extracted,
+            DEPOSIT + FORCED_FEE_PER_SIDE,
+            "the asset operator's net gain equals the independent victim's forced fee"
+        );
+        panic!(
+            "older high-fee intent landed after the correction, charged \
+             {charged_fees} atoms, and let the asset operator withdraw {extracted}"
+        );
+    }
+    assert_eq!(
+        (victim_capital, attacker_capital, charged_fees, extracted),
+        (DEPOSIT, DEPOSIT, 0, 0),
+        "the superseded policy must not tax the already-signed zero-fee trade"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1008,11 +1008,20 @@ impl V16CuEnv {
     }
 
     fn update_trade_fee_policy_with_cu(&mut self, trade_fee_base_bps: u64) -> u64 {
+        let policy_sequence = self
+            .market_state()
+            .0
+            .trade_fee_policy_sequence
+            .checked_add(1)
+            .expect("trade fee policy sequence");
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateTradeFeePolicy { trade_fee_base_bps },
+            ProgInstruction::UpdateTradeFeePolicy {
+                trade_fee_base_bps,
+                policy_sequence,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -13140,6 +13149,7 @@ fn v16_bpf_policy_authority_and_base_unit_tags_are_bounded_and_persist() {
     assert_cu_within("UpdateTradeFeePolicy", trade_fee_cu, CUSTODY_CU_LIMIT);
     let (cfg, _) = env.market_state();
     assert_eq!(cfg.trade_fee_base_bps, 88);
+    assert_eq!(cfg.trade_fee_policy_sequence, 1);
 
     let redirect_cu = env.update_fee_redirect_policy_with_cu(2_500);
     assert_cu_within("UpdateFeeRedirectPolicy", redirect_cu, CUSTODY_CU_LIMIT);
@@ -34507,6 +34517,7 @@ fn v16_attack_global_policy_bounds_reject_grief_values() {
         &mut env,
         ProgInstruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 10_001,
+            policy_sequence: 2,
         },
         "trade fee above the market maximum",
     );
@@ -34594,6 +34605,7 @@ fn v16_attack_trade_fee_policy_follows_asset0_insurance_authority() {
         &env.payer,
         ProgInstruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 500,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -34619,6 +34631,7 @@ fn v16_attack_trade_fee_policy_follows_asset0_insurance_authority() {
         &env.payer,
         ProgInstruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 500,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(new_insurance.pubkey(), true),
@@ -34711,7 +34724,8 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
 
     assert!(
         attempt(ProgInstruction::UpdateTradeFeePolicy {
-            trade_fee_base_bps: 123
+            trade_fee_base_bps: 123,
+            policy_sequence: 1,
         })
         .is_err(),
         "asset-1 authority must not control the market-wide trade fee"
@@ -59468,6 +59482,7 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_default_runtime_authorities
         &env.payer,
         ProgInstruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 500,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(old_marketauth.pubkey(), true),
@@ -59492,6 +59507,7 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_default_runtime_authorities
         &env.payer,
         ProgInstruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 500,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(new_marketauth.pubkey(), true),
@@ -59719,6 +59735,58 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 #[test]
+fn v16_bpf_trade_fee_policy_sequence_accepts_gaps_and_rejects_replays() {
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(37);
+    let update = |env: &mut V16CuEnv, sequence: u64, fee_bps: u64| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateTradeFeePolicy {
+                trade_fee_base_bps: fee_bps,
+                policy_sequence: sequence,
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin],
+        )
+    };
+
+    let first_cu = update(&mut env, 17, 1_234).expect("first sequence with a forward gap");
+    assert_cu_within("UpdateTradeFeePolicy sequenced", first_cu, CUSTODY_CU_LIMIT);
+    let accepted = env.svm.get_account(&env.market).unwrap();
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.trade_fee_base_bps, 1_234);
+    assert_eq!(cfg.trade_fee_policy_sequence, 17);
+    assert_eq!(
+        cfg.permissionless_market_init_fee, 37,
+        "the ABI-compatible sequence word must not corrupt the adjacent init fee"
+    );
+
+    for stale_sequence in [0, 16, 17] {
+        assert!(
+            update(&mut env, stale_sequence, 9_999).is_err(),
+            "zero, lower, and equal policy sequences must reject"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            accepted,
+            "a rejected policy replay must leave the complete market byte-identical"
+        );
+    }
+
+    update(&mut env, 1_000_000, 4_321).expect("large forward sequence gaps remain valid");
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.trade_fee_base_bps, 4_321);
+    assert_eq!(cfg.trade_fee_policy_sequence, 1_000_000);
+    assert_eq!(cfg.permissionless_market_init_fee, 37);
+}
+
+#[test]
 fn v16_attack_delayed_trade_fee_policy_cannot_tax_presigned_trade() {
     const PRICE: u64 = 100;
     const DEPOSIT: u128 = 10_000;
@@ -59754,14 +59822,18 @@ fn v16_attack_delayed_trade_fee_policy_cannot_tax_presigned_trade() {
     // policy. An untrusted relayer must not be able to restore the older fee
     // immediately before submitting the already-signed trade.
     let blockhash = env.svm.latest_blockhash();
-    let make_policy_tx = |trade_fee_base_bps| {
+    let make_policy_tx = |trade_fee_base_bps, policy_sequence| {
         let instruction = Instruction {
             program_id: env.program_id,
             accounts: vec![
                 AccountMeta::new(env.admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
             ],
-            data: ProgInstruction::UpdateTradeFeePolicy { trade_fee_base_bps }.encode(),
+            data: ProgInstruction::UpdateTradeFeePolicy {
+                trade_fee_base_bps,
+                policy_sequence,
+            }
+            .encode(),
         };
         Transaction::new_signed_with_payer(
             &[heap_ix(), cu_ix(), instruction],
@@ -59770,8 +59842,8 @@ fn v16_attack_delayed_trade_fee_policy_cannot_tax_presigned_trade() {
             blockhash,
         )
     };
-    let delayed_high_fee = make_policy_tx(FORCED_FEE_BPS);
-    let correcting_zero_fee = make_policy_tx(0);
+    let delayed_high_fee = make_policy_tx(FORCED_FEE_BPS, 1);
+    let correcting_zero_fee = make_policy_tx(0, 2);
     env.svm
         .send_transaction(correcting_zero_fee)
         .expect("newer zero-fee policy lands first");

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -824,17 +824,41 @@ fn kani_v16_update_backing_fee_policy_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_update_trade_fee_policy_decode_preserves_wire_fields() {
     let trade_fee_base_bps: u64 = kani::any();
+    let policy_sequence: u64 = kani::any();
 
-    let mut data = [0u8; 9];
+    let mut data = [0u8; 17];
     data[0] = 55;
     data[1..9].copy_from_slice(&trade_fee_base_bps.to_le_bytes());
+    data[9..17].copy_from_slice(&policy_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: got,
-        } => assert_eq!(got, trade_fee_base_bps),
+            policy_sequence: got_sequence,
+        } => {
+            assert_eq!(got, trade_fee_base_bps);
+            assert_eq!(got_sequence, policy_sequence);
+        }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_update_trade_fee_policy_requires_exact_framing() {
+    let instruction = Instruction::UpdateTradeFeePolicy {
+        trade_fee_base_bps: kani::any(),
+        policy_sequence: kani::any(),
+    };
+    let mut data = instruction.encode();
+    assert_eq!(data.len(), 17);
+    assert!(Instruction::decode(&data).is_ok());
+
+    data.pop();
+    assert!(Instruction::decode(&data).is_err());
+
+    data.push(0);
+    data.push(kani::any());
+    assert!(Instruction::decode(&data).is_err());
 }
 
 #[kani::proof]
@@ -1252,6 +1276,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::UpdateTradeFeePolicy {
             trade_fee_base_bps: 25,
+            policy_sequence: 1,
         },
         extra,
     );


### PR DESCRIPTION
## What changed

- add an exact-parent public LiteSVM RED proving that a delayed, still-valid asset-0 insurance-authority trade-fee policy can overwrite a newer correction
- sequence `UpdateTradeFeePolicy` intents and reject zero, duplicate, lower, and delayed sequences while accepting forward gaps
- preserve the 448-byte zero-copy market config ABI by splitting the former publicly `u64`-bounded init-fee `u128` into its reachable low word and a new `u64` sequence word
- add public boundary/rollback coverage and focused Kani wire-field and exact-framing proofs

## Impact and root cause

Tag 55 authenticated the current authority but did not order that authority's signed intents. An untrusted relayer can retain an older 10,000 bps update, land the honest authority's newer zero-fee correction, let an independent victim sign a zero-fee trade on the visible policy, restore the old floor, and submit the already-signed trade.

The exact-parent RED uses an attacker-operated permissionless asset. The trade charges 1,000 atoms to each side; the attacker withdraws both 1,000-atom domain fees and nets exactly the independent victim's 1,000-atom loss. This is distinct from #256 (compromised-authority live fee hike) and #296 (cross-generation replay): it needs neither key compromise nor market reinitialization.

The fix requires `policy_sequence` to strictly exceed the last accepted value. Gaps remain valid so dropped transactions do not stall administration. Legacy nine-byte payloads fail exact decoding, and the independently signed trade remains executable at zero fee after the replay rejects.

## TDD history

- RED: `a6fa601cc509126505124894ed9ec85d8c67b7ed`
- GREEN: `fef78ea87a4dbf1e1032439351b60c4846608ae6`
- exact parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- pinned engine: `143e68c4917ed0400a27b952f036a5677047cd84`

## Verification

- `cargo build-sbf --tools-version v1.52`
- public LiteSVM/CU suite: 567/567 passed
- library tests: 6/6 passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- Kani field preservation: 817 checks, 0 failures
- Kani exact/short/trailing framing: 1,533 checks, 0 failures