### PR TITLE
[BLOCKER LoF] Make deposit intents one-shot across retry variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ This section describes intent and operational ordering, not argument-by-argument
   - initializes a program-owned portfolio account and binds `owner = signer`
 - **Deposit** (tag 3)
   - transfers collateral into vault; credits engine balance for that account
+  - binds the signed request to `portfolio_id` and consumes a nonzero portfolio-local `intent_id`;
+    a 64-ID replay window allows distinct deposits to land out of order but rejects fee-bump or
+    blockhash retry variants for an already consumed economic intent
 - **Withdraw** (tag 4)
   - performs oracle-read + engine checks; withdraws from vault via PDA signer; debits engine
 - **ClosePortfolio** (tag 8)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -65,7 +65,11 @@ pub mod constants {
     pub const PORTFOLIO_MATCHER_CONFIG_LEN: usize = 104;
     pub const PORTFOLIO_ID_OFF: usize = PORTFOLIO_MATCHER_CONFIG_OFF + PORTFOLIO_MATCHER_CONFIG_LEN;
     pub const PORTFOLIO_ID_LEN: usize = 8;
-    pub const PORTFOLIO_ACCOUNT_LEN: usize = PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN;
+    pub const PORTFOLIO_OWNER_REPLAY_OFF: usize = PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN;
+    pub const PORTFOLIO_OWNER_REPLAY_LEN: usize = 16;
+    pub const LEGACY_PORTFOLIO_ID: u64 = u64::MAX;
+    pub const PORTFOLIO_ACCOUNT_LEN: usize =
+        PORTFOLIO_OWNER_REPLAY_OFF + PORTFOLIO_OWNER_REPLAY_LEN;
     pub const MAX_MATCHER_TAIL_ACCOUNTS: usize = 32;
     pub const MATCHER_ABI_VERSION: u32 = 3;
     pub const MATCHER_CONTEXT_MIN_LEN: usize = 64;
@@ -156,13 +160,13 @@ pub mod state {
     use crate::{
         constants::{
             ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
+            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO,
+            LEGACY_PORTFOLIO_ID, MAGIC, MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN,
+            ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
             ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
             PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
-            VERSION, WRAPPER_CONFIG_LEN,
+            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_OWNER_REPLAY_LEN,
+            PORTFOLIO_OWNER_REPLAY_OFF, PORTFOLIO_STATE_LEN, VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
     };
@@ -800,6 +804,28 @@ pub mod state {
         Ok(id)
     }
 
+    /// Return the incarnation ID used by owner-signed intents. Portfolios created before the
+    /// incarnation tail existed migrate to a deterministic sentinel on their first such intent.
+    #[inline]
+    pub fn read_owner_intent_portfolio_id(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        let Some(id_bytes) = data.get(PORTFOLIO_ID_OFF..PORTFOLIO_ID_OFF + PORTFOLIO_ID_LEN) else {
+            return Ok(LEGACY_PORTFOLIO_ID);
+        };
+        let id = u64::from_le_bytes(id_bytes.try_into().unwrap());
+        if id != 0 {
+            return Ok(id);
+        }
+        if let Some(replay) = data.get(
+            PORTFOLIO_OWNER_REPLAY_OFF..PORTFOLIO_OWNER_REPLAY_OFF + PORTFOLIO_OWNER_REPLAY_LEN,
+        ) {
+            if replay.iter().any(|byte| *byte != 0) {
+                return Err(ProgramError::InvalidAccountData);
+            }
+        }
+        Ok(LEGACY_PORTFOLIO_ID)
+    }
+
     #[inline]
     fn write_portfolio_id(data: &mut [u8], id: u64) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
@@ -821,6 +847,85 @@ pub mod state {
             .checked_add(1)
             .ok_or(PercolatorError::EngineCounterOverflow)?;
         Ok((id, next))
+    }
+
+    /// Advance a bounded at-most-once window while allowing distinct owner intents to land out of
+    /// order. Bit zero represents `max_seen`; bit N represents `max_seen - N`.
+    #[inline]
+    pub fn advance_owner_intent_replay_window(
+        max_seen: u64,
+        seen_bitmap: u64,
+        intent_id: u64,
+    ) -> Option<(u64, u64)> {
+        if intent_id == 0
+            || (max_seen == 0 && seen_bitmap != 0)
+            || (max_seen != 0 && seen_bitmap & 1 == 0)
+        {
+            return None;
+        }
+        if max_seen == 0 {
+            return Some((intent_id, 1));
+        }
+        if intent_id > max_seen {
+            let distance = intent_id - max_seen;
+            let shifted = if distance >= u64::BITS as u64 {
+                0
+            } else {
+                seen_bitmap << distance
+            };
+            return Some((intent_id, shifted | 1));
+        }
+        let distance = max_seen - intent_id;
+        if distance >= u64::BITS as u64 {
+            return None;
+        }
+        let bit = 1u64 << distance;
+        if seen_bitmap & bit != 0 {
+            return None;
+        }
+        Some((max_seen, seen_bitmap | bit))
+    }
+
+    #[inline]
+    pub fn next_owner_intent_id(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        let max_seen = data
+            .get(
+                PORTFOLIO_OWNER_REPLAY_OFF..PORTFOLIO_OWNER_REPLAY_OFF + PORTFOLIO_OWNER_REPLAY_LEN,
+            )
+            .map(|window| u64::from_le_bytes(window[0..8].try_into().unwrap()))
+            .unwrap_or(0);
+        max_seen
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineCounterOverflow.into())
+    }
+
+    #[inline]
+    pub fn consume_owner_intent(
+        data: &mut [u8],
+        expected_portfolio_id: u64,
+        intent_id: u64,
+    ) -> Result<(), ProgramError> {
+        let actual_portfolio_id = read_owner_intent_portfolio_id(data)?;
+        if actual_portfolio_id != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        if read_u64(data, PORTFOLIO_ID_OFF)? == 0 {
+            write_portfolio_id(data, LEGACY_PORTFOLIO_ID)?;
+        }
+        let window = data
+            .get_mut(
+                PORTFOLIO_OWNER_REPLAY_OFF..PORTFOLIO_OWNER_REPLAY_OFF + PORTFOLIO_OWNER_REPLAY_LEN,
+            )
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let max_seen = u64::from_le_bytes(window[0..8].try_into().unwrap());
+        let seen_bitmap = u64::from_le_bytes(window[8..16].try_into().unwrap());
+        let (next_max_seen, next_seen_bitmap) =
+            advance_owner_intent_replay_window(max_seen, seen_bitmap, intent_id)
+                .ok_or(PercolatorError::EngineStale)?;
+        window[0..8].copy_from_slice(&next_max_seen.to_le_bytes());
+        window[8..16].copy_from_slice(&next_seen_bitmap.to_le_bytes());
+        Ok(())
     }
 
     #[inline]
@@ -2476,6 +2581,8 @@ pub mod ix {
         },
         InitPortfolio,
         Deposit {
+            portfolio_id: u64,
+            intent_id: u64,
             amount: u128,
         },
         Withdraw {
@@ -2707,6 +2814,8 @@ pub mod ix {
                 },
                 1 => Self::InitPortfolio,
                 3 => Self::Deposit {
+                    portfolio_id: read_u64(&mut rest)?,
+                    intent_id: read_u64(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                 },
                 4 => Self::Withdraw {
@@ -2999,8 +3108,14 @@ pub mod ix {
                     push_u128(&mut out, maintenance_fee_per_slot);
                 }
                 Self::InitPortfolio => out.push(1),
-                Self::Deposit { amount } => {
+                Self::Deposit {
+                    portfolio_id,
+                    intent_id,
+                    amount,
+                } => {
                     out.push(3);
+                    push_u64(&mut out, portfolio_id);
+                    push_u64(&mut out, intent_id);
                     push_u128(&mut out, amount);
                 }
                 Self::Withdraw { amount } => {
@@ -5217,7 +5332,11 @@ pub mod processor {
                 maintenance_fee_per_slot,
             ),
             Instruction::InitPortfolio => handle_init_portfolio(program_id, accounts),
-            Instruction::Deposit { amount } => handle_deposit(program_id, accounts, amount),
+            Instruction::Deposit {
+                portfolio_id,
+                intent_id,
+                amount,
+            } => handle_deposit(program_id, accounts, portfolio_id, intent_id, amount),
             Instruction::Withdraw { amount } => handle_withdraw(program_id, accounts, amount),
             Instruction::PermissionlessCrank {
                 now_slot,
@@ -5668,6 +5787,8 @@ pub mod processor {
     fn handle_deposit<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        portfolio_id: u64,
+        intent_id: u64,
         amount: u128,
     ) -> ProgramResult {
         let owner = account(accounts, 0)?;
@@ -5706,10 +5827,17 @@ pub mod processor {
             }
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             let mut portfolio_data = portfolio_ai.try_borrow_mut_data()?;
+            {
+                let portfolio = state::portfolio_view_mut_for_market_slots(
+                    &mut portfolio_data,
+                    max_market_slots,
+                )?;
+                expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
+                expect_portfolio_view_owner(&portfolio, owner.key)?;
+            }
+            state::consume_owner_intent(&mut portfolio_data, portfolio_id, intent_id)?;
             let mut portfolio =
                 state::portfolio_view_mut_for_market_slots(&mut portfolio_data, max_market_slots)?;
-            expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
-            expect_portfolio_view_owner(&portfolio, owner.key)?;
             group
                 .deposit_not_atomic(&mut portfolio, amount)
                 .map_err(map_v16_error)?;
@@ -12203,6 +12331,31 @@ pub mod processor {
                 state::allocate_portfolio_id(u64::MAX),
                 Err(PercolatorError::EngineCounterOverflow.into())
             );
+        }
+
+        #[test]
+        fn owner_intent_replay_window_accepts_bounded_reordering_once() {
+            let (max_seen, bitmap) = state::advance_owner_intent_replay_window(0, 0, 100).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_owner_intent_replay_window(max_seen, bitmap, 102).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_owner_intent_replay_window(max_seen, bitmap, 101).unwrap();
+            assert_eq!((max_seen, bitmap), (102, 0b111));
+            assert_eq!(
+                state::advance_owner_intent_replay_window(max_seen, bitmap, 101),
+                None
+            );
+            assert_eq!(
+                state::advance_owner_intent_replay_window(max_seen, bitmap, 38),
+                None
+            );
+        }
+
+        #[test]
+        fn owner_intent_replay_window_rejects_zero_and_malformed_state() {
+            assert_eq!(state::advance_owner_intent_replay_window(0, 0, 0), None);
+            assert_eq!(state::advance_owner_intent_replay_window(0, 1, 1), None);
+            assert_eq!(state::advance_owner_intent_replay_window(1, 0, 2), None);
         }
 
         fn test_wrapper_config(price: u64) -> state::WrapperConfigV16 {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -31721,6 +31721,151 @@ fn v16_attack_wrong_token_program_rejected() {
     );
 }
 
+fn run_deposit_retry_replay_case(replay_retained: bool) -> (u64, u64, u64) {
+    const INITIAL_CAPITAL: u128 = 1_000;
+    const TOP_UP: u128 = 500;
+    const POSITION_Q: i128 = 10 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let victim_owner = Keypair::new();
+    let winner_owner = Keypair::new();
+    let publisher_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let winner = env.create_portfolio(&winner_owner);
+    let publisher = env.create_portfolio(&publisher_owner);
+    env.deposit(&victim_owner, victim, INITIAL_CAPITAL);
+    env.deposit(&winner_owner, winner, INITIAL_CAPITAL);
+    env.trade_with_cu(
+        &victim_owner,
+        victim,
+        &winner_owner,
+        winner,
+        -POSITION_Q,
+        100,
+        0,
+    );
+
+    let source = env.token_account(victim_owner.pubkey(), (2 * TOP_UP) as u64);
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let deposit_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::Deposit { amount: TOP_UP }.encode(),
+    };
+    let intended = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), deposit_ix.clone()],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            deposit_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        blockhash,
+    );
+    env.svm
+        .send_transaction(intended)
+        .expect("the victim's intended top-up lands");
+    assert_eq!(env.token_amount(source), TOP_UP as u64);
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 200);
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(publisher, false),
+        ],
+        &[],
+    )
+    .expect("publish the first honest mark step");
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 300);
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(publisher, false),
+        ],
+        &[],
+    )
+    .expect("publish the second honest mark step");
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        300,
+        "the retained top-up must land after the honest adverse price is committed"
+    );
+
+    if replay_retained {
+        let source_before = env.svm.get_account(&source).unwrap();
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let victim_before = env.svm.get_account(&victim).unwrap();
+        let vault_before = env.svm.get_account(&env.vault).unwrap();
+        env.svm
+            .send_transaction(retained)
+            .expect_err("a retained fee-bump variant must not debit the deposit source twice");
+        assert_eq!(env.svm.get_account(&source).unwrap(), source_before);
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    }
+
+    env.resolve();
+    let winner_dest_first = env.close_resolved(&winner_owner, winner);
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let winner_dest_retry = env.close_resolved(&winner_owner, winner);
+    (
+        env.token_amount(source),
+        env.token_amount(winner_dest_first) + env.token_amount(winner_dest_retry),
+        env.token_amount(victim_dest),
+    )
+}
+
+#[test]
+fn v16_attack_deposit_retry_replay_funds_independent_winner() {
+    let control = run_deposit_retry_replay_case(false);
+    let replay = run_deposit_retry_replay_case(true);
+
+    assert_eq!(control.0, 500, "control retains the unsigned source half");
+    assert_eq!(
+        replay.0, 500,
+        "rejected retry retains the unsigned source half"
+    );
+    assert_eq!(control.2, 0, "the insolvent victim has no terminal payout");
+    assert_eq!(
+        replay.2, 0,
+        "the replay does not return value to the victim"
+    );
+    assert_eq!(
+        replay.1, control.1,
+        "rejecting the retained retry must prevent an extra independent-winner payout"
+    );
+}
+
 // security.md sweep — haircut proportionality with disparate claims (#33/#37): two resolved winners
 // with very different positive-pnl faces (100 vs 900) sharing insufficient backing must be paid
 // PROPORTIONALLY to their claim size (~1:9), and the total must not exceed the backing.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -494,6 +494,16 @@ fn heap_ix() -> Instruction {
     ComputeBudgetInstruction::request_heap_frame(128 * 1024)
 }
 
