### PR TITLE
[BLOCKER LoF] Block fee rewards ahead of committed marks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=e09ecb2f46ead56e9304e856fc58980ddabe43bf#e09ecb2f46ead56e9304e856fc58980ddabe43bf"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "e09ecb2f46ead56e9304e856fc58980ddabe43bf" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "e09ecb2f46ead56e9304e856fc58980ddabe43bf" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4555,6 +4555,50 @@ pub mod processor {
         Ok(())
     }
 
+    fn reject_portfolio_pending_price_managed_mark_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+    ) -> ProgramResult {
+        let active_bitmap = portfolio
+            .header
+            .active_bitmap
+            .map(percolator::V16PodU64::get);
+        let max_market_slots = group.header.config.max_market_slots.get() as usize;
+        let mut slot_index = 0usize;
+        while slot_index < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot_index]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            let active = percolator::active_bitmap_get(active_bitmap, slot_index);
+            if active != leg.active {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            if active {
+                let asset_index = leg.asset_index as usize;
+                if asset_index >= max_market_slots || asset_index >= group.markets.len() {
+                    return Err(PercolatorError::EngineInvalidLeg.into());
+                }
+                let asset = group.markets[asset_index].engine.asset;
+                if leg.market_id != asset.market_id.get() {
+                    return Err(PercolatorError::EngineInvalidLeg.into());
+                }
+                let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+                if oracle_v16::profile_is_price_managed(&profile) {
+                    let effective_price = asset.effective_price.get();
+                    if asset.raw_oracle_target_price.get() != effective_price
+                        || profile.mark_ewma_e6 != effective_price
+                        || profile.oracle_target_price_e6 != effective_price
+                    {
+                        return Err(PercolatorError::EngineLockActive.into());
+                    }
+                }
+            }
+            slot_index += 1;
+        }
+        Ok(())
+    }
+
     fn read_oracle_profile_for_asset(
         market_data: &[u8],
         cfg: &WrapperConfigV16,
@@ -8544,6 +8588,7 @@ pub mod processor {
             let mut portfolio =
                 state::portfolio_view_mut_for_market_slots(&mut portfolio_data, max_market_slots)?;
             expect_portfolio_view_account_key(&portfolio, portfolio_ai.key)?;
+            reject_portfolio_pending_price_managed_mark_view(&cfg, &group, &portfolio)?;
 
             let charged_total;
             if let Some(cranker_portfolio_ai) = accounts.get(2) {

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,170 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// An authenticated adverse mark is committed wrapper-side before the public crank applies it to
+// engine state. A permissionless fee sync must not collect and reward maintenance debt against the
+// stale engine mark, because that reward can consume backing owed to an independent winning trader.
+#[test]
+fn v16_attack_fee_sync_cannot_front_run_authenticated_mark_loss() {
+    fn run(attempt_fee_first: bool) -> (bool, u64, u64, u64) {
+        const OPEN_PRICE: u64 = 100;
+        const ADVERSE_PRICE: u64 = 50;
+        const DEPOSIT: u128 = 100_000;
+        const SIZE_Q: u128 = 1_000 * POS_SCALE;
+        const FEE_PER_SLOT: u128 = 12_500;
+
+        let mut env = V16CuEnv::new_with_market_params_price_move_and_maintenance_fee(
+            1,
+            10_000,
+            10_000,
+            10_000,
+            FEE_PER_SLOT,
+        );
+        env.svm.warp_to_slot(1);
+        env.configure_auth_mark_with_cu(1, OPEN_PRICE);
+        env.update_maintenance_fee_policy_with_cu(10_000);
+
+        let victim_owner = Keypair::new();
+        let winner_owner = Keypair::new();
+        let cranker_owner = Keypair::new();
+        let victim = env.create_portfolio(&victim_owner);
+        let winner = env.create_portfolio(&winner_owner);
+        let cranker = env.create_portfolio(&cranker_owner);
+        env.deposit(&victim_owner, victim, DEPOSIT);
+        env.deposit(&winner_owner, winner, DEPOSIT);
+        env.trade_asset_with_cu(
+            0,
+            &victim_owner,
+            victim,
+            &winner_owner,
+            winner,
+            SIZE_Q as i128,
+            OPEN_PRICE,
+            0,
+        );
+
+        // Advance the official mark/account-loss clock without collecting the victim's fee debt.
+        env.svm.warp_to_slot(9);
+        env.push_auth_mark_with_cu(9, OPEN_PRICE);
+        for _ in 0..12 {
+            env.crank(
+                cranker,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 9,
+                    observations: crank_observations(0),
+                },
+            );
+            if env.market_state().1.assets[0].slot_last == 9 {
+                break;
+            }
+        }
+        let victim_before = env.portfolio_state(victim);
+        let (_, group_before) = env.market_state();
+        assert_eq!(victim_before.last_fee_slot.get(), 1);
+        assert_eq!(group_before.assets[0].slot_last, 9);
+
+        // The honest mark is authenticated, but the public crank has not applied it yet.
+        env.svm.warp_to_slot(10);
+        env.push_auth_mark_with_cu(10, ADVERSE_PRICE);
+        let (pending_cfg, pending_group) = env.market_state();
+        assert_eq!(pending_cfg.oracle_target_price_e6, ADVERSE_PRICE);
+        assert_eq!(pending_group.assets[0].raw_oracle_target_price, OPEN_PRICE);
+        assert_eq!(pending_group.assets[0].effective_price, OPEN_PRICE);
+
+        let mut fee_first_rejected = false;
+        if attempt_fee_first {
+            let market_before = env.svm.get_account(&env.market).unwrap();
+            let victim_before = env.svm.get_account(&victim).unwrap();
+            let cranker_before = env.svm.get_account(&cranker).unwrap();
+            match env.try_sync_maintenance_fee_with_cu(victim, Some(cranker), 10) {
+                Ok(_) => {}
+                Err(err) => {
+                    assert!(
+                        err.contains("Custom(21)") || err.contains("custom program error: 0x15"),
+                        "pending-mark fee sync must reject as EngineLockActive: {err}"
+                    );
+                    fee_first_rejected = true;
+                    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+                    assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+                    assert_eq!(env.svm.get_account(&cranker).unwrap(), cranker_before);
+                }
+            }
+        }
+
+        env.crank(
+            victim,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 10,
+                observations: crank_observations(0),
+            },
+        );
+        if !attempt_fee_first || fee_first_rejected {
+            env.sync_maintenance_fee_with_cu(victim, Some(cranker), 10);
+        }
+
+        let reward = env.portfolio_state(cranker).capital.get();
+        assert!(reward > 0, "maintenance sync must pay a real reward");
+        let cranker_dest = env.withdraw(&cranker_owner, cranker, reward);
+        assert_eq!(env.token_amount(cranker_dest), reward as u64);
+        env.close_portfolio_with_cu(&cranker_owner, cranker);
+
+        // Settle both trading accounts using public cranks, then compare terminal user payouts.
+        for _ in 0..12 {
+            for portfolio in [victim, winner] {
+                env.svm.expire_blockhash();
+                let _ = env.send(
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: 10,
+                        observations: crank_observations(0),
+                    },
+                    vec![
+                        AccountMeta::new(env.payer.pubkey(), true),
+                        AccountMeta::new(env.market, false),
+                        AccountMeta::new(portfolio, false),
+                    ],
+                    &[],
+                );
+            }
+        }
+
+        env.resolve();
+        let mut victim_paid = 0u64;
+        let mut winner_paid = 0u64;
+        for _ in 0..24 {
+            let victim_dest = env.close_resolved(&victim_owner, victim);
+            victim_paid = victim_paid
+                .checked_add(env.token_amount(victim_dest))
+                .unwrap();
+            let winner_dest = env.close_resolved(&winner_owner, winner);
+            winner_paid = winner_paid
+                .checked_add(env.token_amount(winner_dest))
+                .unwrap();
+            let victim_state = env.portfolio_state(victim);
+            let winner_state = env.portfolio_state(winner);
+            if victim_state.capital.get() == 0
+                && victim_state.pnl.get() == 0
+                && !resolved_receipt(&victim_state).present
+                && winner_state.capital.get() == 0
+                && winner_state.pnl.get() == 0
+                && !resolved_receipt(&winner_state).present
+            {
+                break;
+            }
+        }
+        (fee_first_rejected, reward as u64, victim_paid, winner_paid)
+    }
+
+    let mark_first = run(false);
+    let fee_first = run(true);
+    println!("mark-first={mark_first:?} fee-first={fee_first:?}");
+    assert!(
+        fee_first.0,
+        "a permissionless fee sync must reject until the authenticated mark is applied"
+    );
+    assert_eq!(
+        (fee_first.1, fee_first.2, fee_first.3),
+        (mark_first.1, mark_first.2, mark_first.3),
+        "fee-sync ordering must not change the cranker reward or terminal user payouts"
+    );
+}


