### PR TITLE
[BLOCKER LoF] Make asset-authority handoffs one-shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,14 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
 - **Per-asset admin keys, isolated — uniform across all assets including asset 0** — one asset's admin
   can never be used against another asset. **✅** Every asset (0..N) carries its own `asset_admin`
   (`AssetOracleProfileV16`): assets 1..N bootstrap it to the activator, **asset 0 bootstraps it to the
-  market admin at `InitMarket`**. `UpdateAssetAuthority { asset_index, kind, new_pubkey }` is scoped to
-  that asset's profile only and now operates on **asset 0 too** (the old `asset_index == 0` rejection is
-  gone). Asset 0 is **not** special for authorities — its only special properties are **fee capture**
-  (it's the insurance-redirect target) and that it **cannot be permissionlessly created** (it's created
-  at `InitMarket`, not via `UpdateAssetLifecycle`).
+  market admin at `InitMarket`**.
+  `UpdateAssetAuthority { asset_index, kind, new_pubkey, expected_sequence }` is scoped to that
+  asset's profile only and now operates on **asset 0 too** (the old `asset_index == 0` rejection is
+  gone). Each authority kind has an independent program-owned sequence; an exact match is consumed
+  on success so a co-signed handoff is one-shot. Asset 0 is **not** special for authorities — its
+  only special properties are **fee capture** (it's the insurance-redirect target) and that it
+  **cannot be permissionlessly created** (it's created at `InitMarket`, not via
+  `UpdateAssetLifecycle`).
 - **Each asset (0..N) has a cold-storage admin** that can **rotate that asset's other keys**
   (insurance/operator/backing/oracle), **shut down/restart that asset after the exit+empty gates**,
   and **can be burned (set to 0)** — a credibly admin-free asset that can't be locally revived after
@@ -179,7 +182,7 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   `asset_admin` (the asset-0 bootstrap state).
 - **Each other asset key can rotate itself; only `asset_admin` can be set to 0.** **✅** (a domain
   authority self-rotates even after the asset admin is burned; required domain authorities cannot be
-  burned). All verified by
+  burned; each handoff consumes the selected authority kind's one-shot sequence). All verified by
   `v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable`.
 - **Market admin can run a scheduled market close** — fully shut the market down and **reclaim the
   account id** — with **safe delays that cannot steal user funds** but **eventually drain an
@@ -733,7 +736,8 @@ At minimum, monitor:
 
 ### Governance / authority handling
 - `UpdateAuthority` rotates `marketauth`; the current authority and the new key must both sign.
-- `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the new key.
+- `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the
+  new key, and every handoff must carry the selected kind's current one-shot sequence.
 - Burning is limited to `asset_admin`. Required market/domain authorities cannot be set to zero.
 
 ---
@@ -830,19 +834,19 @@ These are governance powers, not bugs:
    - change funding/cap policy knobs (within validation bounds), the create fee, the base-unit mint, and the asset set — all now under the one `marketauth` key.
    - force-shutdown any asset including asset 0. Restart is not a separate marketauth power: it requires the target asset's `asset_admin`; marketauth can restart asset 0 only while it still holds the asset-0 admin role.
    - impact: economics/market shape can become unfavorable to users (force-shutdown still honors the trader exit window).
-3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
+3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE, expected_sequence }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
 4. `ResolveMarket`
    - transition market to resolved mode using stored authority price.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
-5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)
+5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE, expected_sequence }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can withdraw resolved-market insurance.
    - impact: resolved insurance extraction capability is delegated.
 6. `WithdrawInsurance` (post-resolution, after positions are closed)
    - withdraw insurance buffer to admin ATA.
    - impact: no insurance backstop remains.
