### PR TITLE
[BLOCKER DoS] Bind recovery forfeits to position episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,8 @@ This section describes intent and operational ordering, not argument-by-argument
 - **CureAndCancelClose** (tag 42)
   - owner-signed close recovery path; optional deposit is transferred first, then the engine cancels the pending close if the cure succeeds
 - **ForfeitRecoveryLeg** (tag 43)
-  - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget
+  - owner-signed recovery-leg forfeit for a selected asset and bounded B-delta budget; the payload
+    binds consent to both the program-assigned `portfolio_id` and the portfolio's `position_epoch`
 - **RebalanceReduce** (tag 44)
   - owner-signed risk-reducing rebalance against the wrapper-authenticated effective price vector;
     the payload binds consent to both the program-assigned `portfolio_id` and the portfolio's

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2676,6 +2676,8 @@ pub mod ix {
             optional_deposit: u128,
         },
         ForfeitRecoveryLeg {
+            portfolio_id: u64,
+            position_epoch: u64,
             asset_index: u16,
             b_delta_budget: u128,
         },
@@ -2951,6 +2953,8 @@ pub mod ix {
                     optional_deposit: read_u128(&mut rest)?,
                 },
                 43 => Self::ForfeitRecoveryLeg {
+                    portfolio_id: read_u64(&mut rest)?,
+                    position_epoch: read_u64(&mut rest)?,
                     asset_index: read_u16(&mut rest)?,
                     b_delta_budget: read_u128(&mut rest)?,
                 },
@@ -3342,10 +3346,14 @@ pub mod ix {
                     push_u128(&mut out, optional_deposit);
                 }
                 Self::ForfeitRecoveryLeg {
+                    portfolio_id,
+                    position_epoch,
                     asset_index,
                     b_delta_budget,
                 } => {
                     out.push(43);
+                    push_u64(&mut out, portfolio_id);
+                    push_u64(&mut out, position_epoch);
                     push_u16(&mut out, asset_index);
                     push_u128(&mut out, b_delta_budget);
                 }
