### PR TITLE
Stale-resolution policy ordering is recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
   - per-asset authorities (insurance/operator/backing/oracle, incl. asset 0) are rotated via
     `UpdateAssetAuthority`, not this instruction
+- **ConfigurePermissionlessResolve** (tag 38)
+  - `ConfigurePermissionlessResolve { sequence, stale_slots, force_close_delay_slots }` is signed by
+    `marketauth`; `sequence` must strictly advance the stored policy watermark, so delayed older
+    intents cannot shorten a corrected stale timer and terminally halt a live market
 - **UpdateAssetLifecycle** (tag 40)
   - appends/reactivates/retires assets 1..N, including permissionless create/reuse when the configured
     create fee is nonzero

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -512,7 +512,11 @@ pub mod state {
         pub collateral_mint: [u8; 32],
         pub secondary_collateral_mint: [u8; 32],
         pub maintenance_fee_per_slot: u128,
-        pub permissionless_market_init_fee: u128,
+        /// Public activation transfers are SPL-token `u64` amounts. The former high word was
+        /// therefore always zero and now stores the stale-resolution policy intent watermark
+        /// without changing the 448-byte market account ABI.
+        pub permissionless_market_init_fee: u64,
+        pub permissionless_resolve_policy_sequence: u64,
         pub trade_fee_base_bps: u64,
         pub permissionless_resolve_stale_slots: u64,
         pub force_close_delay_slots: u64,
@@ -2577,6 +2581,7 @@ pub mod ix {
         },
         SyncInsuranceLedger,
         ConfigurePermissionlessResolve {
+            sequence: u64,
             stale_slots: u64,
             force_close_delay_slots: u64,
         },
@@ -2866,6 +2871,7 @@ pub mod ix {
                 },
                 54 => Self::SyncInsuranceLedger,
                 38 => Self::ConfigurePermissionlessResolve {
+                    sequence: read_u64(&mut rest)?,
                     stale_slots: read_u64(&mut rest)?,
                     force_close_delay_slots: read_u64(&mut rest)?,
                 },
@@ -3169,10 +3175,12 @@ pub mod ix {
                 }
                 Self::SyncInsuranceLedger => out.push(54),
                 Self::ConfigurePermissionlessResolve {
+                    sequence,
                     stale_slots,
                     force_close_delay_slots,
                 } => {
                     out.push(38);
+                    push_u64(&mut out, sequence);
                     push_u64(&mut out, stale_slots);
                     push_u64(&mut out, force_close_delay_slots);
                 }
@@ -5323,11 +5331,13 @@ pub mod processor {
             }
             Instruction::SyncInsuranceLedger => handle_sync_insurance_ledger(program_id, accounts),
             Instruction::ConfigurePermissionlessResolve {
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             } => handle_configure_permissionless_resolve(
                 program_id,
                 accounts,
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             ),
@@ -5550,6 +5560,7 @@ pub mod processor {
             secondary_collateral_mint: [0u8; 32],
             maintenance_fee_per_slot,
             permissionless_market_init_fee: 0,
+            permissionless_resolve_policy_sequence: 0,
             trade_fee_base_bps,
             permissionless_resolve_stale_slots: 0,
             force_close_delay_slots: 0,
@@ -9107,7 +9118,7 @@ pub mod processor {
                 0
             } else {
                 let fee = permissionless_market_init_fee_for_asset(
-                    cfg_pre.permissionless_market_init_fee,
+                    cfg_pre.permissionless_market_init_fee as u128,
                     asset_index,
                 )?;
                 if fee == 0 {
@@ -9146,7 +9157,7 @@ pub mod processor {
                         cfg.marketauth != [0u8; 32] && cfg.marketauth == authority.key.to_bytes();
                     if !still_asset_authority {
                         let expected_fee = permissionless_market_init_fee_for_asset(
-                            cfg.permissionless_market_init_fee,
+                            cfg.permissionless_market_init_fee as u128,
                             asset_index,
                         )?;
                         if expected_fee == 0 || expected_fee != init_fee {
@@ -9710,7 +9721,7 @@ pub mod processor {
         let (mut cfg, _, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
-        cfg.permissionless_market_init_fee = min_init_fee;
+        cfg.permissionless_market_init_fee = min_init_fee as u64;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
     }
 
@@ -9718,6 +9729,7 @@ pub mod processor {
     fn handle_configure_permissionless_resolve<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        sequence: u64,
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> ProgramResult {
@@ -9736,12 +9748,16 @@ pub mod processor {
         let (mut cfg, mode, _, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         expect_live_authority(&cfg.marketauth, admin.key)?;
+        if sequence == 0 || sequence <= cfg.permissionless_resolve_policy_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
         if mode != MarketModeV16::Live {
             return Err(PercolatorError::EngineLockActive.into());
         }
         if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
             return Err(PercolatorError::OracleStale.into());
         }
+        cfg.permissionless_resolve_policy_sequence = sequence;
         cfg.permissionless_resolve_stale_slots = stale_slots;
         cfg.force_close_delay_slots = force_close_delay_slots;
         state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2277,11 +2277,18 @@ impl V16CuEnv {
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> u64 {
+        let sequence = self
+            .market_state()
+            .0
+            .permissionless_resolve_policy_sequence
+            .checked_add(1)
+            .unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigurePermissionlessResolve {
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             },
@@ -25894,6 +25901,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     old_attempt(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -25940,6 +25948,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     new_update(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -36856,6 +36865,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: DELAY,
         },
@@ -54349,6 +54359,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -54369,6 +54380,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 0,
             force_close_delay_slots: 1_000,
         },
@@ -54384,6 +54396,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: percolator_prog::constants::MAX_PERMISSIONLESS_RESOLVE_STALE_SLOTS + 1,
             force_close_delay_slots: 1_000,
         },
@@ -54402,6 +54415,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 0,
         },
@@ -54420,6 +54434,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: percolator_prog::constants::MAX_FORCE_CLOSE_DELAY_SLOTS + 1,
         },
@@ -54440,6 +54455,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_ok = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -54480,6 +54496,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let fresh = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 2,
             stale_slots: 6,
             force_close_delay_slots: 6,
         },
@@ -54507,6 +54524,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let stale = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 3,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -59894,4 +59912,44 @@ fn v16_attack_permissionless_resolve_policy_rejects_delayed_same_generation_inte
         PRICE,
         0,
     );
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 5,
+            stale_slots: CORRECTED_STALE_SLOTS,
+            force_close_delay_slots: FORCE_CLOSE_DELAY_SLOTS,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&admin],
+    )
+    .expect("a forward sequence gap remains valid");
+    let after_gap = env.svm.get_account(&env.market).unwrap();
+    for stale_sequence in [0, 5, 4] {
+        env.svm.expire_blockhash();
+        let rejected = env.send(
+            ProgInstruction::ConfigurePermissionlessResolve {
+                sequence: stale_sequence,
+                stale_slots: CORRECTED_STALE_SLOTS - 1,
+                force_close_delay_slots: FORCE_CLOSE_DELAY_SLOTS,
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&admin],
+        );
+        assert!(
+            rejected.is_err(),
+            "zero, equal, and lower policy sequences must reject"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            after_gap,
+            "rejected policy sequence leaves the market byte-identical"
+        );
+    }
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,181 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// An unprivileged relayer must not land an older, honestly signed stale-resolution policy after a
+// newer correction in the same market generation. Otherwise the retained shorter timer lets any
+// caller terminally halt a funded live market while both admin transactions share one valid recent
+// blockhash.
+#[test]
+fn v16_attack_permissionless_resolve_policy_rejects_delayed_same_generation_intent() {
+    const PRICE: u64 = 100;
+    const DEPOSIT: u128 = 1_000;
+    const SIZE_Q: i128 = 5 * POS_SCALE as i128;
+    const OLD_STALE_SLOTS: u64 = 1;
+    const CORRECTED_STALE_SLOTS: u64 = 100;
+    const FORCE_CLOSE_DELAY_SLOTS: u64 = 5;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_auth_mark_with_cu(0, PRICE);
+
+    let victim = Keypair::new();
+    let counterparty = Keypair::new();
+    let victim_account = env.create_portfolio(&victim);
+    let counterparty_account = env.create_portfolio(&counterparty);
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&counterparty, counterparty_account, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &counterparty,
+        counterparty_account,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    let policy_data = |sequence: u64, stale_slots: u64| {
+        let mut sequenced = vec![38u8];
+        sequenced.extend_from_slice(&sequence.to_le_bytes());
+        sequenced.extend_from_slice(&stale_slots.to_le_bytes());
+        sequenced.extend_from_slice(&FORCE_CLOSE_DELAY_SLOTS.to_le_bytes());
+        if ProgInstruction::decode(&sequenced).is_ok() {
+            sequenced
+        } else {
+            let mut legacy = vec![38u8];
+            legacy.extend_from_slice(&stale_slots.to_le_bytes());
+            legacy.extend_from_slice(&FORCE_CLOSE_DELAY_SLOTS.to_le_bytes());
+            legacy
+        }
+    };
+    let policy_ix = |data: Vec<u8>| Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data,
+    };
+    let retained_blockhash = env.svm.latest_blockhash();
+    let delayed_old_policy = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            policy_ix(policy_data(1, OLD_STALE_SLOTS)),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+    let corrected_policy = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            policy_ix(policy_data(2, CORRECTED_STALE_SLOTS)),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        retained_blockhash,
+    );
+
+    env.svm
+        .send_transaction(corrected_policy)
+        .expect("the honest correction lands first");
+    assert_eq!(
+        env.market_state().0.permissionless_resolve_stale_slots,
+        CORRECTED_STALE_SLOTS
+    );
+    let corrected_market = env.svm.get_account(&env.market).unwrap();
+    let delayed = env.svm.send_transaction(delayed_old_policy);
+    let uses_sequence_wire = policy_data(3, CORRECTED_STALE_SLOTS).len() == 25;
+    if !uses_sequence_wire {
+        delayed.expect("the pre-fix wrapper accepts the superseded short timer");
+        assert_eq!(
+            env.market_state().0.permissionless_resolve_stale_slots,
+            OLD_STALE_SLOTS
+        );
+        let resolve_slot = env
+            .market_state()
+            .0
+            .last_good_oracle_slot
+            .checked_add(OLD_STALE_SLOTS + 1)
+            .unwrap();
+        env.svm.warp_to_slot(resolve_slot);
+        env.send(
+            ProgInstruction::ResolveStalePermissionless {
+                now_slot: resolve_slot,
+            },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .expect("the delayed policy arms unsigned terminal resolution");
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+        assert!(
+            env.try_trade_asset_with_cu(
+                0,
+                &victim,
+                victim_account,
+                &counterparty,
+                counterparty_account,
+                -SIZE_Q,
+                PRICE,
+                0,
+            )
+            .is_err(),
+            "ordinary user trade progress is permanently disabled"
+        );
+        panic!(
+            "a delayed honest stale-resolution intent let a public relayer halt a live funded market"
+        );
+    }
+
+    let delayed_error = format!(
+        "{:?}",
+        delayed.expect_err("the superseded sequence must reject")
+    );
+    let expected_error = format!(
+        "Custom({})",
+        percolator_prog::error::PercolatorError::EngineStale as u32
+    );
+    assert!(
+        delayed_error.contains(&expected_error),
+        "stale policy sequence must fail with {expected_error}, got {delayed_error}"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        corrected_market,
+        "stale sequence rejection leaves the live market byte-identical"
+    );
+
+    let resolve_slot = env
+        .market_state()
+        .0
+        .last_good_oracle_slot
+        .checked_add(OLD_STALE_SLOTS + 1)
+        .unwrap();
+    env.svm.warp_to_slot(resolve_slot);
+    assert!(
+        env.send(
+            ProgInstruction::ResolveStalePermissionless {
+                now_slot: resolve_slot,
+            },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .is_err(),
+        "the retained correction keeps the market outside its stale window"
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &counterparty,
+        counterparty_account,
+        -SIZE_Q,
+        PRICE,
+        0,
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -899,24 +899,35 @@ fn kani_v16_base_unit_payloads_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
+    let sequence: u64 = kani::any();
     let stale_slots: u64 = kani::any();
     let force_close_delay_slots: u64 = kani::any();
     let now_slot: u64 = kani::any();
 
-    let mut configure = [0u8; 17];
+    let mut configure = [0u8; 25];
     configure[0] = 38;
-    configure[1..9].copy_from_slice(&stale_slots.to_le_bytes());
-    configure[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    configure[1..9].copy_from_slice(&sequence.to_le_bytes());
+    configure[9..17].copy_from_slice(&stale_slots.to_le_bytes());
+    configure[17..25].copy_from_slice(&force_close_delay_slots.to_le_bytes());
     match Instruction::decode(&configure).unwrap() {
         Instruction::ConfigurePermissionlessResolve {
+            sequence: got_sequence,
             stale_slots: got_stale,
             force_close_delay_slots: got_delay,
         } => {
+            assert_eq!(got_sequence, sequence);
             assert_eq!(got_stale, stale_slots);
             assert_eq!(got_delay, force_close_delay_slots);
         }
         _ => unreachable!(),
     }
+    assert!(Instruction::decode(&configure[..24]).is_err());
+
+    let mut legacy = [0u8; 17];
+    legacy[0] = 38;
+    legacy[1..9].copy_from_slice(&stale_slots.to_le_bytes());
+    legacy[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 
     let mut resolve = [0u8; 9];
     resolve[0] = 39;
@@ -1272,6 +1283,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 5,
             force_close_delay_slots: 1,
         },


### PR DESCRIPTION
## Closed after all-path recheck

The ordering behavior is real, but the impact is not a persistent DoS under `scripts/loop.md`.

On the exact pre-fix state at `bfe3d0c0`, a delayed short-staleness policy can end ordinary trading early by moving the market to `Resolved`. A follow-up public LiteSVM probe then waited the configured five-slot force-close delay and called `CloseResolved` for both funded users. Both bounded public exits succeeded and each user recovered its complete 1,000-atom deposit.

Because terminal resolution preserves a bounded owner-independent wind-down, this does not satisfy the rule that every bounded owner/keeper continuation must fail. The proposed sequence hardening is therefore not being retained as a LoF/DoS fix.

Original implementation head: `2ce06194`. Full implementation verification was green, but that does not change the failed impact classification.