### PR TITLE
[NOT REAL LoF][SIGNED-INTENT HARDENING] Make backing withdrawals one-shot across retry variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,9 @@ This section describes intent and operational ordering, not argument-by-argument
 - The per-slot effective-price movement cap is a risk parameter set at init; there is no standalone `SetOraclePriceCap` instruction in the current ABI.
 
 ### Insurance management
+- **WithdrawBackingBucket** (tag 50)
+  - provider withdrawal intents carry an asset-level `intent_id`; a 64-intent window accepts
+    bounded out-of-order landing across both domains while rejecting every intent at most once
 - **WithdrawInsurance** (tag 41)
   - unbounded resolved-market insurance withdrawal
   - gated by the asset-0 insurance authority, with shutdown-drain cases for nonzero assets gated by

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -49,6 +49,9 @@ pub mod constants {
     pub const WRAPPER_CONFIG_LEN: usize = 448;
     pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
+    pub const BACKING_WITHDRAW_REPLAY_WINDOW_LEN: usize = 16;
+    pub const ASSET_BACKING_WITHDRAW_REPLAY_OFF: usize =
+        ASSET_ORACLE_WRAPPER_LEN - 3 * BACKING_WITHDRAW_REPLAY_WINDOW_LEN;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
     pub const PORTFOLIO_STATE_LEN: usize = size_of::<PortfolioAccountV16Account>();
@@ -155,14 +158,14 @@ pub mod error {
 pub mod state {
     use crate::{
         constants::{
-            ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN, HEADER_LEN,
-            KIND_BACKING_DOMAIN_LEDGER, KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC,
-            MARKET_GROUP_LEN, MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP,
-            ORACLE_LEG_FLAGS_MASK, ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK,
-            ORACLE_MODE_HYBRID_AFTER_HOURS, ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN,
-            PORTFOLIO_ENGINE_ACCOUNT_LEN, PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN,
-            VERSION, WRAPPER_CONFIG_LEN,
+            ASSET_BACKING_WITHDRAW_REPLAY_OFF, ASSET_ORACLE_PROFILE_LEN, ASSET_ORACLE_WRAPPER_LEN,
+            BACKING_WITHDRAW_REPLAY_WINDOW_LEN, HEADER_LEN, KIND_BACKING_DOMAIN_LEDGER,
+            KIND_INSURANCE_LEDGER, KIND_MARKET, KIND_PORTFOLIO, MAGIC, MARKET_GROUP_LEN,
+            MARKET_GROUP_OFF, MIN_MARKET_ACCOUNT_LEN, ORACLE_LEG_CAP, ORACLE_LEG_FLAGS_MASK,
+            ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK, ORACLE_MODE_HYBRID_AFTER_HOURS,
+            ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN, PORTFOLIO_ENGINE_ACCOUNT_LEN,
+            PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF, PORTFOLIO_MATCHER_CONFIG_LEN,
+            PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_STATE_LEN, VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
     };
@@ -1368,6 +1371,71 @@ pub mod state {
         Ok(profile)
     }
 
+    /// Advance a bounded at-most-once window while allowing distinct signed intents to land out of
+    /// order. Bit zero represents `max_seen`; bit N represents `max_seen - N`.
+    #[inline]
+    pub fn advance_intent_replay_window(
+        max_seen: u64,
+        seen_bitmap: u64,
+        intent_id: u64,
+    ) -> Option<(u64, u64)> {
+        if intent_id == 0
+            || (max_seen == 0 && seen_bitmap != 0)
+            || (max_seen != 0 && seen_bitmap & 1 == 0)
+        {
+            return None;
+        }
+        if max_seen == 0 {
+            if intent_id > u64::BITS as u64 {
+                return None;
+            }
+            return Some((intent_id, 1));
+        }
+        if intent_id > max_seen {
+            let distance = intent_id - max_seen;
+            if distance > u64::BITS as u64 {
+                return None;
+            }
+            let shifted = if distance == u64::BITS as u64 {
+                0
+            } else {
+                seen_bitmap << distance
+            };
+            return Some((intent_id, shifted | 1));
+        }
+        let distance = max_seen - intent_id;
+        if distance >= u64::BITS as u64 {
+            return None;
+        }
+        let bit = 1u64 << distance;
+        if seen_bitmap & bit != 0 {
+            return None;
+        }
+        Some((max_seen, seen_bitmap | bit))
+    }
+
+    #[inline]
+    pub fn read_next_backing_withdraw_intent_id(
+        data: &[u8],
+        asset_index: usize,
+    ) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        let capacity = market_slot_capacity(data)?;
+        if asset_index >= capacity {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let start = dynamic_slot_offset(asset_index)?
+            .checked_add(ASSET_BACKING_WITHDRAW_REPLAY_OFF)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let window = data
+            .get(start..start + BACKING_WITHDRAW_REPLAY_WINDOW_LEN)
+            .ok_or(PercolatorError::InvalidAccountLen)?;
+        let max_seen = u64::from_le_bytes(window[0..8].try_into().unwrap());
+        max_seen
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineCounterOverflow.into())
+    }
+
     pub fn read_market_config_mode_and_capacity(
         data: &[u8],
     ) -> Result<(WrapperConfigV16, MarketModeV16, usize, usize), ProgramError> {
@@ -2528,6 +2596,7 @@ pub mod ix {
         WithdrawBackingBucket {
             domain: u16,
             amount: u128,
+            intent_id: u64,
         },
         ConvertReleasedPnl {
             amount: u128,
@@ -2795,6 +2864,7 @@ pub mod ix {
                 50 => Self::WithdrawBackingBucket {
                     domain: read_u16(&mut rest)?,
                     amount: read_u128(&mut rest)?,
+                    intent_id: read_u64(&mut rest)?,
                 },
                 28 => Self::ConvertReleasedPnl {
                     amount: read_u128(&mut rest)?,
@@ -3089,10 +3159,15 @@ pub mod ix {
                     push_u128(&mut out, amount);
                     push_u64(&mut out, expiry_slot);
                 }
-                Self::WithdrawBackingBucket { domain, amount } => {
+                Self::WithdrawBackingBucket {
+                    domain,
+                    amount,
+                    intent_id,
+                } => {
                     out.push(50);
                     push_u16(&mut out, domain);
                     push_u128(&mut out, amount);
+                    push_u64(&mut out, intent_id);
                 }
                 Self::ConvertReleasedPnl { amount } => {
                     out.push(28);
@@ -5272,9 +5347,11 @@ pub mod processor {
                 amount,
                 expiry_slot,
             } => handle_top_up_backing_bucket(program_id, accounts, domain, amount, expiry_slot),
-            Instruction::WithdrawBackingBucket { domain, amount } => {
-                handle_withdraw_backing_bucket(program_id, accounts, domain, amount)
-            }
+            Instruction::WithdrawBackingBucket {
+                domain,
+                amount,
+                intent_id,
+            } => handle_withdraw_backing_bucket(program_id, accounts, domain, amount, intent_id),
             Instruction::ConvertReleasedPnl { amount } => {
                 handle_convert_released_pnl(program_id, accounts, amount)
             }
@@ -7657,6 +7734,7 @@ pub mod processor {
         accounts: &'a [AccountInfo<'a>],
         domain: u16,
         amount: u128,
+        intent_id: u64,
     ) -> ProgramResult {
         let authority = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -7716,6 +7794,25 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
+            let asset_index = domain_usize / 2;
+            let replay_window = group
+                .markets
+                .get_mut(asset_index)
+                .ok_or(PercolatorError::InvalidInstruction)?
+                .wrapper
+                .get_mut(
+                    constants::ASSET_BACKING_WITHDRAW_REPLAY_OFF
+                        ..constants::ASSET_BACKING_WITHDRAW_REPLAY_OFF
+                            + constants::BACKING_WITHDRAW_REPLAY_WINDOW_LEN,
+                )
+                .ok_or(PercolatorError::InvalidAccountLen)?;
+            let max_seen = u64::from_le_bytes(replay_window[0..8].try_into().unwrap());
+            let seen_bitmap = u64::from_le_bytes(replay_window[8..16].try_into().unwrap());
+            let (next_max_seen, next_seen_bitmap) =
+                state::advance_intent_replay_window(max_seen, seen_bitmap, intent_id)
+                    .ok_or(PercolatorError::EngineStale)?;
+            replay_window[0..8].copy_from_slice(&next_max_seen.to_le_bytes());
+            replay_window[8..16].copy_from_slice(&next_seen_bitmap.to_le_bytes());
             let ledger_authority = if admin_shutdown_authorized && !local_authorized {
                 cfg.marketauth
             } else {
@@ -12202,6 +12299,36 @@ pub mod processor {
             assert_eq!(
                 state::allocate_portfolio_id(u64::MAX),
                 Err(PercolatorError::EngineCounterOverflow.into())
+            );
+        }
+
+        #[test]
+        fn intent_replay_window_accepts_bounded_reordering_once() {
+            let (max_seen, bitmap) = state::advance_intent_replay_window(0, 0, 1).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_intent_replay_window(max_seen, bitmap, 3).unwrap();
+            let (max_seen, bitmap) =
+                state::advance_intent_replay_window(max_seen, bitmap, 2).unwrap();
+            assert_eq!((max_seen, bitmap), (3, 0b111));
+            assert_eq!(
+                state::advance_intent_replay_window(max_seen, bitmap, 2),
+                None
+            );
+            assert_eq!(state::advance_intent_replay_window(100, 1, 36), None);
+        }
+
+        #[test]
+        fn intent_replay_window_rejects_zero_malformed_and_poisoning_jumps() {
+            assert_eq!(state::advance_intent_replay_window(0, 0, 0), None);
+            assert_eq!(state::advance_intent_replay_window(0, 1, 1), None);
+            assert_eq!(state::advance_intent_replay_window(1, 0, 2), None);
+            assert_eq!(state::advance_intent_replay_window(0, 0, 65), None);
+            assert_eq!(state::advance_intent_replay_window(1, 1, 66), None);
+            assert_eq!(
+                constants::ASSET_BACKING_WITHDRAW_REPLAY_OFF
+                    + constants::BACKING_WITHDRAW_REPLAY_WINDOW_LEN,
+                constants::ASSET_ORACLE_WRAPPER_LEN
+                    - 2 * constants::BACKING_WITHDRAW_REPLAY_WINDOW_LEN
             );
         }
 

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3150,11 +3150,20 @@ impl V16CuEnv {
         domain: u16,
         amount: u128,
     ) -> u64 {
+        let intent_id = state::read_next_backing_withdraw_intent_id(
+            &self.svm.get_account(&self.market).unwrap().data,
+            domain as usize / 2,
+        )
+        .unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::WithdrawBackingBucket { domain, amount },
+            ProgInstruction::WithdrawBackingBucket {
+                domain,
+                amount,
+                intent_id,
+            },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -7536,6 +7545,7 @@ fn v16_bpf_cross_margin_positive_pnl_allows_backed_risk_increase_on_negative_leg
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: over_watermark_amount,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -11927,6 +11937,7 @@ fn v16_bpf_failed_backing_withdraw_transfer_rolls_back_bucket_and_ledger() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 40,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -14764,6 +14775,7 @@ fn v16_attack_backing_principal_withdraw_preserves_provider_earnings() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 2,
             amount: PRINCIPAL,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -14828,6 +14840,7 @@ fn v16_attack_backing_principal_withdraw_preserves_provider_earnings() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 2,
             amount: PRINCIPAL,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -19849,6 +19862,7 @@ fn v16_attack_backing_withdraw_cannot_strand_liened_winner() {
             ProgInstruction::WithdrawBackingBucket {
                 domain: 1,
                 amount: amt,
+                intent_id: 1,
             },
             vec![
                 AccountMeta::new(env.admin.pubkey(), true),
@@ -24487,6 +24501,7 @@ fn v16_attack_value_paths_cannot_use_portfolio_as_optional_ledger() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 10,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -24688,6 +24703,7 @@ fn v16_attack_value_paths_cannot_use_market_as_optional_ledger() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 10,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -25452,6 +25468,7 @@ fn v16_attack_domain_indexed_calls_reject_out_of_range_atomically() {
         ProgInstruction::WithdrawBackingBucket {
             domain: BAD_DOMAIN,
             amount: 1,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -31859,6 +31876,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_bucket()
         ProgInstruction::WithdrawBackingBucket {
             domain: 0,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(asset1_backing.pubkey(), true),
@@ -31898,6 +31916,7 @@ fn v16_attack_cross_asset_backing_authority_cannot_withdraw_other_asset_bucket()
         ProgInstruction::WithdrawBackingBucket {
             domain: 2,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(asset1_backing.pubkey(), true),
@@ -32120,6 +32139,7 @@ fn v16_attack_backing_withdraw_pinned_to_canonical_vault() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 500,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -35045,6 +35065,7 @@ fn v16_attack_resolved_backing_withdraw_requires_full_user_wind_down() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
@@ -35383,6 +35404,7 @@ fn v16_attack_backing_bucket_topup_withdraw_input_gates() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 0,
             amount: 1_000_001,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -54609,6 +54631,7 @@ fn v16_attack_live_backing_withdraw_rejects_exposed_target_effective_lag() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 0,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -56663,6 +56686,7 @@ fn v16_attack_live_domain_withdrawals_reject_when_resolve_matured() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 1,
             amount: 20,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -59129,6 +59153,7 @@ fn v16_attack_asset0_backing_rotation_rekeys_live_bucket_withdraw() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 0,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(admin.pubkey(), true),
@@ -59169,6 +59194,7 @@ fn v16_attack_asset0_backing_rotation_rekeys_live_bucket_withdraw() {
         ProgInstruction::WithdrawBackingBucket {
             domain: 0,
             amount: 100,
+            intent_id: 1,
         },
         vec![
             AccountMeta::new(new_backing.pubkey(), true),
@@ -59759,6 +59785,7 @@ fn run_backing_withdraw_retry_replay_case(replay_retained: bool) -> (u64, u64, u
         data: ProgInstruction::WithdrawBackingBucket {
             domain: WINNING_DOMAIN,
             amount: BACKING,
+            intent_id: 1,
         }
         .encode(),
     };
@@ -59859,4 +59886,59 @@ fn v16_attack_backing_withdraw_retry_replay_removes_independent_winner_backing()
         replay.1, control.1,
         "rejecting the retained retry must preserve the independent winner payout"
     );
+}
+
+#[test]
+fn v16_bpf_backing_withdraw_intents_land_out_of_order_once_across_domains() {
+    let mut env = V16CuEnv::new();
+    let admin = env.admin.insecure_clone();
+    env.top_up_backing_bucket(0, 100, 10_000);
+    env.top_up_backing_bucket(1, 100, 10_000);
+    let dest = env.token_account(admin.pubkey(), 0);
+
+    let withdraw = |domain, intent_id| ProgInstruction::WithdrawBackingBucket {
+        domain,
+        amount: 10,
+        intent_id,
+    };
+    for (domain, intent_id) in [(0, 3), (1, 1), (0, 2)] {
+        env.send(
+            withdraw(domain, intent_id),
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&admin],
+        )
+        .expect("distinct bounded intent lands out of order");
+    }
+    assert_eq!(env.token_amount(dest), 30);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let dest_before = env.svm.get_account(&dest).unwrap();
+    env.svm.expire_blockhash();
+    let duplicate = env.send(
+        withdraw(0, 2),
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        duplicate.is_err(),
+        "duplicate withdrawal intent must reject"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    assert_eq!(env.svm.get_account(&dest).unwrap(), dest_before);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,146 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+fn run_backing_withdraw_retry_replay_case(replay_retained: bool) -> (u64, u64, u64) {
+    const BACKING: u128 = 500;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const WINNING_DOMAIN: u16 = 1;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, 100);
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let publisher_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    let publisher = env.create_portfolio(&publisher_owner);
+    env.deposit(&winner_owner, winner, 1_000);
+    env.deposit(&loser_owner, loser, 1_000);
+
+    let first_source = env.token_account(env.admin.pubkey(), BACKING as u64);
+    env.top_up_backing_bucket_from_admin_token_with_cu(
+        first_source,
+        WINNING_DOMAIN,
+        BACKING,
+        10_000,
+    );
+    let provider_dest = env.token_account(env.admin.pubkey(), 0);
+
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let withdraw_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(provider_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::WithdrawBackingBucket {
+            domain: WINNING_DOMAIN,
+            amount: BACKING,
+        }
+        .encode(),
+    };
+    let intended = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), withdraw_ix.clone()],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &env.admin],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            withdraw_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &env.admin],
+        blockhash,
+    );
+    env.svm
+        .send_transaction(intended)
+        .expect("the provider's intended withdrawal lands");
+    assert_eq!(env.token_amount(provider_dest), BACKING as u64);
+
+    let replacement_source = env.token_account(env.admin.pubkey(), BACKING as u64);
+    env.top_up_backing_bucket_from_admin_token_with_cu(
+        replacement_source,
+        WINNING_DOMAIN,
+        BACKING,
+        10_000,
+    );
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q,
+        100,
+        0,
+    );
+
+    if replay_retained {
+        let market_before = env.svm.get_account(&env.market).unwrap();
+        let vault_before = env.svm.get_account(&env.vault).unwrap();
+        let dest_before = env.svm.get_account(&provider_dest).unwrap();
+        env.svm
+            .send_transaction(retained)
+            .expect_err("a retained fee-bump variant must not withdraw replacement backing");
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+        assert_eq!(env.svm.get_account(&provider_dest).unwrap(), dest_before);
+    }
+
+    for (slot, mark) in [(1, 200), (2, 350)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, mark);
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(publisher, false),
+            ],
+            &[],
+        )
+        .expect("publish the honest mark step");
+    }
+
+    env.resolve();
+    let winner_first = env.close_resolved(&winner_owner, winner);
+    let loser_dest = env.close_resolved(&loser_owner, loser);
+    let winner_retry = env.close_resolved(&winner_owner, winner);
+    (
+        env.token_amount(provider_dest),
+        env.token_amount(winner_first) + env.token_amount(winner_retry),
+        env.token_amount(loser_dest),
+    )
+}
+
+#[test]
+fn v16_attack_backing_withdraw_retry_replay_removes_independent_winner_backing() {
+    let control = run_backing_withdraw_retry_replay_case(false);
+    let replay = run_backing_withdraw_retry_replay_case(true);
+
+    assert_eq!(control.0, 500, "control keeps only the intended withdrawal");
+    assert_eq!(
+        replay.0, 500,
+        "rejected retry must not withdraw replacement backing"
+    );
+    assert_eq!(control.2, 0, "the insolvent loser receives no payout");
+    assert_eq!(replay.2, 0, "the replay does not benefit the loser");
+    assert_eq!(
+        replay.1, control.1,
+        "rejecting the retained retry must preserve the independent winner payout"
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -6,7 +6,25 @@ use percolator_prog::ix::{CrankObservationHint, Instruction};
 use percolator_prog::matcher_abi::{
     validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
-use percolator_prog::policy_v16;
+use percolator_prog::{policy_v16, state};
+
+#[kani::proof]
+fn kani_v16_intent_replay_window_is_at_most_once() {
+    let max_seen: u64 = kani::any();
+    let seen_bitmap: u64 = kani::any();
+    let intent_id: u64 = kani::any();
+
+    if let Some((next_max_seen, next_seen_bitmap)) =
+        state::advance_intent_replay_window(max_seen, seen_bitmap, intent_id)
+    {
+        assert_eq!(next_seen_bitmap & 1, 1);
+        assert!(next_max_seen >= intent_id);
+        assert_eq!(
+            state::advance_intent_replay_window(next_max_seen, next_seen_bitmap, intent_id),
+            None
+        );
+    }
+}
 
 #[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
@@ -380,16 +398,24 @@ fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
 fn kani_v16_withdraw_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let amount: u128 = kani::any();
+    let intent_id: u64 = kani::any();
 
-    let data = Instruction::WithdrawBackingBucket { domain, amount }.encode();
+    let data = Instruction::WithdrawBackingBucket {
+        domain,
+        amount,
+        intent_id,
+    }
+    .encode();
 
     match Instruction::decode(&data).unwrap() {
         Instruction::WithdrawBackingBucket {
             domain: got_domain,
             amount: got_amount,
+            intent_id: got_intent_id,
         } => {
             assert_eq!(got_domain, domain);
             assert_eq!(got_amount, amount);
+            assert_eq!(got_intent_id, intent_id);
         }
         _ => unreachable!(),
     }
@@ -1160,6 +1186,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
         Instruction::WithdrawBackingBucket {
             domain: 1,
             amount: 1,
+            intent_id: 1,
         },
         extra,
     );


### PR DESCRIPTION
## Impact

An unprivileged relayer can retain a fee-bump variant of an honest backing provider's already-landed `WithdrawBackingBucket` transaction. If the provider replenishes that bucket while the retained recent blockhash is still valid, the old variant can land again, remove the replacement backing, and reduce an independent trader's terminal payout after a legitimate adverse mark.

This needs no key compromise, oracle compromise, protocol-state injection, or malformed account.

## Exact-parent TDD

- Parent: `36fa587e1424a8c7fdde2c701c10938188a51876`
- RED: `0eeccc06`
- GREEN: `d2e370c7`
- Pre-fix retained withdrawal succeeds at 26,396 CU.
- Public LiteSVM differential: control `(provider_dest=500, winner=2500, loser=0)`; replay `(provider_dest=1000, winner=2000, loser=0)`.

## Fix

Tag 50 now carries an asset-level `intent_id`. A persistent 64-intent replay window accepts distinct withdrawals in bounded out-of-order order across both backing domains, but rejects duplicate, zero, malformed, too-old, and forward-poisoning IDs. The window is consumed only after authority/domain validation and rolls back with the instruction on every later error.

`read_next_backing_withdraw_intent_id` exposes the next client ID. Legacy tag-50 payloads reject instead of silently bypassing replay protection.

## Verification

- `cargo build-sbf --tools-version v1.52`
- built `tests/fixtures/auth_matcher` and `tests/fixtures/hostile_matcher` with the same SBF tools
- `cargo test --all-targets -- --test-threads=1`: 8 unit + 567 LiteSVM/CU tests passed
- `cargo kani --tests --harness kani_v16_intent_replay_window_is_at_most_once`
- `cargo kani --tests --harness kani_v16_withdraw_backing_bucket_decode_preserves_wire_fields`
- `cargo kani --tests --harness kani_v16_custody_payloads_reject_trailing_byte`
- `cargo fmt --all -- --check`
- `git diff --check`