### PR TITLE
[BLOCKER DoS] Bound max-source PnL conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ce5e923c48d35989785427975a82ce74b6b19c72#ce5e923c48d35989785427975a82ce74b6b19c72"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ce5e923c48d35989785427975a82ce74b6b19c72" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ce5e923c48d35989785427975a82ce74b6b19c72" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8390,10 +8390,10 @@ pub mod processor {
             if permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
-            // The v16 engine converts the currently released residual-bounded
-            // amount atomically. Preserve the wrapper caller cap by staging the
-            // conversion and only committing it when the converted amount fits.
-            let converted = group.convert_released_pnl_to_capital_not_atomic(portfolio)?;
+            // Convert one source domain per call so max-shape accounts retain a
+            // bounded continuation. Instruction rollback preserves the caller
+            // cap when the selected step would exceed it.
+            let converted = group.convert_released_pnl_to_capital_step_not_atomic(portfolio)?;
             if converted == 0 || converted > amount {
                 return Err(V16Error::LockActive);
             }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59825,14 +59825,13 @@ fn v16_attack_max_source_conversion_is_bounded_for_unsigned_lp() {
     let total_profit = i128::from(2 * ASSETS) * PROFIT_PER_DOMAIN as i128;
     assert_eq!(victim.pnl.get(), total_profit);
 
+    let mut max_conversion_cu = 0;
     for remaining_domains in (1..=percolator::PORTFOLIO_SOURCE_DOMAIN_CAP).rev() {
         let before = env.portfolio_state(victim_lp);
         env.svm.expire_blockhash();
         let cu = env
             .send(
-                ProgInstruction::ConvertReleasedPnl {
-                    amount: PROFIT_PER_DOMAIN,
-                },
+                ProgInstruction::ConvertReleasedPnl { amount: u128::MAX },
                 vec![
                     AccountMeta::new(victim_owner.pubkey(), true),
                     AccountMeta::new(env.market, false),
@@ -59843,6 +59842,7 @@ fn v16_attack_max_source_conversion_is_bounded_for_unsigned_lp() {
             .unwrap_or_else(|err| {
                 panic!("max-source conversion must have a bounded continuation: {err}")
             });
+        max_conversion_cu = max_conversion_cu.max(cu);
         assert!(
             cu < 1_400_000,
             "source conversion consumed the transaction limit: {cu}"
@@ -59861,6 +59861,7 @@ fn v16_attack_max_source_conversion_is_bounded_for_unsigned_lp() {
             remaining_domains - 1
         );
     }
+    println!("v16 max-source bounded conversion max CU: {max_conversion_cu}");
 
     let final_state = env.portfolio_state(victim_lp);
     assert_eq!(final_state.pnl.get(), 0);

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,157 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Public-interface DoS regression: an LP authorizes a matcher once, after which an unrelated taker
+// can fill against it without the LP owner signing each trade. Repeated ordinary fills and honest
+// mark moves can leave the flat LP with all 32 sparse source domains occupied. Conversion must make
+// bounded rank-decreasing progress; processing the whole source table atomically hits the SVM limit
+// and strands the LP's source-backed profit for as long as the healthy market remains Live.
+#[test]
+fn v16_attack_max_source_conversion_is_bounded_for_unsigned_lp() {
+    const ACTIVE_CAP: u16 = percolator_prog::constants::WRAPPER_MAX_PORTFOLIO_ASSETS;
+    const ASSETS: u16 = 16;
+    const PRICE_LOW: u64 = 100;
+    const PRICE_HIGH: u64 = 101;
+    const SIZE_Q: i128 = POS_SCALE as i128 * 1_000;
+    const PROFIT_PER_DOMAIN: u128 = 1_000;
+
+    let mut env = V16CuEnv::new_with_init_params_and_market_capacity(
+        V16CuMarketParams {
+            max_portfolio_assets: ACTIVE_CAP,
+            maintenance_margin_bps: 10_000,
+            initial_margin_bps: 10_000,
+            max_price_move_bps_per_slot: 10_000,
+            ..V16CuMarketParams::default()
+        },
+        70,
+    );
+    for asset_index in ACTIVE_CAP..ASSETS {
+        let activation_slot = u64::from(asset_index - ACTIVE_CAP + 1);
+        env.activate_asset(asset_index, activation_slot, PRICE_LOW);
+    }
+    let mut slot = u64::from(ASSETS - ACTIVE_CAP);
+    env.svm.warp_to_slot(slot);
+    for asset_index in 0..ASSETS {
+        env.configure_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_LOW);
+    }
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+
+    let attacker_owner = Keypair::new();
+    let victim_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    let victim_lp = env.create_portfolio(&victim_owner);
+    env.deposit(&attacker_owner, attacker, 1_000_000);
+    env.deposit(&victim_owner, victim_lp, 1_000_000);
+    let (matcher_ctx, matcher_delegate, _) =
+        env.init_auth_matcher_context(matcher_program, &victim_owner, victim_lp);
+
+    let cpi_fill = |env: &mut V16CuEnv, asset_index: u16, size_q: i128| {
+        env.svm.expire_blockhash();
+        env.try_trade_cpi_with_cu_on_asset(
+            &attacker_owner,
+            attacker,
+            &victim_owner,
+            victim_lp,
+            matcher_program,
+            matcher_ctx,
+            matcher_delegate,
+            asset_index,
+            size_q,
+            0,
+        )
+        .unwrap_or_else(|err| panic!("unsigned-LP asset {asset_index} fill failed: {err}"));
+    };
+    let settle_both = |env: &mut V16CuEnv, asset_index: u16, now_slot: u64| {
+        for account in [attacker, victim_lp] {
+            env.svm.expire_blockhash();
+            env.crank(
+                account,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot,
+                    observations: crank_observations(asset_index),
+                },
+            );
+        }
+    };
+
+    for asset_index in 0..ASSETS {
+        // Only the attacker signs these fills. First make the LP long and profitable.
+        cpi_fill(&mut env, asset_index, -SIZE_Q);
+        slot += 1;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_HIGH);
+        settle_both(&mut env, asset_index, slot);
+        cpi_fill(&mut env, asset_index, SIZE_Q);
+
+        // Then make the LP short and profitable, retaining the opposite source domain too.
+        cpi_fill(&mut env, asset_index, SIZE_Q);
+        slot += 1;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(asset_index, slot, PRICE_LOW);
+        settle_both(&mut env, asset_index, slot);
+        cpi_fill(&mut env, asset_index, -SIZE_Q);
+    }
+
+    let victim = env.portfolio_state(victim_lp);
+    assert!(percolator::active_bitmap_is_empty(active_bitmap(&victim)));
+    assert_eq!(
+        victim
+            .source_domains
+            .iter()
+            .filter(|source| source.is_occupied())
+            .count(),
+        percolator::PORTFOLIO_SOURCE_DOMAIN_CAP
+    );
+    let total_profit = i128::from(2 * ASSETS) * PROFIT_PER_DOMAIN as i128;
+    assert_eq!(victim.pnl.get(), total_profit);
+
+    for remaining_domains in (1..=percolator::PORTFOLIO_SOURCE_DOMAIN_CAP).rev() {
+        let before = env.portfolio_state(victim_lp);
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::ConvertReleasedPnl {
+                    amount: PROFIT_PER_DOMAIN,
+                },
+                vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim_lp, false),
+                ],
+                &[&victim_owner],
+            )
+            .unwrap_or_else(|err| {
+                panic!("max-source conversion must have a bounded continuation: {err}")
+            });
+        assert!(
+            cu < 1_400_000,
+            "source conversion consumed the transaction limit: {cu}"
+        );
+        let after = env.portfolio_state(victim_lp);
+        assert_eq!(
+            before.pnl.get() - after.pnl.get(),
+            PROFIT_PER_DOMAIN as i128
+        );
+        assert_eq!(
+            after
+                .source_domains
+                .iter()
+                .filter(|source| source.is_occupied())
+                .count(),
+            remaining_domains - 1
+        );
+    }
+
+    let final_state = env.portfolio_state(victim_lp);
+    assert_eq!(final_state.pnl.get(), 0);
+    assert_eq!(final_state.capital.get(), 1_000_000 + total_profit as u128);
+    let destination = env.withdraw(&victim_owner, victim_lp, final_state.capital.get());
+    assert_eq!(
+        env.token_amount(destination),
+        (1_000_000 + total_profit as u128) as u64
+    );
+}