-7. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE_OPERATOR }` (while marketauth holds asset-0's `asset_admin`)
+7. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE_OPERATOR, expected_sequence }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can call bounded live insurance withdrawal.
    - impact: bounded live insurance extraction capability is delegated.
 8. `CloseSlab` (when market is fully empty)
@@ -850,7 +854,8 @@ These are governance powers, not bugs:
     - impact: market is permanently closed.
 
 > **Authority model (items 3, 5, 7).** Asset-0's insurance/operator/oracle(mark)/backing authorities now
-> use the **same per-asset `asset_admin` model as assets 1..N** (`UpdateAssetAuthority { asset_index = 0 }`).
+> use the **same per-asset `asset_admin` model as assets 1..N**
+> (`UpdateAssetAuthority { asset_index = 0, expected_sequence, .. }`).
 > Asset 0's `asset_admin` is bootstrapped to the **market admin** at `InitMarket`, so a malicious admin
 > **can** rotate the shared insurance operator/authority and the mark pusher (items 3/5/7) —
 > exactly the powers the asset_admin has over any asset. To make those delegations sticky, burn

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,10 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    // Keep the first 24 wrapper-reserve bytes isolated for other one-shot counters.
+    pub const ASSET_AUTHORITY_SEQUENCES_OFF: usize = ASSET_ORACLE_PROFILE_LEN + 24;
+    pub const ASSET_AUTHORITY_SEQUENCE_LEN: usize = 8;
+    pub const ASSET_AUTHORITY_SEQUENCE_COUNT: usize = 5;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,10 +159,11 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
-            ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
+            ASSET_AUTHORITY_SEQUENCES_OFF, ASSET_AUTHORITY_SEQUENCE_COUNT,
+            ASSET_AUTHORITY_SEQUENCE_LEN, ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN,
+            HEADER_LEN, KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET,
+            KIND_PORTFOLIO, MAGIC, MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN,
+            ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
             ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
             PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
             PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
@@ -1368,6 +1373,44 @@ pub mod state {
         Ok(profile)
     }
 
+    pub fn read_asset_authority_sequence(
+        data: &[u8],
+        asset_index: usize,
+        kind: u8,
+    ) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        if asset_index >= market_slot_capacity(data)?
+            || kind as usize >= ASSET_AUTHORITY_SEQUENCE_COUNT
+        {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let kind_offset = (kind as usize)
+            .checked_mul(ASSET_AUTHORITY_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let start = dynamic_slot_offset(asset_index)?
+            .checked_add(ASSET_AUTHORITY_SEQUENCES_OFF)
+            .and_then(|offset| offset.checked_add(kind_offset))
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let bytes = data
+            .get(start..start + ASSET_AUTHORITY_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let mut raw = [0u8; ASSET_AUTHORITY_SEQUENCE_LEN];
+        raw.copy_from_slice(bytes);
+        Ok(u64::from_le_bytes(raw))
+    }
+
+    pub fn next_asset_authority_sequence(
+        current_sequence: u64,
+        expected_sequence: u64,
+    ) -> Result<u64, ProgramError> {
+        if current_sequence != expected_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        current_sequence
+            .checked_add(1)
+            .ok_or_else(|| PercolatorError::EngineCounterOverflow.into())
+    }
+
     pub fn read_market_config_mode_and_capacity(
         data: &[u8],
     ) -> Result<(WrapperConfigV16, MarketModeV16, usize, usize), ProgramError> {
@@ -2542,11 +2585,13 @@ pub mod ix {
         },
         /// Rotate one of an asset's per-asset authorities. Gated by the asset's own `asset_admin`
         /// (rotates any; only the admin authority itself is burnable) or the current holder of that
-        /// authority (self-rotation). Isolated to the given asset_index.
+        /// authority (self-rotation). Isolated to the given asset_index; the selected authority
+        /// kind's expected sequence makes the co-signed handoff one-shot.
         UpdateAssetAuthority {
             asset_index: u16,
             kind: u8,
             new_pubkey: [u8; 32],
+            expected_sequence: u64,
         },
         UpdateLiquidationFeePolicy {
             cranker_share_bps: u16,
@@ -2809,6 +2854,7 @@ pub mod ix {
                     asset_index: read_u16(&mut rest)?,
                     kind: read_u8(&mut rest)?,
                     new_pubkey: read_bytes32(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                 },
                 37 => Self::UpdateLiquidationFeePolicy {
                     cranker_share_bps: read_u16(&mut rest)?,
@@ -3110,11 +3156,13 @@ pub mod ix {
                     asset_index,
                     kind,
                     new_pubkey,
+                    expected_sequence,
                 } => {
                     out.push(65);
                     push_u16(&mut out, asset_index);
                     out.push(kind);
                     out.extend_from_slice(&new_pubkey);
+                    push_u64(&mut out, expected_sequence);
                 }
                 Self::UpdateLiquidationFeePolicy { cranker_share_bps } => {
                     out.push(37);
@@ -4555,6 +4603,40 @@ pub mod processor {
         Ok(())
     }
 
+    fn consume_asset_authority_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        kind: u8,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        if kind as usize >= constants::ASSET_AUTHORITY_SEQUENCE_COUNT {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let kind_offset = (kind as usize)
+            .checked_mul(constants::ASSET_AUTHORITY_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let start = constants::ASSET_AUTHORITY_SEQUENCES_OFF
+            .checked_add(kind_offset)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let end = start
+            .checked_add(constants::ASSET_AUTHORITY_SEQUENCE_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let wrapper = &mut group
+            .markets
+            .get_mut(asset_index)
+            .ok_or(PercolatorError::InvalidInstruction)?
+            .wrapper;
+        let sequence_bytes = wrapper
+            .get(start..end)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let mut raw = [0u8; constants::ASSET_AUTHORITY_SEQUENCE_LEN];
+        raw.copy_from_slice(sequence_bytes);
+        let next_sequence =
+            state::next_asset_authority_sequence(u64::from_le_bytes(raw), expected_sequence)?;
+        wrapper[start..end].copy_from_slice(&next_sequence.to_le_bytes());
+        Ok(())
+    }
+
     fn read_oracle_profile_for_asset(
         market_data: &[u8],
         cfg: &WrapperConfigV16,
@@ -5288,7 +5370,15 @@ pub mod processor {
                 asset_index,
                 kind,
                 new_pubkey,
-            } => handle_update_asset_authority(program_id, accounts, asset_index, kind, new_pubkey),
+                expected_sequence,
+            } => handle_update_asset_authority(
+                program_id,
+                accounts,
+                asset_index,
+                kind,
+                new_pubkey,
+                expected_sequence,
+            ),
             Instruction::UpdateLiquidationFeePolicy { cranker_share_bps } => {
                 handle_update_liquidation_fee_policy(program_id, accounts, cranker_share_bps)
             }
@@ -8746,6 +8836,7 @@ pub mod processor {
         asset_index: u16,
         kind: u8,
         new_pubkey: [u8; 32],
+        expected_sequence: u64,
     ) -> ProgramResult {
         let current = account(accounts, 0)?;
         let new_authority = account(accounts, 1)?;
@@ -8795,6 +8886,7 @@ pub mod processor {
         if !admin_signed {
             expect_live_authority(&current_value, current.key)?;
         }
+        consume_asset_authority_sequence_view(&mut group, asset_index, kind, expected_sequence)?;
         match kind {
             ASSET_AUTH_ADMIN => profile.asset_admin = new_pubkey,
             ASSET_AUTH_INSURANCE => profile.insurance_authority = new_pubkey,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1065,6 +1065,12 @@ impl V16CuEnv {
         new_pubkey: [u8; 32],
     ) -> Result<u64, String> {
         self.ensure_signer_account(signer.pubkey());
+        let expected_sequence = state::read_asset_authority_sequence(
+            &self.svm.get_account(&self.market).unwrap().data,
+            asset_index as usize,
+            kind,
+        )
+        .unwrap();
         let mut signers = vec![signer];
         let new_authority_key = if let Some(new_authority) = new_authority {
             self.ensure_signer_account(new_authority.pubkey());
@@ -1078,6 +1084,7 @@ impl V16CuEnv {
                 asset_index,
                 kind,
                 new_pubkey,
+                expected_sequence,
             },
             vec![
                 AccountMeta::new(signer.pubkey(), true),
@@ -25748,6 +25755,12 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
             .unwrap()
     };
     let ins_before = prof0(&env).insurance_authority;
+    let insurance_sequence = state::read_asset_authority_sequence(
+        &env.svm.get_account(&env.market).unwrap().data,
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+    )
+    .unwrap();
     // The current asset-0 admin tries to set asset-0 insurance to a non-signing key -> reject.
     env.svm.expire_blockhash();
     let r2 = send_tx(
@@ -25758,6 +25771,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
             asset_index: 0,
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: victim.pubkey().to_bytes(),
+            expected_sequence: insurance_sequence,
         },
         vec![
             AccountMeta::new(new_asset.pubkey(), true),
@@ -25787,6 +25801,7 @@ fn v16_attack_update_authority_requires_new_authority_signature() {
             asset_index: 0,
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: new_ins.pubkey().to_bytes(),
+            expected_sequence: insurance_sequence,
         },
         vec![
             AccountMeta::new(new_asset.pubkey(), true),
@@ -43491,6 +43506,12 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
             .unwrap()
     };
     let a0_ins_before = prof0(&env).insurance_authority;
+    let expected_sequence = state::read_asset_authority_sequence(
+        &env.svm.get_account(&env.market).unwrap().data,
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+    )
+    .unwrap();
     env.svm.expire_blockhash();
     let r_a0_ins = send_tx(
         &mut env.svm,
@@ -43500,6 +43521,7 @@ fn v16_attack_update_authority_non_holder_cannot_rotate() {
             asset_index: 0,
             kind: processor::ASSET_AUTH_INSURANCE,
             new_pubkey: mallory.pubkey().to_bytes(),
+            expected_sequence,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -44861,6 +44883,12 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
         if let Some(k) = co {
             signers.push(k);
         }
+        let expected_sequence = state::read_asset_authority_sequence(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ai as usize,
+            kind,
+        )
+        .unwrap();
         env.svm.expire_blockhash();
         send_tx(
             &mut env.svm,
@@ -44870,6 +44898,7 @@ fn v16_attack_per_asset_admin_rotates_keys_isolated_and_burnable() {
                 asset_index: ai,
                 kind,
                 new_pubkey: new,
+                expected_sequence,
             },
             vec![
                 AccountMeta::new(signer.pubkey(), true),
@@ -45071,6 +45100,12 @@ fn v16_attack_update_asset_authority_rejects_zero_domain_authority() {
         (processor::ASSET_AUTH_BACKING_BUCKET, "backing authority"),
         (processor::ASSET_AUTH_ORACLE, "oracle authority"),
     ] {
+        let expected_sequence = state::read_asset_authority_sequence(
+            &env.svm.get_account(&env.market).unwrap().data,
+            0,
+            kind,
+        )
+        .unwrap();
         env.svm.expire_blockhash();
         let burn = send_tx(
             &mut env.svm,
@@ -45080,6 +45115,7 @@ fn v16_attack_update_asset_authority_rejects_zero_domain_authority() {
                 asset_index: 0,
                 kind,
                 new_pubkey: [0u8; 32],
+                expected_sequence,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -57828,12 +57864,19 @@ fn v16_attack_oracle_authority_rotation_revokes_old_grants_new() {
     // control of the incoming key).
     let newauth = Keypair::new();
     env.ensure_signer_account(newauth.pubkey());
+    let expected_sequence = state::read_asset_authority_sequence(
+        &env.svm.get_account(&env.market).unwrap().data,
+        0,
+        percolator_prog::processor::ASSET_AUTH_ORACLE,
+    )
+    .unwrap();
     env.svm.expire_blockhash();
     let rot = env.send(
         ProgInstruction::UpdateAssetAuthority {
             asset_index: 0,
             kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
             new_pubkey: newauth.pubkey().to_bytes(),
+            expected_sequence,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -59777,6 +59820,7 @@ fn v16_attack_asset_authority_handoff_cannot_replay_after_same_generation_aba() 
             asset_index: ASSET_INDEX,
             kind: processor::ASSET_AUTH_INSURANCE_OPERATOR,
             new_pubkey: attacker.pubkey().to_bytes(),
+            expected_sequence: 0,
         }
         .encode(),
     };
@@ -59841,6 +59885,29 @@ fn v16_attack_asset_authority_handoff_cannot_replay_after_same_generation_aba() 
         );
         panic!("a retained asset-authority handoff replayed after A-to-C-to-A");
     }
+    let replay_err = format!("{:?}", replay.unwrap_err());
+    assert!(
+        replay_err.contains("Custom(19)") || replay_err.contains("custom program error: 0x13"),
+        "the retained handoff must reject specifically as EngineStale, got {replay_err}"
+    );
+    let sequence = |env: &V16CuEnv, kind: u8| {
+        state::read_asset_authority_sequence(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ASSET_INDEX as usize,
+            kind,
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        sequence(&env, processor::ASSET_AUTH_INSURANCE_OPERATOR),
+        2,
+        "a stale handoff cannot consume the live operator sequence"
+    );
+    assert_eq!(
+        sequence(&env, processor::ASSET_AUTH_INSURANCE),
+        0,
+        "operator handoffs cannot invalidate the independent insurance-authority sequence"
+    );
 
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
@@ -59857,4 +59924,24 @@ fn v16_attack_asset_authority_handoff_cannot_replay_after_same_generation_aba() 
             .is_err(),
         "the displaced operator cannot withdraw the provider reserve"
     );
+
+    let fresh = Keypair::new();
+    env.try_update_per_asset_authority_with_cu(
+        &original,
+        Some(&fresh),
+        ASSET_INDEX,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+        fresh.pubkey().to_bytes(),
+    )
+    .expect("a freshly sequenced handoff remains live after rejecting stale bytes");
+    assert_eq!(
+        state::read_asset_oracle_profile(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ASSET_INDEX as usize,
+        )
+        .unwrap()
+        .insurance_operator,
+        fresh.pubkey().to_bytes()
+    );
+    assert_eq!(sequence(&env, processor::ASSET_AUTH_INSURANCE_OPERATOR), 3);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,144 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Returning a per-asset authority to a prior holder must not reactivate old handoffs that holder
+// signed during the same asset generation. This remains security-critical after asset_admin is
+// burned: a displaced incoming insurance operator can otherwise retain A->B, wait for A->C->A and
+// an independent provider top-up, then replay the old handoff and drain the new reserve.
+#[test]
+fn v16_attack_asset_authority_handoff_cannot_replay_after_same_generation_aba() {
+    const AMOUNT: u128 = 50_000;
+    const ASSET_INDEX: u16 = 1;
+    const DOMAIN: u16 = 2;
+
+    let mut env = V16CuEnv::new();
+    let provider = Keypair::new();
+    let original = Keypair::new();
+    let attacker = Keypair::new();
+    let interim = Keypair::new();
+    for signer in [&provider, &original, &attacker, &interim] {
+        env.ensure_signer_account(signer.pubkey());
+    }
+
+    env.activate_asset_with_authorities(
+        ASSET_INDEX,
+        2,
+        100,
+        provider.pubkey(),
+        original.pubkey(),
+        original.pubkey(),
+        original.pubkey(),
+    );
+
+    // Remove the cold admin so every following operator handoff is owned solely by the live holder.
+    let asset_admin = env.admin.insecure_clone();
+    env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        None,
+        ASSET_INDEX,
+        processor::ASSET_AUTH_ADMIN,
+        [0u8; 32],
+    )
+    .expect("burn asset admin");
+    let profile = state::read_asset_oracle_profile(
+        &env.svm.get_account(&env.market).unwrap().data,
+        ASSET_INDEX as usize,
+    )
+    .unwrap();
+    assert_eq!(profile.asset_admin, [0u8; 32]);
+    assert_eq!(profile.insurance_authority, provider.pubkey().to_bytes());
+    assert_eq!(profile.insurance_operator, original.pubkey().to_bytes());
+
+    let retained_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(original.pubkey(), true),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::UpdateAssetAuthority {
+            asset_index: ASSET_INDEX,
+            kind: processor::ASSET_AUTH_INSURANCE_OPERATOR,
+            new_pubkey: attacker.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            retained_ix,
+        ],
+        Some(&attacker.pubkey()),
+        &[&attacker, &original],
+        env.svm.latest_blockhash(),
+    );
+
+    env.try_update_per_asset_authority_with_cu(
+        &original,
+        Some(&interim),
+        ASSET_INDEX,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+        interim.pubkey().to_bytes(),
+    )
+    .expect("original operator hands off to interim");
+    env.try_update_per_asset_authority_with_cu(
+        &interim,
+        Some(&original),
+        ASSET_INDEX,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+        original.pubkey().to_bytes(),
+    )
+    .expect("interim operator legitimately returns control");
+
+    let source = env.top_up_insurance_domain_with_authority(&provider, DOMAIN, AMOUNT);
+    assert_eq!(env.token_amount(source), 0);
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+        AMOUNT,
+        "the independent provider contribution makes the replay consequence non-vacuous"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(retained);
+    if replay.is_ok() {
+        let replayed_profile = state::read_asset_oracle_profile(
+            &env.svm.get_account(&env.market).unwrap().data,
+            ASSET_INDEX as usize,
+        )
+        .unwrap();
+        assert_eq!(
+            replayed_profile.insurance_operator,
+            attacker.pubkey().to_bytes(),
+            "the retained handoff revived the displaced operator"
+        );
+        let (attacker_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&attacker, ASSET_INDEX, AMOUNT)
+            .expect("the revived operator drains the provider contribution");
+        assert_eq!(env.token_amount(attacker_dest), AMOUNT as u64);
+        assert_eq!(
+            env.market_state().1.insurance_domain_budget[DOMAIN as usize],
+            0
+        );
+        panic!("a retained asset-authority handoff replayed after A-to-C-to-A");
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "rejected stale handoff leaves market state byte-identical"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "rejected stale handoff leaves custody byte-identical"
+    );
+    assert!(
+        env.try_withdraw_insurance_asset_with_authority(&attacker, ASSET_INDEX, AMOUNT)
+            .is_err(),
+        "the displaced operator cannot withdraw the provider reserve"
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -679,6 +679,7 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
 fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let kind: u8 = kani::any();
+    let expected_sequence: u64 = kani::any();
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;
     while i < 32 {
@@ -686,23 +687,42 @@ fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
         i += 1;
     }
 
-    let mut data = [0u8; 36];
+    let mut data = [0u8; 44];
     data[0] = 65;
     data[1..3].copy_from_slice(&asset_index.to_le_bytes());
     data[3] = kind;
     data[4..36].copy_from_slice(&new_pubkey);
+    data[36..44].copy_from_slice(&expected_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateAssetAuthority {
             asset_index: got_asset_index,
             kind: got_kind,
             new_pubkey: got_pubkey,
+            expected_sequence: got_sequence,
         } => {
             assert_eq!(got_asset_index, asset_index);
             assert_eq!(got_kind, kind);
             assert_eq!(got_pubkey, new_pubkey);
+            assert_eq!(got_sequence, expected_sequence);
         }
         _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_asset_authority_sequence_is_exact_and_monotonic() {
+    let current_sequence: u64 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let next =
+        percolator_prog::state::next_asset_authority_sequence(current_sequence, expected_sequence);
+
+    if current_sequence != expected_sequence || current_sequence == u64::MAX {
+        assert!(next.is_err());
+    } else {
+        let next_sequence = next.unwrap();
+        assert_eq!(next_sequence, current_sequence + 1);
+        assert!(next_sequence > current_sequence);
     }
 }
 
@@ -1226,6 +1246,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
             asset_index: 1,
             kind: 0,
             new_pubkey: [1u8; 32],
+            expected_sequence: 7,
         },
         extra,
     );


### PR DESCRIPTION
## Impact

A displaced incoming per-asset authority can retain a fully signed `A -> B` handoff. If the live holder later rotates `A -> C -> A` in the same asset generation, the old bytes again satisfy the wrapper's complete authorization predicate.

The exact-parent LiteSVM reproduction removes the privileged explanation entirely:

1. Activate asset 1 with a distinct insurance provider P and insurance operator A.
2. Burn `asset_admin`, leaving no live admin for the asset.
3. Retain a holder-owned, A+B-signed operator handoff `A -> B`.
4. Land legitimate holder-owned handoffs `A -> C -> A`.
5. P publicly contributes 50,000 tokens to the asset's insurance domain.
6. Replay the retained transaction; B becomes operator and publicly withdraws all 50,000 tokens.

This is a BLOCKER LoF under `scripts/loop.md`: the independent provider and every current authority key remain honest; the attacker only resubmits previously valid signed bytes.

The same public probe also fails on PR #251 at `255e56ee`. Holder consent prevents an asset admin from seizing another holder's role, but it cannot distinguish an old handoff signed by the same holder after an `A -> C -> A` cycle. The fixes are complementary, not duplicates.

## Root cause

`UpdateAssetAuthority` authenticated current/incoming keys but did not bind their signatures to a specific handoff state. Public-key equality therefore recreated authorization after a same-key ABA cycle.

## Fix

- Add `expected_sequence` to the tag-65 ABI.
- Store five independent checked `u64` sequences per asset, one for each authority kind, in existing wrapper reserve bytes.
- Require exact equality and increment only on successful handoff.
- Keep role counters isolated so an oracle rotation cannot invalidate an insurance or backing handoff.
- Reject stale handoffs as `EngineStale`; SVM rollback leaves market and vault byte-identical.
- Preserve fresh handoff liveness after rejecting stale bytes.
- Keep account sizes and engine pin unchanged.

The reserve range is `profile +24..+64`, disjoint from the pending insurance-topup (`+8..+16`) and market-authority (`+16..+24`) counters.

## TDD evidence

- Exact pre-fix parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED commit: `7c5f2748`
- Fix commit: `20da1dd3`
- Before: retained handoff succeeds and B withdraws P's full 50,000-token contribution.
- After: replay rejects specifically as `EngineStale`; operator sequence remains 2; unrelated insurance-authority sequence remains 0; B cannot withdraw; a fresh sequence-2 handoff succeeds and advances to 3.

## Verification

- Reproduced RED on exact parent and independently on PR #251 fixed head `255e56ee`
- `cargo build-sbf --tools-version v1.52` for wrapper, production matcher, auth matcher, and hostile matcher
- `cargo test --all-targets`: 6 unit + 566 LiteSVM/CU tests passed
- `cargo check --all-targets`
- `cargo kani --tests --harness kani_v16_asset_authority_sequence_is_exact_and_monotonic`: 102 checks, 0 failures
- `cargo fmt --all -- --check`
- `git diff --check`
