### PR TITLE
[BLOCKER LoF] Reject delayed stale-resolution policy replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ This section describes intent and operational ordering, not argument-by-argument
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
   - per-asset authorities (insurance/operator/backing/oracle, incl. asset 0) are rotated via
     `UpdateAssetAuthority`, not this instruction
+- **ConfigurePermissionlessResolve** (tag 38)
+  - `sequence` must strictly advance the stored market policy watermark; delayed older policies
+    cannot shorten a corrected stale timer and freeze an unapplied authenticated mark
 - **UpdateAssetLifecycle** (tag 40)
   - appends/reactivates/retires assets 1..N, including permissionless create/reuse when the configured
     create fee is nonzero

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,7 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    pub const PERMISSIONLESS_RESOLVE_POLICY_SEQUENCE_OFF: usize = ASSET_ORACLE_PROFILE_LEN + 64;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -159,7 +160,8 @@ pub mod state {
             KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
             MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
             ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
-            ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
+            ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL,
+            PERMISSIONLESS_RESOLVE_POLICY_SEQUENCE_OFF, PORTFOLIO_ACCOUNT_LEN,
             PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
             PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
             VERSION, WRAPPER_CONFIG_LEN,
@@ -1366,6 +1368,22 @@ pub mod state {
         let profile: AssetOracleProfileV16 = bytemuck::pod_read_unaligned(bytes);
         validate_asset_oracle_profile(&profile)?;
         Ok(profile)
+    }
+
+    pub fn read_permissionless_resolve_policy_sequence(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        validate_market_dynamic_len(data)?;
+        let start = dynamic_slot_offset(0)?
+            .checked_add(PERMISSIONLESS_RESOLVE_POLICY_SEQUENCE_OFF)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let bytes = data
+            .get(start..start + 8)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        Ok(u64::from_le_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| PercolatorError::InvalidAccountLen)?,
+        ))
     }
 
     pub fn read_market_config_mode_and_capacity(
@@ -2577,6 +2595,7 @@ pub mod ix {
         },
         SyncInsuranceLedger,
         ConfigurePermissionlessResolve {
+            sequence: u64,
             stale_slots: u64,
             force_close_delay_slots: u64,
         },
@@ -2866,6 +2885,7 @@ pub mod ix {
                 },
                 54 => Self::SyncInsuranceLedger,
                 38 => Self::ConfigurePermissionlessResolve {
+                    sequence: read_u64(&mut rest)?,
                     stale_slots: read_u64(&mut rest)?,
                     force_close_delay_slots: read_u64(&mut rest)?,
                 },
@@ -3169,10 +3189,12 @@ pub mod ix {
                 }
                 Self::SyncInsuranceLedger => out.push(54),
                 Self::ConfigurePermissionlessResolve {
+                    sequence,
                     stale_slots,
                     force_close_delay_slots,
                 } => {
                     out.push(38);
+                    push_u64(&mut out, sequence);
                     push_u64(&mut out, stale_slots);
                     push_u64(&mut out, force_close_delay_slots);
                 }
@@ -4583,6 +4605,36 @@ pub mod processor {
         Ok(profile)
     }
 
+    fn permissionless_resolve_policy_sequence_view(
+        group: &state::MarketViewMutV16<'_>,
+    ) -> Result<u64, ProgramError> {
+        let start = constants::PERMISSIONLESS_RESOLVE_POLICY_SEQUENCE_OFF;
+        let bytes = group
+            .markets
+            .first()
+            .and_then(|market| market.wrapper.get(start..start + 8))
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        Ok(u64::from_le_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| PercolatorError::InvalidAccountLen)?,
+        ))
+    }
+
+    fn write_permissionless_resolve_policy_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        sequence: u64,
+    ) -> ProgramResult {
+        let start = constants::PERMISSIONLESS_RESOLVE_POLICY_SEQUENCE_OFF;
+        let bytes = group
+            .markets
+            .first_mut()
+            .and_then(|market| market.wrapper.get_mut(start..start + 8))
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        bytes.copy_from_slice(&sequence.to_le_bytes());
+        Ok(())
+    }
+
     fn write_oracle_profile_to_view_if_separate(
         group: &mut state::MarketViewMutV16<'_>,
         asset_index: usize,
@@ -5323,11 +5375,13 @@ pub mod processor {
             }
             Instruction::SyncInsuranceLedger => handle_sync_insurance_ledger(program_id, accounts),
             Instruction::ConfigurePermissionlessResolve {
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             } => handle_configure_permissionless_resolve(
                 program_id,
                 accounts,
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             ),
@@ -9718,6 +9772,7 @@ pub mod processor {
     fn handle_configure_permissionless_resolve<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        sequence: u64,
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> ProgramResult {
@@ -9733,18 +9788,26 @@ pub mod processor {
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
-        let (mut cfg, mode, _, _) =
-            state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
-        expect_live_authority(&cfg.marketauth, admin.key)?;
-        if mode != MarketModeV16::Live {
-            return Err(PercolatorError::EngineLockActive.into());
-        }
-        if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
-            return Err(PercolatorError::OracleStale.into());
-        }
-        cfg.permissionless_resolve_stale_slots = stale_slots;
-        cfg.force_close_delay_slots = force_close_delay_slots;
-        state::write_wrapper_config(&mut market_ai.try_borrow_mut_data()?, &cfg)
+        let mut data = market_ai.try_borrow_mut_data()?;
+        let cfg_after = {
+            let (mut cfg, mut group) = state::market_view_mut(&mut data)?;
+            expect_live_authority(&cfg.marketauth, admin.key)?;
+            let current_sequence = permissionless_resolve_policy_sequence_view(&group)?;
+            if sequence == 0 || sequence <= current_sequence {
+                return Err(PercolatorError::EngineStale.into());
+            }
+            if group.header.mode != 0 {
+                return Err(PercolatorError::EngineLockActive.into());
+            }
+            if oracle_v16::permissionless_stale_matured(&cfg, authenticated_slot_or_fallback(0)) {
+                return Err(PercolatorError::OracleStale.into());
+            }
+            write_permissionless_resolve_policy_sequence_view(&mut group, sequence)?;
+            cfg.permissionless_resolve_stale_slots = stale_slots;
+            cfg.force_close_delay_slots = force_close_delay_slots;
+            cfg
+        };
+        state::write_wrapper_config(&mut data, &cfg_after)
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2277,11 +2277,18 @@ impl V16CuEnv {
         stale_slots: u64,
         force_close_delay_slots: u64,
     ) -> u64 {
+        let sequence = state::read_permissionless_resolve_policy_sequence(
+            &self.svm.get_account(&self.market).unwrap().data,
+        )
+        .unwrap()
+        .checked_add(1)
+        .unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
             ProgInstruction::ConfigurePermissionlessResolve {
+                sequence,
                 stale_slots,
                 force_close_delay_slots,
             },
@@ -25894,6 +25901,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     old_attempt(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -25940,6 +25948,7 @@ fn v16_attack_rotated_marketauth_cannot_replay_policy_updates() {
     );
     new_update(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: 5,
         },
@@ -36856,6 +36865,7 @@ fn v16_attack_force_close_rejects_cross_market_portfolio_substitution() {
         env.program_id,
         &env.payer,
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 100,
             force_close_delay_slots: DELAY,
         },
@@ -54349,6 +54359,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -54369,6 +54380,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 0,
             force_close_delay_slots: 1_000,
         },
@@ -54384,6 +54396,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: percolator_prog::constants::MAX_PERMISSIONLESS_RESOLVE_STALE_SLOTS + 1,
             force_close_delay_slots: 1_000,
         },
@@ -54402,6 +54415,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_zero = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 0,
         },
@@ -54420,6 +54434,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_force_huge = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: percolator_prog::constants::MAX_FORCE_CLOSE_DELAY_SLOTS + 1,
         },
@@ -54440,6 +54455,7 @@ fn v16_attack_configure_permissionless_resolve_gated_and_bounded() {
     env.svm.expire_blockhash();
     let r_ok = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -54480,6 +54496,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let fresh = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 2,
             stale_slots: 6,
             force_close_delay_slots: 6,
         },
@@ -54507,6 +54524,7 @@ fn v16_attack_configure_permissionless_resolve_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let stale = env.send(
         ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 3,
             stale_slots: 1_000,
             force_close_delay_slots: 1_000,
         },
@@ -59758,6 +59776,7 @@ fn v16_attack_delayed_resolve_policy_cannot_freeze_unapplied_auth_mark() {
             AccountMeta::new(env.market, false),
         ],
         data: ProgInstruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: OLD_STALE_SLOTS,
             force_close_delay_slots: FORCE_CLOSE_DELAY_SLOTS,
         }