### PR DESCRIPTION
## Finding

A public, healthy-market path can leave an independent LP with all 32 source-claim domains occupied. The LP authorizes a matcher once; afterward an unrelated taker alone signs ordinary CPI fills while authenticated mark moves create source-backed PnL on both sides of 16 assets.

On the exact `main` parent (`percolator-prog` `36fa587e`, engine `143e68c`), the LP is flat with 32 occupied source domains and 32,000 atoms of backed PnL. `ConvertReleasedPnl` scans and consumes the entire table in one instruction, uses exactly 1,400,000 CU, returns `ProgramFailedToComplete`, and rolls back. Repeating the public instruction cannot reduce the rank, so the LP cannot convert or withdraw those funds while the live market remains in that state.

This is not state injection: the regression uses only public LiteSVM instructions, a real matcher program, authenticated mark pushes, and ordinary signed transactions. The affected LP does not sign the individual fills.

## Fix

- Pin engine PR aeyakovenko/percolator#160, stacked on domain-local burn PR aeyakovenko/percolator#140.
- Route `ConvertReleasedPnl` through the engine's one-source-domain step API.
- Preserve `amount` as a postcondition cap under SVM rollback.
- Permit repeated flat-account steps without an otherwise-unrefreshable health certificate, while retaining H-locks and the full active-account freshness/target-lag gate.

## TDD result

- RED on exact parent: 1,400,000 CU, `ProgramFailedToComplete`, no progress.
- GREEN: all 32 source domains decrease one per call; worst step is 519,091 CU; PnL reaches zero; exact backed capital is withdrawn.
- Existing caller-cap regression remains green.

## Verification

- Engine normal all-target tests: green (50 unit, 9 backing, 2 resolved, 70 V16 spec).
- Engine fuzz/conformance all-target tests: green (including 15 reference, 9 arithmetic/residue, 74 V16 spec).
- Engine focused Kani: 2/2 harnesses green, all covers satisfied.
- Wrapper `cargo build-sbf --tools-version v1.52`: green.
- Wrapper full suite: 6/6 unit and 566/566 LiteSVM/CU tests green.