### PR TITLE
[BLOCKER LoF] Make insurance top-ups one-shot across retry variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - validates side encoding and engine readiness; it is not an admin override
 - **TopUpInsurance** (tag 9)
   - transfers collateral into vault; credits insurance fund in engine
+  - carries asset 0's current `expected_sequence`; every successful top-up advances the sequence,
+    so only one concurrently signed retry can debit a replenished source account
+- **TopUpInsuranceDomain** (tag 56)
+  - funds one asset-side insurance domain and shares that asset's top-up sequence across both sides
 
 ### Trading
 - **TradeNoCpi**

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,9 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    // The first wrapper-reserve word is assigned to live insurance-withdrawal intents.
+    pub const ASSET_INSURANCE_TOPUP_SEQUENCE_OFF: usize = ASSET_ORACLE_PROFILE_LEN + 8;
+    pub const ASSET_INSURANCE_TOPUP_SEQUENCE_LEN: usize = 8;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,6 +158,7 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
+            ASSET_INSURANCE_TOPUP_SEQUENCE_LEN, ASSET_INSURANCE_TOPUP_SEQUENCE_OFF,
             ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
             KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
             MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
@@ -1368,6 +1372,27 @@ pub mod state {
         Ok(profile)
     }
 
+    pub fn read_asset_insurance_topup_sequence(
+        data: &[u8],
+        asset_index: usize,
+    ) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        let capacity = market_slot_capacity(data)?;
+        if asset_index >= capacity {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let start = dynamic_slot_offset(asset_index)?
+            .checked_add(ASSET_INSURANCE_TOPUP_SEQUENCE_OFF)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let end = start
+            .checked_add(ASSET_INSURANCE_TOPUP_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let bytes = data
+            .get(start..end)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+    }
+
     pub fn read_market_config_mode_and_capacity(
         data: &[u8],
     ) -> Result<(WrapperConfigV16, MarketModeV16, usize, usize), ProgramError> {
@@ -2512,10 +2537,12 @@ pub mod ix {
         },
         ClosePortfolio,
         TopUpInsurance {
+            expected_sequence: u64,
             amount: u128,
         },
         TopUpInsuranceDomain {
             domain: u16,
+            expected_sequence: u64,
             amount: u128,
         },
         CloseSlab,
@@ -2779,10 +2806,12 @@ pub mod ix {
                 },
                 8 => Self::ClosePortfolio,
                 9 => Self::TopUpInsurance {
+                    expected_sequence: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 56 => Self::TopUpInsuranceDomain {
                     domain: read_u16(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 13 => Self::CloseSlab,
@@ -3068,13 +3097,22 @@ pub mod ix {
                     out.push(enabled);
                 }
                 Self::ClosePortfolio => out.push(8),
-                Self::TopUpInsurance { amount } => {
+                Self::TopUpInsurance {
+                    expected_sequence,
+                    amount,
+                } => {
                     out.push(9);
+                    push_u64(&mut out, expected_sequence);
                     push_u128(&mut out, amount);
                 }
-                Self::TopUpInsuranceDomain { domain, amount } => {
+                Self::TopUpInsuranceDomain {
+                    domain,
+                    expected_sequence,
+                    amount,
+                } => {
                     out.push(56);
                     push_u16(&mut out, domain);
+                    push_u64(&mut out, expected_sequence);
                     push_u128(&mut out, amount);
                 }
                 Self::CloseSlab => out.push(13),
@@ -4609,6 +4647,36 @@ pub mod processor {
         Ok(())
     }
 
+    fn consume_insurance_topup_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        let market = group
+            .markets
+            .get_mut(asset_index)
+            .ok_or(PercolatorError::InvalidInstruction)?;
+        let bytes = market
+            .wrapper
+            .get_mut(
+                constants::ASSET_INSURANCE_TOPUP_SEQUENCE_OFF
+                    ..constants::ASSET_INSURANCE_TOPUP_SEQUENCE_OFF
+                        + constants::ASSET_INSURANCE_TOPUP_SEQUENCE_LEN,
+            )
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let current = u64::from_le_bytes(bytes.try_into().unwrap());
+        if current != expected_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        bytes.copy_from_slice(
+            &current
+                .checked_add(1)
+                .ok_or(PercolatorError::EngineCounterOverflow)?
+                .to_le_bytes(),
+        );
+        Ok(())
+    }
+
     fn mirror_manual_profile_to_base_config(
         cfg: &mut WrapperConfigV16,
         profile: &state::AssetOracleProfileV16,
@@ -5259,12 +5327,21 @@ pub mod processor {
                 handle_set_matcher_config(program_id, accounts, enabled)
             }
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
-            Instruction::TopUpInsurance { amount } => {
-                handle_top_up_insurance(program_id, accounts, amount)
-            }
-            Instruction::TopUpInsuranceDomain { domain, amount } => {
-                handle_top_up_insurance_domain(program_id, accounts, domain, amount)
-            }
+            Instruction::TopUpInsurance {
+                expected_sequence,
+                amount,
+            } => handle_top_up_insurance(program_id, accounts, expected_sequence, amount),
+            Instruction::TopUpInsuranceDomain {
+                domain,
+                expected_sequence,
+                amount,
+            } => handle_top_up_insurance_domain(
+                program_id,
+                accounts,
+                domain,
+                expected_sequence,
+                amount,
+            ),
             Instruction::CloseSlab => handle_close_slab(program_id, accounts),
             Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
             Instruction::TopUpBackingBucket {
@@ -7118,6 +7195,7 @@ pub mod processor {
     fn handle_top_up_insurance<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_sequence: u64,
         amount: u128,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
@@ -7163,6 +7241,7 @@ pub mod processor {
             let asset0_insurance_authority =
                 domain_authorities_from_view(&group, &cfg, 0)?.insurance_authority;
             expect_live_authority(&asset0_insurance_authority, signer.key)?;
+            consume_insurance_topup_sequence_view(&mut group, 0, expected_sequence)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {
                 Some(ledger_ai.try_borrow_mut_data()?)
             } else {
@@ -7221,6 +7300,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         domain: u16,
+        expected_sequence: u64,
         amount: u128,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
@@ -7240,11 +7320,11 @@ pub mod processor {
         }
         verify_token_program(token_program)?;
         let domain = domain as usize;
+        let asset_index = domain / 2;
         let (cfg_pre, authorities) = {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, group) = state::market_view_mut(&mut market_data)?;
             let configured_slots = group.header.config.max_market_slots.get() as usize;
-            let asset_index = domain / 2;
             if group.header.mode != 0
                 || domain >= configured_slots.saturating_mul(2)
                 || asset_index >= configured_slots
@@ -7273,6 +7353,7 @@ pub mod processor {
             require_domain_accepts_live_topup_view(&group, domain)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain)?;
             expect_live_authority(&authorities.insurance_authority, signer.key)?;
+            consume_insurance_topup_sequence_view(&mut group, asset_index, expected_sequence)?;
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {
                 Some(ledger_ai.try_borrow_mut_data()?)
             } else {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1240,6 +1240,11 @@ impl V16CuEnv {
         state::read_market(&account.data).unwrap()
     }
 
+    fn insurance_topup_sequence(&self, asset_index: usize) -> u64 {
+        let account = self.svm.get_account(&self.market).expect("market account");
+        state::read_asset_insurance_topup_sequence(&account.data, asset_index).unwrap()
+    }
+
     fn portfolio_state(&self, portfolio: Pubkey) -> PortfolioAccountV16 {
         let account = self.svm.get_account(&portfolio).expect("portfolio account");
         state::read_portfolio(&account.data).unwrap()
@@ -2774,11 +2779,15 @@ impl V16CuEnv {
     }
 
     fn top_up_insurance_from_admin_token_with_cu(&mut self, source: Pubkey, amount: u128) -> u64 {
+        let expected_sequence = self.insurance_topup_sequence(0);
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance {
+                expected_sequence,
+                amount,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2833,11 +2842,15 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_topup_sequence(0);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance {
+                expected_sequence,
+                amount,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2869,11 +2882,15 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_topup_sequence(0);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsurance { amount },
+            ProgInstruction::TopUpInsurance {
+                expected_sequence,
+                amount,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2908,11 +2925,16 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_topup_sequence(domain as usize / 2);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsuranceDomain { domain, amount },
+            ProgInstruction::TopUpInsuranceDomain {
+                domain,
+                expected_sequence,
+                amount,
+            },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -2947,11 +2969,16 @@ impl V16CuEnv {
                 },
             )
             .unwrap();
+        let expected_sequence = self.insurance_topup_sequence(domain as usize / 2);
         let cu = send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::TopUpInsuranceDomain { domain, amount },
+            ProgInstruction::TopUpInsuranceDomain {
+                domain,
+                expected_sequence,
+                amount,
+            },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -3986,7 +4013,10 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::TopUpInsurance { amount: 33 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 33,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -4478,7 +4508,10 @@ fn v16_bpf_failed_insurance_topup_transfer_rolls_back_budget_and_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 100,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -4531,6 +4564,7 @@ fn v16_bpf_failed_domain_insurance_topup_transfer_rolls_back_budget_and_ledger()
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 1,
+            expected_sequence: 0,
             amount: 100,
         },
         vec![
@@ -5848,6 +5882,7 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
     let insurance_topup = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 2,
+            expected_sequence: 0,
             amount: 77,
         },
         vec![
@@ -23317,6 +23352,7 @@ fn v16_attack_insurance_ledger_market_binding_enforced() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 100,
         },
         vec![
@@ -23581,7 +23617,10 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -23612,6 +23651,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 30,
         },
         vec![
@@ -23675,7 +23715,10 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -23708,6 +23751,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 1,
             amount: 30,
         },
         vec![
@@ -23868,7 +23912,10 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 100,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24004,7 +24051,10 @@ fn v16_attack_terminal_withdraw_insurance_rejects_portfolio_as_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 100 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 100,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24373,7 +24423,10 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_insurance_source = env.token_account(admin.pubkey(), 25);
     env.svm.expire_blockhash();
     let top_up_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24400,6 +24453,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     let top_up_domain = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 20,
         },
         vec![
@@ -24590,7 +24644,10 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_insurance_source = env.token_account(admin.pubkey(), 25);
     env.svm.expire_blockhash();
     let top_up_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 25 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 25,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24613,6 +24670,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     let top_up_domain = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 20,
         },
         vec![
@@ -24858,13 +24916,17 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
 
     reject_alias(
         &mut env,
-        ProgInstruction::TopUpInsurance { amount: 500 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 500,
+        },
         "TopUpInsurance",
     );
     reject_alias(
         &mut env,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 500,
         },
         "TopUpInsuranceDomain",
@@ -25184,7 +25246,10 @@ fn v16_attack_insurance_topup_pinned_to_canonical_vault() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 500 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 500,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -25250,6 +25315,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 500,
         },
         vec![
@@ -25359,6 +25425,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: BAD_DOMAIN,
+            expected_sequence: 0,
             amount: 123,
         },
         vec![
@@ -28922,6 +28989,7 @@ fn v16_attack_topup_insurance_domain_authority_gated() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 500,
         },
         vec![
@@ -33548,7 +33616,10 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
 
         env.svm.expire_blockhash();
         let result = env.send(
-            ProgInstruction::TopUpInsurance { amount: 2 },
+            ProgInstruction::TopUpInsurance {
+                expected_sequence: 0,
+                amount: 2,
+            },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
                 AccountMeta::new(env.market, false),
@@ -33596,6 +33667,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         let result = env.send(
             ProgInstruction::TopUpInsuranceDomain {
                 domain: 0,
+                expected_sequence: 0,
                 amount: 2,
             },
             vec![
@@ -33622,6 +33694,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         env.send(
             ProgInstruction::TopUpInsuranceDomain {
                 domain: 0,
+                expected_sequence: 0,
                 amount: 1,
             },
             vec![
@@ -55217,7 +55290,10 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
 
     env.svm.expire_blockhash();
     let stale_global_insurance = env.send(
-        ProgInstruction::TopUpInsurance { amount: 20 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 20,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -55236,6 +55312,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let stale_insurance = env.send(
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 25,
         },
         vec![
@@ -57950,7 +58027,10 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::TopUpInsurance { amount: 11 },
+        ProgInstruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 11,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -57980,6 +58060,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
         &env.payer,
         ProgInstruction::TopUpInsuranceDomain {
             domain: 0,
+            expected_sequence: 0,
             amount: 12,
         },
         vec![
@@ -59755,6 +59836,7 @@ fn v16_attack_signed_insurance_topup_cannot_replay_after_source_replenishment() 
         ],
         data: ProgInstruction::TopUpInsuranceDomain {
             domain: DOMAIN,
+            expected_sequence: 0,
             amount: AMOUNT,
         }
         .encode(),
@@ -59826,6 +59908,15 @@ fn v16_attack_signed_insurance_topup_cannot_replay_after_source_replenishment() 
         );
         panic!("a retained insurance top-up replayed after source replenishment");
     }
+    let replay_error = format!("{:?}", replay.unwrap_err());
+    let expected_error = format!(
+        "Custom({})",
+        percolator_prog::error::PercolatorError::EngineStale as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale top-up must fail with {expected_error}, got {replay_error}"
+    );
 
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
@@ -59838,4 +59929,28 @@ fn v16_attack_signed_insurance_topup_cannot_replay_after_source_replenishment() 
         "a rejected retained top-up leaves vault custody byte-identical"
     );
     assert_eq!(env.token_amount(source), AMOUNT as u64);
+    assert_eq!(env.insurance_topup_sequence(ASSET as usize), 1);
+
+    env.send(
+        ProgInstruction::TopUpInsuranceDomain {
+            domain: DOMAIN,
+            expected_sequence: 1,
+            amount: AMOUNT,
+        },
+        vec![
+            AccountMeta::new(provider.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&provider],
+    )
+    .expect("a freshly sequenced top-up remains live");
+    assert_eq!(env.token_amount(source), 0);
+    assert_eq!(env.insurance_topup_sequence(ASSET as usize), 2);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        AMOUNT * 2
+    );
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,125 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A signed insurance top-up authorizes one contribution, not every later balance restored to the
+// same source account. A distinct live insurance operator must not be able to retain a fee-bump
+// variant, replay it after an ordinary SPL replenishment, and withdraw the duplicate contribution.
+#[test]
+fn v16_attack_signed_insurance_topup_cannot_replay_after_source_replenishment() {
+    const ASSET: u16 = 1;
+    const DOMAIN: u16 = 2;
+    const AMOUNT: u128 = 50_000;
+
+    let mut env = V16CuEnv::new();
+    let provider = Keypair::new();
+    let operator = Keypair::new();
+    env.ensure_signer_account(provider.pubkey());
+    env.ensure_signer_account(operator.pubkey());
+    env.activate_asset_with_authorities(
+        ASSET,
+        1,
+        100,
+        provider.pubkey(),
+        operator.pubkey(),
+        env.admin.pubkey(),
+        env.admin.pubkey(),
+    );
+
+    let source = env.token_account(provider.pubkey(), AMOUNT as u64);
+    let reserve = env.token_account(provider.pubkey(), AMOUNT as u64);
+    let topup_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(provider.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::TopUpInsuranceDomain {
+            domain: DOMAIN,
+            amount: AMOUNT,
+        }
+        .encode(),
+    };
+    let blockhash = env.svm.latest_blockhash();
+    let first = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            topup_ix.clone(),
+        ],
+        Some(&operator.pubkey()),
+        &[&operator, &provider],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(2),
+            topup_ix,
+        ],
+        Some(&operator.pubkey()),
+        &[&operator, &provider],
+        blockhash,
+    );
+
+    env.svm
+        .send_transaction(first)
+        .expect("the provider's intended top-up lands");
+    assert_eq!(env.token_amount(source), 0);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        AMOUNT
+    );
+
+    let replenish = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &reserve,
+        &source,
+        &provider.pubkey(),
+        &[],
+        AMOUNT as u64,
+    )
+    .unwrap();
+    send_raw_tx(&mut env.svm, &env.payer, replenish, &[&provider])
+        .expect("an ordinary public SPL transfer replenishes the source");
+    assert_eq!(env.token_amount(source), AMOUNT as u64);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(retained);
+    if replay.is_ok() {
+        assert_eq!(env.token_amount(source), 0);
+        assert_eq!(
+            env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+            AMOUNT * 2,
+            "the retained top-up duplicated the provider's contribution"
+        );
+        let (operator_dest, _) = env
+            .try_withdraw_insurance_domain_with_authority(&operator, DOMAIN, AMOUNT)
+            .expect("the distinct live operator extracts the replayed contribution");
+        assert_eq!(env.token_amount(operator_dest), AMOUNT as u64);
+        assert_eq!(
+            env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+            AMOUNT,
+            "the provider's intended first contribution remains after the duplicate is extracted"
+        );
+        panic!("a retained insurance top-up replayed after source replenishment");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "a rejected retained top-up leaves market state byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "a rejected retained top-up leaves vault custody byte-identical"
+    );
+    assert_eq!(env.token_amount(source), AMOUNT as u64);
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -201,9 +201,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
-    kani::assume(
-        tag == 3 || tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42,
-    );
+    kani::assume(tag == 3 || tag == 4 || tag == 28 || tag == 30 || tag == 41 || tag == 42);
     let amount: u128 = kani::any();
 
     let mut data = [0u8; 17];
@@ -213,7 +211,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     match (tag, Instruction::decode(&data).unwrap()) {
         (3, Instruction::Deposit { amount: got }) => assert_eq!(got, amount),
         (4, Instruction::Withdraw { amount: got }) => assert_eq!(got, amount),
-        (9, Instruction::TopUpInsurance { amount: got }) => assert_eq!(got, amount),
         (28, Instruction::ConvertReleasedPnl { amount: got }) => assert_eq!(got, amount),
         (30, Instruction::CloseResolved { fee_rate_per_slot }) => {
             assert_eq!(fee_rate_per_slot, amount)
@@ -233,18 +230,37 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
+    let expected_sequence: u64 = kani::any();
     let amount: u128 = kani::any();
 
-    let mut top_up = [0u8; 19];
+    let mut base_top_up = [0u8; 25];
+    base_top_up[0] = 9;
+    base_top_up[1..9].copy_from_slice(&expected_sequence.to_le_bytes());
+    base_top_up[9..25].copy_from_slice(&amount.to_le_bytes());
+    match Instruction::decode(&base_top_up).unwrap() {
+        Instruction::TopUpInsurance {
+            expected_sequence: got_sequence,
+            amount: got_amount,
+        } => {
+            assert_eq!(got_sequence, expected_sequence);
+            assert_eq!(got_amount, amount);
+        }
+        _ => unreachable!(),
+    }
+
+    let mut top_up = [0u8; 27];
     top_up[0] = 56;
     top_up[1..3].copy_from_slice(&domain.to_le_bytes());
-    top_up[3..19].copy_from_slice(&amount.to_le_bytes());
+    top_up[3..11].copy_from_slice(&expected_sequence.to_le_bytes());
+    top_up[11..27].copy_from_slice(&amount.to_le_bytes());
     match Instruction::decode(&top_up).unwrap() {
         Instruction::TopUpInsuranceDomain {
             domain: got_domain,
+            expected_sequence: got_sequence,
             amount: got_amount,
         } => {
             assert_eq!(got_domain, domain);
+            assert_eq!(got_sequence, expected_sequence);
             assert_eq!(got_amount, amount);
         }
         _ => unreachable!(),
@@ -264,6 +280,37 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
         }
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_insurance_topups_reject_legacy_and_truncated_payloads() {
+    let domain: u16 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let amount: u128 = kani::any();
+
+    let mut legacy_base = [0u8; 17];
+    legacy_base[0] = 9;
+    legacy_base[1..17].copy_from_slice(&amount.to_le_bytes());
+    assert!(Instruction::decode(&legacy_base).is_err());
+
+    let mut truncated_base = [0u8; 24];
+    truncated_base[0] = 9;
+    truncated_base[1..9].copy_from_slice(&expected_sequence.to_le_bytes());
+    truncated_base[9..24].copy_from_slice(&amount.to_le_bytes()[..15]);
+    assert!(Instruction::decode(&truncated_base).is_err());
+
+    let mut legacy_domain = [0u8; 19];
+    legacy_domain[0] = 56;
+    legacy_domain[1..3].copy_from_slice(&domain.to_le_bytes());
+    legacy_domain[3..19].copy_from_slice(&amount.to_le_bytes());
+    assert!(Instruction::decode(&legacy_domain).is_err());
+
+    let mut truncated_domain = [0u8; 26];
+    truncated_domain[0] = 56;
+    truncated_domain[1..3].copy_from_slice(&domain.to_le_bytes());
+    truncated_domain[3..11].copy_from_slice(&expected_sequence.to_le_bytes());
+    truncated_domain[11..26].copy_from_slice(&amount.to_le_bytes()[..15]);
+    assert!(Instruction::decode(&truncated_domain).is_err());
 }
 
 #[kani::proof]
@@ -1147,7 +1194,21 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(Instruction::InitPortfolio, extra);
     assert_rejects_trailing_byte(Instruction::Deposit { amount: 1 }, extra);
     assert_rejects_trailing_byte(Instruction::Withdraw { amount: 1 }, extra);
-    assert_rejects_trailing_byte(Instruction::TopUpInsurance { amount: 1 }, extra);
+    assert_rejects_trailing_byte(
+        Instruction::TopUpInsurance {
+            expected_sequence: 0,
+            amount: 1,
+        },
+        extra,
+    );
+    assert_rejects_trailing_byte(
+        Instruction::TopUpInsuranceDomain {
+            domain: 0,
+            expected_sequence: 0,
+            amount: 1,
+        },
+        extra,
+    );
     assert_rejects_trailing_byte(
         Instruction::TopUpBackingBucket {
             domain: 1,


### PR DESCRIPTION
## Summary

- add a checked per-asset insurance top-up sequence in the existing wrapper reserve
- require both `TopUpInsurance` and `TopUpInsuranceDomain` to carry the current `expected_sequence`
- consume the shared sequence atomically with the insurance credit and SPL debit
- reject legacy, truncated, trailing, and stale top-up payloads

## Impact

An honest insurance authority can sign two priority-fee variants of one top-up under the same recent blockhash. Before this change, an unprivileged relayer could land one, wait for an ordinary SPL transfer to replenish the exact source token account, then land the retained variant and debit the authority again.

The public LiteSVM reproduction configures the intended two-key split: a cold insurance authority funds the domain and a distinct live operator can withdraw it. After the retained top-up lands, the operator withdraws exactly the duplicated 50,000 atoms while the authority's intended first 50,000-atom contribution remains insured. The exploit uses only public asset activation, SPL transfer, top-up, and withdrawal instructions; it does not mutate protocol state or require a dishonest oracle.

## Fix

Each asset stores a monotonic top-up sequence in its existing 112-byte wrapper reserve. Asset 0's tag 9 route and both tag 56 side domains share that asset's sequence. A successful top-up advances it with checked arithmetic; stale retry variants return `EngineStale`. SVM rollback keeps the sequence, market accounting, ledger, and SPL custody atomic when any later check or transfer fails.

This changes only the wrapper ABI and wrapper-owned state. The engine pin and engine code are unchanged.

## TDD evidence

- exact parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED commit: `e06c3eb18735d3b3b22c70f031503f10292c2e7f`
- fixed commit: `64dd4dd969738d3b7252cd621daf6f06d9e4b619`
- pre-fix: retained retry succeeds, doubles the domain budget, debits the replenished source, and the distinct operator extracts the duplicate
- fixed: retained retry returns `EngineStale`, touched accounts remain byte-identical, the replenished source remains funded, and a fresh sequence-1 top-up succeeds

## Verification

- `cargo build-sbf --tools-version v1.52`
- SBF builds for `percolator-match`, `auth_matcher`, and `hostile_matcher`
- `cargo test --all-targets -- --test-threads=1` (566/566 LiteSVM/CU tests, 6/6 unit tests)
- `cargo check --all-targets`
- Kani top-up sequence/amount wire-field round trip
- Kani legacy/truncated top-up payload rejection
- Kani custody trailing-byte rejection
