### PR TITLE
[BLOCKER LoF] Make backing top-ups one-shot across retry variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - validates side encoding and engine readiness; it is not an admin override
 - **TopUpInsurance** (tag 9)
   - transfers collateral into vault; credits insurance fund in engine
+- **TopUpBackingBucket** (tag 24)
+  - transfers collateral into an asset's backing bucket under that domain's backing authority
+  - carries a nonzero, per-domain `intent_id`; a 64-entry replay window permits bounded
+    out-of-order landing while rejecting retained transaction variants for an already-consumed intent
 
 ### Trading
 - **TradeNoCpi**

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,9 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    pub const BACKING_TOPUP_REPLAY_WINDOW_LEN: usize = 16;
+    pub const ASSET_BACKING_TOPUP_REPLAY_OFF: usize =
+        ASSET_ORACLE_WRAPPER_LEN - 2 * BACKING_TOPUP_REPLAY_WINDOW_LEN;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,14 +158,14 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
-            ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
-            ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
-            PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
-            VERSION, WRAPPER_CONFIG_LEN,
+            ASSET_BACKING_TOPUP_REPLAY_OFF, ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN,
+            BACKING_TOPUP_REPLAY_WINDOW_LEN, HEADER_LEN, KIND_BACKING_DOMAIN_LEDGER,
+            KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC, MARKET_GROUP_LEN,
+            MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK,
+            ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK, ORACLE_MODE_HYBRID_AFTER_HOURS,
+            ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN, PORTFOLIO_ENGINE_ACCOUNT_LEN,
+            PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF, PORTFOLIO_MATCHER_CONFIG_LEN,
+            PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN, VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
     };
@@ -1368,6 +1371,76 @@ pub mod state {
         Ok(profile)
     }
 