### PR DESCRIPTION
## Finding

An unprivileged caller can front-run an already-authenticated adverse mark with the permissionless `SyncMaintenanceFee` route. The wrapper has committed the honest target, but before a public crank applies it, the engine still sees the old effective price and lets the caller collect a larger cranker reward.

Exact public LiteSVM result on parent `36fa587e`:

- mark first: cranker reward 50,000; victim payout 0; independent winner payout 50,000
- fee sync first: cranker reward 100,000; victim payout 0; independent winner payout 0

The attacker signs no privileged instruction and the test uses no state injection.

## Fix

- Pin paired engine fix [percolator#159](https://github.com/aeyakovenko/percolator/pull/159), which rejects live non-flat fee sync while an engine target is ahead of effective state.
- At the wrapper boundary, scan only the target portfolio's bounded active-leg set and reject fee sync while a price-managed wrapper profile or engine raw target is ahead of effective state.
- A permissionless crank remains the successful bounded continuation. Once it applies the committed mark, fee sync retries normally; trading and exits are not blocked.

## TDD

The public LiteSVM regression proves:

- exact pre-fix RED with the divergent economics above;
- early sync rejects as `EngineLockActive`;
- SVM rollback leaves market, victim, and reward portfolio byte-identical;
- public crank applies the mark;
- retry succeeds;
- both orderings terminate at the same `(50,000, 0, 50,000)` outcome.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --all-targets -- --test-threads=1`: 566/566 LiteSVM/CU tests passed, plus 6/6 unit tests
- Existing max-shape crank/trade/liquidation CU tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

Wrapper Kani covers ABI/local validation only; the paired engine PR carries the exact target-lag kernel contract and Kani proof rather than duplicating engine accounting in this repository.