### PR TITLE
[BLOCKER LoF] Reject delayed fee-redirect policy replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The economic and governance model for a permissionless multi-asset market. Statu
 - **Fee routing (configured percentages):**
   - a % of **all trading fees → asset-0 insurance** (`fee_redirect_to_market_0_bps`). **✅**
     (`v16_attack_fee_redirect_split_lands_correctly` asserts the 20% split + conservation;
-    `v16_attack_market0_fees_stay_local`, `..._fee_redirect_full_boundary`.)
+    `v16_attack_market0_fees_stay_local`, `..._fee_redirect_full_boundary`.) Redirect updates carry
+    a strictly increasing signer sequence, so delayed transactions cannot restore a superseded fee
+    destination.
   - a % of **asset-N backing yield → asset-N insurance** and **→ asset-0 insurance**
     (`backing_trade_fee_insurance_share`, redirected via the same market-0 share). **✅** — policy is
     authority-gated + bounded (`v16_attack_backing_fee_policy_authority_gated`), and

--- a/examples/dump_layout.rs
+++ b/examples/dump_layout.rs
@@ -41,7 +41,8 @@ fn main() {
     wcf!(collateral_mint, [u8; 32]);
     wcf!(secondary_collateral_mint, [u8; 32]);
     wcf!(maintenance_fee_per_slot, u128);
-    wcf!(permissionless_market_init_fee, u128);
+    wcf!(permissionless_market_init_fee, u64);
+    wcf!(fee_redirect_policy_sequence, u64);
     wcf!(trade_fee_base_bps, u64);
     wcf!(permissionless_resolve_stale_slots, u64);
     wcf!(force_close_delay_slots, u64);

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -512,7 +512,13 @@ pub mod state {
         pub collateral_mint: [u8; 32],
         pub secondary_collateral_mint: [u8; 32],
         pub maintenance_fee_per_slot: u128,
-        pub permissionless_market_init_fee: u128,
+        /// The public setter and SPL transfer path require this fee to fit in `u64`.
+        /// This occupies the low word of the former `u128` field, preserving the zero-copy ABI.
+        pub permissionless_market_init_fee: u64,
+        /// Last accepted market-authority fee-redirect intent. The high word of the former
+        /// init-fee field was always zero in publicly reachable states, so legacy accounts begin at
+        /// sequence zero without migration.
+        pub fee_redirect_policy_sequence: u64,
         pub trade_fee_base_bps: u64,
         pub permissionless_resolve_stale_slots: u64,
         pub force_close_delay_slots: u64,
@@ -2564,6 +2570,7 @@ pub mod ix {
         },
         UpdateFeeRedirectPolicy {
             redirect_bps: u16,
+            policy_sequence: u64,
         },
         UpdateMarketInitFeePolicy {
             min_init_fee: u128,
@@ -2826,6 +2833,7 @@ pub mod ix {
                 },
                 58 => Self::UpdateFeeRedirectPolicy {
                     redirect_bps: read_u16(&mut rest)?,
+                    policy_sequence: read_u64(&mut rest)?,
                 },
                 59 => Self::UpdateMarketInitFeePolicy {
                     min_init_fee: read_u128(&mut rest)?,
@@ -3138,9 +3146,13 @@ pub mod ix {
                     out.push(55);
                     push_u64(&mut out, trade_fee_base_bps);
                 }
-                Self::UpdateFeeRedirectPolicy { redirect_bps } => {
+                Self::UpdateFeeRedirectPolicy {
+                    redirect_bps,
+                    policy_sequence,
+                } => {
                     out.push(58);
                     push_u16(&mut out, redirect_bps);
+                    push_u64(&mut out, policy_sequence);
                 }
                 Self::UpdateMarketInitFeePolicy { min_init_fee } => {
                     out.push(59);
@@ -4353,10 +4365,10 @@ pub mod processor {
 
     #[inline(always)]
     fn permissionless_market_init_fee_for_asset(
-        base_fee: u128,
+        base_fee: u64,
         asset_index: usize,
     ) -> Result<u128, ProgramError> {
-        let mut fee = base_fee;
+        let mut fee = u128::from(base_fee);
         if fee == 0 {
             return Ok(0);
         }
@@ -5309,9 +5321,15 @@ pub mod processor {
             Instruction::UpdateTradeFeePolicy { trade_fee_base_bps } => {
                 handle_update_trade_fee_policy(program_id, accounts, trade_fee_base_bps)
             }
-            Instruction::UpdateFeeRedirectPolicy { redirect_bps } => {
-                handle_update_fee_redirect_policy(program_id, accounts, redirect_bps)
-            }
+            Instruction::UpdateFeeRedirectPolicy {
+                redirect_bps,
+                policy_sequence,
+            } => handle_update_fee_redirect_policy(
+                program_id,
+                accounts,
+                redirect_bps,
+                policy_sequence,
+            ),
             Instruction::UpdateMarketInitFeePolicy { min_init_fee } => {
                 handle_update_market_init_fee_policy(program_id, accounts, min_init_fee)
             }
@@ -5550,6 +5568,7 @@ pub mod processor {
             secondary_collateral_mint: [0u8; 32],
             maintenance_fee_per_slot,
             permissionless_market_init_fee: 0,
+            fee_redirect_policy_sequence: 0,
             trade_fee_base_bps,
             permissionless_resolve_stale_slots: 0,
             force_close_delay_slots: 0,
@@ -9679,6 +9698,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         redirect_bps: u16,
+        policy_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9691,7 +9711,11 @@ pub mod processor {
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
+        if policy_sequence <= cfg.fee_redirect_policy_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
         cfg.fee_redirect_to_market_0_bps = redirect_bps;
+        cfg.fee_redirect_policy_sequence = policy_sequence;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
     }
 
@@ -9706,7 +9730,7 @@ pub mod processor {
         expect_signer(admin)?;
         expect_writable(market_ai)?;
         expect_owner(market_ai, program_id)?;
-        let _ = amount_to_u64(min_init_fee)?;
+        let min_init_fee = amount_to_u64(min_init_fee)?;
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1023,11 +1023,20 @@ impl V16CuEnv {
     }
 
     fn update_fee_redirect_policy_with_cu(&mut self, redirect_bps: u16) -> u64 {
+        let policy_sequence = self
+            .market_state()
+            .0
+            .fee_redirect_policy_sequence
+            .checked_add(1)
+            .expect("fee redirect policy sequence");
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps },
+            ProgInstruction::UpdateFeeRedirectPolicy {
+                redirect_bps,
+                policy_sequence,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -25885,6 +25894,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     old_attempt(
         ProgInstruction::UpdateFeeRedirectPolicy {
             redirect_bps: 2_000,
+            policy_sequence: 1,
         },
         "fee redirect replay",
     );
@@ -25931,6 +25941,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     new_update(
         ProgInstruction::UpdateFeeRedirectPolicy {
             redirect_bps: 2_000,
+            policy_sequence: 1,
         },
         "fee redirect update",
     );
@@ -29838,6 +29849,7 @@ fn v16_attack_fee_redirect_gated_bounded_no_leak() {
         &env.payer,
         ProgInstruction::UpdateFeeRedirectPolicy {
             redirect_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -29854,6 +29866,7 @@ fn v16_attack_fee_redirect_gated_bounded_no_leak() {
         &env.payer,
         ProgInstruction::UpdateFeeRedirectPolicy {
             redirect_bps: 20_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -29870,6 +29883,7 @@ fn v16_attack_fee_redirect_gated_bounded_no_leak() {
         &env.payer,
         ProgInstruction::UpdateFeeRedirectPolicy {
             redirect_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -34718,7 +34732,8 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
     );
     assert!(
         attempt(ProgInstruction::UpdateFeeRedirectPolicy {
-            redirect_bps: 5_000
+            redirect_bps: 5_000,
+            policy_sequence: 1,
         })
         .is_err(),
         "asset-1 authority must not control market-0 fee redirect"
@@ -59719,6 +59734,62 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 }
 
 #[test]
+fn v16_bpf_fee_redirect_policy_sequence_accepts_gaps_and_rejects_replays() {
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(37);
+    let update = |env: &mut V16CuEnv, sequence: u64, redirect_bps: u16| {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateFeeRedirectPolicy {
+                redirect_bps,
+                policy_sequence: sequence,
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin],
+        )
+    };
+
+    let first_cu = update(&mut env, 17, 1_234).expect("first sequence with a forward gap");
+    assert_cu_within(
+        "UpdateFeeRedirectPolicy sequenced",
+        first_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    let accepted = env.svm.get_account(&env.market).unwrap();
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.fee_redirect_to_market_0_bps, 1_234);
+    assert_eq!(cfg.fee_redirect_policy_sequence, 17);
+    assert_eq!(
+        cfg.permissionless_market_init_fee, 37,
+        "the ABI-compatible sequence word must not corrupt the adjacent init fee"
+    );
+
+    for stale_sequence in [0, 16, 17] {
+        assert!(
+            update(&mut env, stale_sequence, 9_999).is_err(),
+            "zero, lower, and equal policy sequences must reject"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            accepted,
+            "a rejected policy replay must leave the complete market byte-identical"
+        );
+    }
+
+    update(&mut env, 1_000_000, 4_321).expect("large forward sequence gaps remain valid");
+    let cfg = env.market_state().0;
+    assert_eq!(cfg.fee_redirect_to_market_0_bps, 4_321);
+    assert_eq!(cfg.fee_redirect_policy_sequence, 1_000_000);
+    assert_eq!(cfg.permissionless_market_init_fee, 37);
+}
+
+#[test]
 fn v16_attack_delayed_fee_redirect_cannot_divert_canonical_insurance() {
     const PRICE: u64 = 100;
     const DEPOSIT: u128 = 10_000;
@@ -59753,14 +59824,18 @@ fn v16_attack_delayed_fee_redirect_cannot_divert_canonical_insurance() {
     // Both remain valid under one recent blockhash. Once the correction is
     // visible, the independent victim signs the fee-bearing trade.
     let blockhash = env.svm.latest_blockhash();
-    let make_policy_tx = |redirect_bps| {
+    let make_policy_tx = |redirect_bps, policy_sequence| {
         let instruction = Instruction {
             program_id: env.program_id,
             accounts: vec![
                 AccountMeta::new(env.admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
             ],
-            data: ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps }.encode(),
+            data: ProgInstruction::UpdateFeeRedirectPolicy {
+                redirect_bps,
+                policy_sequence,
+            }
+            .encode(),
         };
         Transaction::new_signed_with_payer(
             &[heap_ix(), cu_ix(), instruction],
@@ -59769,8 +59844,8 @@ fn v16_attack_delayed_fee_redirect_cannot_divert_canonical_insurance() {
             blockhash,
         )
     };
-    let delayed_local_redirect = make_policy_tx(0);
-    let correcting_canonical_redirect = make_policy_tx(10_000);
+    let delayed_local_redirect = make_policy_tx(0, 1);
+    let correcting_canonical_redirect = make_policy_tx(10_000, 2);
     env.svm
         .send_transaction(correcting_canonical_redirect)
         .expect("newer canonical redirect lands first");

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,131 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_attack_delayed_fee_redirect_cannot_divert_canonical_insurance() {
+    const PRICE: u64 = 100;
+    const DEPOSIT: u128 = 10_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const FEE_BPS: u64 = 10_000;
+    const FEE_PER_SIDE: u128 = 1_000;
+
+    let mut env = V16CuEnv::new();
+    let attacker = Keypair::new();
+    env.update_market_init_fee_policy_with_cu(1);
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &attacker,
+        1,
+        1,
+        PRICE,
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        attacker.pubkey(),
+        1,
+    );
+
+    let victim = Keypair::new();
+    let victim_portfolio = env.create_portfolio(&victim);
+    let attacker_portfolio = env.create_portfolio(&attacker);
+    env.deposit(&victim, victim_portfolio, DEPOSIT);
+    env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+
+    // The honest market authority signs an old local-fee intent and then a
+    // correction routing all non-base fees to canonical asset-0 insurance.
+    // Both remain valid under one recent blockhash. Once the correction is
+    // visible, the independent victim signs the fee-bearing trade.
+    let blockhash = env.svm.latest_blockhash();
+    let make_policy_tx = |redirect_bps| {
+        let instruction = Instruction {
+            program_id: env.program_id,
+            accounts: vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            data: ProgInstruction::UpdateFeeRedirectPolicy { redirect_bps }.encode(),
+        };
+        Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), instruction],
+            Some(&env.payer.pubkey()),
+            &[&env.payer, &env.admin],
+            blockhash,
+        )
+    };
+    let delayed_local_redirect = make_policy_tx(0);
+    let correcting_canonical_redirect = make_policy_tx(10_000);
+    env.svm
+        .send_transaction(correcting_canonical_redirect)
+        .expect("newer canonical redirect lands first");
+    assert_eq!(env.market_state().0.fee_redirect_to_market_0_bps, 10_000);
+
+    let trade_instruction = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim_portfolio, false),
+            AccountMeta::new(attacker_portfolio, false),
+        ],
+        data: ProgInstruction::TradeNoCpi {
+            asset_index: 1,
+            size_q: SIZE_Q,
+            exec_price: PRICE,
+            fee_bps: FEE_BPS,
+        }
+        .encode(),
+    };
+    let presigned_trade = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), trade_instruction],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim, &attacker],
+        blockhash,
+    );
+
+    let before = env.market_state().1.insurance_domain_budget;
+    let delayed_accepted = env.svm.send_transaction(delayed_local_redirect).is_ok();
+    env.svm
+        .send_transaction(presigned_trade)
+        .expect("the independently signed trade remains executable");
+
+    let (_, group) = env.market_state();
+    let canonical_fee = (group.insurance_domain_budget[0] - before[0])
+        + (group.insurance_domain_budget[1] - before[1]);
+    let local_fee = (group.insurance_domain_budget[2] - before[2])
+        + (group.insurance_domain_budget[3] - before[3]);
+    let victim_capital = env.portfolio_state(victim_portfolio).capital.get();
+    let attacker_capital = env.portfolio_state(attacker_portfolio).capital.get();
+    let extracted = if local_fee == 0 {
+        0
+    } else {
+        let (destination, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker, 1, local_fee)
+            .expect("permissionless asset operator withdraws the diverted fees");
+        env.token_amount(destination) as u128
+    };
+
+    if delayed_accepted {
+        assert_eq!(canonical_fee, 0);
+        assert_eq!(local_fee, FEE_PER_SIDE * 2);
+        assert_eq!(victim_capital, DEPOSIT - FEE_PER_SIDE);
+        assert_eq!(attacker_capital, DEPOSIT - FEE_PER_SIDE);
+        assert_eq!(extracted, FEE_PER_SIDE * 2);
+        assert_eq!(
+            attacker_capital + extracted,
+            DEPOSIT + FEE_PER_SIDE,
+            "operator gain must equal the independent victim's diverted fee"
+        );
+        panic!(
+            "older local-redirect intent landed after the correction and let \
+             the asset operator extract {extracted} atoms from canonical insurance"
+        );
+    }
+
+    assert_eq!(canonical_fee, FEE_PER_SIDE * 2);
+    assert_eq!(local_fee, 0);
+    assert_eq!(victim_capital, DEPOSIT - FEE_PER_SIDE);
+    assert_eq!(attacker_capital, DEPOSIT - FEE_PER_SIDE);
+    assert_eq!(extracted, 0);
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -840,15 +840,41 @@ fn kani_v16_update_trade_fee_policy_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_update_fee_redirect_policy_decode_preserves_wire_fields() {
     let redirect_bps: u16 = kani::any();
+    let policy_sequence: u64 = kani::any();
 
-    let mut data = [0u8; 3];
+    let mut data = [0u8; 11];
     data[0] = 58;
     data[1..3].copy_from_slice(&redirect_bps.to_le_bytes());
+    data[3..11].copy_from_slice(&policy_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
-        Instruction::UpdateFeeRedirectPolicy { redirect_bps: got } => assert_eq!(got, redirect_bps),
+        Instruction::UpdateFeeRedirectPolicy {
+            redirect_bps: got,
+            policy_sequence: got_sequence,
+        } => {
+            assert_eq!(got, redirect_bps);
+            assert_eq!(got_sequence, policy_sequence);
+        }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_update_fee_redirect_policy_requires_exact_framing() {
+    let instruction = Instruction::UpdateFeeRedirectPolicy {
+        redirect_bps: kani::any(),
+        policy_sequence: kani::any(),
+    };
+    let mut data = instruction.encode();
+    assert_eq!(data.len(), 11);
+    assert!(Instruction::decode(&data).is_ok());
+
+    data.pop();
+    assert!(Instruction::decode(&data).is_err());
+
+    data.push(0);
+    data.push(kani::any());
+    assert!(Instruction::decode(&data).is_err());
 }
 
 #[kani::proof]
@@ -1256,7 +1282,10 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
         extra,
     );
     assert_rejects_trailing_byte(
-        Instruction::UpdateFeeRedirectPolicy { redirect_bps: 250 },
+        Instruction::UpdateFeeRedirectPolicy {
+            redirect_bps: 250,
+            policy_sequence: 1,
+        },
         extra,
     );
     assert_rejects_trailing_byte(


### PR DESCRIPTION
## Root cause

`UpdateFeeRedirectPolicy` authenticated `marketauth` but carried no intent ordering. Two honestly signed updates could remain valid under one recent blockhash and land in reverse order. An unprivileged relayer could therefore restore an old 0% redirect after a visible 100% correction, route a subsequent permissionless-asset trade's fees away from canonical asset-0 insurance, and let that asset's distinct operator withdraw them.

The exact-parent public LiteSVM RED keeps the fee amount fixed: an independent victim signs the same fee-bearing trade after the canonical redirect is visible. The delayed policy changes only the fee destination. The operator extracts 2,000 atoms and ends 1,000 ahead, equal to the victim/canonical fund's independent loss.

## Fix

- Add a signer-chosen `u64 policy_sequence` to tag 58.
- Require strict advancement; forward gaps succeed, while zero/equal/lower intents reject atomically.
- Reject legacy short and trailing-byte payloads through exact framing.
- Preserve the 448-byte zero-copy market ABI by splitting the publicly `u64`-bounded permissionless-init-fee `u128` into its existing low word plus a sequence high word. Publicly reachable legacy accounts start at sequence zero.
- Keep the already-signed trade executable under the accepted redirect.

This is same-generation intent ordering and is distinct from #317's market-generation binding. The two protections compose.

## Red/green evidence

- Exact parent `36fa587e`, RED commit `5af86122`: stale 0% intent lands after 100%; canonical insurance receives zero; attacker-operated asset withdraws 2,000 atoms.
- Fixed head `ae107419`: stale intent rejects; the trade executes; canonical insurance receives all 2,000 atoms; attacker extracts zero.

## Validation

- `cargo test --test v16_cu -- --nocapture`: 567 passed, including all max-shape CU gates
- `cargo test --lib`: 6 passed
- Kani field preservation: 817 checks, 0 failures
- Kani exact framing: 1,533 checks, 0 failures
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`