@@ -59835,10 +59854,30 @@ fn v16_attack_delayed_resolve_policy_cannot_freeze_unapplied_auth_mark() {
         );
     }
 
+    let replay_error = format!(
+        "{:?}",
+        replay.expect_err("the superseded policy sequence must reject")
+    );
+    let expected_error = format!(
+        "Custom({})",
+        percolator_prog::error::PercolatorError::EngineStale as u32
+    );
+    assert!(
+        replay_error.contains(&expected_error),
+        "stale policy sequence must return {expected_error}, got {replay_error}"
+    );
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
         market_before_replay,
         "rejected stale policy leaves the live market byte-identical"
+    );
+    assert_eq!(
+        state::read_permissionless_resolve_policy_sequence(
+            &env.svm.get_account(&env.market).unwrap().data
+        )
+        .unwrap(),
+        2,
+        "oracle profile writes preserve the accepted policy watermark"
     );
     assert_eq!(
         env.market_state().0.permissionless_resolve_stale_slots,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,153 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A retained short stale-resolution policy must not override a later correction and freeze an
+// authenticated AuthMark before an honest cranker can apply it. Once the short policy is mature,
+// every crank rejects while permissionless resolution succeeds, so the stale settlement transfers
+// value from the honest long to the short relative to the already-committed oracle target.
+#[test]
+fn v16_attack_delayed_resolve_policy_cannot_freeze_unapplied_auth_mark() {
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 10_000 * POS_SCALE as i128;
+    const OLD_STALE_SLOTS: u64 = 2;
+    const CORRECTED_STALE_SLOTS: u64 = 100;
+    const FORCE_CLOSE_DELAY_SLOTS: u64 = 5;
+
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let victim = Keypair::new();
+    let attacker = Keypair::new();
+    let victim_account = env.create_portfolio(&victim);
+    let attacker_account = env.create_portfolio(&attacker);
+    env.deposit(&victim, victim_account, DEPOSIT);
+    env.deposit(&attacker, attacker_account, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &victim,
+        victim_account,
+        &attacker,
+        attacker_account,
+        SIZE_Q,
+        100,
+        0,
+    );
+
+    let retained_policy_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        data: ProgInstruction::ConfigurePermissionlessResolve {
+            stale_slots: OLD_STALE_SLOTS,
+            force_close_delay_slots: FORCE_CLOSE_DELAY_SLOTS,
+        }
+        .encode(),
+    };
+    let retained_policy = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            retained_policy_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &admin],
+        env.svm.latest_blockhash(),
+    );
+
+    // The first fee variant lands as intended; the admin then corrects the timer while the retained
+    // variant remains valid under the same recent blockhash.
+    env.configure_permissionless_resolve_with_cu(OLD_STALE_SLOTS, FORCE_CLOSE_DELAY_SLOTS);
+    env.configure_permissionless_resolve_with_cu(CORRECTED_STALE_SLOTS, FORCE_CLOSE_DELAY_SLOTS);
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 110);
+    let (cfg_before_replay, group_before_replay) = env.market_state();
+    assert_eq!(cfg_before_replay.mark_ewma_e6, 110);
+    assert_eq!(group_before_replay.assets[0].effective_price, 100);
+    assert_eq!(
+        cfg_before_replay.permissionless_resolve_stale_slots,
+        CORRECTED_STALE_SLOTS
+    );
+
+    env.svm.warp_to_slot(3);
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let replay = env.svm.send_transaction(retained_policy);
+    if replay.is_ok() {
+        assert_eq!(
+            env.market_state().0.permissionless_resolve_stale_slots,
+            OLD_STALE_SLOTS
+        );
+        let crank = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim_account, false),
+            ],
+            &[],
+        );
+        assert!(
+            crank.is_err(),
+            "the displaced timer must make the accepted AuthMark uncrankable"
+        );
+        env.send(
+            ProgInstruction::ResolveStalePermissionless { now_slot: 3 },
+            vec![AccountMeta::new(env.market, false)],
+            &[],
+        )
+        .expect("the displaced timer arms permissionless stale resolution");
+
+        env.svm.warp_to_slot(8);
+        let attacker_dest = env.close_resolved(&attacker, attacker_account);
+        let victim_dest = env.close_resolved(&victim, victim_account);
+        let attacker_paid = env.token_amount(attacker_dest);
+        let victim_paid = env.token_amount(victim_dest);
+        assert_eq!(attacker_paid, DEPOSIT as u64);
+        assert_eq!(victim_paid, DEPOSIT as u64);
+        panic!(
+            "delayed resolve policy froze target 110 at 100: victim received {victim_paid}, \
+             attacker retained {attacker_paid}; applying the authenticated target pays 1,100,000 \
+             and 900,000 respectively"
+        );
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_replay,
+        "rejected stale policy leaves the live market byte-identical"
+    );
+    assert_eq!(
+        env.market_state().0.permissionless_resolve_stale_slots,
+        CORRECTED_STALE_SLOTS
+    );
+    for portfolio in [victim_account, attacker_account] {
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 3,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        )
+        .expect("an honest cranker applies the authenticated target");
+    }
+    assert_eq!(env.market_state().1.assets[0].effective_price, 110);
+    env.resolve();
+    env.svm.warp_to_slot(8);
+    let attacker_dest = env.close_resolved(&attacker, attacker_account);
+    let victim_dest = env.close_resolved(&victim, victim_account);
+    assert_eq!(env.token_amount(attacker_dest), 900_000);
+    assert_eq!(env.token_amount(victim_dest), 1_100_000);
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -899,24 +899,35 @@ fn kani_v16_base_unit_payloads_decode_preserves_wire_fields() {
 
 #[kani::proof]
 fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
+    let sequence: u64 = kani::any();
     let stale_slots: u64 = kani::any();
     let force_close_delay_slots: u64 = kani::any();
     let now_slot: u64 = kani::any();
 
-    let mut configure = [0u8; 17];
+    let mut configure = [0u8; 25];
     configure[0] = 38;
-    configure[1..9].copy_from_slice(&stale_slots.to_le_bytes());
-    configure[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    configure[1..9].copy_from_slice(&sequence.to_le_bytes());
+    configure[9..17].copy_from_slice(&stale_slots.to_le_bytes());
+    configure[17..25].copy_from_slice(&force_close_delay_slots.to_le_bytes());
     match Instruction::decode(&configure).unwrap() {
         Instruction::ConfigurePermissionlessResolve {
+            sequence: got_sequence,
             stale_slots: got_stale,
             force_close_delay_slots: got_delay,
         } => {
+            assert_eq!(got_sequence, sequence);
             assert_eq!(got_stale, stale_slots);
             assert_eq!(got_delay, force_close_delay_slots);
         }
         _ => unreachable!(),
     }
+    assert!(Instruction::decode(&configure[..24]).is_err());
+
+    let mut legacy = [0u8; 17];
+    legacy[0] = 38;
+    legacy[1..9].copy_from_slice(&stale_slots.to_le_bytes());
+    legacy[9..17].copy_from_slice(&force_close_delay_slots.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 
     let mut resolve = [0u8; 9];
     resolve[0] = 39;
@@ -1272,6 +1283,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::ConfigurePermissionlessResolve {
+            sequence: 1,
             stale_slots: 5,
             force_close_delay_slots: 1,
         },


### PR DESCRIPTION
## Impact

An unprivileged relayer can retain an older, honestly signed short stale-resolution policy and land it after the market authority's later long-window correction. Once that short timer is already mature, every public crank rejects as oracle-stale while `ResolveStalePermissionless` succeeds, so an authenticated but unapplied mark is frozen out of terminal settlement.

The exact-parent public LiteSVM reproduction uses a normally initialized AuthMark market, two funded independent users, and no state injection:

1. The long victim and short attacker open 10,000 lots at 100 with 1,000,000 atoms each.
2. The honest market authority signs ordinary retry variants for a 2-slot policy; one lands.
3. The authority corrects the policy to 100 slots while the retained variant remains valid.
4. The honest oracle commits AuthMark 110.
5. At slot 3, the relayer lands the retained 2-slot policy.
6. An honest crank now rejects, but permissionless resolution succeeds at effective price 100.
7. After the normal exit delay, both users receive 1,000,000. Applying the already-authenticated mark first pays the victim 1,100,000 and the short 900,000.

The stale policy therefore leaves the attacker 100,000 atoms better off and the independent victim 100,000 atoms worse off relative to the accepted oracle target. This is `[BLOCKER LoF]` under `scripts/loop.md`: no admin key is compromised; the attacker only resubmits previously honest signed bytes.

This supplies the missing value-impact proof for the earlier closed #341. That probe showed early terminal shutdown but did not establish loss because both users could still withdraw. The new RED demonstrates stale-price value transfer, not fund stranding.

## Root cause

Tag 38 authenticated `marketauth` but did not bind a signed policy to an ordering watermark. Solana transaction deduplication distinguishes fee variants, so an old policy could become live after its correction.

## Fix

- Add a signer-chosen monotonic `sequence` to `ConfigurePermissionlessResolve`.
- Require nonzero strict advancement; delayed equal/lower intents return `EngineStale`.
- Store the watermark in asset 0's existing wrapper reserve at `+64..+72`.
- Keep this range disjoint from pending insurance top-up (`+8..+16`), market-authority (`+16..+24`), and per-asset-authority (`+24..+64`) counters.
- Reject legacy/truncated/trailing payloads under exact framing.
- Preserve account sizes, wrapper config layout, engine pin, and every user crank/exit path.

## TDD evidence

- Exact parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED commit: `cbaa2bf6`
- Fixed commit: `8747c2c9`
- Before: stale replay succeeds; honest crank rejects; stale resolution freezes 110 at 100; payouts are 1,000,000/1,000,000 instead of 1,100,000/900,000.
- After: replay returns `EngineStale`; market bytes remain identical; the sequence-2 watermark survives the AuthMark profile write; honest cranks apply 110; payouts are 1,100,000/900,000.

## Verification

- `cargo build-sbf --tools-version v1.52` for wrapper, production matcher, auth matcher, and hostile matcher
- `cargo check --all-targets`
- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 public LiteSVM/CU tests passed
- production matcher `cargo test --all-targets`: 35/35 passed
- `cargo kani --tests --harness kani_v16_permissionless_resolve_decode_preserves_wire_fields`: 841 checks, 0 failures
- `cargo fmt --all -- --check`
- `git diff --check`
