### PR TITLE
[BLOCKER LoF] Bind terminal resolves to authority incarnations

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Assets 1..N are **truly permissionless ⇒ untrusted**. The protocol must guaran
   `base_unit_authority`). `marketauth` is the only key that can: **create market 0** (`InitMarket`),
   **create/retire assets 1..N and set the permissionless-create-fee policy**, **safely force-shutdown
   any asset including asset 0** (`ASSET_ACTION_SHUTDOWN` → RECOVERY with the `force_close_delay_slots`
-  exit window so traders can exit), **resolve/close the market** (`ResolveMarket`/`CloseSlab`),
+  exit window so traders can exit), **resolve/close the market**
+  (`ResolveMarket { expected_sequence }`/`CloseSlab`),
   **market policies**, and **rotate/swap the base-unit mint**. It is rotated via
   `UpdateAuthority { new_pubkey, expected_sequence }` (current `marketauth` signs, the non-zero
   replacement co-signs, and the checked market sequence makes the handoff one-shot; burn-to-zero is
@@ -386,6 +387,10 @@ This section describes intent and operational ordering, not argument-by-argument
   - setting `new_pubkey` to all zeros is rejected; `marketauth` must remain live for final slab reclaim
   - per-asset authorities (insurance/operator/backing/oracle, incl. asset 0) are rotated via
     `UpdateAssetAuthority`, not this instruction
+- **ResolveMarket** (tag 19)
+  - `ResolveMarket { expected_sequence }`: current `marketauth` signs and the expected sequence must
+    equal the program-owned market handoff sequence, so returning a pubkey to authority cannot revive
+    terminal actions signed during one of its prior incarnations
 - **UpdateAssetLifecycle** (tag 40)
   - appends/reactivates/retires assets 1..N, including permissionless create/reuse when the configured
     create fee is nonzero
@@ -736,7 +741,8 @@ At minimum, monitor:
 
 ### Governance / authority handling
 - `UpdateAuthority` rotates `marketauth`; the current authority and new key must both sign, and the
-  handoff must carry the current one-shot sequence.
+  handoff must carry the current one-shot sequence. `ResolveMarket` must carry that same current
+  sequence, which binds terminal authorization to the active authority incarnation.
 - `UpdateAssetAuthority` rotates per-asset authorities; non-admin self-rotation also requires the new key.
 - Burning is limited to `asset_admin`. Required market/domain authorities cannot be set to zero.
 
@@ -837,7 +843,7 @@ These are governance powers, not bugs:
 3. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_ORACLE }` (while marketauth holds asset-0's `asset_admin`)
    - choose who can push asset-0 AuthMark/EwmaMark updates.
    - impact: authority mark input control/censorship surface.
-4. `ResolveMarket`
+4. `ResolveMarket { expected_sequence }`
    - transition market to resolved mode using stored authority price.
    - impact: trading/deposits/new accounts are halted; market enters wind-down.
 5. `UpdateAssetAuthority { asset_index = 0, kind = ASSET_AUTH_INSURANCE }` (while marketauth holds asset-0's `asset_admin`)

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -1390,12 +1390,20 @@ pub mod state {
         current_sequence: u64,
         expected_sequence: u64,
     ) -> Result<u64, ProgramError> {
-        if current_sequence != expected_sequence {
-            return Err(PercolatorError::EngineStale.into());
-        }
+        require_marketauth_sequence(current_sequence, expected_sequence)?;
         current_sequence
             .checked_add(1)
             .ok_or_else(|| PercolatorError::EngineCounterOverflow.into())
+    }
+
+    pub fn require_marketauth_sequence(
+        current_sequence: u64,
+        expected_sequence: u64,
+    ) -> Result<(), ProgramError> {
+        if current_sequence != expected_sequence {
+            return Err(PercolatorError::EngineStale.into());
+        }
+        Ok(())
     }
 
     pub fn read_market_config_mode_and_capacity(
@@ -2549,7 +2557,10 @@ pub mod ix {
             amount: u128,
         },
         CloseSlab,
-        ResolveMarket,
+        /// Resolve only for the market-authority incarnation that authorized these bytes.
+        ResolveMarket {
+            expected_sequence: u64,
+        },
         TopUpBackingBucket {
             domain: u16,
             amount: u128,
@@ -2818,7 +2829,9 @@ pub mod ix {
                     amount: read_u128(&mut rest)?,
                 },
                 13 => Self::CloseSlab,
-                19 => Self::ResolveMarket,
+                19 => Self::ResolveMarket {
+                    expected_sequence: read_u64(&mut rest)?,
+                },
                 24 => Self::TopUpBackingBucket {
                     domain: read_u16(&mut rest)?,
                     amount: read_u128(&mut rest)?,
@@ -3111,7 +3124,10 @@ pub mod ix {
                     push_u128(&mut out, amount);
                 }
                 Self::CloseSlab => out.push(13),
-                Self::ResolveMarket => out.push(19),
+                Self::ResolveMarket { expected_sequence } => {
+                    out.push(19);
+                    push_u64(&mut out, expected_sequence);
+                }
                 Self::TopUpBackingBucket {
                     domain,
                     amount,
@@ -4592,13 +4608,12 @@ pub mod processor {
         Ok(())
     }
 
-    fn consume_marketauth_sequence_view(
-        group: &mut state::MarketViewMutV16<'_>,
-        expected_sequence: u64,
-    ) -> ProgramResult {
-        let wrapper = &mut group
+    fn read_marketauth_sequence_view(
+        group: &state::MarketViewMutV16<'_>,
+    ) -> Result<u64, ProgramError> {
+        let wrapper = &group
             .markets
-            .get_mut(0)
+            .get(0)
             .ok_or(PercolatorError::InvalidAccountLen)?
             .wrapper;
         let sequence_bytes = wrapper
@@ -4610,8 +4625,27 @@ pub mod processor {
             .ok_or(PercolatorError::InvalidAccountLen)?;
         let mut raw = [0u8; constants::ASSET_MARKETAUTH_SEQUENCE_LEN];
         raw.copy_from_slice(sequence_bytes);
-        let current_sequence = u64::from_le_bytes(raw);
+        Ok(u64::from_le_bytes(raw))
+    }
+
+    fn require_marketauth_sequence_view(
+        group: &state::MarketViewMutV16<'_>,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        state::require_marketauth_sequence(read_marketauth_sequence_view(group)?, expected_sequence)
+    }
+
+    fn consume_marketauth_sequence_view(
+        group: &mut state::MarketViewMutV16<'_>,
+        expected_sequence: u64,
+    ) -> ProgramResult {
+        let current_sequence = read_marketauth_sequence_view(group)?;
         let next_sequence = state::next_marketauth_sequence(current_sequence, expected_sequence)?;
+        let wrapper = &mut group
+            .markets
+            .get_mut(0)
+            .ok_or(PercolatorError::InvalidAccountLen)?
+            .wrapper;
         wrapper[constants::ASSET_MARKETAUTH_SEQUENCE_OFF
             ..constants::ASSET_MARKETAUTH_SEQUENCE_OFF + constants::ASSET_MARKETAUTH_SEQUENCE_LEN]
             .copy_from_slice(&next_sequence.to_le_bytes());
@@ -5329,7 +5363,9 @@ pub mod processor {
                 handle_top_up_insurance_domain(program_id, accounts, domain, amount)
             }
             Instruction::CloseSlab => handle_close_slab(program_id, accounts),
-            Instruction::ResolveMarket => handle_resolve_market(program_id, accounts),
+            Instruction::ResolveMarket { expected_sequence } => {
+                handle_resolve_market(program_id, accounts, expected_sequence)
+            }
             Instruction::TopUpBackingBucket {
                 domain,
                 amount,
@@ -8729,6 +8765,7 @@ pub mod processor {
     fn handle_resolve_market<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_sequence: u64,
     ) -> ProgramResult {
         let admin = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -8741,6 +8778,7 @@ pub mod processor {
             return Err(PercolatorError::EngineLockActive.into());
         }
         expect_live_authority(&cfg.marketauth, admin.key)?;
+        require_marketauth_sequence_view(&group, expected_sequence)?;
         let slot = Clock::get()
             .map(|c| c.slot)
             .unwrap_or(group.header.current_slot.get());

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -25651,6 +25651,139 @@ fn v16_attack_funding_direction_mark_below_index_conserves() {
     );
 }
 
+// A signed terminal action belongs to one market-authority incarnation, not merely to a pubkey.
+// Returning A to power after A -> C -> A must not revive a retained ResolveMarket signed during the
+// prior A incarnation and let an unprivileged relayer crystallize an independent trader's loss.
+#[test]
+fn v16_attack_presigned_resolve_does_not_revive_after_marketauth_aba() {
+    const PRICE: u64 = 100;
+    const ADVERSE_PRICE: u64 = 110;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = (10_000 * POS_SCALE) as i128;
+
+    let mut env = V16CuEnv::new();
+    env.configure_auth_mark_with_cu(0, PRICE);
+    let authority_a = env.admin.insecure_clone();
+    let authority_c = Keypair::new();
+    env.ensure_signer_account(authority_c.pubkey());
+
+    env.svm.expire_blockhash();
+    let retained_resolve = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(authority_a.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                data: ProgInstruction::ResolveMarket.encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &authority_a],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: authority_c.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(authority_a.pubkey(), true),
+            AccountMeta::new(authority_c.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&authority_a, &authority_c],
+    )
+    .expect("rotate A to C");
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAuthority {
+            new_pubkey: authority_a.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(authority_c.pubkey(), true),
+            AccountMeta::new(authority_a.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&authority_c, &authority_a],
+    )
+    .expect("rotate C back to a fresh A incarnation");
+
+    let winner_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&winner_owner, winner, DEPOSIT);
+    env.deposit(&victim_owner, victim, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &victim_owner,
+        victim,
+        SIZE_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(10);
+    env.push_auth_mark_with_cu(10, ADVERSE_PRICE);
+    for slot in [10u64, 11] {
+        env.svm.warp_to_slot(slot);
+        for portfolio in [victim, winner] {
+            env.svm.expire_blockhash();
+            let _ = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                &[],
+            );
+        }
+    }
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        ADVERSE_PRICE,
+        "honest authenticated mark creates a non-vacuous temporary PnL transfer"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let winner_before = env.svm.get_account(&winner).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(retained_resolve);
+    if replay.is_err() {
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&winner).unwrap(), winner_before);
+        assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+        assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+        assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+        return;
+    }
+
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Resolved);
+    env.svm.warp_to_slot(12);
+    let victim_dest = env.close_resolved(&victim_owner, victim);
+    let winner_dest = env.close_resolved(&winner_owner, winner);
+    let victim_payout = env.token_amount(victim_dest) as u128;
+    let winner_payout = env.token_amount(winner_dest) as u128;
+    assert_eq!(victim_payout, 900_000);
+    assert_eq!(winner_payout, 1_100_000);
+    panic!(
+        "retained resolve from the prior A incarnation transferred {} atoms of independent victim capital",
+        winner_payout - DEPOSIT
+    );
+}
+
 // security.md sweep — UpdateAuthority new-authority binding (#6): setting an authority to a non-zero
 // key requires THAT key to co-sign (handle_update_authority: expect_signer(new_authority) + key match).
 // Otherwise an admin (or attacker) could assign an authority to a key nobody controls (griefing/brick).

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2230,11 +2230,14 @@ impl V16CuEnv {
     }
 
     fn resolve(&mut self) -> u64 {
+        let expected_sequence =
+            state::read_marketauth_sequence(&self.svm.get_account(&self.market).unwrap().data)
+                .unwrap();
         send_tx(
             &mut self.svm,
             self.program_id,
             &self.payer,
-            ProgInstruction::ResolveMarket,
+            ProgInstruction::ResolveMarket { expected_sequence },
             vec![
                 AccountMeta::new(self.admin.pubkey(), true),
                 AccountMeta::new(self.market, false),
@@ -22439,7 +22442,9 @@ fn v16_attack_non_admin_cannot_resolve_or_configure() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(mallory.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -23888,7 +23893,9 @@ fn v16_attack_terminal_insurance_ledger_rejects_cross_market_reuse() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -24024,7 +24031,9 @@ fn v16_attack_terminal_withdraw_insurance_rejects_portfolio_as_ledger() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(admin.pubkey(), true),
             AccountMeta::new(market_b, false),
@@ -25678,7 +25687,10 @@ fn v16_attack_presigned_resolve_does_not_revive_after_marketauth_aba() {
                     AccountMeta::new(authority_a.pubkey(), true),
                     AccountMeta::new(env.market, false),
                 ],
-                data: ProgInstruction::ResolveMarket.encode(),
+                data: ProgInstruction::ResolveMarket {
+                    expected_sequence: 0,
+                }
+                .encode(),
             },
         ],
         Some(&env.payer.pubkey()),
@@ -25690,6 +25702,7 @@ fn v16_attack_presigned_resolve_does_not_revive_after_marketauth_aba() {
     env.send(
         ProgInstruction::UpdateAuthority {
             new_pubkey: authority_c.pubkey().to_bytes(),
+            expected_sequence: 0,
         },
         vec![
             AccountMeta::new(authority_a.pubkey(), true),
@@ -25703,6 +25716,7 @@ fn v16_attack_presigned_resolve_does_not_revive_after_marketauth_aba() {
     env.send(
         ProgInstruction::UpdateAuthority {
             new_pubkey: authority_a.pubkey().to_bytes(),
+            expected_sequence: 1,
         },
         vec![
             AccountMeta::new(authority_c.pubkey(), true),
@@ -27793,7 +27807,9 @@ fn v16_attack_close_slab_rejects_stale_marketauth_after_rotation() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 1,
+        },
         vec![
             AccountMeta::new(new_admin.pubkey(), true),
             AccountMeta::new(env.market, false),
@@ -28004,7 +28020,9 @@ fn v16_attack_close_slab_rejects_market_as_lamport_destination() {
         &mut svm,
         program_id,
         &payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 1,
+        },
         vec![
             AccountMeta::new(market.pubkey(), true),
             AccountMeta::new(market.pubkey(), false),
@@ -30872,7 +30890,9 @@ fn v16_attack_close_resolved_rejects_cross_market_portfolio_payout() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::ResolveMarket,
+        ProgInstruction::ResolveMarket {
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(env.admin.pubkey(), true),
             AccountMeta::new(market_b, false),

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -680,6 +680,34 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+fn kani_v16_resolve_market_decode_preserves_authority_sequence() {
+    let expected_sequence: u64 = kani::any();
+    let mut data = [0u8; 9];
+    data[0] = 19;
+    data[1..9].copy_from_slice(&expected_sequence.to_le_bytes());
+
+    match Instruction::decode(&data).unwrap() {
+        Instruction::ResolveMarket {
+            expected_sequence: got_sequence,
+        } => assert_eq!(got_sequence, expected_sequence),
+        _ => unreachable!(),
+    }
+
+    let mut with_trailing = [0u8; 10];
+    with_trailing[..9].copy_from_slice(&data);
+    with_trailing[9] = kani::any();
+    assert!(Instruction::decode(&with_trailing).is_err());
+}
+
+#[kani::proof]
+fn kani_v16_marketauth_sequence_gate_is_exact() {
+    let current_sequence: u64 = kani::any();
+    let expected_sequence: u64 = kani::any();
+    let accepted = state::require_marketauth_sequence(current_sequence, expected_sequence).is_ok();
+    assert_eq!(accepted, current_sequence == expected_sequence);
+}
+
+#[kani::proof]
 fn kani_v16_marketauth_sequence_is_exact_and_monotonic() {
     let current_sequence: u64 = kani::any();
     let expected_sequence: u64 = kani::any();
@@ -1233,7 +1261,6 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
     assert_rejects_trailing_byte(Instruction::CloseSlab, extra);
-    assert_rejects_trailing_byte(Instruction::ResolveMarket, extra);
     assert_rejects_trailing_byte(
         Instruction::UpdateAuthority {
             new_pubkey: [1u8; 32],


### PR DESCRIPTION
## Classification

`[BLOCKER LoF]`

Stacked on #345, which introduces the program-owned monotonic market-authority handoff sequence.

## Public exploit

An unprivileged relayer retains a valid `ResolveMarket` transaction signed by authority A. The
transaction initially fails while the market is not resolvable. After legitimate A -> C -> A
authority handoffs and an honest authenticated mark move from 100 to 110, the old bytes become
valid again because the wrapper checked only the current signer pubkey.

On exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`, RED commit `4f8b1290`
demonstrates the retained transaction resolving at the stale 100 mark:

- victim payout: 900,000
- winner payout: 1,100,000
- independent victim loss transferred to the winner: 100,000 atoms

The reproduction uses only normal public instructions, initialized SPL custody, valid authority
handoffs, two independent traders, and an unprivileged relayer. It does not inject protocol state,
assume a compromised key, or rely on an initialization footgun.

## Fix

- Encode `ResolveMarket { expected_sequence }`.
- Require that sequence to equal the program-owned market-authority handoff sequence before
  resolution.
- Reuse the existing handoff counter from #345; do not add another mirror counter.
- Prove exact sequence-gate behavior and wire-field/trailing-byte decoding with focused Kani
  harnesses.

The sequence is an authority-incarnation identifier. It advances only on a successful authority
handoff, so retained bytes from an earlier A incarnation remain stale after A returns.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1`
  - 6/6 library tests
  - 567/567 LiteSVM/CU tests
- `cargo kani --tests --harness kani_v16_resolve_market_decode_preserves_authority_sequence`
- `cargo kani --tests --harness kani_v16_marketauth_sequence_gate_is_exact`

Both Kani harnesses verified with zero failures.