+    /// Advance a bounded at-most-once window while allowing distinct signed intents to land out of
+    /// order. Bit zero represents `max_seen`; bit N represents `max_seen - N`.
+    #[inline]
+    pub fn advance_intent_replay_window(
+        max_seen: u64,
+        seen_bitmap: u64,
+        intent_id: u64,
+    ) -> Option<(u64, u64)> {
+        if intent_id == 0
+            || (max_seen == 0 && seen_bitmap != 0)
+            || (max_seen != 0 && seen_bitmap & 1 == 0)
+        {
+            return None;
+        }
+        if max_seen == 0 {
+            if intent_id > u64::BITS as u64 {
+                return None;
+            }
+            return Some((intent_id, 1));
+        }
+        if intent_id > max_seen {
+            let distance = intent_id - max_seen;
+            if distance > u64::BITS as u64 {
+                return None;
+            }
+            let shifted = if distance == u64::BITS as u64 {
+                0
+            } else {
+                seen_bitmap << distance
+            };
+            return Some((intent_id, shifted | 1));
+        }
+        let distance = max_seen - intent_id;
+        if distance >= u64::BITS as u64 {
+            return None;
+        }
+        let bit = 1u64 << distance;
+        if seen_bitmap & bit != 0 {
+            return None;
+        }
+        Some((max_seen, seen_bitmap | bit))
+    }
+
+    #[inline]
+    pub fn read_next_backing_topup_intent_id(
+        data: &[u8],
+        domain: usize,
+    ) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        let capacity = market_slot_capacity(data)?;
+        let domain_capacity = capacity
+            .checked_mul(2)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        if domain >= domain_capacity {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let asset_index = domain / 2;
+        let start = dynamic_slot_offset(asset_index)?
+            .checked_add(ASSET_BACKING_TOPUP_REPLAY_OFF)
+            .and_then(|offset| offset.checked_add((domain % 2) * BACKING_TOPUP_REPLAY_WINDOW_LEN))
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let window = data
+            .get(start..start + BACKING_TOPUP_REPLAY_WINDOW_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let max_seen = u64::from_le_bytes(window[0..8].try_into().unwrap());
+        max_seen
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineCounterOverflow.into())
+    }
+
     pub fn read_market_config_mode_and_capacity(
         data: &[u8],
     ) -> Result<(WrapperConfigV16, MarketModeV16, usize, usize), ProgramError> {
@@ -2524,6 +2597,7 @@ pub mod ix {
             domain: u16,
             amount: u128,
             expiry_slot: u64,
+            intent_id: u64,
         },
         WithdrawBackingBucket {
             domain: u16,
@@ -2791,6 +2865,7 @@ pub mod ix {
                     domain: read_u16(&mut rest)?,
                     amount: read_u128(&mut rest)?,
                     expiry_slot: read_u64(&mut rest)?,
+                    intent_id: read_u64(&mut rest)?,
                 },
                 50 => Self::WithdrawBackingBucket {
                     domain: read_u16(&mut rest)?,
@@ -3083,11 +3158,13 @@ pub mod ix {
                     domain,
                     amount,
                     expiry_slot,
+                    intent_id,
                 } => {
                     out.push(24);
                     push_u16(&mut out, domain);
                     push_u128(&mut out, amount);
                     push_u64(&mut out, expiry_slot);
+                    push_u64(&mut out, intent_id);
                 }
                 Self::WithdrawBackingBucket { domain, amount } => {
                     out.push(50);
@@ -5271,7 +5348,15 @@ pub mod processor {
                 domain,
                 amount,
                 expiry_slot,
-            } => handle_top_up_backing_bucket(program_id, accounts, domain, amount, expiry_slot),
+                intent_id,
+            } => handle_top_up_backing_bucket(
+                program_id,
+                accounts,
+                domain,
+                amount,
+                expiry_slot,
+                intent_id,
+            ),
             Instruction::WithdrawBackingBucket { domain, amount } => {
                 handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
             }
@@ -7557,6 +7642,7 @@ pub mod processor {
         domain: u16,
         amount: u128,
         expiry_slot: u64,
+        intent_id: u64,
     ) -> ProgramResult {
         let signer = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -7608,6 +7694,26 @@ pub mod processor {
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain_usize)?;
             expect_live_authority(&authorities.backing_bucket_authority, signer.key)?;
+            let asset_index = domain_usize / 2;
+            let replay_window = group
+                .markets
+                .get_mut(asset_index)
+                .ok_or(PercolatorError::InvalidInstruction)?
+                .wrapper
+                .get_mut(
+                    constants::ASSET_BACKING_TOPUP_REPLAY_OFF
+                        + (domain_usize % 2) * constants::BACKING_TOPUP_REPLAY_WINDOW_LEN
+                        ..constants::ASSET_BACKING_TOPUP_REPLAY_OFF
+                            + (domain_usize % 2 + 1) * constants::BACKING_TOPUP_REPLAY_WINDOW_LEN,
+                )
+                .ok_or(PercolatorError::InvalidAccountLen)?;
+            let max_seen = u64::from_le_bytes(replay_window[0..8].try_into().unwrap());
+            let seen_bitmap = u64::from_le_bytes(replay_window[8..16].try_into().unwrap());
+            let (next_max_seen, next_seen_bitmap) =
+                state::advance_intent_replay_window(max_seen, seen_bitmap, intent_id)
+                    .ok_or(PercolatorError::EngineStale)?;
+            replay_window[0..8].copy_from_slice(&next_max_seen.to_le_bytes());
+            replay_window[8..16].copy_from_slice(&next_seen_bitmap.to_le_bytes());
             let mut ledger_data = if let Some(ledger_ai) = ledger_ai {
                 Some(ledger_ai.try_borrow_mut_data()?)
             } else {
@@ -12202,6 +12308,35 @@ pub mod processor {
             assert_eq!(
                 state::allocate_portfolio_id(u64::MAX),
                 Err(PercolatorError::EngineCounterOverflow.into())
+            );
+        }
+
+        #[test]
+        fn intent_replay_window_accepts_bounded_reordering_once() {
+            let (max_seen, bitmap) = state::advance_intent_replay_window(0, 0, 1).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_intent_replay_window(max_seen, bitmap, 3).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_intent_replay_window(max_seen, bitmap, 2).unwrap();
+            assert_eq!((max_seen, bitmap), (3, 0b111));
+            assert_eq!(
+                state::advance_intent_replay_window(max_seen, bitmap, 2),
+                None
+            );
+            assert_eq!(state::advance_intent_replay_window(100, 1, 36), None);
+        }
+
+        #[test]
+        fn intent_replay_window_rejects_zero_and_malformed_state() {
+            assert_eq!(state::advance_intent_replay_window(0, 0, 0), None);
+            assert_eq!(state::advance_intent_replay_window(0, 1, 1), None);
+            assert_eq!(state::advance_intent_replay_window(1, 0, 2), None);
+            assert_eq!(state::advance_intent_replay_window(0, 0, 65), None);
+            assert_eq!(state::advance_intent_replay_window(1, 1, 66), None);
+            assert_eq!(
+                constants::ASSET_BACKING_TOPUP_REPLAY_OFF
+                    + 2 * constants::BACKING_TOPUP_REPLAY_WINDOW_LEN,
+                constants::ASSET_ORACLE_WRAPPER_LEN
             );
         }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,136 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+fn run_backing_topup_retry_replay_case(replay_retained: bool) -> (u64, u64, u64) {
+    const BACKING: u128 = 500;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const WINNING_DOMAIN: u16 = 1;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let publisher_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    let publisher = env.create_portfolio(&publisher_owner);
+    env.deposit(&winner_owner, winner, 1_000);
+    env.deposit(&loser_owner, loser, 1_000);
+
+    let source = env.token_account(env.admin.pubkey(), (2 * BACKING) as u64);
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let topup_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::TopUpBackingBucket {
+            domain: WINNING_DOMAIN,
+            amount: BACKING,
+            expiry_slot: 10_000,
+        }
+        .encode(),
+    };
+    let intended = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), topup_ix.clone()],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &env.admin],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            topup_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &env.admin],
+        blockhash,
+    );
+    env.svm
+        .send_transaction(intended)
+        .expect("the provider's intended top-up lands");
+    assert_eq!(env.token_amount(source), BACKING as u64);
+
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q,
+        100,
+        0,
+    );
+
+    for (slot, mark) in [(1, 200), (2, 350)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, mark);
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(publisher, false),
+            ],
+            &[],
+        )
+        .expect("publish the honest mark step");
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        350,
+        "the retained top-up lands only after the adverse mark is committed"
+    );
+
+    if replay_retained {
+        let source_before = env.svm.get_account(&source).unwrap();
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let vault_before = env.svm.get_account(&env.vault).unwrap();
+        env.svm
+            .send_transaction(retained)
+            .expect_err("a retained fee-bump variant must not debit the provider twice");
+        assert_eq!(env.svm.get_account(&source).unwrap(), source_before);
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    }
+
+    env.resolve();
+    let winner_first = env.close_resolved(&winner_owner, winner);
+    let loser_dest = env.close_resolved(&loser_owner, loser);
+    let winner_retry = env.close_resolved(&winner_owner, winner);
+    (
+        env.token_amount(source),
+        env.token_amount(winner_first) + env.token_amount(winner_retry),
+        env.token_amount(loser_dest),
+    )
+}
+
+#[test]
+fn v16_attack_backing_topup_retry_replay_funds_independent_winner() {
+    let control = run_backing_topup_retry_replay_case(false);
+    let replay = run_backing_topup_retry_replay_case(true);
+
+    assert_eq!(control.0, 500, "control retains the unsigned source half");
+    assert_eq!(
+        replay.0, 500,
+        "rejected retry retains the unsigned source half"
+    );
+    assert_eq!(control.2, 0, "the insolvent loser receives no payout");
+    assert_eq!(replay.2, 0, "the replay does not benefit the loser");
+    assert_eq!(
+        replay.1, control.1,
+        "rejecting the retained retry must prevent an extra independent-winner payout"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1240,6 +1240,15 @@ impl V16CuEnv {
         state::read_market(&account.data).unwrap()
     }
 
+    fn next_backing_topup_intent_id(&self, domain: u16) -> u64 {
+        self.next_backing_topup_intent_id_for_market(self.market, domain)
+    }
+
+    fn next_backing_topup_intent_id_for_market(&self, market: Pubkey, domain: u16) -> u64 {
+        let account = self.svm.get_account(&market).expect("market account");
+        state::read_next_backing_topup_intent_id(&account.data, domain as usize).unwrap()
+    }
+
     fn portfolio_state(&self, portfolio: Pubkey) -> PortfolioAccountV16 {
         let account = self.svm.get_account(&portfolio).expect("portfolio account");
         state::read_portfolio(&account.data).unwrap()
@@ -2798,6 +2807,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> u64 {
+        let intent_id = self.next_backing_topup_intent_id(domain);
         send_tx(
             &mut self.svm,
             self.program_id,
@@ -2806,6 +2816,7 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                intent_id,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -2972,6 +2983,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let intent_id = self.next_backing_topup_intent_id(domain);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -2993,6 +3005,7 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                intent_id,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -3014,6 +3027,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> (Pubkey, u64) {
+        let intent_id = self.next_backing_topup_intent_id(domain);
         let source = Pubkey::new_unique();
         self.svm
             .set_account(
@@ -3035,6 +3049,7 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                intent_id,
             },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
@@ -3057,6 +3072,7 @@ impl V16CuEnv {
         amount: u128,
         expiry_slot: u64,
     ) -> Pubkey {
+        let intent_id = self.next_backing_topup_intent_id(domain);
         self.ensure_signer_account(authority.pubkey());
         let source = self.token_account(authority.pubkey(), amount as u64);
         send_tx(
@@ -3067,6 +3083,7 @@ impl V16CuEnv {
                 domain,
                 amount,
                 expiry_slot,
+                intent_id,
             },
             vec![
                 AccountMeta::new(authority.pubkey(), true),
@@ -3933,6 +3950,7 @@ fn v16_bpf_mainnet_realistic_system_spl_ata_bootstrap_deposits_and_ledgers() {
             domain: 1,
             amount: 77,
             expiry_slot: 10,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -4232,6 +4250,7 @@ fn top_up_backing_bucket_to_market(
     amount: u128,
     expiry_slot: u64,
 ) -> Pubkey {
+    let intent_id = env.next_backing_topup_intent_id_for_market(market, domain);
     let source = env.token_account(env.admin.pubkey(), amount as u64);
     env.svm.expire_blockhash();
     send_tx(
@@ -4242,6 +4261,7 @@ fn top_up_backing_bucket_to_market(
             domain,
             amount,
             expiry_slot,
+            intent_id,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -4562,6 +4582,7 @@ fn v16_bpf_failed_domain_insurance_topup_transfer_rolls_back_budget_and_ledger()
 #[test]
 fn v16_bpf_failed_backing_topup_transfer_rolls_back_bucket_and_ledger() {
     let mut env = V16CuEnv::new();
+    let intent_id = env.next_backing_topup_intent_id(1);
     let ledger = env.backing_domain_ledger_account();
     let source = Pubkey::new_unique();
     env.svm
@@ -4589,6 +4610,7 @@ fn v16_bpf_failed_backing_topup_transfer_rolls_back_bucket_and_ledger() {
             domain: 1,
             amount: 100,
             expiry_slot: 10,
+            intent_id,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -5872,12 +5894,14 @@ fn v16_attack_retired_asset_domain_authority_cannot_refund_slot_and_block_reuse(
 
     let backing_source = env.token_account(rekeyed_backing_authority.pubkey(), 88);
     let backing_source_before = env.svm.get_account(&backing_source).unwrap();
+    let backing_intent_id = env.next_backing_topup_intent_id(2);
     env.svm.expire_blockhash();
     let backing_topup = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 2,
             amount: 88,
             expiry_slot: 10,
+            intent_id: backing_intent_id,
         },
         vec![
             AccountMeta::new(rekeyed_backing_authority.pubkey(), true),
@@ -22949,6 +22973,7 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
     .expect("init market B");
 
     let source_b = env.token_account(admin.pubkey(), 100);
+    let market_b_intent_id = env.next_backing_topup_intent_id_for_market(market_b, 1);
     env.svm.expire_blockhash();
     send_tx(
         &mut env.svm,
@@ -22958,6 +22983,7 @@ fn v16_attack_backing_ledger_market_binding_enforced() {
             domain: 1,
             amount: 100,
             expiry_slot: 10,
+            intent_id: market_b_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -23637,6 +23663,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
 
     let backing_source = env.token_account(admin.pubkey(), 40);
     let backing_source_before = env.svm.get_account(&backing_source).unwrap();
+    let backing_reject_intent_id = env.next_backing_topup_intent_id_for_market(market_b, 1);
     env.svm.expire_blockhash();
     let backing_reject = send_tx(
         &mut env.svm,
@@ -23646,6 +23673,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
             domain: 1,
             amount: 40,
             expiry_slot: 10,
+            intent_id: backing_reject_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -23733,6 +23761,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
 
     let backing_ledger_b = env.backing_domain_ledger_account();
     let backing_ok_source = env.token_account(admin.pubkey(), 40);
+    let backing_ok_intent_id = env.next_backing_topup_intent_id_for_market(market_b, 1);
     env.svm.expire_blockhash();
     let backing_ok = send_tx(
         &mut env.svm,
@@ -23742,6 +23771,7 @@ fn v16_attack_topup_optional_ledgers_reject_cross_market_reuse() {
             domain: 1,
             amount: 40,
             expiry_slot: 10,
+            intent_id: backing_ok_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24424,12 +24454,14 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
     );
 
     let top_up_backing_source = env.token_account(admin.pubkey(), 30);
+    let top_up_backing_intent_id = env.next_backing_topup_intent_id(1);
     env.svm.expire_blockhash();
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
             amount: 30,
             expiry_slot: 10,
+            intent_id: top_up_backing_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24633,12 +24665,14 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
     assert_eq!(env.token_amount(top_up_domain_source), 20);
 
     let top_up_backing_source = env.token_account(admin.pubkey(), 30);
+    let top_up_backing_intent_id = env.next_backing_topup_intent_id(1);
     env.svm.expire_blockhash();
     let top_up_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
             amount: 30,
             expiry_slot: 10,
+            intent_id: top_up_backing_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24870,12 +24904,14 @@ fn v16_attack_topups_cannot_use_vault_as_source() {
         "TopUpInsuranceDomain",
     );
     let expiry_slot = env.svm.get_sysvar::<Clock>().slot + 10_000;
+    let backing_intent_id = env.next_backing_topup_intent_id(1);
     reject_alias(
         &mut env,
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
             amount: 500,
             expiry_slot,
+            intent_id: backing_intent_id,
         },
         "TopUpBackingBucket",
     );
@@ -25282,6 +25318,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
     );
 
     let backing_src = env.token_account_for_mint(env.mint, admin.pubkey(), 700);
+    let backing_intent_id = env.next_backing_topup_intent_id(1);
     let market_before = env.svm.get_account(&env.market).unwrap();
     let source_before = env.svm.get_account(&backing_src).unwrap();
     let fake_before = env.svm.get_account(&fake_vault).unwrap();
@@ -25294,6 +25331,7 @@ fn v16_attack_domain_topups_pinned_to_canonical_vault() {
             domain: 1,
             amount: 700,
             expiry_slot: 10_000,
+            intent_id: backing_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -25391,6 +25429,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
             domain: BAD_DOMAIN,
             amount: 456,
             expiry_slot: 10_000,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -31780,6 +31819,7 @@ fn v16_attack_haircut_proportional_to_claim_size() {
 fn v16_attack_topup_backing_bucket_authority_gated() {
     let mut env = V16CuEnv::new();
     let (_, g0) = env.market_state();
+    let intent_id = env.next_backing_topup_intent_id(0);
     let donor = Keypair::new();
     env.ensure_signer_account(donor.pubkey());
     let src = env.token_account_for_mint(env.mint, donor.pubkey(), 500);
@@ -31793,6 +31833,7 @@ fn v16_attack_topup_backing_bucket_authority_gated() {
             domain: 0,
             amount: 500,
             expiry_slot: 10_000,
+            intent_id,
         },
         vec![
             AccountMeta::new(donor.pubkey(), true),
@@ -31949,6 +31990,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_earnings
 
     let ledger2 = env.backing_domain_ledger_account();
     let source2 = env.token_account(asset1_backing.pubkey(), 300);
+    let intent_id = env.next_backing_topup_intent_id(2);
     env.svm.expire_blockhash();
     send_tx(
         &mut env.svm,
@@ -31958,6 +32000,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_earnings
             domain: 2,
             amount: 300,
             expiry_slot: 10_000,
+            intent_id,
         },
         vec![
             AccountMeta::new(asset1_backing.pubkey(), true),
@@ -33656,6 +33699,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
         let ledger_before = env.svm.get_account(&ledger).unwrap();
         let source_before = env.svm.get_account(&source).unwrap();
         let vault_before = env.svm.get_account(&env.vault).unwrap();
+        let intent_id = env.next_backing_topup_intent_id(1);
 
         env.svm.expire_blockhash();
         let result = env.send(
@@ -33663,6 +33707,7 @@ fn v16_attack_topups_cannot_bypass_cumulative_tvl_cap() {
                 domain: 1,
                 amount: 2,
                 expiry_slot: 10_000,
+                intent_id,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -35295,6 +35340,7 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
 
     // helper: inline TopUpBackingBucket returning Result (the env helper panics on reject).
     let top_up = |env: &mut V16CuEnv, amount: u128, expiry: u64| -> Result<u64, String> {
+        let intent_id = env.next_backing_topup_intent_id(0);
         let source = Pubkey::new_unique();
         env.svm
             .set_account(
@@ -35317,6 +35363,7 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
                 domain: 0,
                 amount,
                 expiry_slot: expiry,
+                intent_id,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -55252,12 +55299,14 @@ fn v16_attack_live_value_paths_reject_when_resolve_matured() {
         "TopUpInsuranceDomain must reject once the market is resolve-matured"
     );
 
+    let stale_backing_intent_id = env.next_backing_topup_intent_id(1);
     env.svm.expire_blockhash();
     let stale_backing = env.send(
         ProgInstruction::TopUpBackingBucket {
             domain: 1,
             amount: 30,
             expiry_slot: 100,
+            intent_id: stale_backing_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -58004,6 +58053,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
 
     let backing_source = env.token_account_for_mint(env.mint, admin.pubkey(), 13);
     let backing_source_before = env.svm.get_account(&backing_source).unwrap();
+    let backing_intent_id = env.next_backing_topup_intent_id(1);
     env.svm.expire_blockhash();
     let backing_reject = send_tx(
         &mut env.svm,
@@ -58013,6 +58063,7 @@ fn v16_attack_value_topups_reject_delegated_canonical_vault() {
             domain: 1,
             amount: 13,
             expiry_slot: 10_000,
+            intent_id: backing_intent_id,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -59558,12 +59609,14 @@ fn v16_attack_backing_topup_rejects_lapsed_expiry() {
     let admin = env.admin.insecure_clone();
     let source = env.token_account(admin.pubkey(), 50);
     let topup = |env: &mut V16CuEnv, expiry: u64| -> Result<u64, String> {
+        let intent_id = env.next_backing_topup_intent_id(1);
         env.svm.expire_blockhash();
         env.send(
             ProgInstruction::TopUpBackingBucket {
                 domain: 1,
                 amount: 50,
                 expiry_slot: expiry,
+                intent_id,
             },
             vec![
                 AccountMeta::new(admin.pubkey(), true),
@@ -59718,6 +59771,89 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     }
 }
 
+#[test]
+fn v16_backing_topup_intents_allow_bounded_out_of_order_landing() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+
+    let opposite_domain_source = env.token_account(admin.pubkey(), 1);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::TopUpBackingBucket {
+            domain: 0,
+            amount: 1,
+            expiry_slot: 10_000,
+            intent_id: 1,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(opposite_domain_source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    )
+    .expect("one domain's intent must not consume the opposite domain's replay window");
+    assert_eq!(env.next_backing_topup_intent_id(0), 2);
+    assert_eq!(env.next_backing_topup_intent_id(1), 1);
+
+    for intent_id in [3, 1, 2] {
+        let source = env.token_account(admin.pubkey(), 1);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::TopUpBackingBucket {
+                domain: 1,
+                amount: 1,
+                expiry_slot: 10_000,
+                intent_id,
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(source, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&admin],
+        )
+        .expect("distinct backing intents may land out of order");
+        assert_eq!(env.token_amount(source), 0);
+    }
+    assert_eq!(env.next_backing_topup_intent_id(1), 4);
+
+    for (intent_id, label) in [(68, "far-future"), (2, "consumed")] {
+        let rejected_source = env.token_account(admin.pubkey(), 1);
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let source_before = env.svm.get_account(&rejected_source).unwrap();
+        let vault_before = env.svm.get_account(&env.vault).unwrap();
+        env.svm.expire_blockhash();
+        let rejected = env.send(
+            ProgInstruction::TopUpBackingBucket {
+                domain: 1,
+                amount: 1,
+                expiry_slot: 10_000,
+                intent_id,
+            },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(rejected_source, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&admin],
+        );
+        assert!(rejected.is_err(), "{} backing intent must reject", label);
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(
+            env.svm.get_account(&rejected_source).unwrap(),
+            source_before
+        );
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    }
+}
+
 fn run_backing_topup_retry_replay_case(replay_retained: bool) -> (u64, u64, u64) {
     const BACKING: u128 = 500;
     const SIZE_Q: i128 = 10 * POS_SCALE as i128;
@@ -59736,6 +59872,7 @@ fn run_backing_topup_retry_replay_case(replay_retained: bool) -> (u64, u64, u64)
     env.deposit(&loser_owner, loser, 1_000);
 
     let source = env.token_account(env.admin.pubkey(), (2 * BACKING) as u64);
+    let intent_id = env.next_backing_topup_intent_id(WINNING_DOMAIN);
     env.svm.expire_blockhash();
     let blockhash = env.svm.latest_blockhash();
     let topup_ix = Instruction {
@@ -59751,6 +59888,7 @@ fn run_backing_topup_retry_replay_case(replay_retained: bool) -> (u64, u64, u64)
             domain: WINNING_DOMAIN,
             amount: BACKING,
             expiry_slot: 10_000,
+            intent_id,
         }
         .encode(),
     };

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -6,7 +6,25 @@ use percolator_prog::ix::{CrankObservationHint, Instruction};
 use percolator_prog::matcher_abi::{
     validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
-use percolator_prog::policy_v16;
+use percolator_prog::{policy_v16, state};
+
+#[kani::proof]
+fn kani_v16_intent_replay_window_is_at_most_once() {
+    let max_seen: u64 = kani::any();
+    let seen_bitmap: u64 = kani::any();
+    let intent_id: u64 = kani::any();
+
+    if let Some((next_max_seen, next_seen_bitmap)) =
+        state::advance_intent_replay_window(max_seen, seen_bitmap, intent_id)
+    {
+        assert_eq!(next_seen_bitmap & 1, 1);
+        assert!(next_max_seen >= intent_id);
+        assert_eq!(
+            state::advance_intent_replay_window(next_max_seen, next_seen_bitmap, intent_id),
+            None
+        );
+    }
+}
 
 #[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
@@ -355,22 +373,26 @@ fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let amount: u128 = kani::any();
     let expiry_slot: u64 = kani::any();
+    let intent_id: u64 = kani::any();
 
-    let mut data = [0u8; 27];
+    let mut data = [0u8; 35];
     data[0] = 24;
     data[1..3].copy_from_slice(&domain.to_le_bytes());
     data[3..19].copy_from_slice(&amount.to_le_bytes());
     data[19..27].copy_from_slice(&expiry_slot.to_le_bytes());
+    data[27..35].copy_from_slice(&intent_id.to_le_bytes());
 
     match Instruction::decode(&data).unwrap() {
         Instruction::TopUpBackingBucket {
             domain: got_domain,
             amount: got_amount,
             expiry_slot: got_expiry,
+            intent_id: got_intent_id,
         } => {
             assert_eq!(got_domain, domain);
             assert_eq!(got_amount, amount);
             assert_eq!(got_expiry, expiry_slot);
+            assert_eq!(got_intent_id, intent_id);
         }
         _ => unreachable!(),
     }
@@ -1153,6 +1175,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
             domain: 1,
             amount: 1,
             expiry_slot: 10,
+            intent_id: 1,
         },
         extra,
     );
@@ -1496,7 +1519,7 @@ fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let top_up_domain = [56u8; 17];
     assert!(Instruction::decode(&top_up_domain).is_err());
 
-    let top_up_backing = [24u8; 25];
+    let top_up_backing = [24u8; 34];
     assert!(Instruction::decode(&top_up_backing).is_err());
 
     let withdraw_insurance = [23u8; 16];


### PR DESCRIPTION
## What changed

- Add a nonzero `intent_id` to `TopUpBackingBucket`.
- Track a 64-entry replay window independently for each backing domain, allowing bounded out-of-order landing while rejecting duplicate retained variants.
- Reject initial or forward jumps greater than 64 so an old authority cannot poison the counter with `u64::MAX`.
- Add wire-format, truncation, replay-window, cross-domain isolation, and public LiteSVM regression coverage.

## Public exploit

An honest backing provider signs two fee-bump variants of the same 500-unit top-up using the same blockhash and instruction payload. The intended variant lands. After a normal public trade and an honest adverse mark move, an unprivileged relayer lands the retained variant before resolution.

On exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`:

- control: provider source `500`, independent winner payout `2500`, loser payout `0`
- replay: provider source `0`, independent winner payout `3000`, loser payout `0`
- retained transaction succeeds at `34,844 CU`

The exploit uses only public instructions, a normally initialized AuthMark market, real SPL token accounts, and no protocol-state injection. The second debit becomes backing for an independent winner, so this is net extractable loss from the honest provider.

## Root cause

`TopUpBackingBucket` had no at-most-once identity. Solana fee-bump variants may share the same semantic instruction and recent blockhash but have distinct transaction signatures, so both variants could execute.

## TDD commits

- RED: `e2bd5e3e` reproduces the retained-variant loss on the exact parent.
- GREEN: `1037c355` rejects the retained duplicate atomically while preserving bounded out-of-order intents.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets` (`8` library + `567` LiteSVM/CU tests green)
- focused RED/GREEN exploit and out-of-order/cross-domain LiteSVM tests
- Kani: replay-window at-most-once, backing-top-up wire preservation, custody trailing-byte rejection
- `cargo fmt --check`
- `git diff --check`

## Integration note

The new `intent_id` is appended after `expiry_slot`. The replay state occupies the final 32 bytes of each 512-byte asset wrapper as two independent 16-byte domain windows.