### PR TITLE
[NOT REAL LoF][CUSTODY HARDENING] Make asset insurance withdrawals at-most-once

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ This section describes intent and operational ordering, not argument-by-argument
   - requires market resolved and all accounts closed
 - **WithdrawInsuranceAsset** (tag 57)
   - live/recovery asset-scoped withdrawal from that asset's funded long+short insurance budget
+  - carries the per-asset `expected_sequence`; every successful withdrawal advances the sequence, so
+    only one concurrently signed retry can spend a reserve even if a later top-up restores its balance
   - gated by that asset's `insurance_operator`; `marketauth` can only use the shutdown-drain path
     for nonzero assets after the shutdown timeout and after the asset is empty
   - the asset `insurance_authority` funds the asset domains and owns terminal recovery accounting,

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,8 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    pub const ASSET_INSURANCE_WITHDRAW_SEQUENCE_OFF: usize = ASSET_ORACLE_PROFILE_LEN;
+    pub const ASSET_INSURANCE_WITHDRAW_SEQUENCE_LEN: usize = 8;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,6 +157,7 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
+            ASSET_INSURANCE_WITHDRAW_SEQUENCE_LEN, ASSET_INSURANCE_WITHDRAW_SEQUENCE_OFF,
             ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
             KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
             MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
@@ -1366,6 +1369,27 @@ pub mod state {
         let profile: AssetOracleProfileV16 = bytemuck::pod_read_unaligned(bytes);
         validate_asset_oracle_profile(&profile)?;
         Ok(profile)
+    }
+
+    pub fn read_asset_insurance_withdraw_sequence(
+        data: &[u8],
+        asset_index: usize,
+    ) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        let capacity = market_slot_capacity(data)?;
+        if asset_index >= capacity {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let start = dynamic_slot_offset(asset_index)?
+            .checked_add(ASSET_INSURANCE_WITHDRAW_SEQUENCE_OFF)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let end = start
+            .checked_add(ASSET_INSURANCE_WITHDRAW_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let bytes = data
+            .get(start..end)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
     }
 
     pub fn read_market_config_mode_and_capacity(
@@ -2645,6 +2669,7 @@ pub mod ix {
         },
         WithdrawInsuranceAsset {
             asset_index: u16,
+            expected_sequence: u64,
             amount: u128,
         },
         CureAndCancelClose {
@@ -2918,6 +2943,7 @@ pub mod ix {
                 },
                 57 => Self::WithdrawInsuranceAsset {
                     asset_index: read_u16(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 42 => Self::CureAndCancelClose {
@@ -3302,10 +3328,12 @@ pub mod ix {
                 }
                 Self::WithdrawInsuranceAsset {
                     asset_index,
+                    expected_sequence,
                     amount,
                 } => {
                     out.push(57);
                     push_u16(&mut out, asset_index);
+                    push_u64(&mut out, expected_sequence);
                     push_u128(&mut out, amount);
                 }
                 Self::CureAndCancelClose { optional_deposit } => {
@@ -4609,6 +4637,36 @@ pub mod processor {
         Ok(())
     }
 
+    fn consume_insurance_withdraw_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        let market = group
+            .markets
+            .get_mut(asset_index)
+            .ok_or(PercolatorError::InvalidInstruction)?;
+        let bytes = market
+            .wrapper
+            .get_mut(
+                constants::ASSET_INSURANCE_WITHDRAW_SEQUENCE_OFF
+                    ..constants::ASSET_INSURANCE_WITHDRAW_SEQUENCE_OFF
+                        + constants::ASSET_INSURANCE_WITHDRAW_SEQUENCE_LEN,
+            )
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let current = u64::from_le_bytes(bytes.try_into().unwrap());
+        if current != expected_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        bytes.copy_from_slice(
+            &current
+                .checked_add(1)
+                .ok_or(PercolatorError::EngineCounterOverflow)?
+                .to_le_bytes(),
+        );
+        Ok(())
+    }
+
     fn mirror_manual_profile_to_base_config(
         cfg: &mut WrapperConfigV16,
         profile: &state::AssetOracleProfileV16,
@@ -5449,8 +5507,15 @@ pub mod processor {
             }
             Instruction::WithdrawInsuranceAsset {
                 asset_index,
+                expected_sequence,
                 amount,
-            } => handle_withdraw_insurance_asset(program_id, accounts, asset_index, amount),
+            } => handle_withdraw_insurance_asset(
+                program_id,
+                accounts,
+                asset_index,
+                expected_sequence,
+                amount,
+            ),
             Instruction::CureAndCancelClose { optional_deposit } => {
                 handle_cure_and_cancel_close(program_id, accounts, optional_deposit)
             }
@@ -8086,6 +8151,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         asset_index: u16,
+        expected_sequence: u64,
         amount: u128,
     ) -> ProgramResult {
         let operator = account(accounts, 0)?;
@@ -8122,6 +8188,11 @@ pub mod processor {
                 || long_domain >= configured_slots.saturating_mul(2)
             {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            if state::read_asset_insurance_withdraw_sequence(&market_data, asset_index)?
+                != expected_sequence
+            {
+                return Err(PercolatorError::EngineStale.into());
             }
             let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
             expect_key(vault_authority_ai, &vault_authority)?;
@@ -8201,6 +8272,7 @@ pub mod processor {
             };
             // Atomic insurance/vault/budget withdraw through the engine (maintains the
             // insurance_domain_budget_remaining_total aggregate).
+            consume_insurance_withdraw_sequence_view(&mut group, asset_index, expected_sequence)?;
             debit_market_insurance_budget_view(&mut group, asset_index, amount)?;
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_withdrawn_atoms = ledger

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1240,6 +1240,11 @@ impl V16CuEnv {
         state::read_market(&account.data).unwrap()
     }
 
+    fn insurance_withdraw_sequence(&self, asset_index: u16) -> u64 {
+        let account = self.svm.get_account(&self.market).expect("market account");
+        state::read_asset_insurance_withdraw_sequence(&account.data, asset_index as usize).unwrap()
+    }
+
     fn portfolio_state(&self, portfolio: Pubkey) -> PortfolioAccountV16 {
         let account = self.svm.get_account(&portfolio).expect("portfolio account");
         state::read_portfolio(&account.data).unwrap()
@@ -3095,12 +3100,14 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_withdraw_sequence(0);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::WithdrawInsuranceAsset {
                 asset_index: 0,
+                expected_sequence,
                 amount,
             },
             vec![
@@ -3123,12 +3130,15 @@ impl V16CuEnv {
         domain: u16,
         amount: u128,
     ) -> u64 {
+        let asset_index = (domain / 2) as u16;
+        let expected_sequence = self.insurance_withdraw_sequence(asset_index);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::WithdrawInsuranceAsset {
-                asset_index: (domain / 2) as u16,
+                asset_index,
+                expected_sequence,
                 amount,
             },
             vec![
@@ -3254,12 +3264,14 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_withdraw_sequence(asset_index);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::WithdrawInsuranceAsset {
                 asset_index,
+                expected_sequence,
                 amount,
             },
             vec![
@@ -23146,6 +23158,7 @@ fn v16_attack_insurance_ledger_authority_binding_enforced() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -23193,6 +23206,7 @@ fn v16_attack_insurance_ledger_authority_binding_enforced() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -23373,6 +23387,7 @@ fn v16_attack_insurance_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -23431,6 +23446,7 @@ fn v16_attack_insurance_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -24457,6 +24473,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let withdraw_insurance = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 10,
         },
         vec![
@@ -24662,6 +24679,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let withdraw_insurance = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 10,
         },
         vec![
@@ -25420,6 +25438,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: BAD_DOMAIN as u16,
+            expected_sequence: 0,
             amount: 1,
         },
         vec![
@@ -28206,6 +28225,7 @@ fn v16_attack_withdraw_insurance_asset_operator_gated() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 500_000,
         },
         vec![
@@ -28271,6 +28291,7 @@ fn v16_attack_withdraw_insurance_asset_rejects_noncanonical_vault() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -28321,6 +28342,7 @@ fn v16_attack_withdraw_insurance_asset_rejects_noncanonical_vault() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -28403,6 +28425,7 @@ fn v16_attack_live_asset_insurance_withdraw_uses_operator_not_authority() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 1,
+            expected_sequence: 0,
             amount: 40,
         },
         vec![
@@ -46731,6 +46754,7 @@ fn v16_attack_dual_mint_domain_insurance_no_double_withdraw() {
     let double_withdraw = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: env.insurance_withdraw_sequence(0),
             amount: 1,
         },
         vec![
@@ -46764,6 +46788,7 @@ fn v16_attack_dual_mint_domain_insurance_no_double_withdraw() {
     let legitimate_secondary = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: env.insurance_withdraw_sequence(0),
             amount: 1,
         },
         vec![
@@ -47105,6 +47130,7 @@ fn v16_attack_market_admin_cannot_drain_foreign_asset_or_user_collateral() {
     let r_foreign = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 1,
+            expected_sequence: 0,
             amount: 500,
         },
         vec![
@@ -47133,6 +47159,7 @@ fn v16_attack_market_admin_cannot_drain_foreign_asset_or_user_collateral() {
     let r_owner = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 1,
+            expected_sequence: 0,
             amount: 200,
         },
         vec![
@@ -48332,6 +48359,7 @@ fn v16_bpf_terminal_asset_insurance_partial_ledger_middle_domain_stays_bounded_o
         .send(
             ProgInstruction::WithdrawInsuranceAsset {
                 asset_index: MIDDLE_ASSET as u16,
+                expected_sequence: 0,
                 amount: PARTIAL,
             },
             vec![
@@ -56641,6 +56669,7 @@ fn v16_attack_live_domain_withdrawals_reject_when_resolve_matured() {
     let stale_insurance = env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 20,
         },
         vec![
@@ -59018,6 +59047,7 @@ fn v16_attack_asset0_operator_rotation_rekeys_live_insurance_withdraw() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 100,
         },
         vec![
@@ -59058,6 +59088,7 @@ fn v16_attack_asset0_operator_rotation_rekeys_live_insurance_withdraw() {
         &env.payer,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 100,
         },
         vec![
@@ -59645,6 +59676,7 @@ fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topu
         ],
         data: ProgInstruction::WithdrawInsuranceAsset {
             asset_index: ASSET,
+            expected_sequence: 0,
             amount: AMOUNT,
         }
         .encode(),
@@ -59666,6 +59698,7 @@ fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topu
     env.send(
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: ASSET,
+            expected_sequence: 0,
             amount: AMOUNT,
         },
         vec![
@@ -59689,7 +59722,6 @@ fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topu
     assert_eq!(env.token_amount(second_source), 0);
     let market_before = env.svm.get_account(&env.market).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
-    let provider_balance_before = env.token_amount(second_source);
 
     let replay = env.svm.send_transaction(retained_withdraw);
     if replay.is_ok() {
@@ -59705,6 +59737,15 @@ fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topu
         );
         panic!("a retained withdrawal replayed across a same-generation insurance top-up");
     }
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        percolator_prog::error::PercolatorError::EngineStale as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale withdrawal must fail with {expected_error}, got {replay_error}"
+    );
 
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
@@ -59717,7 +59758,34 @@ fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topu
         "rejected stale withdrawal leaves custody byte-identical"
     );
     assert_eq!(env.token_amount(retained_dest), AMOUNT as u64);
-    assert_eq!(env.token_amount(second_source), provider_balance_before);
+    assert_eq!(env.token_amount(second_source), 0);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        AMOUNT,
+        "the rejected replay preserves the independent replenishment"
+    );
+    assert_eq!(env.insurance_withdraw_sequence(ASSET), 1);
+
+    let current_dest = env.token_account(operator.pubkey(), 0);
+    env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET,
+            expected_sequence: 1,
+            amount: AMOUNT,
+        },
+        vec![
+            AccountMeta::new(operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(current_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&operator],
+    )
+    .expect("a freshly sequenced withdrawal remains live");
+    assert_eq!(env.token_amount(current_dest), AMOUNT as u64);
+    assert_eq!(env.insurance_withdraw_sequence(ASSET), 2);
 }
 
 fn assert_underfunded_ewma_exit_uses_collected_fee(path: NoCpiReportedPricePath) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59603,6 +59603,123 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
     );
 }
 
+// A signed insurance withdrawal authorizes one transition, not every later reserve that happens to
+// restore the same balance. Two fee-bump variants of the same withdrawal can be valid under one
+// recent blockhash: after one lands and the independent insurance authority replenishes the domain,
+// the retained retry must not consume the new contribution.
+#[test]
+fn v16_attack_signed_insurance_withdraw_cannot_replay_after_same_generation_topup() {
+    const ASSET: u16 = 1;
+    const DOMAIN: u16 = 2;
+    const AMOUNT: u128 = 50_000;
+
+    let mut env = V16CuEnv::new();
+    let provider = Keypair::new();
+    let operator = Keypair::new();
+    env.ensure_signer_account(provider.pubkey());
+    env.ensure_signer_account(operator.pubkey());
+
+    env.svm.warp_to_slot(1);
+    env.activate_asset_with_authorities(
+        ASSET,
+        1,
+        100,
+        provider.pubkey(),
+        operator.pubkey(),
+        provider.pubkey(),
+        provider.pubkey(),
+    );
+    let first_source = env.top_up_insurance_domain_with_authority(&provider, DOMAIN, AMOUNT);
+    assert_eq!(env.token_amount(first_source), 0);
+
+    let retained_dest = env.token_account(operator.pubkey(), 0);
+    let retained_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(retained_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET,
+            amount: AMOUNT,
+        }
+        .encode(),
+    };
+    let retained_withdraw = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            retained_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &operator],
+        env.svm.latest_blockhash(),
+    );
+
+    // The same withdrawal without the priority-fee instruction lands first. Both operator-signed
+    // variants remain valid under the same recent blockhash.
+    env.send(
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET,
+            amount: AMOUNT,
+        },
+        vec![
+            AccountMeta::new(operator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(retained_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&operator],
+    )
+    .expect("the separately encoded retry withdraws the first reserve");
+    assert_eq!(env.token_amount(retained_dest), AMOUNT as u64);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        0
+    );
+
+    let second_source = env.top_up_insurance_domain_with_authority(&provider, DOMAIN, AMOUNT);
+    assert_eq!(env.token_amount(second_source), 0);
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let provider_balance_before = env.token_amount(second_source);
+
+    let replay = env.svm.send_transaction(retained_withdraw);
+    if replay.is_ok() {
+        assert_eq!(
+            env.token_amount(retained_dest),
+            (AMOUNT * 2) as u64,
+            "the retained retry consumed the independent replenishment"
+        );
+        assert_eq!(
+            env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+            0,
+            "the replacement insurance budget was debited"
+        );
+        panic!("a retained withdrawal replayed across a same-generation insurance top-up");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale withdrawal leaves accounting byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected stale withdrawal leaves custody byte-identical"
+    );
+    assert_eq!(env.token_amount(retained_dest), AMOUNT as u64);
+    assert_eq!(env.token_amount(second_source), provider_balance_before);
+}
+
 fn assert_underfunded_ewma_exit_uses_collected_fee(path: NoCpiReportedPricePath) {
     const MARK: u64 = 1_000_000;
     const SIZE_Q: i128 = POS_SCALE as i128;

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -233,6 +233,7 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
+    let expected_sequence: u64 = kani::any();
     let amount: u128 = kani::any();
 
     let mut top_up = [0u8; 19];
@@ -250,20 +251,43 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
         _ => unreachable!(),
     }
 
-    let mut withdraw = [0u8; 19];
+    let mut withdraw = [0u8; 27];
     withdraw[0] = 57;
     withdraw[1..3].copy_from_slice(&asset_index.to_le_bytes());
-    withdraw[3..19].copy_from_slice(&amount.to_le_bytes());
+    withdraw[3..11].copy_from_slice(&expected_sequence.to_le_bytes());
+    withdraw[11..27].copy_from_slice(&amount.to_le_bytes());
     match Instruction::decode(&withdraw).unwrap() {
         Instruction::WithdrawInsuranceAsset {
             asset_index: got_asset,
+            expected_sequence: got_sequence,
             amount: got_amount,
         } => {
             assert_eq!(got_asset, asset_index);
+            assert_eq!(got_sequence, expected_sequence);
             assert_eq!(got_amount, amount);
         }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_asset_insurance_withdraw_rejects_legacy_and_truncated_payloads() {
+    let asset_index: u16 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let amount: u128 = kani::any();
+
+    let mut legacy = [0u8; 19];
+    legacy[0] = 57;
+    legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    legacy[3..19].copy_from_slice(&amount.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
+
+    let mut truncated = [0u8; 26];
+    truncated[0] = 57;
+    truncated[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    truncated[3..11].copy_from_slice(&expected_sequence.to_le_bytes());
+    truncated[11..26].copy_from_slice(&amount.to_le_bytes()[..15]);
+    assert!(Instruction::decode(&truncated).is_err());
 }
 
 #[kani::proof]
@@ -1167,6 +1191,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::WithdrawInsuranceAsset {
             asset_index: 0,
+            expected_sequence: 0,
             amount: 1,
         },
         extra,


### PR DESCRIPTION
## Summary

- add a monotonic per-asset insurance-withdrawal sequence in the existing wrapper reserve
- require tag 57 callers to provide the current `expected_sequence`
- consume the sequence atomically with the engine debit and SPL transfer
- reject legacy, truncated, trailing, or stale withdrawal payloads

## Impact

An honest insurance operator can sign two fee-bump variants of the same withdrawal under one recent blockhash. Before this change, an unprivileged relayer could land one, wait for the independent insurance authority to replenish the same asset domain, then land the retained variant and transfer the new contribution to the operator. The later top-up restored the amount/budget preconditions, so no committed-state incarnation distinguished the already-consumed intent.

The public LiteSVM reproduction uses the same asset, amount, destination, operator signature, and recent blockhash. The transaction variants differ only by a priority-fee instruction. It uses only normal public activation, top-up, and withdrawal instructions; there is no protocol-state injection.

## TDD evidence

- exact parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED test commit: `1650b5ac`
- fixed commit: `f80cc5d7`
- pre-fix result: the retained retry succeeds after the independent top-up, transfers a second 50,000 atoms, and empties the replacement domain budget
- fixed result: the retained retry returns `EngineStale`, leaves market/vault custody byte-identical, preserves the replacement budget, and a freshly sequenced withdrawal remains live

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1` (566 LiteSVM/CU tests + 6 unit tests)
- `cargo check --all-targets`
- Kani wire-field round-trip harness
- Kani legacy/truncated payload rejection harness
- Kani custody trailing-byte rejection harness

No engine change and no market account growth are required.