### PR TITLE
[PRIVILEGED LoF] Commit authenticated marks before asset shutdown

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9291,6 +9291,50 @@ pub mod processor {
                 }
                 match group.markets[asset_index].engine.asset.lifecycle {
                     ASSET_LIFECYCLE_ACTIVE | ASSET_LIFECYCLE_DRAIN_ONLY => {
+                        let asset = group.markets[asset_index].engine.asset;
+                        let current_price = asset.effective_price.get();
+                        let committed_target = if oracle_v16::profile_is_price_managed(&profile) {
+                            profile.mark_ewma_e6
+                        } else {
+                            current_price
+                        };
+                        if committed_target == 0 {
+                            return Err(PercolatorError::OracleInvalid.into());
+                        }
+                        let exposed =
+                            asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+                        let segment_dt =
+                            asset_segment_dt_view(&group, asset_index, authenticated_slot)?;
+                        let shutdown_price = oracle_v16::effective_price_from_target(
+                            current_price,
+                            committed_target,
+                            group.header.config.max_price_move_bps_per_slot.get(),
+                            segment_dt,
+                            exposed,
+                        );
+                        if shutdown_price != current_price {
+                            let shutdown_dt = authenticated_slot
+                                .checked_sub(asset.slot_last.get())
+                                .ok_or(PercolatorError::EngineStale)?;
+                            if shutdown_dt > group.header.config.max_accrual_dt_slots.get() {
+                                return Err(PercolatorError::EngineStale.into());
+                            }
+                            let funding_rate_e9 = permissionless_funding_rate_e9_view(
+                                &profile,
+                                &group,
+                                asset_index,
+                                shutdown_price,
+                            )?;
+                            group
+                                .accrue_asset_to_not_atomic(
+                                    asset_index,
+                                    authenticated_slot,
+                                    shutdown_price,
+                                    funding_rate_e9,
+                                    true,
+                                )
+                                .map_err(map_v16_error)?;
+                        }
                         let frozen_mark = group.markets[asset_index]
                             .engine
                             .asset

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,137 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A non-oracle asset admin may shut an asset down, but that power must not erase an already
+// authenticated oracle target. Otherwise a compromised admin can wait for an adverse honest mark,
+// freeze the previous effective price, and force-close its counterparty without paying the mark PnL.
+#[test]
+fn v16_attack_shutdown_cannot_discard_pending_authenticated_mark() {
+    const OPEN_MARK: u64 = 100;
+    const AUTHENTICATED_MARK: u64 = 200;
+    const EXPECTED_FROZEN_MARK: u64 = 105;
+    const DEPOSIT: u128 = 10_000;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const OPEN_SLOT: u64 = 1;
+    const MARK_SLOT: u64 = 2;
+    const FORCE_CLOSE_DELAY: u64 = 2;
+    const FORCE_CLOSE_SLOT: u64 = MARK_SLOT + FORCE_CLOSE_DELAY;
+
+    fn run(accrue_before_shutdown: bool) -> (u64, u64, u64) {
+        let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 500);
+        env.configure_permissionless_resolve_with_cu(1_000, FORCE_CLOSE_DELAY);
+
+        // Separate the trusted oracle from the non-oracle market/asset admin. The oracle signs the
+        // adverse target; only the later shutdown uses the compromised administrative capability.
+        let oracle = Keypair::new();
+        env.ensure_signer_account(oracle.pubkey());
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::UpdateAssetAuthority {
+                asset_index: 0,
+                kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
+                new_pubkey: oracle.pubkey().to_bytes(),
+            },
+            vec![
+                AccountMeta::new(env.admin.pubkey(), true),
+                AccountMeta::new(oracle.pubkey(), true),
+                AccountMeta::new(env.market, false),
+            ],
+            &[&env.admin, &oracle],
+        )
+        .expect("install a distinct honest oracle authority");
+
+        env.svm.warp_to_slot(OPEN_SLOT);
+        env.configure_auth_mark_for_asset_with_authority(0, &oracle, OPEN_SLOT, OPEN_MARK);
+
+        let victim_owner = Keypair::new();
+        let attacker_owner = Keypair::new();
+        let victim = env.create_portfolio(&victim_owner);
+        let attacker = env.create_portfolio(&attacker_owner);
+        env.deposit(&victim_owner, victim, DEPOSIT);
+        env.deposit(&attacker_owner, attacker, DEPOSIT);
+        env.trade_asset_with_cu(
+            0,
+            &victim_owner,
+            victim,
+            &attacker_owner,
+            attacker,
+            SIZE_Q,
+            OPEN_MARK,
+            0,
+        );
+
+        env.svm.warp_to_slot(MARK_SLOT);
+        env.push_auth_mark_for_asset_with_authority(0, &oracle, MARK_SLOT, AUTHENTICATED_MARK);
+        let (_, pending) = env.market_state();
+        assert_eq!(pending.assets[0].effective_price, OPEN_MARK);
+        assert_eq!(
+            state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0,)
+                .unwrap()
+                .oracle_target_price_e6,
+            AUTHENTICATED_MARK,
+            "the honest adverse mark is committed before the admin acts"
+        );
+
+        if accrue_before_shutdown {
+            env.crank(
+                victim,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: MARK_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+        env.update_asset_lifecycle_as_admin_with_cu(
+            percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+            0,
+            MARK_SLOT,
+            0,
+        );
+        let frozen_price = env.market_state().1.assets[0].effective_price;
+
+        env.svm.warp_to_slot(FORCE_CLOSE_SLOT);
+        let cranker = Keypair::new();
+        env.force_close_abandoned_asset_with_cu(
+            &cranker,
+            victim,
+            attacker,
+            0,
+            FORCE_CLOSE_SLOT,
+            SIZE_Q as u128,
+        );
+        assert!(!has_active_leg_for_asset(&env.portfolio_state(victim), 0));
+        assert!(!has_active_leg_for_asset(&env.portfolio_state(attacker), 0));
+
+        env.resolve();
+        env.svm.warp_to_slot(FORCE_CLOSE_SLOT + FORCE_CLOSE_DELAY);
+        let attacker_dest = env.close_resolved(&attacker_owner, attacker);
+        let victim_dest = env.close_resolved(&victim_owner, victim);
+        (
+            env.token_amount(victim_dest),
+            env.token_amount(attacker_dest),
+            frozen_price,
+        )
+    }
+
+    let (control_victim_payout, control_attacker_payout, control_mark) = run(true);
+    assert_eq!(control_mark, EXPECTED_FROZEN_MARK);
+    assert_eq!(
+        (control_victim_payout, control_attacker_payout),
+        (10_050, 9_950),
+        "control realizes the honest mark into final SPL payouts"
+    );
+
+    let (attacked_victim_payout, attacked_attacker_payout, attacked_mark) = run(false);
+    assert_eq!(
+        (attacked_victim_payout, attacked_attacker_payout),
+        (control_victim_payout, control_attacker_payout),
+        "non-oracle shutdown authority cannot erase an independent user's mark PnL"
+    );
+    assert_eq!(
+        attacked_mark, EXPECTED_FROZEN_MARK,
+        "shutdown must first commit the circuit-breaker-bounded authenticated target"
+    );
+}


### PR DESCRIPTION
## Finding

A compromised non-oracle market/asset administrator could call the public asset-shutdown instruction after an independent honest oracle had authenticated an adverse mark but before a permissionless crank committed it. Shutdown froze the previous effective price and overwrote the pending target. Subsequent public recovery force-close and resolution therefore settled at the stale mark, transferring value from the independent winner to the privileged counterparty.

The public LiteSVM repro uses separate oracle and admin keys. With a 100 -> 200 authenticated target and a 5% per-slot circuit breaker, the vulnerable path froze at 100 and paid victim/attacker 10,000/10,000, while crank-before-shutdown froze at 105 and paid 10,050/9,950.

## Fix

Before transitioning an active or drain-only asset to shutdown, derive the circuit-breaker-bounded price from the already authenticated stored target and accrue the asset to that price. Reject a mark-bearing shutdown that is too stale for one bounded accrual segment, leaving the permissionless crank path available. Manual-price shutdown behavior is unchanged.

## TDD verification

- Exact-parent RED: `v16_attack_shutdown_cannot_discard_pending_authenticated_mark` observed 10,000/10,000 on shutdown-before-crank versus 10,050/9,950 in the honest control.
- Fixed GREEN: the same public sequence freezes at 105 and both paths pay 10,050/9,950.
- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 integration/BPF/CU tests passed.
- `cargo fmt --all -- --check`
- `git diff --check`