### PR TITLE
[BLOCKER LoF] Prevent market-authority handoff ABA replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   any asset including asset 0** (`ASSET_ACTION_SHUTDOWN` → RECOVERY with the `force_close_delay_slots`
   exit window so traders can exit), **resolve/close the market** (`ResolveMarket`/`CloseSlab`),
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
-  `UpdateAuthority { new_pubkey }` (current `marketauth` signs and the non-zero replacement co-signs;
-  burn-to-zero is rejected). Everything else — restart, insurance/operator/backing/oracle on
+  `UpdateAuthority { new_pubkey, expected_sequence }` (current `marketauth` signs, the non-zero
+  replacement co-signs, and the checked market sequence makes the handoff one-shot; burn-to-zero is
+  rejected). Everything else — restart, insurance/operator/backing/oracle on
   **every** asset including 0 — is per-asset (`asset_admin` + `UpdateAssetAuthority`), never a separate
   marketauth-only path. `marketauth` can restart an asset only while it is also that asset's
   `asset_admin` (the asset-0 bootstrap state).
@@ -379,7 +380,9 @@ This section describes intent and operational ordering, not argument-by-argument
   - initializes slab header/config + calls `RiskEngine::init_in_place(risk_params, clock.slot, init_price)`
   - binds the collateral mint, initializes asset 0, and sets `marketauth` to the init signer
 - **UpdateAuthority** (tag 32) — single-purpose: rotate the one market-level `marketauth` key
-  - `UpdateAuthority { new_pubkey }`: current `marketauth` signs; a non-zero replacement co-signs
+  - `UpdateAuthority { new_pubkey, expected_sequence }`: current `marketauth` signs; a non-zero
+    replacement co-signs; `expected_sequence` must equal the program-owned market handoff sequence
+    and increments on success
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
   - per-asset authorities (insurance/operator/backing/oracle, incl. asset 0) are rotated via
     `UpdateAssetAuthority`, not this instruction
@@ -732,7 +735,8 @@ At minimum, monitor:
 - liquidation frequency spikes
 
 ### Governance / authority handling