+fn owner_deposit_instruction(svm: &LiteSVM, portfolio: Pubkey, amount: u128) -> ProgInstruction {
+    let account = svm.get_account(&portfolio).expect("portfolio account");
+    ProgInstruction::Deposit {
+        portfolio_id: state::read_owner_intent_portfolio_id(&account.data)
+            .expect("owner-intent portfolio id"),
+        intent_id: state::next_owner_intent_id(&account.data).expect("next owner-intent id"),
+        amount,
+    }
+}
+
 struct V16CuEnv {
     svm: LiteSVM,
     program_id: Pubkey,
@@ -1393,6 +1403,10 @@ impl V16CuEnv {
         (source, cu)
     }
 
+    fn deposit_instruction(&self, portfolio: Pubkey, amount: u128) -> ProgInstruction {
+        owner_deposit_instruction(&self.svm, portfolio, amount)
+    }
+
     fn deposit_with_cu(
         &mut self,
         owner: &Keypair,
@@ -1414,7 +1428,7 @@ impl V16CuEnv {
             .unwrap();
         let cu = self
             .send(
-                ProgInstruction::Deposit { amount },
+                self.deposit_instruction(portfolio, amount),
                 vec![
                     AccountMeta::new(owner.pubkey(), true),
                     AccountMeta::new(self.market, false),
@@ -3900,11 +3914,12 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
     )
     .expect("mint backing collateral");
 
+    let deposit_ix = owner_deposit_instruction(&svm, portfolio.pubkey(), 123);
     send_tx(
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::Deposit { amount: 123 },
+        deposit_ix,
         vec![
             AccountMeta::new(user.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -4205,11 +4220,12 @@ fn deposit_to_market(
 ) -> Pubkey {
     let source = env.token_account(owner.pubkey(), amount as u64);
     env.svm.expire_blockhash();
+    let deposit_ix = env.deposit_instruction(portfolio, amount);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::Deposit { amount },
+        deposit_ix,
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(market, false),
@@ -4425,7 +4441,7 @@ fn v16_bpf_failed_deposit_spl_transfer_rolls_back_engine_credit() {
     let source_before = env.svm.get_account(&source).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
     let result = env.send(
-        ProgInstruction::Deposit { amount: 100 },
+        env.deposit_instruction(portfolio, 100),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -19753,7 +19769,7 @@ fn v16_attack_zero_amount_inputs_are_safe() {
     env.svm.expire_blockhash();
     let src = env.token_account(la.pubkey(), 0);
     let r_dep = env.send(
-        ProgInstruction::Deposit { amount: 0 },
+        env.deposit_instruction(pa, 0),
         vec![
             AccountMeta::new(la.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -19910,7 +19926,7 @@ fn v16_attack_deposit_underfunded_source_is_atomic() {
         .unwrap();
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 1_000_000 },
+        env.deposit_instruction(p, 1_000_000),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -19942,7 +19958,7 @@ fn v16_attack_deposit_underfunded_source_is_atomic() {
     // a valid deposit within balance still works afterward (state not corrupted).
     env.svm.expire_blockhash();
     let r2 = env.send(
-        ProgInstruction::Deposit { amount: 100 },
+        env.deposit_instruction(p, 100),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -22182,11 +22198,12 @@ fn v16_attack_cure_rejects_cross_market_portfolio_before_transfer() {
     .expect("init market-B portfolio");
     let deposit_b = env.token_account_for_mint(env.mint, owner.pubkey(), 100);
     env.svm.expire_blockhash();
+    let deposit_ix = env.deposit_instruction(portfolio_b, 100);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::Deposit { amount: 100 },
+        deposit_ix,
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -22529,7 +22546,7 @@ fn v16_regression_vault_pinned_to_canonical_ata_no_fragmentation() {
     let atk_src = env.token_account_for_mint(env.mint, attacker.pubkey(), 500_000);
     env.svm.expire_blockhash();
     let dep = env.send(
-        ProgInstruction::Deposit { amount: 500_000 },
+        env.deposit_instruction(ap, 500_000),
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24749,7 +24766,7 @@ fn v16_attack_deposit_from_vault_as_source_rejected() {
     // attacker tries to "deposit" using the VAULT as the source (vault is owned by vault_authority, not attacker).
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 500_000 },
+        env.deposit_instruction(ap, 500_000),
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -24782,7 +24799,7 @@ fn v16_attack_deposit_from_vault_as_source_rejected() {
     let other_src = env.token_account_for_mint(env.mint, other.pubkey(), 500_000);
     env.svm.expire_blockhash();
     let r2 = env.send(
-        ProgInstruction::Deposit { amount: 500_000 },
+        env.deposit_instruction(ap, 500_000),
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -25065,7 +25082,7 @@ fn v16_attack_resolved_mode_gates_all_live_ops() {
     let src = env.token_account_for_mint(env.mint, owner.pubkey(), 100);
     env.svm.expire_blockhash();
     let r_dep = env.send(
-        ProgInstruction::Deposit { amount: 100 },
+        env.deposit_instruction(p, 100),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -30108,11 +30125,12 @@ fn v16_attack_cross_market_portfolio_cannot_drain_foreign_vault() {
         )
         .unwrap();
     env.svm.expire_blockhash();
+    let deposit_ix = env.deposit_instruction(pb, 1_000_000);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::Deposit { amount: 1_000_000 },
+        deposit_ix,
         vec![
             AccountMeta::new(victim.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -30704,11 +30722,12 @@ fn v16_attack_close_resolved_rejects_cross_market_portfolio_payout() {
         )
         .unwrap();
     env.svm.expire_blockhash();
+    let deposit_ix = env.deposit_instruction(pb, 1_000_000);
     send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::Deposit { amount: 1_000_000 },
+        deposit_ix,
         vec![
             AccountMeta::new(victim.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -31219,11 +31238,12 @@ fn v16_attack_permissionless_crank_rejects_cross_market_target_portfolio() {
             )
             .unwrap();
         env.svm.expire_blockhash();
+        let deposit_ix = env.deposit_instruction(portfolio, 1_000_000);
         send_tx(
             &mut env.svm,
             env.program_id,
             &env.payer,
-            ProgInstruction::Deposit { amount: 1_000_000 },
+            deposit_ix,
             vec![
                 AccountMeta::new(owner.pubkey(), true),
                 AccountMeta::new(market_b, false),
@@ -31697,7 +31717,7 @@ fn v16_attack_wrong_token_program_rejected() {
     let src = env.token_account_for_mint(env.mint, owner.pubkey(), 100);
     env.svm.expire_blockhash();
     let r2 = env.send(
-        ProgInstruction::Deposit { amount: 100 },
+        env.deposit_instruction(p, 100),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -31760,7 +31780,7 @@ fn run_deposit_retry_replay_case(replay_retained: bool) -> (u64, u64, u64) {
             AccountMeta::new(env.vault, false),
             AccountMeta::new_readonly(spl_token::ID, false),
         ],
-        data: ProgInstruction::Deposit { amount: TOP_UP }.encode(),
+        data: env.deposit_instruction(victim, TOP_UP).encode(),
     };
     let intended = Transaction::new_signed_with_payer(
         &[heap_ix(), cu_ix(), deposit_ix.clone()],
@@ -31864,6 +31884,75 @@ fn v16_attack_deposit_retry_replay_funds_independent_winner() {
         replay.1, control.1,
         "rejecting the retained retry must prevent an extra independent-winner payout"
     );
+}
+
+#[test]
+fn v16_deposit_distinct_intents_can_land_out_of_order() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    let source = env.token_account(owner.pubkey(), 300);
+    let account = env.svm.get_account(&portfolio).unwrap();
+    let portfolio_id = state::read_owner_intent_portfolio_id(&account.data).unwrap();
+    let first_intent_id = state::next_owner_intent_id(&account.data).unwrap();
+    let accounts = vec![
+        AccountMeta::new(owner.pubkey(), true),
+        AccountMeta::new(env.market, false),
+        AccountMeta::new(portfolio, false),
+        AccountMeta::new(source, false),
+        AccountMeta::new(env.vault, false),
+        AccountMeta::new_readonly(spl_token::ID, false),
+    ];
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let later = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: accounts.clone(),
+                data: ProgInstruction::Deposit {
+                    portfolio_id,
+                    intent_id: first_intent_id + 1,
+                    amount: 200,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &owner],
+        blockhash,
+    );
+    let earlier = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts,
+                data: ProgInstruction::Deposit {
+                    portfolio_id,
+                    intent_id: first_intent_id,
+                    amount: 100,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &owner],
+        blockhash,
+    );
+
+    env.svm
+        .send_transaction(later)
+        .expect("later distinct deposit lands first");
+    env.svm
+        .send_transaction(earlier)
+        .expect("earlier distinct deposit remains valid");
+    assert_eq!(env.token_amount(source), 0);
+    let (destination, _) = env.withdraw_with_cu(&owner, portfolio, 300);
+    assert_eq!(env.token_amount(destination), 300);
 }
 
 // security.md sweep — haircut proportionality with disparate claims (#33/#37): two resolved winners
@@ -33395,7 +33484,7 @@ fn v16_attack_large_amount_deposit_withdraw_exact() {
     let src_over = env.token_account_for_mint(env.mint, owner.pubkey(), over as u64);
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: over },
+        env.deposit_instruction(p, over),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -33619,7 +33708,7 @@ fn v16_attack_cumulative_tvl_cap_enforced() {
     let src = env.token_account_for_mint(env.mint, b.pubkey(), 100);
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 100 },
+        env.deposit_instruction(pb, 100),
         vec![
             AccountMeta::new(b.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -34332,7 +34421,7 @@ fn v16_attack_deposit_during_active_close_safe() {
     let src = env.token_account_for_mint(env.mint, owner.pubkey(), 500);
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 500 },
+        env.deposit_instruction(p, 500),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -43067,7 +43156,11 @@ fn v16_attack_deposit_into_uninitialized_portfolio_rejects() {
 
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 1_000 },
+        ProgInstruction::Deposit {
+            portfolio_id: 1,
+            intent_id: 1,
+            amount: 1_000,
+        },
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -43175,7 +43268,7 @@ fn v16_attack_deposit_wrong_mint_source_rejects() {
 
     env.svm.expire_blockhash();
     let r = env.send(
-        ProgInstruction::Deposit { amount: 1_000_000 },
+        env.deposit_instruction(p, 1_000_000),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -43210,7 +43303,7 @@ fn v16_attack_deposit_wrong_mint_source_rejects() {
     let good_source = env.token_account_for_mint(env.mint, owner.pubkey(), 500);
     env.svm.expire_blockhash();
     let ok = env.send(
-        ProgInstruction::Deposit { amount: 500 },
+        env.deposit_instruction(p, 500),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -46678,7 +46771,7 @@ fn v16_attack_deposit_primary_only_withdraw_either() {
         .unwrap();
     env.svm.expire_blockhash();
     let r_dep = env.send(
-        ProgInstruction::Deposit { amount: 500 },
+        env.deposit_instruction(p, 500),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(market, false),
@@ -55275,7 +55368,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
     let fresh_deposit_source = env.token_account_for_mint(env.mint, taker.pubkey(), 50_000);
     env.svm.expire_blockhash();
     let fresh_deposit = env.send(
-        ProgInstruction::Deposit { amount: 50_000 },
+        env.deposit_instruction(taker_portfolio, 50_000),
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -55322,7 +55415,7 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
 
     env.svm.expire_blockhash();
     let stale_deposit = env.send(
-        ProgInstruction::Deposit { amount: 75_000 },
+        env.deposit_instruction(taker_portfolio, 75_000),
         vec![
             AccountMeta::new(taker.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -57343,7 +57436,7 @@ fn v16_attack_deposit_withdraw_amount_over_u64_max_rejects_no_truncation() {
     let src = env.token_account(owner.pubkey(), 1_000);
     env.svm.expire_blockhash();
     let r_dep = env.send(
-        ProgInstruction::Deposit { amount: over },
+        env.deposit_instruction(p, over),
         vec![
             AccountMeta::new(owner.pubkey(), true),
             AccountMeta::new(env.market, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -7,6 +7,7 @@ use percolator_prog::matcher_abi::{
     validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
 use percolator_prog::policy_v16;
+use percolator_prog::state;
 
 #[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
@@ -201,9 +202,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 #[kani::proof]
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
-    kani::assume(
-        tag == 3 || tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42,
-    );
+    kani::assume(tag == 4 || tag == 9 || tag == 28 || tag == 30 || tag == 41 || tag == 42);
     let amount: u128 = kani::any();
 
     let mut data = [0u8; 17];
@@ -211,7 +210,6 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     data[1..17].copy_from_slice(&amount.to_le_bytes());
 
     match (tag, Instruction::decode(&data).unwrap()) {
-        (3, Instruction::Deposit { amount: got }) => assert_eq!(got, amount),
         (4, Instruction::Withdraw { amount: got }) => assert_eq!(got, amount),
         (9, Instruction::TopUpInsurance { amount: got }) => assert_eq!(got, amount),
         (28, Instruction::ConvertReleasedPnl { amount: got }) => assert_eq!(got, amount),
@@ -226,6 +224,56 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
             },
         ) => assert_eq!(got, amount),
         _ => unreachable!(),
+    }
+}
+
+#[kani::proof]
+fn kani_v16_deposit_intent_decode_preserves_wire_fields() {
+    let portfolio_id: u64 = kani::any();
+    let intent_id: u64 = kani::any();
+    let amount: u128 = kani::any();
+    let encoded = Instruction::Deposit {
+        portfolio_id,
+        intent_id,
+        amount,
+    }
+    .encode();
+
+    assert_eq!(encoded.len(), 33);
+    match Instruction::decode(&encoded).unwrap() {
+        Instruction::Deposit {
+            portfolio_id: got_portfolio_id,
+            intent_id: got_intent_id,
+            amount: got_amount,
+        } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_intent_id, intent_id);
+            assert_eq!(got_amount, amount);
+        }
+        _ => unreachable!(),
+    }
+
+    let mut legacy = [0u8; 17];
+    legacy[0] = 3;
+    legacy[1..17].copy_from_slice(&amount.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
+}
+
+#[kani::proof]
+fn kani_v16_owner_intent_consumption_is_at_most_once() {
+    let max_seen: u64 = kani::any();
+    let seen_bitmap: u64 = kani::any();
+    let intent_id: u64 = kani::any();
+
+    if let Some((next_max_seen, next_seen_bitmap)) =
+        state::advance_owner_intent_replay_window(max_seen, seen_bitmap, intent_id)
+    {
+        assert!(state::advance_owner_intent_replay_window(
+            next_max_seen,
+            next_seen_bitmap,
+            intent_id,
+        )
+        .is_none());
     }
 }
 
@@ -1145,7 +1193,14 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
     assert_rejects_trailing_byte(Instruction::InitPortfolio, extra);
-    assert_rejects_trailing_byte(Instruction::Deposit { amount: 1 }, extra);
+    assert_rejects_trailing_byte(
+        Instruction::Deposit {
+            portfolio_id: 1,
+            intent_id: 1,
+            amount: 1,
+        },
+        extra,
+    );
     assert_rejects_trailing_byte(Instruction::Withdraw { amount: 1 }, extra);
     assert_rejects_trailing_byte(Instruction::TopUpInsurance { amount: 1 }, extra);
     assert_rejects_trailing_byte(


### PR DESCRIPTION
## Impact

An unprivileged relayer can retain multiple fee/blockhash variants of the same owner-signed `Deposit` intent and land more than one variant. If the duplicate lands after an adverse mark, it can force a second top-up into the now-insolvent portfolio and transfer that value to an independent winning trader during terminal settlement.

The public LiteSVM reproduction uses only normal instructions and real SPL accounts. A victim and independent winner open opposite positions with 1,000 collateral each. The victim signs two priority variants for one 500 deposit. After the intended variant lands, honest AuthMark updates move 100 -> 200 -> 300. Before this fix, the retained variant also succeeds at 49,193 CU. The victim source falls from 500 to 0 and the independent winner's terminal payout rises from 2,500 to 3,000.

## Root cause

`Deposit` was owner-signed but carried no portfolio incarnation or economic-intent identity. Solana transaction deduplication distinguishes fee/blockhash variants, so the program treated both as independent deposits.

## Fix

- Bind `Deposit` to the program-assigned `portfolio_id`.
- Consume a nonzero portfolio-local `intent_id` in a 64-ID replay bitmap.
- Permit distinct owner intents to land out of order while rejecting duplicate, zero, malformed, and too-old IDs.
- Grow legacy portfolio accounts and migrate pre-incarnation portfolios to the existing deterministic sentinel.
- Reject the legacy 17-byte deposit payload instead of silently accepting an unbound request.

The replay storage is intentionally generic owner-intent storage. PR #343 should rebase onto this change and reuse this window rather than allocating a second portfolio replay tail.

## TDD evidence

- `d80ae797` is the test-only RED commit on exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`; it fails because the retained transaction succeeds and transfers the extra 500.
- `11ca66a7` makes the same test GREEN and asserts source, market, portfolio, and vault rollback on duplicate rejection.
- A positive public LiteSVM test lands two distinct deposit IDs in reverse order and withdraws the exact 300 deposited.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 8/8 library and 567/567 LiteSVM/CU tests pass.
- `cargo kani --tests --harness kani_v16_deposit_intent_decode_preserves_wire_fields`: pass.
- `cargo kani --tests --harness kani_v16_owner_intent_consumption_is_at_most_once`: 12/12 checks pass.
- `cargo kani --tests --harness kani_v16_custody_payloads_reject_trailing_byte`: 1,500/1,500 checks pass (8 unreachable).
- Current wrapper, auth matcher, hostile matcher, and external matcher SBF fixtures were rebuilt before the full run.