@@ -5488,9 +5496,18 @@ pub mod processor {
                 handle_cure_and_cancel_close(program_id, accounts, optional_deposit)
             }
             Instruction::ForfeitRecoveryLeg {
+                portfolio_id,
+                position_epoch,
                 asset_index,
                 b_delta_budget,
-            } => handle_forfeit_recovery_leg(program_id, accounts, asset_index, b_delta_budget),
+            } => handle_forfeit_recovery_leg(
+                program_id,
+                accounts,
+                portfolio_id,
+                position_epoch,
+                asset_index,
+                b_delta_budget,
+            ),
             Instruction::RebalanceReduce {
                 portfolio_id,
                 position_epoch,
@@ -8522,6 +8539,8 @@ pub mod processor {
     fn handle_forfeit_recovery_leg<'a>(
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
+        expected_portfolio_id: u64,
+        expected_position_epoch: u64,
         asset_index: u16,
         b_delta_budget: u128,
     ) -> ProgramResult {
@@ -8529,6 +8548,15 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let portfolio_ai = account(accounts, 2)?;
+        expect_owner(portfolio_ai, program_id)?;
+        if state::read_portfolio_id(&portfolio_ai.try_borrow_data()?)? != expected_portfolio_id {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
+        if state::read_portfolio_position_epoch(&portfolio_ai.try_borrow_data()?)?
+            != expected_position_epoch
+        {
+            return Err(PercolatorError::EngineProvenanceMismatch.into());
+        }
         with_one_portfolio_view(program_id, accounts, true, |group, portfolio, cfg| {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -29402,6 +29402,254 @@ fn v16_attack_reset_pending_rejects_fresh_counterparty_and_completes_recovery() 
     );
 }
 
+#[test]
+fn v16_attack_presigned_forfeit_does_not_replay_across_recovery_episodes() {
+    const VICTIM_CAPITAL: u128 = 20_000;
+    const FIRST_LOSER_CAPITAL: u128 = 10_000;
+    const SECOND_LOSER_CAPITAL: u128 = 20_000;
+    const FIRST_GAIN: i128 = 10_000;
+    const SECOND_GAIN: i128 = 20_000;
+    const POSITION_Q: i128 = 10_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: 1,
+        max_trading_fee_bps: 10,
+        max_price_move_bps_per_slot: 10_000,
+        max_bankrupt_close_lifetime_slots: 1,
+        public_b_chunk_atoms: 1,
+        maintenance_fee_per_slot: 0,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_auth_mark_with_cu(0, 1);
+
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&victim_owner, victim, VICTIM_CAPITAL);
+
+    let first_loser_owner = Keypair::new();
+    let first_loser = env.create_portfolio(&first_loser_owner);
+    env.deposit(&first_loser_owner, first_loser, FIRST_LOSER_CAPITAL);
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &first_loser_owner,
+        first_loser,
+        POSITION_Q,
+        1,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 2);
+    env.crank(
+        first_loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+    );
+    env.crank_steps(
+        first_loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: Vec::new(),
+        },
+        3,
+    );
+    env.crank(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: Vec::new(),
+        },
+    );
+    assert_eq!(
+        env.portfolio_state(victim).pnl.get(),
+        FIRST_GAIN,
+        "the first gain is honestly settled before the owner consents to forfeit"
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::ResetPending,
+        "first public bankruptcy must create a forfeitable survivor leg"
+    );
+
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let forfeit_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        data: ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: 0,
+            b_delta_budget: 1,
+        }
+        .encode(),
+    };
+    let intended = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), forfeit_ix.clone()],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            forfeit_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        blockhash,
+    );
+    env.svm
+        .send_transaction(intended)
+        .expect("the intended first-episode forfeit lands");
+    env.finalize_reset_side_with_cu(0, 0);
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+        "the first episode is fully cleared before fresh risk opens"
+    );
+
+    let second_loser_owner = Keypair::new();
+    let second_loser = env.create_portfolio(&second_loser_owner);
+    env.deposit(&second_loser_owner, second_loser, SECOND_LOSER_CAPITAL);
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &second_loser_owner,
+        second_loser,
+        POSITION_Q,
+        2,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_with_cu(2, 4);
+    env.crank(
+        second_loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations(0),
+        },
+    );
+    env.crank_steps(
+        second_loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: Vec::new(),
+        },
+        3,
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].mode_long,
+        SideModeV16::ResetPending,
+        "the second public bankruptcy must recreate a forfeitable survivor leg"
+    );
+    assert_eq!(
+        env.portfolio_state(victim).pnl.get(),
+        FIRST_GAIN,
+        "only the first settled gain is in PnL; the fresh second gain remains attached to the leg"
+    );
+
+    let victim_before_replay = env.svm.get_account(&victim).unwrap();
+    let market_before_replay = env.svm.get_account(&env.market).unwrap();
+    let vault_before_replay = env.svm.get_account(&env.vault).unwrap();
+    let replay = env.svm.send_transaction(retained);
+    if replay.is_err() {
+        assert_eq!(
+            env.svm.get_account(&victim).unwrap(),
+            victim_before_replay,
+            "rejected stale consent must leave the victim unchanged"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.market).unwrap(),
+            market_before_replay,
+            "rejected stale consent must leave the market unchanged"
+        );
+        assert_eq!(
+            env.svm.get_account(&env.vault).unwrap(),
+            vault_before_replay,
+            "rejected stale consent must move no custody"
+        );
+        return;
+    }
+
+    let replay_cu = replay.unwrap().compute_units_consumed;
+    let victim_after = env.portfolio_state(victim);
+    let (_, group_after) = env.market_state();
+    assert_cu_within("retained recovery-episode forfeit", replay_cu, CUSTODY_CU_LIMIT);
+    assert_eq!(victim_after.capital.get(), VICTIM_CAPITAL);
+    assert_eq!(victim_after.pnl.get(), FIRST_GAIN);
+    assert!(!has_active_leg_for_asset(&victim_after, 0));
+    assert_eq!(group_after.vault, 50_000);
+    assert_eq!(group_after.c_tot, VICTIM_CAPITAL);
+    assert_eq!(group_after.insurance, 0);
+
+    env.finalize_reset_side_with_cu(0, 0);
+    env.resolve();
+    let mut victim_out = 0u64;
+    let mut first_loser_out = 0u64;
+    let mut second_loser_out = 0u64;
+    for _ in 0..4 {
+        let first_loser_dest = env.close_resolved(&first_loser_owner, first_loser);
+        let second_loser_dest = env.close_resolved(&second_loser_owner, second_loser);
+        let victim_dest = env.close_resolved(&victim_owner, victim);
+        first_loser_out += env.token_amount(first_loser_dest);
+        second_loser_out += env.token_amount(second_loser_dest);
+        victim_out += env.token_amount(victim_dest);
+    }
+    assert_eq!(first_loser_out, 0);
+    assert_eq!(second_loser_out, 0);
+    assert_eq!(
+        victim_out,
+        u64::try_from(VICTIM_CAPITAL + FIRST_GAIN as u128).unwrap(),
+        "the stale replay discards the fresh second gain instead of paying it"
+    );
+    assert_eq!(
+        u128::from(victim_out) + SECOND_GAIN as u128,
+        group_after.vault,
+        "the missing second gain remains as an unowned vault residual"
+    );
+
+    env.close_portfolio_with_cu(&victim_owner, victim);
+    env.close_portfolio_with_cu(&first_loser_owner, first_loser);
+    env.close_portfolio_with_cu(&second_loser_owner, second_loser);
+    let drained = env.market_state().1;
+    assert_eq!(drained.vault, SECOND_GAIN as u128);
+    assert_eq!(drained.c_tot, 0);
+    assert_eq!(drained.insurance, 0);
+    assert_eq!(drained.materialized_portfolio_count, 0);
+
+    let close_dest = env.token_account(env.admin.pubkey(), 0);
+    let close = env.send(
+        ProgInstruction::CloseSlab,
+        vec![
+            AccountMeta::new(env.admin.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new(close_dest, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&env.admin.insecure_clone()],
+    );
+    assert!(
+        close.is_err(),
+        "the replay-created unowned residual must keep terminal close stuck"
+    );
+    panic!(
+        "stale first-episode forfeit consent deleted a fresh {SECOND_GAIN}-atom backed gain \
+         and left it permanently unowned in the market vault"
+    );
+}
+
 // security.md sweep — operation-sequence conservation (#32/#33 fuzz-lite): a long varied sequence of
 // deposits/trades/flips/price-moves/cranks/withdrawals must never drift the core invariants. Checks
 // real-vault==accounting, c_tot==Σcapitals, senior conservation, OI balance at every checkpoint.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -3410,8 +3410,12 @@ impl V16CuEnv {
         asset_index: u16,
         b_delta_budget: u128,
     ) -> u64 {
+        let portfolio_id = self.portfolio_id(portfolio);
+        let position_epoch = self.portfolio_position_epoch(portfolio);
         self.send(
             ProgInstruction::ForfeitRecoveryLeg {
+                portfolio_id,
+                position_epoch,
                 asset_index,
                 b_delta_budget,
             },
@@ -16197,6 +16201,8 @@ fn v16_attack_public_helpers_cannot_use_market_as_portfolio_alias() {
     env.svm.expire_blockhash();
     let forfeit = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: 1,
+            position_epoch: 0,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -28819,6 +28825,8 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         market_b.to_bytes(),
         "control forfeit target is genuinely bound to market B"
     );
+    let foreign_portfolio_id = env.portfolio_id(foreign);
+    let foreign_position_epoch = env.portfolio_position_epoch(foreign);
 
     let market_a_before = env.svm.get_account(&env.market).unwrap();
     let market_b_before = env.svm.get_account(&market_b).unwrap();
@@ -28832,6 +28840,8 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
         env.program_id,
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: foreign_portfolio_id,
+            position_epoch: foreign_position_epoch,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -28861,12 +28871,16 @@ fn v16_attack_forfeit_recovery_leg_rejects_cross_market_portfolio_substitution()
     assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_a_before);
     assert_eq!(env.svm.get_account(&vault_b).unwrap(), vault_b_before);
 
+    let local_portfolio_id = env.portfolio_id(local);
+    let local_position_epoch = env.portfolio_position_epoch(local);
     env.svm.expire_blockhash();
     let ok = send_tx(
         &mut env.svm,
         env.program_id,
         &env.payer,
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: local_portfolio_id,
+            position_epoch: local_position_epoch,
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -29013,6 +29027,8 @@ fn v16_attack_recovery_tools_owner_gated() {
     env.svm.expire_blockhash();
     let r1 = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             b_delta_budget: 1,
         },
@@ -29477,6 +29493,8 @@ fn v16_attack_presigned_forfeit_does_not_replay_across_recovery_episodes() {
 
     env.svm.expire_blockhash();
     let blockhash = env.svm.latest_blockhash();
+    let signed_portfolio_id = env.portfolio_id(victim);
+    let signed_position_epoch = env.portfolio_position_epoch(victim);
     let forfeit_ix = Instruction {
         program_id: env.program_id,
         accounts: vec![
@@ -29485,6 +29503,8 @@ fn v16_attack_presigned_forfeit_does_not_replay_across_recovery_episodes() {
             AccountMeta::new(victim, false),
         ],
         data: ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: signed_portfolio_id,
+            position_epoch: signed_position_epoch,
             asset_index: 0,
             b_delta_budget: 1,
         }
@@ -54577,6 +54597,8 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     env.svm.expire_blockhash();
     let r_grief = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             b_delta_budget: 1_000,
         },
@@ -54606,6 +54628,8 @@ fn v16_attack_forfeit_recovery_leg_owner_gated_and_zero_budget_rejected() {
     env.svm.expire_blockhash();
     let r_zero = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(pa),
+            position_epoch: env.portfolio_position_epoch(pa),
             asset_index: 0,
             b_delta_budget: 0,
         },
@@ -56517,6 +56541,8 @@ fn v16_attack_forfeit_recovery_leg_rejects_when_resolve_matured() {
     env.svm.expire_blockhash();
     let rejected = env.send(
         ProgInstruction::ForfeitRecoveryLeg {
+            portfolio_id: env.portfolio_id(stale_long),
+            position_epoch: env.portfolio_position_epoch(stale_long),
             asset_index: 0,
             b_delta_budget: 1,
         },

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -278,15 +278,21 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let now_slot: u64 = kani::any();
 
     let forfeit = Instruction::ForfeitRecoveryLeg {
+        portfolio_id,
+        position_epoch,
         asset_index,
         b_delta_budget,
     }
     .encode();
     match Instruction::decode(&forfeit).unwrap() {
         Instruction::ForfeitRecoveryLeg {
+            portfolio_id: got_portfolio_id,
+            position_epoch: got_position_epoch,
             asset_index: got_asset,
             b_delta_budget: got_budget,
         } => {
+            assert_eq!(got_portfolio_id, portfolio_id);
+            assert_eq!(got_position_epoch, position_epoch);
             assert_eq!(got_asset, asset_index);
             assert_eq!(got_budget, b_delta_budget);
         }
@@ -356,6 +362,17 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
         Instruction::SyncMaintenanceFee { now_slot: got } => assert_eq!(got, now_slot),
         _ => unreachable!(),
     }
+}
+
+#[kani::proof]
+fn kani_v16_legacy_unbound_forfeit_payload_is_rejected() {
+    let asset_index: u16 = kani::any();
+    let b_delta_budget: u128 = kani::any();
+    let mut legacy = [0u8; 19];
+    legacy[0] = 43;
+    legacy[1..3].copy_from_slice(&asset_index.to_le_bytes());
+    legacy[3..19].copy_from_slice(&b_delta_budget.to_le_bytes());
+    assert!(Instruction::decode(&legacy).is_err());
 }
 
 #[kani::proof]
@@ -1400,6 +1417,8 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     );
     assert_rejects_trailing_byte(
         Instruction::ForfeitRecoveryLeg {
+            portfolio_id: 1,
+            position_epoch: 0,
             asset_index: 0,
             b_delta_budget: 1,
         },


### PR DESCRIPTION
## What changed

- Bind `ForfeitRecoveryLeg` consent to the program-assigned `portfolio_id` and the wrapper-owned `position_epoch`.
- Reject stale provenance before dispatching the recovery mutation into the engine.
- Keep successful forfeits on the existing checked epoch-advance path introduced by #316.
- Reject legacy unbound and trailing-byte payloads with Kani coverage.

## Impact and root cause

An owner can pre-sign fee variants of one legitimate recovery-leg forfeit. After one variant lands, the retained variant remains valid for the blockhash lifetime. Before this change, the wrapper authenticated only the owner and asset, so the retained transaction could land during a later position/recovery episode on the same live portfolio.

The public LiteSVM reproduction creates two ordinary bankruptcy episodes without account reinitialization or injected protocol state. Replaying first-episode consent in episode two deletes a fresh 20,000-atom backed gain. Resolution then pays the victim only 30,000 of the expected 50,000 atoms and leaves 20,000 atoms permanently unowned in the canonical vault; all portfolios close, but `CloseSlab` has no successful path. This is classified as blocker DoS rather than LoF because the value is permanently stranded rather than extracted by another user.

This PR is intentionally stacked on #316 so it reuses the same position-episode primitive instead of adding a duplicate counter.

## TDD

- Exact-main RED: `6a6d0dce` (`v16_attack_presigned_forfeit_does_not_replay_across_recovery_episodes` fails after proving the 20,000-atom terminal residual).
- Stacked RED: `5296d91a`.
- GREEN fix: `fd4cf323`.

## Verification

- `cargo build-sbf --tools-version v1.52`
- built `tests/fixtures/auth_matcher` and `tests/fixtures/hostile_matcher` with platform-tools v1.52
- `cargo test --all-targets -- --test-threads=1`: 7 unit + 568 LiteSVM/CU tests passed
- focused recovery-forfeit suite: 4/4 passed
- Kani wire-field preservation: passed
- Kani legacy unbound payload rejection: passed
- Kani trailing-byte rejection: passed