### PR TITLE
[BLOCKER LoF] Bind backing top-ups to provider-approved fee terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ The economic and governance model for a permissionless multi-asset market. Statu
     `v16_attack_backing_fee_split_conserves` drives a real BPF risk-increase that grows a
     counterparty-backing lien and asserts the fee splits with no leakage: `charged ==
     insurance_pool_delta + provider_delta`, `insurance_delta == floor(charged * share_bps)`, and the
-    per-domain insurance budget mirrors the insurance share.
+    per-domain insurance budget mirrors the insurance share. The
+    per-domain fee rate and insurance split are immutable while that backing bucket holds provider
+    principal, liens, consumed/impaired backing, or unwithdrawn earnings; idempotent writes remain
+    valid and an empty domain can be reconfigured.
 
 ### Isolation — traders are safe from other assets, even faulty ones
 Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guarantee:

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -7350,6 +7350,14 @@ pub mod processor {
             .ok_or(PercolatorError::EngineArithmeticOverflow.into())
     }
 
+    fn backing_bucket_has_provider_value(bucket: &percolator::BackingBucketV16) -> bool {
+        bucket.fresh_unliened_backing_num != 0
+            || bucket.valid_liened_backing_num != 0
+            || bucket.consumed_liened_backing_num != 0
+            || bucket.impaired_liened_backing_num != 0
+            || bucket.utilization_fee_earnings != 0
+    }
+
     fn sync_backing_domain_ledger(
         ledger: &mut state::BackingDomainLedgerAccountV16,
         bucket: &percolator::BackingBucketV16,
@@ -9593,6 +9601,28 @@ pub mod processor {
                 Ok(())
             };
         let mut market_data = market_ai.try_borrow_mut_data()?;
+        let mut profile = state::read_asset_oracle_profile(&market_data, asset_index)?;
+        let (old_fee, old_insurance_share_bps) = if asset_index == 0 && long_side {
+            (
+                cfg.backing_trade_fee_bps_long,
+                cfg.backing_trade_fee_insurance_share_bps_long,
+            )
+        } else if asset_index == 0 {
+            (
+                cfg.backing_trade_fee_bps_short,
+                cfg.backing_trade_fee_insurance_share_bps_short,
+            )
+        } else if long_side {
+            (
+                profile.backing_trade_fee_bps_long,
+                profile.backing_trade_fee_insurance_share_bps_long,
+            )
+        } else {
+            (
+                profile.backing_trade_fee_bps_short,
+                profile.backing_trade_fee_insurance_share_bps_short,
+            )
+        };
         {
             let (_cfg, group) = state::market_view_mut(&mut market_data)?;
             if asset_index >= group.markets.len() {
@@ -9604,15 +9634,14 @@ pub mod processor {
             {
                 return Err(PercolatorError::EngineLockActive.into());
             }
+            if (fee_bps != old_fee || insurance_share_bps != old_insurance_share_bps)
+                && backing_bucket_has_provider_value(&backing_domain_parts_view(&group, domain)?.1)
+            {
+                return Err(PercolatorError::EngineLockActive.into());
+            }
         }
+        adjust_policy_count(&mut cfg, old_fee, fee_bps)?;
         if asset_index == 0 {
-            let mut profile = state::read_asset_oracle_profile(&market_data, asset_index)?;
-            let old_fee = if long_side {
-                cfg.backing_trade_fee_bps_long
-            } else {
-                cfg.backing_trade_fee_bps_short
-            };
-            adjust_policy_count(&mut cfg, old_fee, fee_bps)?;
             if long_side {
                 cfg.backing_trade_fee_bps_long = fee_bps;
                 cfg.backing_trade_fee_insurance_share_bps_long = insurance_share_bps;
@@ -9627,13 +9656,6 @@ pub mod processor {
             state::write_wrapper_config(&mut market_data, &cfg)?;
             state::write_asset_oracle_profile(&mut market_data, asset_index, &profile)
         } else {
-            let mut profile = state::read_asset_oracle_profile(&market_data, asset_index)?;
-            let old_fee = if long_side {
-                profile.backing_trade_fee_bps_long
-            } else {
-                profile.backing_trade_fee_bps_short
-            };
-            adjust_policy_count(&mut cfg, old_fee, fee_bps)?;
             if long_side {
                 profile.backing_trade_fee_bps_long = fee_bps;
                 profile.backing_trade_fee_insurance_share_bps_long = insurance_share_bps;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2524,6 +2524,8 @@ pub mod ix {
             domain: u16,
             amount: u128,
             expiry_slot: u64,
+            expected_fee_bps: u16,
+            expected_insurance_share_bps: u16,
         },
         WithdrawBackingBucket {
             domain: u16,
@@ -2791,6 +2793,8 @@ pub mod ix {
                     domain: read_u16(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                     expiry_slot: read_u64(&mut rest)?,
+                    expected_fee_bps: read_u16(&mut rest)?,
+                    expected_insurance_share_bps: read_u16(&mut rest)?,
                 },
                 50 => Self::WithdrawBackingBucket {
                     domain: read_u16(&mut rest)?,
@@ -3083,11 +3087,15 @@ pub mod ix {
                     domain,
                     amount,
                     expiry_slot,
+                    expected_fee_bps,
+                    expected_insurance_share_bps,
                 } => {
                     out.push(24);
                     push_u16(&mut out, domain);
                     push_u128(&mut out, amount);
                     push_u64(&mut out, expiry_slot);
+                    push_u16(&mut out, expected_fee_bps);
+                    push_u16(&mut out, expected_insurance_share_bps);
                 }
                 Self::WithdrawBackingBucket { domain, amount } => {
                     out.push(50);
@@ -5271,7 +5279,17 @@ pub mod processor {
                 domain,
                 amount,
                 expiry_slot,
-            } => handle_top_up_backing_bucket(program_id, accounts, domain, amount, expiry_slot),
+                expected_fee_bps,
+                expected_insurance_share_bps,
+            } => handle_top_up_backing_bucket(
+                program_id,
+                accounts,
+                domain,
+                amount,
+                expiry_slot,
+                expected_fee_bps,
+                expected_insurance_share_bps,
+            ),
             Instruction::WithdrawBackingBucket { domain, amount } => {
                 handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
             }
@@ -7565,6 +7583,8 @@ pub mod processor {
         domain: u16,
         amount: u128,
         expiry_slot: u64,
+        expected_fee_bps: u16,
+        expected_insurance_share_bps: u16,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -7595,6 +7615,11 @@ pub mod processor {
                 return Err(PercolatorError::EngineLockActive.into());
             }
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
+            if backing_fee_policy_for_domain_view(&group, &cfg, domain_usize)?
+                != (expected_fee_bps, expected_insurance_share_bps)
+            {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
             let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
             (cfg, authorities)
@@ -7614,6 +7639,11 @@ pub mod processor {
             }
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
+            if backing_fee_policy_for_domain_view(&group, &cfg, domain_usize)?
+                != (expected_fee_bps, expected_insurance_share_bps)
+            {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
             let authorities = domain_authorities_from_view(&group, &cfg, domain_usize)?;
             expect_live_authority(&authorities.backing_bucket_authority, signer.key)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59719,6 +59719,55 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 #[test]
+fn v16_bpf_funded_backing_domain_locks_fee_terms_until_empty() {
+    let mut env = V16CuEnv::new();
+    env.update_backing_fee_policy_with_cu(1, 100, 0);
+    env.top_up_backing_bucket_with_cu(1, 100, 10);
+
+    let accepted = env.svm.get_account(&env.market).unwrap();
+    let update = |env: &mut V16CuEnv, fee_bps: u16, insurance_share_bps: u16| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateBackingFeePolicy {
+                domain: 1,
+                fee_bps,
+                insurance_share_bps,
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin],
+        )
+    };
+
+    for (fee_bps, insurance_share_bps) in [(100, 5_000), (200, 0), (0, 0)] {
+        assert!(
+            update(&mut env, fee_bps, insurance_share_bps).is_err(),
+            "funded backing terms must not change"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            accepted,
+            "a rejected funded-domain policy change must roll back byte-identically"
+        );
+    }
+    update(&mut env, 100, 0).expect("an idempotent funded-domain policy write remains valid");
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), accepted);
+
+    let destination = env.token_account(env.admin.pubkey(), 0);
+    env.withdraw_backing_bucket_to_admin_token_with_cu(destination, 1, 100);
+    assert_eq!(env.token_amount(destination), 100);
+    update(&mut env, 200, 5_000).expect("an empty domain can be reconfigured");
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.backing_trade_fee_bps_short, 200);
+    assert_eq!(cfg.backing_trade_fee_insurance_share_bps_short, 5_000);
+}
+
+#[test]
 fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
     const INITIAL_PRICE: u64 = 100;
     const LP_DEPOSIT: u128 = 3_130;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1240,6 +1240,11 @@ impl V16CuEnv {
         state::read_market(&account.data).unwrap()
     }
 
+    fn backing_fee_policy(&self, domain: u16) -> (u16, u16) {
+        let account = self.svm.get_account(&self.market).expect("market account");
+        backing_fee_policy_for_market_data(&account.data, domain)
+    }
+
     fn portfolio_state(&self, portfolio: Pubkey) -> PortfolioAccountV16 {
         let account = self.svm.get_account(&portfolio).expect("portfolio account");
         state::read_portfolio(&account.data).unwrap()
@@ -2798,6 +2803,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> u64 {
+        let (expected_fee_bps, expected_insurance_share_bps) = self.backing_fee_policy(domain);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2806,6 +2812,8 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                expected_fee_bps,
+                expected_insurance_share_bps,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2972,6 +2980,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let (expected_fee_bps, expected_insurance_share_bps) = self.backing_fee_policy(domain);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -2993,6 +3002,8 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                expected_fee_bps,
+                expected_insurance_share_bps,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -3014,6 +3025,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let (expected_fee_bps, expected_insurance_share_bps) = self.backing_fee_policy(domain);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3035,6 +3047,8 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                expected_fee_bps,
+                expected_insurance_share_bps,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -3057,6 +3071,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> Pubkey {
+        let (expected_fee_bps, expected_insurance_share_bps) = self.backing_fee_policy(domain);
         self.ensure_signer_account(authority.pubkey());
         let source = self.token_account(authority.pubkey(), amount as u64);
         send_tx(
@@ -3067,6 +3082,8 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                expected_fee_bps,
+                expected_insurance_share_bps,
             },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
@@ -3933,6 +3950,8 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
             domain: 1,
             amount: 77,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -4224,6 +4243,22 @@ fn deposit_to_market(
     source
 }
 
+fn backing_fee_policy_for_market_data(data: &[u8], domain: u16) -> (u16, u16) {
+    let profile =
+        state::read_asset_oracle_profile(data, domain as usize / 2).expect("asset oracle profile");
+    if domain % 2 == 0 {
+        (
+            profile.backing_trade_fee_bps_long,
+            profile.backing_trade_fee_insurance_share_bps_long,
+        )
+    } else {
+        (
+            profile.backing_trade_fee_bps_short,
+            profile.backing_trade_fee_insurance_share_bps_short,
+        )
+    }
+}
+
 fn top_up_backing_bucket_to_market(
     env: &mut V16CuEnv,
     market: Pubkey,
@@ -4232,6 +4267,9 @@ fn top_up_backing_bucket_to_market(
     amount: u128,
     expiry_slot: u64,
 ) -> Pubkey {
+    let market_account = env.svm.get_account(&market).expect("market account");
+    let (expected_fee_bps, expected_insurance_share_bps) =
+        backing_fee_policy_for_market_data(&market_account.data, domain);
     let source = env.token_account(env.admin.pubkey(), amount as u64);
     env.svm.expire_blockhash();
     send_tx(
@@ -4242,6 +4280,8 @@ fn top_up_backing_bucket_to_market(
             domain,
             amount,
             expiry_slot,
+            expected_fee_bps,
+            expected_insurance_share_bps,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -4589,6 +4629,8 @@ fn v16_bpf_failed_backing_topup_transfer_rolls_back_bucket_and_ledger() {
             domain: 1,
             amount: 100,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -5878,6 +5920,8 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
             domain: 2,
             amount: 88,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(rekeyed_backing_authority.pubkey(), true),
@@ -22958,6 +23002,8 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
             domain: 1,
             amount: 100,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -23646,6 +23692,8 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
             domain: 1,
             amount: 40,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -23742,6 +23790,8 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
             domain: 1,
             amount: 40,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24430,6 +24480,8 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
             domain: 1,
             amount: 30,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24639,6 +24691,8 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
             domain: 1,
             amount: 30,
             expiry_slot: 10,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24876,6 +24930,8 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
             domain: 1,
             amount: 500,
             expiry_slot,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         "TopUpBackingBucket",
     );
@@ -25294,6 +25350,8 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
             domain: 1,
             amount: 700,
             expiry_slot: 10_000,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -25391,6 +25449,8 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
             domain: BAD_DOMAIN,
             amount: 456,
             expiry_slot: 10_000,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -31793,6 +31853,8 @@ fn v16_attack_topup_backing_bucket_authority_gated() {
             domain: 0,
             amount: 500,
             expiry_slot: 10_000,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(donor.pubkey(), true),
@@ -31958,6 +32020,8 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_earnings
             domain: 2,
             amount: 300,
             expiry_slot: 10_000,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(asset1_backing.pubkey(), true),
@@ -33663,6 +33727,8 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
                 domain: 1,
                 amount: 2,
                 expiry_slot: 10_000,
+                expected_fee_bps: 0,
+                expected_insurance_share_bps: 0,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -35317,6 +35383,8 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
                 domain: 0,
                 amount,
                 expiry_slot: expiry,
+                expected_fee_bps: 0,
+                expected_insurance_share_bps: 0,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -55258,6 +55326,8 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
             domain: 1,
             amount: 30,
             expiry_slot: 100,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58013,6 +58083,8 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
             domain: 1,
             amount: 13,
             expiry_slot: 10_000,
+            expected_fee_bps: 0,
+            expected_insurance_share_bps: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -59564,6 +59636,8 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
                 domain: 1,
                 amount: 50,
                 expiry_slot: expiry,
+                expected_fee_bps: 0,
+                expected_insurance_share_bps: 0,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -59874,6 +59948,8 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
                     domain: WINNING_DOMAIN,
                     amount: 5_000,
                     expiry_slot: 100,
+                    expected_fee_bps: BACKING_FEE_BPS,
+                    expected_insurance_share_bps: 0,
                 }
                 .encode(),
             },
@@ -59886,8 +59962,28 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
     // The stale split wins the ordering race while the bucket is still empty, then the provider's
     // retained top-up lands. Freezing terms only after funding cannot protect this ordering.
     let delayed_accepted = env.svm.send_transaction(delayed_insurance_split).is_ok();
+    let market_before_retained_top_up = env.svm.get_account(&env.market).unwrap();
+    let source_before_retained_top_up = env.svm.get_account(&backing_source).unwrap();
+    let vault_before_retained_top_up = env.svm.get_account(&env.vault).unwrap();
+    let ledger_before_retained_top_up = env.svm.get_account(&ledger.pubkey()).unwrap();
     let retained_top_up_accepted = env.svm.send_transaction(retained_top_up).is_ok();
     if !retained_top_up_accepted {
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_retained_top_up
+        );
+        assert_eq!(
+            env.svm.get_account(&backing_source).unwrap(),
+            source_before_retained_top_up
+        );
+        assert_eq!(
+            env.svm.get_account(&env.vault).unwrap(),
+            vault_before_retained_top_up
+        );
+        assert_eq!(
+            env.svm.get_account(&ledger.pubkey()).unwrap(),
+            ledger_before_retained_top_up
+        );
         env.svm.expire_blockhash();
         send_tx(
             &mut env.svm,
@@ -59911,6 +60007,8 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
                 domain: WINNING_DOMAIN,
                 amount: 5_000,
                 expiry_slot: 100,
+                expected_fee_bps: BACKING_FEE_BPS,
+                expected_insurance_share_bps: 0,
             },
             vec![
                 AccountMeta::new(provider.pubkey(), true),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,281 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
+    const INITIAL_PRICE: u64 = 100;
+    const LP_DEPOSIT: u128 = 3_130;
+    const TRADER_DEPOSIT: u128 = 10_000;
+    const WINNING_SIZE_Q: i128 = 200 * POS_SCALE as i128;
+    const LOSING_SIZE_Q: i128 = 100 * POS_SCALE as i128;
+    const INCREASE_Q: i128 = 20 * POS_SCALE as i128;
+    const WINNING_DOMAIN: u16 = 3;
+    const BACKING_FEE_BPS: u16 = 5_000;
+    const EXPECTED_FEE: u128 = 70;
+
+    let mut env =
+        V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(2, 1_000, 1_000, 500, 30);
+    env.update_market_init_fee_policy_with_cu(1);
+    let attacker_operator = Keypair::new();
+    let policy_oracle_authority = Keypair::new();
+    let provider = Keypair::new();
+    let market_trader = Keypair::new();
+    let lp = Keypair::new();
+    env.ensure_signer_account(policy_oracle_authority.pubkey());
+    env.ensure_signer_account(provider.pubkey());
+
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, INITIAL_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(1, 1, INITIAL_PRICE);
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_RETIRE,
+        1,
+        2,
+        0,
+    );
+    env.svm.warp_to_slot(3);
+    env.activate_permissionless_asset_with_fee(
+        &attacker_operator,
+        1,
+        3,
+        INITIAL_PRICE,
+        policy_oracle_authority.pubkey(),
+        attacker_operator.pubkey(),
+        provider.pubkey(),
+        policy_oracle_authority.pubkey(),
+        1,
+    );
+    env.configure_auth_mark_for_asset_with_authority(1, &policy_oracle_authority, 3, INITIAL_PRICE);
+
+    // The honest insurance authority signs an older 100%-to-insurance split
+    // and a newer 0% correction under one live blockhash. The correction lands
+    // while the domain is empty; an independent provider then commits backing
+    // under those visible terms.
+    let policy_blockhash = env.svm.latest_blockhash();
+    let make_policy_tx = |insurance_share_bps| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(policy_oracle_authority.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::UpdateBackingFeePolicy {
+                domain: WINNING_DOMAIN,
+                fee_bps: BACKING_FEE_BPS,
+                insurance_share_bps,
+            }
+            .encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &policy_oracle_authority],
+            policy_blockhash,
+        )
+    };
+    let delayed_insurance_split = make_policy_tx(10_000);
+    let correcting_provider_split = make_policy_tx(0);
+    env.svm
+        .send_transaction(correcting_provider_split)
+        .expect("newer provider-fee policy lands before backing is funded");
+
+    let ledger = Keypair::new();
+    let payer = env.payer.insecure_clone();
+    system_create_account_for_test(
+        &mut env.svm,
+        &payer,
+        &ledger,
+        state::backing_domain_ledger_account_len(),
+        env.program_id,
+    );
+    let backing_source = env.token_account(provider.pubkey(), 5_000);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: WINNING_DOMAIN,
+            amount: 5_000,
+            expiry_slot: 100,
+        },
+        vec![
+            AccountMeta::new(provider.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(backing_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(ledger.pubkey(), false),
+        ],
+        &[&provider],
+    )
+    .expect("independent provider funds backing under the corrected split");
+
+    let attacker_account = env.create_portfolio(&attacker_operator);
+    let market_trader_account = env.create_portfolio(&market_trader);
+    let lp_account = env.create_portfolio(&lp);
+    env.deposit(&attacker_operator, attacker_account, TRADER_DEPOSIT);
+    env.deposit(&market_trader, market_trader_account, TRADER_DEPOSIT);
+    env.deposit(&lp, lp_account, LP_DEPOSIT);
+
+    env.trade_asset_with_cu(
+        1,
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        -WINNING_SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    );
+    env.trade_asset_with_cu(
+        0,
+        &market_trader,
+        market_trader_account,
+        &lp,
+        lp_account,
+        -LOSING_SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_for_asset_with_authority(1, &policy_oracle_authority, 4, INITIAL_PRICE);
+    env.push_auth_mark_for_asset_as_admin(0, 4, INITIAL_PRICE);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+        (lp_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 4,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    env.sync_maintenance_fee_with_cu(lp_account, None, 4);
+
+    env.svm.warp_to_slot(5);
+    env.push_auth_mark_for_asset_with_authority(1, &policy_oracle_authority, 5, 105);
+    env.push_auth_mark_for_asset_as_admin(0, 5, 95);
+    for (portfolio, asset_index) in [
+        (market_trader_account, 1),
+        (lp_account, 1),
+        (market_trader_account, 0),
+    ] {
+        env.crank_steps(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 5,
+                observations: crank_observations(asset_index),
+            },
+            4,
+        );
+    }
+    assert_eq!(
+        env.portfolio_state(lp_account).pnl.get(),
+        1_000,
+        "the independent LP has real source-backed positive PnL"
+    );
+
+    let trade_instruction = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(attacker_operator.pubkey(), true),
+            AccountMeta::new(lp.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_account, false),
+            AccountMeta::new(lp_account, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 0,
+            size_q: -INCREASE_Q,
+            exec_price: 95,
+            fee_bps: 0,
+        }
+        .encode(),
+    };
+    let presigned_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), trade_instruction],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &attacker_operator, &lp],
+        env.svm.latest_blockhash(),
+    );
+
+    let (_, before) = env.market_state();
+    let provider_before =
+        before.source_backing_buckets[WINNING_DOMAIN as usize].utilization_fee_earnings;
+    let insurance_before = before.insurance_domain_budget[WINNING_DOMAIN as usize];
+    let lp_before = env.portfolio_state(lp_account).capital.get();
+
+    let delayed_accepted = env.svm.send_transaction(delayed_insurance_split).is_ok();
+    env.svm
+        .send_transaction(presigned_trade)
+        .expect("the fee-bearing trade remains executable");
+
+    let (_, after) = env.market_state();
+    let provider_fee = after.source_backing_buckets[WINNING_DOMAIN as usize]
+        .utilization_fee_earnings
+        .saturating_sub(provider_before);
+    let insurance_fee =
+        after.insurance_domain_budget[WINNING_DOMAIN as usize].saturating_sub(insurance_before);
+    let charged = lp_before.saturating_sub(env.portfolio_state(lp_account).capital.get());
+    assert_eq!(provider_fee + insurance_fee, EXPECTED_FEE);
+    assert_eq!(charged, EXPECTED_FEE);
+
+    let attacker_extracted = if insurance_fee == 0 {
+        0
+    } else {
+        let (destination, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker_operator, 1, insurance_fee)
+            .expect("asset insurance operator withdraws the diverted fee");
+        env.token_amount(destination) as u128
+    };
+    let provider_withdrawn = if provider_fee == 0 {
+        0
+    } else {
+        let destination = env.token_account(provider.pubkey(), 0);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::WithdrawBackingBucketEarnings {
+                domain: WINNING_DOMAIN,
+                amount: provider_fee,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(ledger.pubkey(), false),
+                AccountMeta::new(destination, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&provider],
+        )
+        .expect("provider withdraws the fee earned under the corrected policy");
+        env.token_amount(destination) as u128
+    };
+
+    if delayed_accepted {
+        assert_eq!((provider_fee, insurance_fee), (0, EXPECTED_FEE));
+        assert_eq!(attacker_extracted, EXPECTED_FEE);
+        assert_eq!(provider_withdrawn, 0);
+        panic!(
+            "delayed insurance split diverted and publicly extracted \
+             {attacker_extracted} atoms owed to the independent backing provider"
+        );
+    }
+    assert_eq!(
+        (
+            provider_fee,
+            insurance_fee,
+            attacker_extracted,
+            provider_withdrawn,
+        ),
+        (EXPECTED_FEE, 0, 0, EXPECTED_FEE),
+        "funded backing must retain the provider split visible at deposit"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59856,24 +59856,74 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
         env.program_id,
     );
     let backing_source = env.token_account(provider.pubkey(), 5_000);
-    env.svm.expire_blockhash();
-    env.send(
-        ProgInstruction::TopUpBackingBucket {
-            domain: WINNING_DOMAIN,
-            amount: 5_000,
-            expiry_slot: 100,
-        },
-        vec![
-            AccountMeta::new(provider.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(backing_source, false),
-            AccountMeta::new(env.vault, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-            AccountMeta::new(ledger.pubkey(), false),
+    let retained_top_up = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(provider.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(backing_source, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                    AccountMeta::new(ledger.pubkey(), false),
+                ],
+                data: ProgInstruction::TopUpBackingBucket {
+                    domain: WINNING_DOMAIN,
+                    amount: 5_000,
+                    expiry_slot: 100,
+                }
+                .encode(),
+            },
         ],
-        &[&provider],
-    )
-    .expect("independent provider funds backing under the corrected split");
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &provider],
+        policy_blockhash,
+    );
+
+    // The stale split wins the ordering race while the bucket is still empty, then the provider's
+    // retained top-up lands. Freezing terms only after funding cannot protect this ordering.
+    let delayed_accepted = env.svm.send_transaction(delayed_insurance_split).is_ok();
+    let retained_top_up_accepted = env.svm.send_transaction(retained_top_up).is_ok();
+    if !retained_top_up_accepted {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateBackingFeePolicy {
+                domain: WINNING_DOMAIN,
+                fee_bps: BACKING_FEE_BPS,
+                insurance_share_bps: 0,
+            },
+            vec![
+                AccountMeta::new(policy_oracle_authority.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&policy_oracle_authority],
+        )
+        .expect("restore provider-fee policy after rejecting the stale top-up");
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::TopUpBackingBucket {
+                domain: WINNING_DOMAIN,
+                amount: 5_000,
+                expiry_slot: 100,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(backing_source, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger.pubkey(), false),
+            ],
+            &[&provider],
+        )
+        .expect("provider retries after the accepted policy is restored");
+    }
 
     let attacker_account = env.create_portfolio(&attacker_operator);
     let market_trader_account = env.create_portfolio(&market_trader);
@@ -59976,7 +60026,6 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
     let insurance_before = before.insurance_domain_budget[WINNING_DOMAIN as usize];
     let lp_before = env.portfolio_state(lp_account).capital.get();
 
-    let delayed_accepted = env.svm.send_transaction(delayed_insurance_split).is_ok();
     env.svm
         .send_transaction(presigned_trade)
         .expect("the fee-bearing trade remains executable");
@@ -60024,12 +60073,12 @@ fn v16_attack_delayed_backing_split_cannot_divert_provider_fee_to_operator() {
         env.token_amount(destination) as u128
     };
 
-    if delayed_accepted {
+    if delayed_accepted && retained_top_up_accepted {
         assert_eq!((provider_fee, insurance_fee), (0, EXPECTED_FEE));
         assert_eq!(attacker_extracted, EXPECTED_FEE);
         assert_eq!(provider_withdrawn, 0);
         panic!(
-            "delayed insurance split diverted and publicly extracted \
+            "stale split front-ran the retained provider top-up and publicly extracted \
              {attacker_extracted} atoms owed to the independent backing provider"
         );
     }

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -355,22 +355,30 @@ fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let amount: u128 = kani::any();
     let expiry_slot: u64 = kani::any();
+    let expected_fee_bps: u16 = kani::any();
+    let expected_insurance_share_bps: u16 = kani::any();
 
-    let mut data = [0u8; 27];
+    let mut data = [0u8; 31];
     data[0] = 24;
     data[1..3].copy_from_slice(&domain.to_le_bytes());
     data[3..19].copy_from_slice(&amount.to_le_bytes());
     data[19..27].copy_from_slice(&expiry_slot.to_le_bytes());
+    data[27..29].copy_from_slice(&expected_fee_bps.to_le_bytes());
+    data[29..31].copy_from_slice(&expected_insurance_share_bps.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TopUpBackingBucket {
             domain: got_domain,
             amount: got_amount,
             expiry_slot: got_expiry,
+            expected_fee_bps: got_fee_bps,
+            expected_insurance_share_bps: got_insurance_share_bps,
         } => {
             assert_eq!(got_domain, domain);
             assert_eq!(got_amount, amount);
             assert_eq!(got_expiry, expiry_slot);
+            assert_eq!(got_fee_bps, expected_fee_bps);
+            assert_eq!(got_insurance_share_bps, expected_insurance_share_bps);
         }
         _ => unreachable!(),
     }
@@ -1153,6 +1161,8 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
             domain: 1,
             amount: 1,
             expiry_slot: 10,
+            expected_fee_bps: 20,
+            expected_insurance_share_bps: 30,
         },
         extra,
     );
@@ -1496,7 +1506,7 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let top_up_domain = [56u8; 17];
     assert!(Instruction::decode(&top_up_domain).is_err());
 
-    let top_up_backing = [24u8; 25];
+    let top_up_backing = [24u8; 29];
     assert!(Instruction::decode(&top_up_backing).is_err());
 
     let withdraw_insurance = [23u8; 16];


### PR DESCRIPTION
## Root cause

`UpdateBackingFeePolicy` authenticated the domain insurance authority but did not bind an independent provider's backing deposit to the fee rate and insurance split that the provider accepted. An unprivileged relayer could reorder older and newer honestly signed transactions in either direction:

1. fund first, then land an older policy; or
2. land an older policy while the bucket is empty, then land the provider's already-signed top-up.

A subsequent public trade accrued a real utilization fee under the displaced split, and a distinct domain insurance operator could withdraw value owed to the backing provider.

## Change

- Freeze each backing domain's fee rate and insurance split while its bucket contains provider principal, liens, consumed/impaired backing, or unwithdrawn provider earnings.
- Extend `TopUpBackingBucket` with `expected_fee_bps` and `expected_insurance_share_bps`; reject atomically unless both match live policy before any accounting or token movement.
- Keep exact idempotent policy writes valid and allow reconfiguration after the bucket is fully empty.
- Update all wrapper call sites and add Kani wire-field, truncation, and trailing-byte coverage.
- Add public LiteSVM coverage for both transaction orders, byte-identical rollback, a matching-policy retry, real fee accrual, and provider/operator withdrawals.

This changes tag 24's payload from 27 to 31 bytes. It does not reject trades or exits; only policy changes over live provider value and deposits whose signed terms no longer match are rejected.

## Red/green evidence

- Exact main parent `36fa587e`: RED commit `9b8ac341` publicly diverts and extracts 70 atoms from an independent provider when the stale policy lands after funding.
- Incomplete funded-only fix `395149cd`: RED commit `af03de2b` publicly diverts and extracts the same 70 atoms when the stale policy lands immediately before the provider's retained top-up.
- Fixed head `400f24f6`: both orderings are closed. The stale top-up rolls back market, source, vault, and ledger byte-identically; after restoring the accepted terms, the provider can retry, earn the fee, and withdraw it.

No state injection, dishonest oracle, or compromised signer is required; the adversary only relays honest signed transactions within the live blockhash window.

## Validation

- `cargo test --test v16_cu`: 567 passed
- backing-focused public LiteSVM/CU tests: 42 passed
- `cargo test --lib`: 6 passed
- `cargo check --tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- Kani `kani_v16_top_up_backing_bucket_decode_preserves_wire_fields`: 821 checks passed
- Kani `kani_v16_custody_payloads_reject_trailing_byte`: 1,500 checks passed
- Kani `kani_v16_every_active_payload_rejects_one_byte_truncation`: 849 checks passed