-- `UpdateAuthority` rotates `marketauth`; the current authority and the new key must both sign.
+- `UpdateAuthority` rotates `marketauth`; the current authority and new key must both sign, and the
+  handoff must carry the current one-shot sequence.
 - `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the new key.
 - Burning is limited to `asset_admin`. Required market/domain authorities cannot be set to zero.
 
@@ -823,7 +827,7 @@ mark/insurance/operator) are reachable until asset-0's `asset_admin` is rotated 
 
 These are governance powers, not bugs:
 
-1. `UpdateAuthority { new_pubkey }`
+1. `UpdateAuthority { new_pubkey, expected_sequence }`
    - rotate `marketauth` to an attacker key.
    - impact: governance capture.
 2. Policy updates / `UpdateMarketInitFeePolicy` / `UpdateBaseUnitMints` / asset create+retire+force-shutdown

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,8 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    pub const ASSET_MARKETAUTH_SEQUENCE_OFF: usize = ASSET_ORACLE_PROFILE_LEN + 16;
+    pub const ASSET_MARKETAUTH_SEQUENCE_LEN: usize = 8;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,14 +157,14 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
-            ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
-            ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
-            PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
-            VERSION, WRAPPER_CONFIG_LEN,
+            ASSET_MARKETAUTH_SEQUENCE_LEN, ASSET_MARKETAUTH_SEQUENCE_OFF, ASSET_ORACLE_PROFILE_LEN,
+            ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN, KIND_BACKING_DOMAIN_LEDGER,
+            KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC, MARKET_GROUP_LEN,
+            MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK,
+            ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK, ORACLE_MODE_HYBRID_AFTER_HOURS,
+            ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN, PORTFOLIO_ENGINE_ACCOUNT_LEN,
+            PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF, PORTFOLIO_MATCHER_CONFIG_LEN,
+            PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN, VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
     };
@@ -1368,6 +1370,34 @@ pub mod state {
         Ok(profile)
     }
 
+    pub fn read_marketauth_sequence(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        if market_slot_capacity(data)? == 0 {
+            return Err(PercolatorError::InvalidAccountLen.into());
+        }
+        let start = dynamic_slot_offset(0)?
+            .checked_add(ASSET_MARKETAUTH_SEQUENCE_OFF)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let bytes = data
+            .get(start..start + ASSET_MARKETAUTH_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let mut raw = [0u8; ASSET_MARKETAUTH_SEQUENCE_LEN];
+        raw.copy_from_slice(bytes);
+        Ok(u64::from_le_bytes(raw))
+    }
+
+    pub fn next_marketauth_sequence(
+        current_sequence: u64,
+        expected_sequence: u64,
+    ) -> Result<u64, ProgramError> {
+        if current_sequence != expected_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        current_sequence
+            .checked_add(1)
+            .ok_or_else(|| PercolatorError::EngineCounterOverflow.into())
+    }
+
     pub fn read_market_config_mode_and_capacity(
         data: &[u8],
     ) -> Result<(WrapperConfigV16, MarketModeV16, usize, usize), ProgramError> {
@@ -2536,9 +2566,11 @@ pub mod ix {
             fee_rate_per_slot: u128,
         },
         /// Rotate the single market-level authority (`marketauth`). The current `marketauth` must sign;
-        /// the non-zero replacement must co-sign. Burning `marketauth` to zero is rejected.
+        /// the non-zero replacement must co-sign. Burning `marketauth` to zero is rejected. The
+        /// expected sequence makes each co-signed handoff one-shot.
         UpdateAuthority {
             new_pubkey: [u8; 32],
+            expected_sequence: u64,
         },
         /// Rotate one of an asset's per-asset authorities. Gated by the asset's own `asset_admin`
         /// (rotates any; only the admin authority itself is burnable) or the current holder of that
@@ -2804,6 +2836,7 @@ pub mod ix {
                 },
                 32 => Self::UpdateAuthority {
                     new_pubkey: read_bytes32(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                 },
                 65 => Self::UpdateAssetAuthority {
                     asset_index: read_u16(&mut rest)?,
@@ -3102,9 +3135,13 @@ pub mod ix {
                     out.push(30);
                     push_u128(&mut out, fee_rate_per_slot);
                 }
-                Self::UpdateAuthority { new_pubkey } => {
+                Self::UpdateAuthority {
+                    new_pubkey,
+                    expected_sequence,
+                } => {
                     out.push(32);
                     out.extend_from_slice(&new_pubkey);
+                    push_u64(&mut out, expected_sequence);
                 }
                 Self::UpdateAssetAuthority {
                     asset_index,
@@ -4555,6 +4592,32 @@ pub mod processor {
         Ok(())
     }
 
+    fn consume_marketauth_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        let wrapper = &mut group
+            .markets
+            .get_mut(0)
+            .ok_or(PercolatorError::InvalidAccountLen)?
+            .wrapper;
+        let sequence_bytes = wrapper
+            .get(
+                constants::ASSET_MARKETAUTH_SEQUENCE_OFF
+                    ..constants::ASSET_MARKETAUTH_SEQUENCE_OFF
+                        + constants::ASSET_MARKETAUTH_SEQUENCE_LEN,
+            )
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let mut raw = [0u8; constants::ASSET_MARKETAUTH_SEQUENCE_LEN];
+        raw.copy_from_slice(sequence_bytes);
+        let current_sequence = u64::from_le_bytes(raw);
+        let next_sequence = state::next_marketauth_sequence(current_sequence, expected_sequence)?;
+        wrapper[constants::ASSET_MARKETAUTH_SEQUENCE_OFF
+            ..constants::ASSET_MARKETAUTH_SEQUENCE_OFF + constants::ASSET_MARKETAUTH_SEQUENCE_LEN]
+            .copy_from_slice(&next_sequence.to_le_bytes());
+        Ok(())
+    }
+
     fn read_oracle_profile_for_asset(
         market_data: &[u8],
         cfg: &WrapperConfigV16,
@@ -5281,9 +5344,10 @@ pub mod processor {
             Instruction::CloseResolved { fee_rate_per_slot } => {
                 handle_close_resolved(program_id, accounts, fee_rate_per_slot)
             }
-            Instruction::UpdateAuthority { new_pubkey } => {
-                handle_update_authority(program_id, accounts, new_pubkey)
-            }
+            Instruction::UpdateAuthority {
+                new_pubkey,
+                expected_sequence,
+            } => handle_update_authority(program_id, accounts, new_pubkey, expected_sequence),
             Instruction::UpdateAssetAuthority {
                 asset_index,
                 kind,
@@ -8694,6 +8758,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         new_pubkey: [u8; 32],
+        expected_sequence: u64,
     ) -> ProgramResult {
         let current = account(accounts, 0)?;
         let new_authority = account(accounts, 1)?;
@@ -8717,6 +8782,7 @@ pub mod processor {
             expect_live_authority(&cfg.marketauth, current.key)?;
             let old_marketauth = cfg.marketauth;
             let mut profile = read_oracle_profile_from_view(&group, &cfg, 0)?;
+            consume_marketauth_sequence_view(&mut group, expected_sequence)?;
             if profile.asset_admin == old_marketauth {
                 profile.asset_admin = new_pubkey;
             }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,136 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Returning the market authority to a prior holder must not reactivate every old handoff that
+// holder signed during the same market generation. Otherwise a displaced incoming key can retain
+// its co-signed transaction, wait for the old holder to fund insurance, and seize the new reserve.
+#[test]
+fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba() {
+    const AMOUNT: u128 = 50_000;
+
+    let mut env = V16CuEnv::new();
+    let original = env.admin.insecure_clone();
+    let attacker = Keypair::new();
+    let interim = Keypair::new();
+    env.ensure_signer_account(attacker.pubkey());
+    env.ensure_signer_account(interim.pubkey());
+
+    let retained_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(original.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::UpdateAuthority {
+            new_pubkey: attacker.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            retained_ix,
+        ],
+        Some(&attacker.pubkey()),
+        &[&attacker, &original],
+        env.svm.latest_blockhash(),
+    );
+
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: interim.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(original.pubkey(), true),
+            AccountMeta::new(interim.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&original, &interim],
+    )
+    .expect("the original authority hands off to the interim key");
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: original.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(interim.pubkey(), true),
+            AccountMeta::new(original.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&interim, &original],
+    )
+    .expect("the interim authority legitimately returns control");
+
+    let source = env.top_up_insurance(AMOUNT);
+    assert_eq!(env.token_amount(source), 0);
+    let profile_before =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+            .unwrap();
+    assert_eq!(
+        env.market_state().0.marketauth,
+        original.pubkey().to_bytes()
+    );
+    assert_eq!(
+        profile_before.insurance_authority,
+        original.pubkey().to_bytes()
+    );
+    assert_eq!(
+        profile_before.insurance_operator,
+        original.pubkey().to_bytes()
+    );
+    let group_before = env.market_state().1;
+    assert_eq!(
+        group_before.insurance_domain_budget[0] + group_before.insurance_domain_budget[1],
+        AMOUNT,
+        "the original authority's contribution makes the replay consequence non-vacuous"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(retained);
+    if replay.is_ok() {
+        let profile_after =
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+                .unwrap();
+        assert_eq!(
+            env.market_state().0.marketauth,
+            attacker.pubkey().to_bytes()
+        );
+        assert_eq!(
+            profile_after.insurance_operator,
+            attacker.pubkey().to_bytes(),
+            "the retained handoff revived the displaced live-withdrawal key"
+        );
+        let (attacker_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker, 0, AMOUNT)
+            .expect("the revived operator drains the new contribution");
+        assert_eq!(env.token_amount(attacker_dest), AMOUNT as u64);
+        let group_after = env.market_state().1;
+        assert_eq!(
+            group_after.insurance_domain_budget[0] + group_after.insurance_domain_budget[1],
+            0
+        );
+        panic!("a retained market-authority handoff replayed after A-to-C-to-A");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale handoff leaves market state byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected stale handoff leaves custody byte-identical"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1039,12 +1039,16 @@ impl V16CuEnv {
 
     fn update_asset_authority_with_cu(&mut self, new_authority: &Keypair) -> u64 {
         self.ensure_signer_account(new_authority.pubkey());
+        let expected_sequence =
+            state::read_marketauth_sequence(&self.svm.get_account(&self.market).unwrap().data)
+                .unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::UpdateAuthority {
                 new_pubkey: new_authority.pubkey().to_bytes(),
+                expected_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -25664,6 +25668,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: victim.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -25692,6 +25697,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: new_asset.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -25724,6 +25730,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: env.admin.pubkey().to_bytes(),
+            expected_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -27848,6 +27855,7 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
         &payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: market.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -43471,6 +43479,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: mallory.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -43535,6 +43544,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: new_admin.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -43573,6 +43583,7 @@ fn v16_attack_marketauth_renounce_rejected_even_with_fallback() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: [0u8; 32],
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -43602,6 +43613,7 @@ fn v16_attack_marketauth_renounce_rejected_even_with_fallback() {
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: [0u8; 32],
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -59741,6 +59753,7 @@ fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba()
         ],
         data: ProgInstruction::UpdateAuthority {
             new_pubkey: attacker.pubkey().to_bytes(),
+            expected_sequence: 0,
         }
         .encode(),
     };
@@ -59762,6 +59775,7 @@ fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba()
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: interim.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(original.pubkey(), true),
@@ -59777,6 +59791,7 @@ fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba()
         &env.payer,
         ProgInstruction::UpdateAuthority {
             new_pubkey: original.pubkey().to_bytes(),
+            expected_sequence: 1,
         },
         vec![
             AccountMeta::new(interim.pubkey(), true),
@@ -59838,6 +59853,16 @@ fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba()
         );
         panic!("a retained market-authority handoff replayed after A-to-C-to-A");
     }
+    let replay_err = format!("{:?}", replay.unwrap_err());
+    assert!(
+        replay_err.contains("Custom(19)") || replay_err.contains("custom program error: 0x13"),
+        "the retained handoff must reject specifically as EngineStale, got {replay_err}"
+    );
+    assert_eq!(
+        state::read_marketauth_sequence(&env.svm.get_account(&env.market).unwrap().data).unwrap(),
+        2,
+        "a stale retained handoff cannot consume the current sequence"
+    );
 
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
@@ -59848,5 +59873,35 @@ fn v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba()
         env.svm.get_account(&env.vault).unwrap(),
         vault_before,
         "rejected stale handoff leaves custody byte-identical"
+    );
+
+    assert!(
+        env.try_withdraw_insurance_asset_with_authority(&attacker, 0, AMOUNT)
+            .is_err(),
+        "the displaced incoming key cannot withdraw the restored authority's reserve"
+    );
+
+    let fresh = Keypair::new();
+    env.ensure_signer_account(fresh.pubkey());
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: fresh.pubkey().to_bytes(),
+            expected_sequence: 2,
+        },
+        vec![
+            AccountMeta::new(original.pubkey(), true),
+            AccountMeta::new(fresh.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&original, &fresh],
+    )
+    .expect("a freshly sequenced handoff remains live after rejecting stale bytes");
+    assert_eq!(env.market_state().0.marketauth, fresh.pubkey().to_bytes());
+    assert_eq!(
+        state::read_marketauth_sequence(&env.svm.get_account(&env.market).unwrap().data).unwrap(),
+        3
     );
 }

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -6,7 +6,7 @@ use percolator_prog::ix::{CrankObservationHint, Instruction};
 use percolator_prog::matcher_abi::{
     validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
-use percolator_prog::policy_v16;
+use percolator_prog::{policy_v16, state};
 
 #[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
@@ -654,6 +654,7 @@ fn kani_v16_legacy_permissionless_crank_size_payload_is_rejected() {
 
 #[kani::proof]
 fn kani_v16_update_authority_decode_preserves_wire_fields() {
+    let expected_sequence: u64 = kani::any();
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;
     while i < 32 {
@@ -661,17 +662,35 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 33];
+    let mut data = [0u8; 41];
     data[0] = 32;
     data[1..33].copy_from_slice(&new_pubkey);
+    data[33..41].copy_from_slice(&expected_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateAuthority {
             new_pubkey: got_pubkey,
+            expected_sequence: got_sequence,
         } => {
             assert_eq!(got_pubkey, new_pubkey);
+            assert_eq!(got_sequence, expected_sequence);
         }
         _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_marketauth_sequence_is_exact_and_monotonic() {
+    let current_sequence: u64 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let next = state::next_marketauth_sequence(current_sequence, expected_sequence);
+
+    if current_sequence != expected_sequence || current_sequence == u64::MAX {
+        assert!(next.is_err());
+    } else {
+        let next_sequence = next.unwrap();
+        assert_eq!(next_sequence, current_sequence + 1);
+        assert!(next_sequence > current_sequence);
     }
 }
 
@@ -1218,6 +1237,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     assert_rejects_trailing_byte(
         Instruction::UpdateAuthority {
             new_pubkey: [1u8; 32],
+            expected_sequence: 7,
         },
         extra,
     );


### PR DESCRIPTION
## Impact

A displaced incoming market authority can retain a fully signed `A -> B` handoff. If governance legitimately rotates `A -> C -> A` while that transaction remains valid, the old bytes become authorized again because the wrapper previously bound the handoff only to the current key, not to a specific authority-state incarnation.

The exact-parent LiteSVM reproduction uses only public instructions and real signed transactions. After `A -> C -> A`, A contributes 50,000 tokens to asset-0 insurance. Replaying the retained `A -> B` transaction rekeys the live asset-0 insurance operator to B, and B withdraws the full 50,000-token contribution.

This is a BLOCKER LoF under `scripts/loop.md`: the victim's keys remain honest, while an unprivileged relayer resubmits previously honest signed bytes during their validity window.

## Root cause

`UpdateAuthority` required both current and incoming signatures but had no program-owned monotonic sequence. Returning to a prior public key recreated the complete authorization predicate for every still-valid transaction that key had signed.

## Fix

- Add `expected_sequence` to the tag-32 ABI.
- Persist a checked monotonic market-authority sequence in asset 0's existing wrapper reserve; account sizes and the engine pin are unchanged.
- Require exact sequence equality and increment on every successful handoff.
- Reject stale retained handoffs with `EngineStale`; SVM rollback leaves the market and vault byte-identical.
- Keep fresh handoffs live after a stale rejection.
- Document the one-shot handoff contract and prove the sequence transition exact/monotonic with Kani.

## TDD evidence

- Exact pre-fix parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED commit: `3d6d7468` (`v16_attack_market_authority_handoff_cannot_replay_after_same_generation_aba`)
- Fix commit: `14d3b88d`
- Before the fix: retained transaction succeeds and B publicly withdraws 50,000 tokens.
- After the fix: retained transaction rejects specifically as `EngineStale`, market/vault bytes are unchanged, B cannot withdraw, and a fresh sequence-2 handoff succeeds.

## Verification

- `cargo build-sbf --tools-version v1.52` for wrapper, production matcher, auth matcher, and hostile matcher
- `cargo test --all-targets`: 6 unit + 566 LiteSVM/CU tests passed
- `cargo kani --tests --harness kani_v16_marketauth_sequence_is_exact_and_monotonic`: 102 checks, 0 failures
- `cargo fmt --all -- --check`
- `git diff --check`
