### PR TITLE
[BLOCKER LoF] Reject delayed backing-fee policy replay

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -568,7 +568,8 @@ pub mod state {
         pub backing_trade_fee_bps_short: u16,
         pub backing_trade_fee_insurance_share_bps_long: u16,
         pub backing_trade_fee_insurance_share_bps_short: u16,
-        pub _padding0: [u8; 6],
+        /// Monotonic watermark shared by signed control-plane intents for this asset.
+        pub(crate) asset_intent_sequence_le: [u8; 6],
         pub insurance_authority: [u8; 32],
         pub insurance_operator: [u8; 32],
         pub backing_bucket_authority: [u8; 32],
@@ -589,6 +590,27 @@ pub mod state {
         // (insurance/operator/backing/oracle) and itself, and can be burned (set to 0). Isolated:
         // it can never act on another asset. Set to the activator at creation.
         pub asset_admin: [u8; 32],
+    }
+
+    impl AssetOracleProfileV16 {
+        pub const MAX_ASSET_INTENT_SEQUENCE: u64 = (1u64 << 48) - 1;
+
+        #[inline]
+        pub fn asset_intent_sequence(&self) -> u64 {
+            let mut bytes = [0u8; 8];
+            bytes[..6].copy_from_slice(&self.asset_intent_sequence_le);
+            u64::from_le_bytes(bytes)
+        }
+
+        #[inline]
+        pub fn set_asset_intent_sequence(&mut self, sequence: u64) -> Result<(), ProgramError> {
+            if sequence > Self::MAX_ASSET_INTENT_SEQUENCE {
+                return Err(PercolatorError::EngineCounterOverflow.into());
+            }
+            self.asset_intent_sequence_le
+                .copy_from_slice(&sequence.to_le_bytes()[..6]);
+            Ok(())
+        }
     }
 
     /// Aggregate backing-domain accounting for an authority-controlled vault.
@@ -1123,7 +1145,6 @@ pub mod state {
                 profile.backing_trade_fee_insurance_share_bps_short,
             )
             || profile.invert > 1
-            || profile._padding0 != [0u8; 6]
             || profile.oracle_leg_count as usize > ORACLE_LEG_CAP
             || (profile.oracle_leg_flags & !ORACLE_LEG_FLAGS_MASK) != 0
         {
@@ -1214,7 +1235,7 @@ pub mod state {
             backing_trade_fee_bps_short: 0,
             backing_trade_fee_insurance_share_bps_long: 0,
             backing_trade_fee_insurance_share_bps_short: 0,
-            _padding0: [0u8; 6],
+            asset_intent_sequence_le: [0u8; 6],
             insurance_authority: [0u8; 32],
             insurance_operator: [0u8; 32],
             backing_bucket_authority: [0u8; 32],
@@ -1249,7 +1270,7 @@ pub mod state {
                 .backing_trade_fee_insurance_share_bps_long,
             backing_trade_fee_insurance_share_bps_short: config
                 .backing_trade_fee_insurance_share_bps_short,
-            _padding0: [0u8; 6],
+            asset_intent_sequence_le: [0u8; 6],
             // At InitMarket the market key bootstraps asset 0 exactly like an activator bootstraps a
             // permissionless asset 1..N: it is asset 0's cold-storage admin and all its sub-authorities.
             insurance_authority: config.marketauth,
@@ -2558,6 +2579,7 @@ pub mod ix {
             domain: u16,
             fee_bps: u16,
             insurance_share_bps: u16,
+            policy_sequence: u64,
         },
         UpdateTradeFeePolicy {
             trade_fee_base_bps: u64,
@@ -2820,6 +2842,7 @@ pub mod ix {
                     domain: read_u16(&mut rest)?,
                     fee_bps: read_u16(&mut rest)?,
                     insurance_share_bps: read_u16(&mut rest)?,
+                    policy_sequence: read_u64(&mut rest)?,
                 },
                 55 => Self::UpdateTradeFeePolicy {
                     trade_fee_base_bps: read_u64(&mut rest)?,
@@ -3128,11 +3151,13 @@ pub mod ix {
                     domain,
                     fee_bps,
                     insurance_share_bps,
+                    policy_sequence,
                 } => {
                     out.push(51);
                     push_u16(&mut out, domain);
                     push_u16(&mut out, fee_bps);
                     push_u16(&mut out, insurance_share_bps);
+                    push_u64(&mut out, policy_sequence);
                 }
                 Self::UpdateTradeFeePolicy { trade_fee_base_bps } => {
                     out.push(55);
@@ -4646,11 +4671,22 @@ pub mod processor {
             existing.backing_trade_fee_insurance_share_bps_long;
         profile.backing_trade_fee_insurance_share_bps_short =
             existing.backing_trade_fee_insurance_share_bps_short;
+        profile.asset_intent_sequence_le = existing.asset_intent_sequence_le;
         profile.insurance_authority = existing.insurance_authority;
         profile.insurance_operator = existing.insurance_operator;
         profile.backing_bucket_authority = existing.backing_bucket_authority;
         profile.oracle_authority = existing.oracle_authority;
         profile
+    }
+
+    fn advance_asset_intent_sequence(
+        profile: &mut state::AssetOracleProfileV16,
+        intent_sequence: u64,
+    ) -> ProgramResult {
+        if intent_sequence <= profile.asset_intent_sequence() {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        profile.set_asset_intent_sequence(intent_sequence)
     }
 
     fn backing_fee_policy_count_from_profile(profile: &state::AssetOracleProfileV16) -> u16 {
@@ -5299,12 +5335,14 @@ pub mod processor {
                 domain,
                 fee_bps,
                 insurance_share_bps,
+                policy_sequence,
             } => handle_update_backing_fee_policy(
                 program_id,
                 accounts,
                 domain,
                 fee_bps,
                 insurance_share_bps,
+                policy_sequence,
             ),
             Instruction::UpdateTradeFeePolicy { trade_fee_base_bps } => {
                 handle_update_trade_fee_policy(program_id, accounts, trade_fee_base_bps)
@@ -9549,6 +9587,7 @@ pub mod processor {
         domain: u16,
         fee_bps: u16,
         insurance_share_bps: u16,
+        policy_sequence: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -9624,6 +9663,7 @@ pub mod processor {
                 profile.backing_trade_fee_bps_short = fee_bps;
                 profile.backing_trade_fee_insurance_share_bps_short = insurance_share_bps;
             }
+            advance_asset_intent_sequence(&mut profile, policy_sequence)?;
             state::write_wrapper_config(&mut market_data, &cfg)?;
             state::write_asset_oracle_profile(&mut market_data, asset_index, &profile)
         } else {
@@ -9641,6 +9681,7 @@ pub mod processor {
                 profile.backing_trade_fee_bps_short = fee_bps;
                 profile.backing_trade_fee_insurance_share_bps_short = insurance_share_bps;
             }
+            advance_asset_intent_sequence(&mut profile, policy_sequence)?;
             state::write_wrapper_config(&mut market_data, &cfg)?;
             state::write_asset_oracle_profile(&mut market_data, asset_index, &profile)
         }
@@ -9855,7 +9896,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                asset_intent_sequence_le: existing_profile.asset_intent_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -9981,7 +10022,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                asset_intent_sequence_le: existing_profile.asset_intent_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -10089,7 +10130,7 @@ pub mod processor {
                     .backing_trade_fee_insurance_share_bps_long,
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
-                _padding0: [0u8; 6],
+                asset_intent_sequence_le: existing_profile.asset_intent_sequence_le,
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -45654,6 +45654,165 @@ fn v16_attack_backing_fee_split_conserves() {
     assert_domain_budget_remaining_total_consistent(&ga, "backing fee insurance share");
 }
 
+// A relayer must not be able to land an older, authority-signed backing-fee policy after the
+// authority's newer zero-fee correction and charge a source-backed trade under the superseded terms.
+#[test]
+fn v16_attack_delayed_backing_fee_policy_replay_charges_superseded_fee() {
+    fn run(replay_old_policy: bool) -> (u128, u128, u128) {
+        const INITIAL_PRICE: u64 = 100;
+        const ASSET0_MARK: u64 = 105;
+        const ASSET1_MARK: u64 = 95;
+        const ASSET0_SIZE_Q: i128 = 20_000 * POS_SCALE as i128;
+        const ASSET1_SIZE_Q: i128 = 10_000 * POS_SCALE as i128;
+        const SAFE_INCREASE_Q: i128 = 1_000 * POS_SCALE as i128;
+        const DEPOSIT: u128 = 313_000;
+        const WINNING_DOMAIN: u16 = 1;
+
+        let mut env = V16CuEnv::new_with_market_params_and_price_move(4, 1_000, 1_000, 500);
+        env.svm.warp_to_slot(1);
+        env.configure_auth_mark_for_asset_as_admin(0, 1, INITIAL_PRICE);
+        env.configure_auth_mark_for_asset_as_admin(1, 1, INITIAL_PRICE);
+
+        let cross_owner = Keypair::new();
+        let counterparty_owner = Keypair::new();
+        let cross_account = env.create_portfolio(&cross_owner);
+        let counterparty_account = env.create_portfolio(&counterparty_owner);
+        env.deposit(&cross_owner, cross_account, DEPOSIT);
+        env.deposit(&counterparty_owner, counterparty_account, 1_000_000);
+        env.top_up_backing_bucket(WINNING_DOMAIN, 150_000, 10);
+
+        env.trade_asset_with_cu(
+            0,
+            &cross_owner,
+            cross_account,
+            &counterparty_owner,
+            counterparty_account,
+            ASSET0_SIZE_Q,
+            INITIAL_PRICE,
+            0,
+        );
+        env.trade_asset_with_cu(
+            1,
+            &cross_owner,
+            cross_account,
+            &counterparty_owner,
+            counterparty_account,
+            ASSET1_SIZE_Q,
+            INITIAL_PRICE,
+            0,
+        );
+
+        env.svm.warp_to_slot(2);
+        env.push_auth_mark_for_asset_as_admin(0, 2, ASSET0_MARK);
+        env.push_auth_mark_for_asset_as_admin(1, 2, ASSET1_MARK);
+        for (portfolio, asset_index) in [
+            (counterparty_account, 0),
+            (cross_account, 0),
+            (counterparty_account, 1),
+        ] {
+            env.crank(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 2,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+
+        let make_policy_tx = |fee_bps: u16| {
+            let instruction = Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(env.admin.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                data: ProgInstruction::UpdateBackingFeePolicy {
+                    domain: WINNING_DOMAIN,
+                    fee_bps,
+                    insurance_share_bps: 0,
+                }
+                .encode(),
+            };
+            Transaction::new_signed_with_payer(
+                &[heap_ix(), cu_ix(), instruction],
+                Some(&env.payer.pubkey()),
+                &[&env.payer, &env.admin],
+                env.svm.latest_blockhash(),
+            )
+        };
+        let old_high_fee = make_policy_tx(5_000);
+        let newer_zero_fee = make_policy_tx(0);
+        env.svm
+            .send_transaction(newer_zero_fee)
+            .expect("newer zero-fee policy");
+        if replay_old_policy {
+            env.svm
+                .send_transaction(old_high_fee)
+                .expect_err("delayed old high-fee policy must reject");
+        }
+
+        let (_, before_group) = env.market_state();
+        let capital_before = env.portfolio_state(cross_account).capital.get()
+            + env.portfolio_state(counterparty_account).capital.get();
+        let provider_before =
+            before_group.source_backing_buckets[WINNING_DOMAIN as usize].utilization_fee_earnings;
+        let lien_before: u128 = env
+            .portfolio_state(cross_account)
+            .source_domains
+            .iter()
+            .map(|slot| slot.source_lien_counterparty_backing_num.get())
+            .sum();
+
+        env.svm.warp_to_slot(3);
+        env.trade_asset_with_cu(
+            1,
+            &cross_owner,
+            cross_account,
+            &counterparty_owner,
+            counterparty_account,
+            SAFE_INCREASE_Q,
+            ASSET1_MARK,
+            0,
+        );
+
+        let (_, after_group) = env.market_state();
+        let capital_after = env.portfolio_state(cross_account).capital.get()
+            + env.portfolio_state(counterparty_account).capital.get();
+        let provider_after =
+            after_group.source_backing_buckets[WINNING_DOMAIN as usize].utilization_fee_earnings;
+        let lien_after: u128 = env
+            .portfolio_state(cross_account)
+            .source_domains
+            .iter()
+            .map(|slot| slot.source_lien_counterparty_backing_num.get())
+            .sum();
+        assert!(
+            lien_after > lien_before,
+            "public risk increase must create the source-backed lien that incurs the fee"
+        );
+        (
+            capital_before - capital_after,
+            provider_after - provider_before,
+            lien_after - lien_before,
+        )
+    }
+
+    let current_policy = run(false);
+    let delayed_policy = run(true);
+    assert_eq!(
+        current_policy.0, 0,
+        "the current zero-fee policy charges nothing"
+    );
+    assert_eq!(
+        current_policy.1, 0,
+        "the provider earns nothing under the current policy"
+    );
+    assert_eq!(
+        delayed_policy, current_policy,
+        "a delayed superseded policy must not change trader cost or provider earnings"
+    );
+}
+
 // security.md sweep — permissionless asset-create fee gate (#5 / README L52): when the configured
 // permissionless market-init fee is ZERO, asset creation is NOT permissionless — only the market-wide
 // asset authority may append a new asset; a stranger is rejected with Unauthorized.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -989,6 +989,12 @@ impl V16CuEnv {
         fee_bps: u16,
         insurance_share_bps: u16,
     ) -> u64 {
+        let profile = state::read_asset_oracle_profile(
+            &self.svm.get_account(&self.market).unwrap().data,
+            domain as usize / 2,
+        )
+        .unwrap();
+        let policy_sequence = profile.asset_intent_sequence().checked_add(1).unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -997,6 +1003,7 @@ impl V16CuEnv {
                 domain,
                 fee_bps,
                 insurance_share_bps,
+                policy_sequence,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -25539,6 +25546,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
             domain: BAD_DOMAIN,
             fee_bps: 77,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -34320,6 +34328,7 @@ fn v16_attack_backing_fee_policy_authority_gated() {
             domain: 0,
             fee_bps: 77,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
@@ -34341,6 +34350,7 @@ fn v16_attack_backing_fee_policy_authority_gated() {
             domain: 0,
             fee_bps: 77,
             insurance_share_bps: 20_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -34399,6 +34409,7 @@ fn v16_attack_cross_asset_insurance_authority_cannot_update_other_backing_fee_po
             domain: 0,
             fee_bps: 91,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(asset1_insurance.pubkey(), true),
@@ -34425,6 +34436,7 @@ fn v16_attack_cross_asset_insurance_authority_cannot_update_other_backing_fee_po
             domain: 2,
             fee_bps: 91,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(asset1_insurance.pubkey(), true),
@@ -34523,6 +34535,7 @@ fn v16_attack_global_policy_bounds_reject_grief_values() {
             domain: 0,
             fee_bps: 0,
             insurance_share_bps: 1,
+            policy_sequence: 1,
         },
         "nonzero backing insurance split on a zero backing fee",
     );
@@ -34746,6 +34759,7 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
             domain: 0,
             fee_bps: 55,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         })
         .is_err(),
         "asset-1 authority must not control market-0 backing-fee policy"
@@ -34790,6 +34804,7 @@ fn v16_attack_permissionless_asset_authority_cannot_update_marketwide_policies()
             domain: 2,
             fee_bps: 111,
             insurance_share_bps: 5_000,
+            policy_sequence: 1,
         },
         vec![
             AccountMeta::new(creator.pubkey(), true),
@@ -45730,6 +45745,7 @@ fn v16_attack_delayed_backing_fee_policy_replay_charges_superseded_fee() {
                     domain: WINNING_DOMAIN,
                     fee_bps,
                     insurance_share_bps: 0,
+                    policy_sequence: if fee_bps == 0 { 2 } else { 1 },
                 }
                 .encode(),
             };
@@ -50019,6 +50035,7 @@ fn v16_attack_non_active_asset_cannot_enable_backing_fee_batch_gate() {
                 domain: 2,
                 fee_bps: 77,
                 insurance_share_bps: 5_000,
+                policy_sequence: 1,
             },
             vec![
                 AccountMeta::new(creator.pubkey(), true),
@@ -50101,25 +50118,31 @@ fn v16_attack_retired_reused_asset_backing_fee_policy_cannot_stick_batch_gate() 
         1,
     );
 
-    let update_policy =
-        |env: &mut V16CuEnv, signer: &Keypair, fee_bps: u16| -> Result<u64, String> {
-            env.svm.expire_blockhash();
-            send_tx(
-                &mut env.svm,
-                env.program_id,
-                &env.payer,
-                ProgInstruction::UpdateBackingFeePolicy {
-                    domain: 2,
-                    fee_bps,
-                    insurance_share_bps: if fee_bps == 0 { 0 } else { 5_000 },
-                },
-                vec![
-                    AccountMeta::new(signer.pubkey(), true),
-                    AccountMeta::new(env.market, false),
-                ],
-                &[signer],
-            )
-        };
+    let update_policy = |env: &mut V16CuEnv,
+                         signer: &Keypair,
+                         fee_bps: u16|
+     -> Result<u64, String> {
+        env.svm.expire_blockhash();
+        let profile =
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+                .unwrap();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateBackingFeePolicy {
+                domain: 2,
+                fee_bps,
+                insurance_share_bps: if fee_bps == 0 { 0 } else { 5_000 },
+                policy_sequence: profile.asset_intent_sequence() + 1,
+            },
+            vec![
+                AccountMeta::new(signer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[signer],
+        )
+    };
 
     update_policy(&mut env, &old_creator, 77).expect("old asset authority sets active policy");
     let (cfg_with_policy, _) = env.market_state();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -800,25 +800,34 @@ fn kani_v16_update_backing_fee_policy_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let fee_bps: u16 = kani::any();
     let insurance_share_bps: u16 = kani::any();
+    let policy_sequence: u64 = kani::any();
 
-    let mut data = [0u8; 7];
+    let mut data = [0u8; 15];
     data[0] = 51;
     data[1..3].copy_from_slice(&domain.to_le_bytes());
     data[3..5].copy_from_slice(&fee_bps.to_le_bytes());
     data[5..7].copy_from_slice(&insurance_share_bps.to_le_bytes());
+    data[7..15].copy_from_slice(&policy_sequence.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::UpdateBackingFeePolicy {
             domain: got_domain,
             fee_bps: got_fee_bps,
             insurance_share_bps: got_insurance_share_bps,
+            policy_sequence: got_policy_sequence,
         } => {
             assert_eq!(got_domain, domain);
             assert_eq!(got_fee_bps, fee_bps);
             assert_eq!(got_insurance_share_bps, insurance_share_bps);
+            assert_eq!(got_policy_sequence, policy_sequence);
         }
         _ => unreachable!(),
     }
+
+    let mut trailing = [0u8; 16];
+    trailing[..15].copy_from_slice(&data);
+    trailing[15] = kani::any();
+    assert!(Instruction::decode(&trailing).is_err());
 }
 
 #[kani::proof]
@@ -1246,6 +1255,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
             domain: 0,
             fee_bps: 25,
             insurance_share_bps: 0,
+            policy_sequence: 1,
         },
         extra,
     );


### PR DESCRIPTION
## Impact

`UpdateBackingFeePolicy` had no ordering watermark. An unprivileged relayer can land a newer honest-authority correction, then land an older still-valid signed policy transaction and reinstate a superseded fee. The public LiteSVM repro uses a normally initialized live market, two independent traders, authenticated marks, permissionless cranks, and real provider backing; it does not inject account bytes or engine state.

On the exact parent (`36fa587e`), the stale transaction succeeds at 92,099 CU. The same source-backed risk increase then debits the independent trader by 750 atoms and credits provider earnings by 750 atoms, while the control schedule charges neither and both create the same lien.

## Fix

- Add `policy_sequence` to tag 51.
- Persist a 48-bit monotonic per-asset control-plane watermark in existing profile padding.
- Reject non-increasing intents as `EngineStale`.
- Preserve the watermark across all profile/lifecycle rewrites.
- Prove exact decoding plus trailing-byte rejection in the focused Kani harness.

The watermark is deliberately generic (`asset_intent_sequence`) so #335 can rebase and reuse it for authenticated-mark intent ordering instead of consuming the same padding independently.

## TDD

- RED: `72f4e7cf` on exact parent `36fa587e`.
- GREEN: `a6792054`.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1` (6/6 unit, 566/566 LiteSVM/CU)
- `cargo check --tests`
- `cargo kani --tests --harness kani_v16_update_backing_fee_policy_decode_preserves_wire_fields` (834 checks, 0 failures)