### PR TITLE
[BLOCKER LoF] Reject unsigned stale-cohort novation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=d81b86252c028d7977c14bcf75c06eb199a61b2b#d81b86252c028d7977c14bcf75c06eb199a61b2b"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d81b86252c028d7977c14bcf75c06eb199a61b2b" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d81b86252c028d7977c14bcf75c06eb199a61b2b" }
 
 [dev-dependencies]
 bincode = "1"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The economic and governance model for a permissionless multi-asset market. Statu
 - A **10 MiB slab fits 5,834 assets** with the current layout (per-asset slot is 1797 B; 5,835 would exceed Solana's 10 MiB account cap), and
   per-trader CU stays bounded **independent of N** (a trader pays only for the assets they actually
   touch, not all N). **✅** — no 64-asset cap (`v16_attack_market_exceeds_64_assets_position_holds_any_14_legs`),
-  and a real BPF trade on asset **index 5833 of a 5,834-asset / near-10 MiB market is under the tx CU limit** — flat
+  and a real BPF trade on asset **index 5781 of a 5,782-asset / near-10 MiB market is under the tx CU limit** — flat
   vs. small-N, proving O(1)-in-N (`v16_bpf_10m_market_over_5000_assets_trades_with_bounded_cu`). The same
   regression also exercises high public domain indices above 11,000, proving backing/insurance management
   is not capped at one-byte domain ids. The portfolio's

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4117,6 +4117,34 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
+    pub fn unsigned_lp_adds_unsettled_cohort_exposure(
+        current_q: i128,
+        delta_q: i128,
+        stale_long_counterparties: bool,
+        stale_short_counterparties: bool,
+        unresolved_negative_pnl: bool,
+    ) -> Option<bool> {
+        let next_q = current_q.checked_add(delta_q)?;
+        if next_q == i128::MIN {
+            return None;
+        }
+        let current_long = if current_q > 0 { current_q as u128 } else { 0 };
+        let current_short = if current_q < 0 {
+            current_q.unsigned_abs()
+        } else {
+            0
+        };
+        let next_long = if next_q > 0 { next_q as u128 } else { 0 };
+        let next_short = if next_q < 0 { next_q.unsigned_abs() } else { 0 };
+        let adds_long = next_long > current_long;
+        let adds_short = next_short > current_short;
+        Some(
+            (adds_long && stale_short_counterparties)
+                || (adds_short && stale_long_counterparties)
+                || ((adds_long || adds_short) && unresolved_negative_pnl),
+        )
+    }
+
     pub fn price_move_bps_ceil(old: u64, new: u64) -> Option<u64> {
         if old == 0 || old == new {
             return Some(0);
@@ -10979,6 +11007,34 @@ pub mod processor {
         Ok(0)
     }
 
+    fn signed_positions_for_cpi_requests_view(
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        cpi_requests: &[(u16, i128)],
+        request_market_ids: &[u64; MATCHER_BATCH_MAX_LEGS],
+    ) -> Result<[i128; MATCHER_BATCH_MAX_LEGS], ProgramError> {
+        let mut positions = [0i128; MATCHER_BATCH_MAX_LEGS];
+        let mut slot = 0usize;
+        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            if leg.active {
+                for (request_index, &(asset_index, _)) in cpi_requests.iter().enumerate() {
+                    if leg.asset_index == asset_index as u32
+                        && leg.market_id == request_market_ids[request_index]
+                    {
+                        positions[request_index] = match leg.side {
+                            SideV16::Long => leg.basis_pos_q.unsigned_abs() as i128,
+                            SideV16::Short => -(leg.basis_pos_q.unsigned_abs() as i128),
+                        };
+                    }
+                }
+            }
+            slot += 1;
+        }
+        Ok(positions)
+    }
+
     fn ensure_trade_portfolio_current_for_requests_view(
         group: &state::MarketViewMutV16<'_>,
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
@@ -11057,13 +11113,25 @@ pub mod processor {
         account_b: &percolator::PortfolioV16ViewMut<'_>,
         cpi_requests: &[(u16, i128)],
     ) -> ProgramResult {
-        for &(asset_index_u16, size_q) in cpi_requests {
+        if cpi_requests.len() > MATCHER_BATCH_MAX_LEGS {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let mut request_market_ids = [0u64; MATCHER_BATCH_MAX_LEGS];
+        for (request_index, &(asset_index_u16, _)) in cpi_requests.iter().enumerate() {
             let asset_index = asset_index_u16 as usize;
             if asset_index >= group.header.config.max_market_slots.get() as usize
                 || asset_index >= group.markets.len()
             {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
+            request_market_ids[request_index] =
+                group.markets[asset_index].engine.asset.market_id.get();
+        }
+        let account_b_positions =
+            signed_positions_for_cpi_requests_view(account_b, cpi_requests, &request_market_ids)?;
+        for (request_index, &(asset_index_u16, size_q)) in cpi_requests.iter().enumerate() {
+            let asset_index = asset_index_u16 as usize;
+            let account_b_pos = account_b_positions[request_index];
             match group.markets[asset_index].engine.asset.lifecycle {
                 ASSET_LIFECYCLE_ACTIVE => {}
                 ASSET_LIFECYCLE_DRAIN_ONLY | ASSET_LIFECYCLE_RECOVERY => {
@@ -11076,8 +11144,6 @@ pub mod processor {
                     }
                     let account_a_pos =
                         signed_position_for_asset_view(group, account_a, asset_index)?;
-                    let account_b_pos =
-                        signed_position_for_asset_view(group, account_b, asset_index)?;
                     if requested_delta_must_increase_risk(account_a_pos, size_q)
                         || requested_delta_must_increase_risk(account_b_pos, -size_q)
                     {
@@ -11085,6 +11151,21 @@ pub mod processor {
                     }
                 }
                 _ => return Err(PercolatorError::EngineLockActive.into()),
+            }
+            let lp_delta = size_q
+                .checked_neg()
+                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            let asset = &group.markets[asset_index].engine.asset;
+            let unsafe_unsigned_exposure = policy_v16::unsigned_lp_adds_unsettled_cohort_exposure(
+                account_b_pos,
+                lp_delta,
+                asset.stale_account_count_long.get() != 0,
+                asset.stale_account_count_short.get() != 0,
+                group.header.negative_pnl_account_count.get() != 0,
+            )
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            if unsafe_unsigned_exposure {
+                return Err(PercolatorError::EngineLockActive.into());
             }
         }
         Ok(())

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4017,14 +4017,14 @@ pub mod oracle_v16 {
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
 
-    pub fn stale_cohort_has_external_account(
-        stale_account_count: u64,
-        account_a_is_stale: bool,
-        account_b_is_stale: bool,
+    pub fn pending_counter_has_external_account(
+        pending_account_count: u64,
+        account_a_is_pending: bool,
+        account_b_is_pending: bool,
     ) -> Option<bool> {
-        let local_stale_count =
-            (account_a_is_stale as u64).checked_add(account_b_is_stale as u64)?;
-        Some(stale_account_count.checked_sub(local_stale_count)? != 0)
+        let local_pending_count =
+            (account_a_is_pending as u64).checked_add(account_b_is_pending as u64)?;
+        Some(pending_account_count.checked_sub(local_pending_count)? != 0)
     }
 
     pub fn unsigned_lp_adds_unsettled_cohort_exposure(
@@ -11049,6 +11049,12 @@ pub mod processor {
             &request_kf_epoch_long,
             &request_kf_epoch_short,
         )?;
+        let external_negative_pnl = policy_v16::pending_counter_has_external_account(
+            group.header.negative_pnl_account_count.get(),
+            account_a.header.pnl.get() < 0,
+            account_b.header.pnl.get() < 0,
+        )
+        .ok_or(PercolatorError::EngineCounterUnderflow)?;
         for (request_index, &(asset_index_u16, size_q)) in cpi_requests.iter().enumerate() {
             let asset_index = asset_index_u16 as usize;
             let account_a_state = account_a_states[request_index];
@@ -11078,13 +11084,13 @@ pub mod processor {
                 .checked_neg()
                 .ok_or(PercolatorError::EngineArithmeticOverflow)?;
             let asset = &group.markets[asset_index].engine.asset;
-            let external_stale_long = policy_v16::stale_cohort_has_external_account(
+            let external_stale_long = policy_v16::pending_counter_has_external_account(
                 asset.stale_account_count_long.get(),
                 account_a_state.stale_long,
                 account_b_state.stale_long,
             )
             .ok_or(PercolatorError::EngineCounterUnderflow)?;
-            let external_stale_short = policy_v16::stale_cohort_has_external_account(
+            let external_stale_short = policy_v16::pending_counter_has_external_account(
                 asset.stale_account_count_short.get(),
                 account_a_state.stale_short,
                 account_b_state.stale_short,
@@ -11095,7 +11101,7 @@ pub mod processor {
                 lp_delta,
                 external_stale_long,
                 external_stale_short,
-                group.header.negative_pnl_account_count.get() != 0,
+                external_negative_pnl,
             )
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
             if unsafe_unsigned_exposure {

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -368,106 +368,6 @@ pub mod state {
                 resolved_payout_ledger: ResolvedPayoutLedgerV16::EMPTY,
             })
         }
-
-        pub fn accrue_asset_to_not_atomic(
-            &mut self,
-            asset_index: usize,
-            now_slot: u64,
-            effective_price: u64,
-            funding_rate_e9: i128,
-            _protective_progress_committed: bool,
-        ) -> Result<percolator::AccrueAssetOutcomeV16, V16Error> {
-            if self.mode != MarketModeV16::Live
-                || asset_index >= self.config.max_market_slots as usize
-                || asset_index >= self.assets.len()
-                || effective_price == 0
-                || now_slot < self.current_slot
-            {
-                return Err(V16Error::InvalidConfig);
-            }
-            let old = self.assets[asset_index];
-            if now_slot < old.slot_last {
-                return Err(V16Error::InvalidConfig);
-            }
-            let dt_total = now_slot - old.slot_last;
-            let segment_dt = dt_total.min(self.config.max_accrual_dt_slots);
-            let exposed = old.oi_eff_long_q != 0 || old.oi_eff_short_q != 0;
-            let balanced = old.oi_eff_long_q != 0 && old.oi_eff_short_q != 0;
-            let price_move_active = effective_price != old.effective_price && exposed;
-            let funding_active =
-                segment_dt != 0 && funding_rate_e9 != 0 && balanced && old.fund_px_last > 0;
-            let price_delta = effective_price as i128 - old.effective_price as i128;
-            let k_delta = price_delta
-                .checked_mul(percolator::ADL_ONE as i128)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            let funding_delta = if funding_active {
-                funding_rate_e9
-                    .checked_mul(segment_dt as i128)
-                    .and_then(|v| v.checked_mul(effective_price as i128))
-                    .map(|v| v / percolator::FUNDING_DEN as i128)
-                    .and_then(|v| v.checked_mul(percolator::ADL_ONE as i128))
-                    .ok_or(V16Error::ArithmeticOverflow)?
-            } else {
-                0
-            };
-            let mut asset = old;
-            asset.k_long = asset
-                .k_long
-                .checked_add(k_delta)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            asset.k_short = asset
-                .k_short
-                .checked_sub(k_delta)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            asset.f_long_num = asset
-                .f_long_num
-                .checked_sub(funding_delta)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            asset.f_short_num = asset
-                .f_short_num
-                .checked_add(funding_delta)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            asset.effective_price = effective_price;
-            asset.fund_px_last = effective_price;
-            asset.slot_last = asset
-                .slot_last
-                .checked_add(segment_dt)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            self.assets[asset_index] = asset;
-            self.current_slot = now_slot;
-            self.slot_last = self
-                .assets
-                .iter()
-                .filter(|asset| {
-                    matches!(
-                        asset.lifecycle,
-                        percolator::AssetLifecycleV16::Active
-                            | percolator::AssetLifecycleV16::DrainOnly
-                    )
-                })
-                .map(|asset| asset.slot_last)
-                .min()
-                .unwrap_or(now_slot);
-            if price_move_active {
-                self.oracle_epoch = self
-                    .oracle_epoch
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-            }
-            if funding_active {
-                self.funding_epoch = self
-                    .funding_epoch
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-            }
-            Ok(percolator::AccrueAssetOutcomeV16 {
-                dt: segment_dt,
-                price_move_active,
-                funding_active,
-                equity_active: price_move_active || funding_active,
-                loss_stale_after: asset.slot_last < now_slot,
-            })
-        }
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -4116,6 +4016,16 @@ pub mod oracle_v16 {
 
 pub mod policy_v16 {
     use crate::constants::MAX_DYNAMIC_TRADE_FEE_BPS;
+
+    pub fn stale_cohort_has_external_account(
+        stale_account_count: u64,
+        account_a_is_stale: bool,
+        account_b_is_stale: bool,
+    ) -> Option<bool> {
+        let local_stale_count =
+            (account_a_is_stale as u64).checked_add(account_b_is_stale as u64)?;
+        Some(stale_account_count.checked_sub(local_stale_count)? != 0)
+    }
 
     pub fn unsigned_lp_adds_unsettled_cohort_exposure(
         current_q: i128,
@@ -10982,37 +10892,21 @@ pub mod processor {
         Ok(false)
     }
 
-    fn signed_position_for_asset_view(
-        group: &state::MarketViewMutV16<'_>,
-        portfolio: &percolator::PortfolioV16ViewMut<'_>,
-        asset_index: usize,
-    ) -> Result<i128, ProgramError> {
-        if asset_index >= group.markets.len() {
-            return Err(PercolatorError::EngineInvalidConfig.into());
-        }
-        let market_id = group.markets[asset_index].engine.asset.market_id.get();
-        let mut slot = 0usize;
-        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = portfolio.header.legs[slot]
-                .try_to_runtime()
-                .map_err(map_v16_error)?;
-            if leg.active && leg.asset_index as usize == asset_index && leg.market_id == market_id {
-                return Ok(match leg.side {
-                    SideV16::Long => leg.basis_pos_q.unsigned_abs() as i128,
-                    SideV16::Short => -(leg.basis_pos_q.unsigned_abs() as i128),
-                });
-            }
-            slot += 1;
-        }
-        Ok(0)
+    #[derive(Clone, Copy, Default)]
+    struct CpiPortfolioRequestState {
+        signed_position: i128,
+        stale_long: bool,
+        stale_short: bool,
     }
 
-    fn signed_positions_for_cpi_requests_view(
+    fn portfolio_states_for_cpi_requests_view(
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
         cpi_requests: &[(u16, i128)],
         request_market_ids: &[u64; MATCHER_BATCH_MAX_LEGS],
-    ) -> Result<[i128; MATCHER_BATCH_MAX_LEGS], ProgramError> {
-        let mut positions = [0i128; MATCHER_BATCH_MAX_LEGS];
+        request_kf_epoch_long: &[u64; MATCHER_BATCH_MAX_LEGS],
+        request_kf_epoch_short: &[u64; MATCHER_BATCH_MAX_LEGS],
+    ) -> Result<[CpiPortfolioRequestState; MATCHER_BATCH_MAX_LEGS], ProgramError> {
+        let mut states = [CpiPortfolioRequestState::default(); MATCHER_BATCH_MAX_LEGS];
         let mut slot = 0usize;
         while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = portfolio.header.legs[slot]
@@ -11023,16 +10917,26 @@ pub mod processor {
                     if leg.asset_index == asset_index as u32
                         && leg.market_id == request_market_ids[request_index]
                     {
-                        positions[request_index] = match leg.side {
-                            SideV16::Long => leg.basis_pos_q.unsigned_abs() as i128,
-                            SideV16::Short => -(leg.basis_pos_q.unsigned_abs() as i128),
+                        states[request_index] = match leg.side {
+                            SideV16::Long => CpiPortfolioRequestState {
+                                signed_position: leg.basis_pos_q.unsigned_abs() as i128,
+                                stale_long: leg.kf_epoch_snap
+                                    != request_kf_epoch_long[request_index],
+                                stale_short: false,
+                            },
+                            SideV16::Short => CpiPortfolioRequestState {
+                                signed_position: -(leg.basis_pos_q.unsigned_abs() as i128),
+                                stale_long: false,
+                                stale_short: leg.kf_epoch_snap
+                                    != request_kf_epoch_short[request_index],
+                            },
                         };
                     }
                 }
             }
             slot += 1;
         }
-        Ok(positions)
+        Ok(states)
     }
 
     fn ensure_trade_portfolio_current_for_requests_view(
@@ -11117,6 +11021,8 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let mut request_market_ids = [0u64; MATCHER_BATCH_MAX_LEGS];
+        let mut request_kf_epoch_long = [0u64; MATCHER_BATCH_MAX_LEGS];
+        let mut request_kf_epoch_short = [0u64; MATCHER_BATCH_MAX_LEGS];
         for (request_index, &(asset_index_u16, _)) in cpi_requests.iter().enumerate() {
             let asset_index = asset_index_u16 as usize;
             if asset_index >= group.header.config.max_market_slots.get() as usize
@@ -11124,14 +11030,29 @@ pub mod processor {
             {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
-            request_market_ids[request_index] =
-                group.markets[asset_index].engine.asset.market_id.get();
+            let asset = &group.markets[asset_index].engine.asset;
+            request_market_ids[request_index] = asset.market_id.get();
+            request_kf_epoch_long[request_index] = asset.kf_epoch_long.get();
+            request_kf_epoch_short[request_index] = asset.kf_epoch_short.get();
         }
-        let account_b_positions =
-            signed_positions_for_cpi_requests_view(account_b, cpi_requests, &request_market_ids)?;
+        let account_a_states = portfolio_states_for_cpi_requests_view(
+            account_a,
+            cpi_requests,
+            &request_market_ids,
+            &request_kf_epoch_long,
+            &request_kf_epoch_short,
+        )?;
+        let account_b_states = portfolio_states_for_cpi_requests_view(
+            account_b,
+            cpi_requests,
+            &request_market_ids,
+            &request_kf_epoch_long,
+            &request_kf_epoch_short,
+        )?;
         for (request_index, &(asset_index_u16, size_q)) in cpi_requests.iter().enumerate() {
             let asset_index = asset_index_u16 as usize;
-            let account_b_pos = account_b_positions[request_index];
+            let account_a_state = account_a_states[request_index];
+            let account_b_state = account_b_states[request_index];
             match group.markets[asset_index].engine.asset.lifecycle {
                 ASSET_LIFECYCLE_ACTIVE => {}
                 ASSET_LIFECYCLE_DRAIN_ONLY | ASSET_LIFECYCLE_RECOVERY => {
@@ -11142,10 +11063,11 @@ pub mod processor {
                     if !account_a_has_asset && !account_b_has_asset {
                         return Err(PercolatorError::EngineLockActive.into());
                     }
-                    let account_a_pos =
-                        signed_position_for_asset_view(group, account_a, asset_index)?;
-                    if requested_delta_must_increase_risk(account_a_pos, size_q)
-                        || requested_delta_must_increase_risk(account_b_pos, -size_q)
+                    if requested_delta_must_increase_risk(account_a_state.signed_position, size_q)
+                        || requested_delta_must_increase_risk(
+                            account_b_state.signed_position,
+                            -size_q,
+                        )
                     {
                         return Err(PercolatorError::EngineLockActive.into());
                     }
@@ -11156,11 +11078,23 @@ pub mod processor {
                 .checked_neg()
                 .ok_or(PercolatorError::EngineArithmeticOverflow)?;
             let asset = &group.markets[asset_index].engine.asset;
+            let external_stale_long = policy_v16::stale_cohort_has_external_account(
+                asset.stale_account_count_long.get(),
+                account_a_state.stale_long,
+                account_b_state.stale_long,
+            )
+            .ok_or(PercolatorError::EngineCounterUnderflow)?;
+            let external_stale_short = policy_v16::stale_cohort_has_external_account(
+                asset.stale_account_count_short.get(),
+                account_a_state.stale_short,
+                account_b_state.stale_short,
+            )
+            .ok_or(PercolatorError::EngineCounterUnderflow)?;
             let unsafe_unsigned_exposure = policy_v16::unsigned_lp_adds_unsettled_cohort_exposure(
-                account_b_pos,
+                account_b_state.signed_position,
                 lp_delta,
-                asset.stale_account_count_long.get() != 0,
-                asset.stale_account_count_short.get() != 0,
+                external_stale_long,
+                external_stale_short,
                 group.header.negative_pnl_account_count.get() != 0,
             )
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,416 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_attack_stale_loser_cannot_shift_preexisting_bankruptcy_to_fresh_lp() {
+    const OPEN_PRICE: u64 = 100;
+    const LOSS_PRICE: u64 = 500;
+    const RECOVERY_PRICE: u64 = 501;
+    const SIZE_Q: u128 = 10 * POS_SCALE;
+    const WINNER_DEPOSIT: u64 = 5_000;
+    const LOSER_DEPOSIT: u64 = 1_000;
+    const ATTACKER_DEPOSIT: u64 = WINNER_DEPOSIT + LOSER_DEPOSIT;
+    const LP_DEPOSIT: u64 = 1_000_000;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(0, OPEN_PRICE);
+    env.top_up_backing_bucket(1, 10_000, 100);
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let entrant_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    let entrant = env.create_portfolio(&entrant_owner);
+    env.deposit(&winner_owner, winner, WINNER_DEPOSIT.into());
+    env.deposit(&loser_owner, loser, LOSER_DEPOSIT.into());
+    env.deposit(&entrant_owner, entrant, LP_DEPOSIT.into());
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let (matcher_context, matcher_delegate, _) =
+        env.init_auth_matcher_context(matcher_program, &entrant_owner, entrant);
+
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q as i128,
+        OPEN_PRICE,
+        0,
+    );
+    for slot in 1..=3 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, LOSS_PRICE);
+        env.crank(
+            winner,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+
+    let before_group = env.market_state().1;
+    let winner_before = env.portfolio_state(winner);
+    let loser_before = env.portfolio_state(loser);
+    assert_eq!(winner_before.pnl.get(), 4_000);
+    assert_eq!(
+        loser_before.pnl.get(),
+        0,
+        "the losing leg is deliberately stale"
+    );
+    assert!(has_active_leg_for_asset(&winner_before, 0));
+    assert!(has_active_leg_for_asset(&loser_before, 0));
+    assert_eq!(before_group.assets[0].effective_price, LOSS_PRICE);
+    assert_eq!(before_group.negative_pnl_account_count, 0);
+
+    // The winner controls the taker and the losing account, while an independent LP has authorized
+    // the production CPI matcher. Moving the winner's long to that LP before the loser settles used
+    // to leave the later social loss attached to the LP's fresh position.
+    let market_before_transfer = env.svm.get_account(&env.market).unwrap();
+    let winner_before_transfer = env.svm.get_account(&winner).unwrap();
+    let entrant_before_transfer = env.svm.get_account(&entrant).unwrap();
+    let matcher_before_transfer = env.svm.get_account(&matcher_context).unwrap();
+    env.svm.expire_blockhash();
+    let batch_transfer = env.send(
+        ProgInstruction::BatchTradeCpi {
+            legs: vec![BatchTradeCpiLeg {
+                asset_index: 0,
+                size_q: -(SIZE_Q as i128),
+                fee_bps: 0,
+                limit_price: 0,
+            }],
+        },
+        vec![
+            AccountMeta::new(winner_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(winner, false),
+            AccountMeta::new(entrant, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new(matcher_context, false),
+            AccountMeta::new_readonly(matcher_delegate, false),
+        ],
+        &[&winner_owner],
+    );
+    assert!(
+        batch_transfer.is_err(),
+        "the batch matcher route must reject the same historical cohort transfer"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&winner).unwrap(),
+        winner_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&entrant).unwrap(),
+        entrant_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&matcher_context).unwrap(),
+        matcher_before_transfer
+    );
+
+    env.svm.expire_blockhash();
+    let transfer = env.try_trade_cpi_with_cu_on_asset(
+        &winner_owner,
+        winner,
+        &entrant_owner,
+        entrant,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        -(SIZE_Q as i128),
+        0,
+    );
+    assert!(
+        transfer.is_err(),
+        "a stale settlement cohort must not be novated to a fresh LP"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&winner).unwrap(),
+        winner_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&entrant).unwrap(),
+        entrant_before_transfer
+    );
+    assert_eq!(
+        env.svm.get_account(&matcher_context).unwrap(),
+        matcher_before_transfer,
+        "SVM rollback includes the production matcher CPI"
+    );
+
+    // The accounting lock is not a market-wide trade pause. With both owners signing, the same
+    // position can be transferred and returned while the losing cohort is stale; only an unsigned
+    // matcher may not place that historical obligation on its LP.
+    env.try_trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &entrant_owner,
+        entrant,
+        -(SIZE_Q as i128),
+        LOSS_PRICE,
+        0,
+    )
+    .expect("fully signed stale-cohort transfer must remain live");
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(winner), 0));
+    assert!(has_active_leg_for_asset(&env.portfolio_state(entrant), 0));
+    env.try_trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &entrant_owner,
+        entrant,
+        SIZE_Q as i128,
+        LOSS_PRICE,
+        0,
+    )
+    .expect("fully signed stale-cohort return must remain live");
+    assert!(has_active_leg_for_asset(&env.portfolio_state(winner), 0));
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(entrant), 0));
+
+    let market_before_conversion = env.svm.get_account(&env.market).unwrap();
+    let winner_before_conversion = env.svm.get_account(&winner).unwrap();
+    env.svm.expire_blockhash();
+    let conversion = env.send(
+        ProgInstruction::ConvertReleasedPnl { amount: 4_000 },
+        vec![
+            AccountMeta::new(winner_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(winner, false),
+        ],
+        &[&winner_owner],
+    );
+    assert!(
+        conversion.is_err(),
+        "the winner must not release source-backed PnL before its counterparty settles"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_conversion
+    );
+    assert_eq!(
+        env.svm.get_account(&winner).unwrap(),
+        winner_before_conversion
+    );
+
+    // There is also a one-crank interval after the loser settles K/F and principal but before its
+    // bankruptcy residual is booked. The source-side stale count is zero in that interval, so the
+    // global negative-PnL H-lock must independently keep the winner's claim non-favorable.
+    env.crank(
+        loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    let mid_group = env.market_state().1;
+    let loser_mid = env.portfolio_state(loser);
+    assert_eq!(mid_group.assets[0].stale_account_count_short, 0);
+    assert_eq!(mid_group.negative_pnl_account_count, 1);
+    assert_eq!(loser_mid.capital.get(), 0);
+    assert_eq!(loser_mid.pnl.get(), -3_000);
+    assert!(!close_progress(&loser_mid).active);
+
+    let market_before_negative_conversion = env.svm.get_account(&env.market).unwrap();
+    let winner_before_negative_conversion = env.svm.get_account(&winner).unwrap();
+    env.svm.expire_blockhash();
+    let negative_conversion = env.send(
+        ProgInstruction::ConvertReleasedPnl { amount: 4_000 },
+        vec![
+            AccountMeta::new(winner_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(winner, false),
+        ],
+        &[&winner_owner],
+    );
+    assert!(
+        negative_conversion.is_err(),
+        "unresolved negative PnL must keep source-backed winner credit non-favorable"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_negative_conversion
+    );
+    assert_eq!(
+        env.svm.get_account(&winner).unwrap(),
+        winner_before_negative_conversion
+    );
+
+    let mut successful_cranks = 0usize;
+    for _ in 0..64 {
+        let group = env.market_state().1;
+        let asset = &group.assets[0];
+        if asset.stale_account_count_long == 0
+            && asset.stale_account_count_short == 0
+            && asset.stored_pos_count_short == 0
+            && group.negative_pnl_account_count == 0
+            && group.b_stale_account_count == 0
+            && group
+                .pending_domain_loss_barriers
+                .iter()
+                .all(|&barrier| barrier == 0)
+        {
+            break;
+        }
+
+        let mut round_progressed = false;
+        for portfolio in [loser, winner] {
+            env.svm.expire_blockhash();
+            let result = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 3,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                ],
+                &[],
+            );
+            if result.is_ok() {
+                round_progressed = true;
+                successful_cranks += 1;
+            }
+        }
+        assert!(
+            round_progressed,
+            "an honest permissionless cranker must make progress while settlement work remains"
+        );
+    }
+
+    let winner_after = env.portfolio_state(winner);
+    let loser_after = env.portfolio_state(loser);
+    let entrant_after = env.portfolio_state(entrant);
+    let settled_group = env.market_state().1;
+    assert!(successful_cranks > 0);
+    assert_eq!(settled_group.assets[0].stale_account_count_long, 0);
+    assert_eq!(settled_group.assets[0].stale_account_count_short, 0);
+    assert_eq!(settled_group.assets[0].stored_pos_count_long, 1);
+    assert_eq!(settled_group.assets[0].stored_pos_count_short, 0);
+    assert_eq!(settled_group.assets[0].mode_long, SideModeV16::ResetPending);
+    assert_eq!(settled_group.assets[0].mode_short, SideModeV16::Normal);
+    assert_eq!(settled_group.negative_pnl_account_count, 0);
+    assert_eq!(settled_group.b_stale_account_count, 0);
+    assert!(settled_group
+        .pending_domain_loss_barriers
+        .iter()
+        .all(|&barrier| barrier == 0));
+    assert!(close_progress(&loser_after).finalized);
+    assert_eq!(close_progress(&loser_after).b_loss_booked, 3_000);
+    assert_eq!(
+        winner_after.pnl.get(),
+        1_000,
+        "the preexisting winner, not the fresh LP, absorbs the social loss"
+    );
+    assert_eq!(entrant_after.capital.get(), LP_DEPOSIT as u128);
+    assert_eq!(entrant_after.pnl.get(), 0);
+    assert!(!has_active_leg_for_asset(&entrant_after, 0));
+    assert!(has_active_leg_for_asset(&winner_after, 0));
+    assert!(!has_active_leg_for_asset(&loser_after, 0));
+
+    // Market accrual remains public while the winning side is ResetPending. Its surviving stored
+    // leg belongs to the frozen prior epoch, so a later segment must not invent stale K/F work
+    // that the old leg can never consume.
+    env.svm.warp_to_slot(4);
+    env.push_auth_mark_with_cu(4, RECOVERY_PRICE);
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 4,
+            observations: crank_observations(0),
+        },
+    );
+    let post_reset_accrual = env.market_state().1;
+    assert_eq!(post_reset_accrual.assets[0].effective_price, RECOVERY_PRICE);
+    assert_eq!(
+        post_reset_accrual.assets[0].stale_account_count_long, 0,
+        "post-reset accrual must not strand a prior-generation leg"
+    );
+
+    // The surviving prior-generation leg has no live OI. Its owner can detach it without
+    // forfeiting already-settled PnL, after which anyone can finalize the side reset.
+    env.forfeit_recovery_leg_with_cu(&winner_owner, winner, 0, 1);
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(winner), 0));
+    assert_eq!(env.portfolio_state(winner).pnl.get(), 1_000);
+    env.finalize_reset_side_with_cu(0, 0);
+    let recovered_group = env.market_state().1;
+    assert_eq!(recovered_group.assets[0].stored_pos_count_long, 0);
+    assert_eq!(recovered_group.assets[0].mode_long, SideModeV16::Normal);
+
+    // The gate is temporary: after recovery the production CPI route can open a fresh cohort.
+    env.trade_cpi_with_cu_on_asset(
+        &winner_owner,
+        winner,
+        &entrant_owner,
+        entrant,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        POS_SCALE as i128,
+        0,
+    );
+    assert!(has_active_leg_for_asset(&env.portfolio_state(winner), 0));
+    assert!(has_active_leg_for_asset(&env.portfolio_state(entrant), 0));
+
+    // Close the fresh cohort without fees so terminal payouts measure only the exploit accounting.
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &entrant_owner,
+        entrant,
+        -(POS_SCALE as i128),
+        RECOVERY_PRICE,
+        0,
+    );
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(winner), 0));
+    assert!(!has_active_leg_for_asset(&env.portfolio_state(entrant), 0));
+    assert_eq!(
+        env.portfolio_state(winner).capital.get(),
+        WINNER_DEPOSIT as u128
+    );
+    assert_eq!(env.portfolio_state(winner).pnl.get(), 1_000);
+    assert_eq!(
+        env.portfolio_state(entrant).capital.get(),
+        LP_DEPOSIT as u128
+    );
+
+    env.resolve();
+    let mut winner_payout = 0u64;
+    let mut loser_payout = 0u64;
+    let mut entrant_payout = 0u64;
+    for _ in 0..24 {
+        let winner_destination = env.close_resolved(&winner_owner, winner);
+        let loser_destination = env.close_resolved(&loser_owner, loser);
+        let entrant_destination = env.close_resolved(&entrant_owner, entrant);
+        winner_payout += env.token_amount(winner_destination);
+        loser_payout += env.token_amount(loser_destination);
+        entrant_payout += env.token_amount(entrant_destination);
+    }
+    assert_eq!(
+        winner_payout + loser_payout,
+        ATTACKER_DEPOSIT,
+        "the attacker cannot extract the backing provider's funds"
+    );
+    assert_eq!(
+        entrant_payout, LP_DEPOSIT,
+        "the fresh LP recovers its full principal"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60150,3 +60150,95 @@ fn v16_attack_stale_loser_cannot_shift_preexisting_bankruptcy_to_fresh_lp() {
         "the fresh LP recovers its full principal"
     );
 }
+
+#[test]
+fn v16_cpi_cured_local_negative_exit_is_not_external_bankruptcy() {
+    const OPEN_PRICE: u64 = 100;
+    const LOSS_PRICE: u64 = 500;
+    const SIZE_Q: u128 = 10 * POS_SCALE;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 10_000);
+    env.configure_auth_mark_with_cu(0, OPEN_PRICE);
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&winner_owner, winner, 5_000);
+    env.deposit(&loser_owner, loser, 1_000);
+    env.deposit(&lp_owner, lp, 1_000_000);
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let (matcher_context, matcher_delegate, _) =
+        env.init_auth_matcher_context(matcher_program, &lp_owner, lp);
+
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q as i128,
+        OPEN_PRICE,
+        0,
+    );
+    for slot in 1..=3 {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, LOSS_PRICE);
+        env.crank(
+            winner,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.crank(
+        loser,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 3,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(env.portfolio_state(loser).capital.get(), 0);
+    assert_eq!(env.portfolio_state(loser).pnl.get(), -3_000);
+    assert_eq!(env.market_state().1.negative_pnl_account_count, 1);
+
+    // Deposit cures enough principal for the engine's inline settlement, but intentionally leaves
+    // the aggregate negative-PnL counter pending until the trade executes.
+    env.deposit(&loser_owner, loser, 4_000);
+    assert_eq!(env.portfolio_state(loser).capital.get(), 4_000);
+    assert_eq!(env.portfolio_state(loser).pnl.get(), -3_000);
+    assert_eq!(env.market_state().1.negative_pnl_account_count, 1);
+
+    env.try_trade_cpi_with_cu_on_asset(
+        &loser_owner,
+        loser,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        0,
+        SIZE_Q as i128,
+        0,
+    )
+    .expect("a locally curable negative account must retain its CPI exit");
+
+    let loser_after = env.portfolio_state(loser);
+    let lp_after = env.portfolio_state(lp);
+    let group_after = env.market_state().1;
+    assert_eq!(loser_after.capital.get(), 1_000);
+    assert_eq!(loser_after.pnl.get(), 0);
+    assert!(!has_active_leg_for_asset(&loser_after, 0));
+    assert!(has_active_leg_for_asset(&lp_after, 0));
+    assert_eq!(group_after.negative_pnl_account_count, 0);
+    assert_eq!(
+        group_after.assets[0].oi_eff_long_q,
+        group_after.assets[0].oi_eff_short_q
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -1266,6 +1266,30 @@ impl V16CuEnv {
         self.svm.set_account(self.market, account).unwrap();
     }
 
+    fn accrue_asset_for_test(
+        &mut self,
+        asset_index: usize,
+        now_slot: u64,
+        effective_price: u64,
+        funding_rate_e9: i128,
+    ) -> percolator::AccrueAssetOutcomeV16 {
+        let mut account = self.svm.get_account(&self.market).expect("market account");
+        let outcome = {
+            let (_, mut group) = state::market_view_mut(&mut account.data).unwrap();
+            group
+                .accrue_asset_to_not_atomic(
+                    asset_index,
+                    now_slot,
+                    effective_price,
+                    funding_rate_e9,
+                    true,
+                )
+                .unwrap()
+        };
+        self.svm.set_account(self.market, account).unwrap();
+        outcome
+    }
+
     fn mark_b_stale_gap(&mut self, portfolio: Pubkey, asset_index: usize, target_b: u128) {
         let mut market_account = self.svm.get_account(&self.market).expect("market account");
         let mut portfolio_account = self.svm.get_account(&portfolio).expect("portfolio account");
@@ -7658,11 +7682,9 @@ fn v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides() {
         0,
     );
 
+    let out = env.accrue_asset_for_test(0, 1, INITIAL_PRICE, FUNDING_RATE_E9);
+    assert!(out.funding_active);
     env.mutate_market(|_, group| {
-        let out = group
-            .accrue_asset_to_not_atomic(0, 1, INITIAL_PRICE, FUNDING_RATE_E9, true)
-            .unwrap();
-        assert!(out.funding_active);
         group.assets[0].raw_oracle_target_price = INITIAL_PRICE;
     });
     env.svm.warp_to_slot(1);
@@ -8682,8 +8704,8 @@ fn v16_bpf_nonflat_fee_sync_settles_hidden_loss_before_sweeping_fee() {
     assert_eq!(long_before_move.capital.get(), 100);
     assert_eq!(long_before_move.pnl.get(), 0);
 
+    env.accrue_asset_for_test(0, 1, 50, 0);
     env.mutate_market(|_, group| {
-        group.accrue_asset_to_not_atomic(0, 1, 50, 0, true).unwrap();
         group.assets[0].raw_oracle_target_price = 50;
     });
     env.svm.warp_to_slot(1);
@@ -8741,10 +8763,8 @@ fn v16_bpf_fee_sync_rejects_reused_market_slot_stale_leg_without_mutation() {
     );
 
     let old_market_id = env.market_state().1.assets[0].market_id;
+    env.accrue_asset_for_test(0, 1, 100, 0);
     env.mutate_market(|_, group| {
-        group
-            .accrue_asset_to_not_atomic(0, 1, 100, 0, true)
-            .unwrap();
         group.assets[0].market_id = old_market_id + 1;
         group.next_market_id = group.next_market_id.max(old_market_id + 2);
     });
@@ -47446,7 +47466,7 @@ fn grow_market_to_10m_with_high_active_asset(
 
 #[test]
 fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
     const TRADE_SLOT: u64 = 1;
@@ -47561,10 +47581,10 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
 //
 // We cannot activate thousands of assets via thousands of UpdateAssetLifecycle txs (far too slow), so
 // we CONSTRUCT the market state directly: start from a known-good 1-asset market, make asset 0
-// active+flat via ConfigureAuthMark, grow the on-chain account to market_account_len_for_capacity(5834),
-// then via the host mirror set max_market_slots=5834 and clone asset 0's active state into a high
-// traded index (index 5833). All intermediate slots stay canonical DISABLED slots (validate_shape accepts them).
-// A real BPF TradeNoCpi on index 5833 then opens a balanced position; its CU is compared to a
+// active+flat via ConfigureAuthMark, grow the on-chain account to market_account_len_for_capacity(5782),
+// then via the host mirror set max_market_slots=5782 and clone asset 0's active state into a high
+// traded index (index 5781). All intermediate slots stay canonical DISABLED slots (validate_shape accepts them).
+// A real BPF TradeNoCpi on index 5781 then opens a balanced position; its CU is compared to a
 // small-N trade to prove per-trade compute does NOT scale with the thousands-of-assets count.
 //
 // Mechanism notes worth recording (verified against the pinned engine + wrapper):
@@ -47578,9 +47598,9 @@ fn v16_bpf_10m_market_liquidation_high_asset_stays_bounded() {
 //     profile bytes into the high slot so the high index has a valid, current (non-stale) mark.
 #[test]
 fn v16_bpf_10m_market_over_5000_assets_trades_with_bounded_cu() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
-    const TRADED: usize = N - 1; // 5833 — a HIGH index, proving the trade isn't special to asset 0.
+    const TRADED: usize = N - 1; // 5781 — a HIGH index, proving the trade isn't special to asset 0.
     const PRICE: u64 = 100;
     const TRADE_SLOT: u64 = 10;
 
@@ -47793,7 +47813,7 @@ fn v16_bpf_10m_market_over_5000_assets_trades_with_bounded_cu() {
 // then close the slab.
 #[test]
 fn v16_bpf_terminal_insurance_last_domain_withdraw_stays_bounded_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
@@ -47913,7 +47933,7 @@ fn v16_bpf_terminal_insurance_last_domain_withdraw_stays_bounded_on_10m_market()
 // withdrawal counters.
 #[test]
 fn v16_bpf_terminal_insurance_ledger_last_domain_withdraw_stays_bounded_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
@@ -47995,7 +48015,7 @@ fn v16_bpf_terminal_insurance_ledger_last_domain_withdraw_stays_bounded_on_10m_m
 // every remaining atom, there is no residual insurance balance to reconcile.
 #[test]
 fn v16_bpf_terminal_insurance_initialized_ledger_full_drain_stays_bounded_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
@@ -48096,7 +48116,7 @@ fn v16_bpf_terminal_insurance_initialized_ledger_full_drain_stays_bounded_on_10m
 // withdrawal cannot brick ledger-using insurance operators on a near-10 MiB market.
 #[test]
 fn v16_bpf_terminal_insurance_partial_ledger_withdraw_stays_bounded_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const SOLANA_MAX_ACCOUNT_DATA_LEN: usize = 10 * 1024 * 1024;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
@@ -48192,7 +48212,7 @@ fn v16_bpf_terminal_insurance_partial_ledger_withdraw_stays_bounded_on_10m_marke
 // can force a full account walk before the tail authority can recover even one atom.
 #[test]
 fn v16_bpf_terminal_insurance_partial_ledger_ignores_other_authority_budget_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
     const OTHER_AUTHORITY_FUNDED: u128 = 77;
@@ -48275,7 +48295,7 @@ fn v16_bpf_terminal_insurance_partial_ledger_ignores_other_authority_budget_on_1
 
 #[test]
 fn v16_bpf_terminal_asset_insurance_partial_ledger_middle_domain_stays_bounded_on_10m_market() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const MIDDLE_ASSET: usize = N / 2;
     const HIGH_ASSET: usize = N - 1;
     const PRICE: u64 = 100;
@@ -50419,7 +50439,7 @@ fn v16_bpf_batch_trade_cpi_14_legs_under_tx_limit() {
 // a smaller tail budget for real integrations.
 #[test]
 fn v16_attack_10m_batch_tradecpi_max_tail_rejects_before_cu_exhaustion() {
-    const N: usize = 5_834;
+    const N: usize = 5_782;
     const TAIL_LEGS: usize = percolator_prog::constants::WRAPPER_MAX_PORTFOLIO_ASSETS as usize;
     const FIRST_TAIL_ASSET: usize = N - TAIL_LEGS;
     const PRICE: u64 = 100;
@@ -51413,11 +51433,11 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         );
 
         env.svm.warp_to_slot(16);
+        for asset_index in 0..8usize {
+            env.accrue_asset_for_test(asset_index, 16, 95, 0);
+        }
         env.mutate_market(|_, group| {
             for asset_index in 0..8usize {
-                group
-                    .accrue_asset_to_not_atomic(asset_index, 16, 95, 0, true)
-                    .unwrap();
                 group.assets[asset_index].raw_oracle_target_price = 95;
             }
         });
@@ -51564,11 +51584,11 @@ fn v16_attack_tradecpi_active_stale_rejects_before_hostile_matcher_cpi() {
         );
 
         env.svm.warp_to_slot(16);
+        for asset_index in 0..8usize {
+            env.accrue_asset_for_test(asset_index, 16, 95, 0);
+        }
         env.mutate_market(|_, group| {
             for asset_index in 0..8usize {
-                group
-                    .accrue_asset_to_not_atomic(asset_index, 16, 95, 0, true)
-                    .unwrap();
                 group.assets[asset_index].raw_oracle_target_price = 95;
             }
         });

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -10,34 +10,34 @@ use percolator_prog::policy_v16;
 
 #[kani::proof]
 fn kani_v16_unsigned_lp_cohort_gate_is_side_exact_and_preserves_reductions() {
-    let stale_account_count: u8 = kani::any();
-    let account_a_is_stale: bool = kani::any();
-    let account_b_is_stale: bool = kani::any();
-    let local_stale_count = account_a_is_stale as u64 + account_b_is_stale as u64;
-    let external = policy_v16::stale_cohort_has_external_account(
-        stale_account_count as u64,
-        account_a_is_stale,
-        account_b_is_stale,
+    let pending_account_count: u8 = kani::any();
+    let account_a_is_pending: bool = kani::any();
+    let account_b_is_pending: bool = kani::any();
+    let local_pending_count = account_a_is_pending as u64 + account_b_is_pending as u64;
+    let external = policy_v16::pending_counter_has_external_account(
+        pending_account_count as u64,
+        account_a_is_pending,
+        account_b_is_pending,
     );
-    if (stale_account_count as u64) < local_stale_count {
+    if (pending_account_count as u64) < local_pending_count {
         assert!(external.is_none());
     } else {
         assert_eq!(
             external.unwrap(),
-            stale_account_count as u64 > local_stale_count
+            pending_account_count as u64 > local_pending_count
         );
     }
     kani::cover!(
-        stale_account_count as u64 == local_stale_count && local_stale_count != 0,
-        "the two atomic trade accounts consume the complete stale cohort"
+        pending_account_count as u64 == local_pending_count && local_pending_count != 0,
+        "the two atomic trade accounts consume the complete pending cohort"
     );
     kani::cover!(
-        stale_account_count as u64 > local_stale_count,
-        "an external stale account remains after local settlement"
+        pending_account_count as u64 > local_pending_count,
+        "an external pending account remains after local settlement"
     );
     kani::cover!(
-        (stale_account_count as u64) < local_stale_count,
-        "an inconsistent stale counter fails closed"
+        (pending_account_count as u64) < local_pending_count,
+        "an inconsistent pending counter fails closed"
     );
 
     let current_q: i64 = kani::any();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -10,6 +10,36 @@ use percolator_prog::policy_v16;
 
 #[kani::proof]
 fn kani_v16_unsigned_lp_cohort_gate_is_side_exact_and_preserves_reductions() {
+    let stale_account_count: u8 = kani::any();
+    let account_a_is_stale: bool = kani::any();
+    let account_b_is_stale: bool = kani::any();
+    let local_stale_count = account_a_is_stale as u64 + account_b_is_stale as u64;
+    let external = policy_v16::stale_cohort_has_external_account(
+        stale_account_count as u64,
+        account_a_is_stale,
+        account_b_is_stale,
+    );
+    if (stale_account_count as u64) < local_stale_count {
+        assert!(external.is_none());
+    } else {
+        assert_eq!(
+            external.unwrap(),
+            stale_account_count as u64 > local_stale_count
+        );
+    }
+    kani::cover!(
+        stale_account_count as u64 == local_stale_count && local_stale_count != 0,
+        "the two atomic trade accounts consume the complete stale cohort"
+    );
+    kani::cover!(
+        stale_account_count as u64 > local_stale_count,
+        "an external stale account remains after local settlement"
+    );
+    kani::cover!(
+        (stale_account_count as u64) < local_stale_count,
+        "an inconsistent stale counter fails closed"
+    );
+
     let current_q: i64 = kani::any();
     let delta_q: i64 = kani::any();
     let stale_long: bool = kani::any();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -177,6 +177,7 @@ fn kani_v16_collected_base_fee_cannot_fund_mark_movement() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_init_market_decode_preserves_wire_fields() {
     // Full-width symbolic inputs (audit: avoid the u16->u64/u128 widening collapse so
     // narrow-read / high-byte decode bugs are observable).
@@ -281,6 +282,7 @@ fn kani_v16_init_market_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
     let tag: u8 = kani::any();
     kani::assume(
@@ -312,6 +314,7 @@ fn kani_v16_amount_instructions_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let asset_index: u16 = kani::any();
@@ -349,6 +352,7 @@ fn kani_v16_domain_topup_and_asset_insurance_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let side: u8 = kani::any();
@@ -433,6 +437,7 @@ fn kani_v16_recovery_close_progress_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let amount: u128 = kani::any();
@@ -459,6 +464,7 @@ fn kani_v16_top_up_backing_bucket_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_withdraw_backing_bucket_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let amount: u128 = kani::any();
@@ -478,6 +484,7 @@ fn kani_v16_withdraw_backing_bucket_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
     let action: u8 = kani::any();
     let asset_index: u16 = kani::any();
@@ -525,6 +532,7 @@ fn kani_v16_asset_lifecycle_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
@@ -555,6 +563,7 @@ fn kani_v16_tradenocpi_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_tradecpi_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
@@ -666,6 +675,7 @@ fn kani_v16_matcher_return_accepts_only_bound_echoed_fills() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_permissionless_crank_decode_preserves_wire_fields() {
     let now_slot: u64 = kani::any();
     let asset_index_0: u16 = kani::any();
@@ -735,6 +745,7 @@ fn kani_v16_legacy_permissionless_crank_size_payload_is_rejected() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_authority_decode_preserves_wire_fields() {
     let mut new_pubkey = [0u8; 32];
     let mut i = 0;
@@ -758,6 +769,7 @@ fn kani_v16_update_authority_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let kind: u8 = kani::any();
@@ -789,6 +801,7 @@ fn kani_v16_update_asset_authority_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let now_slot: u64 = kani::any();
@@ -816,6 +829,7 @@ fn kani_v16_restart_asset_oracle_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle() {
     let asset_index: u16 = kani::any();
     let size_q: i128 = kani::any();
@@ -846,6 +860,7 @@ fn kani_v16_batch_trade_nocpi_decode_does_not_collide_with_restart_asset_oracle(
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
 
@@ -862,6 +877,7 @@ fn kani_v16_update_liquidation_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_maintenance_fee_policy_decode_preserves_wire_fields() {
     let cranker_share_bps: u16 = kani::any();
 
@@ -878,6 +894,7 @@ fn kani_v16_update_maintenance_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_backing_fee_policy_decode_preserves_wire_fields() {
     let domain: u16 = kani::any();
     let fee_bps: u16 = kani::any();
@@ -904,6 +921,7 @@ fn kani_v16_update_backing_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_trade_fee_policy_decode_preserves_wire_fields() {
     let trade_fee_base_bps: u64 = kani::any();
 
@@ -920,6 +938,7 @@ fn kani_v16_update_trade_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_fee_redirect_policy_decode_preserves_wire_fields() {
     let redirect_bps: u16 = kani::any();
 
@@ -934,6 +953,7 @@ fn kani_v16_update_fee_redirect_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_update_market_init_fee_policy_decode_preserves_wire_fields() {
     let min_init_fee: u128 = kani::any();
 
@@ -950,6 +970,7 @@ fn kani_v16_update_market_init_fee_policy_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_base_unit_payloads_decode_preserves_wire_fields() {
     let primary_mint: [u8; 32] = kani::any();
     let secondary_mint: [u8; 32] = kani::any();
@@ -980,6 +1001,7 @@ fn kani_v16_base_unit_payloads_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
     let stale_slots: u64 = kani::any();
     let force_close_delay_slots: u64 = kani::any();
@@ -1012,6 +1034,7 @@ fn kani_v16_permissionless_resolve_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
     let oracle_leg_count: u8 = kani::any();
@@ -1082,13 +1105,24 @@ fn kani_v16_configure_hybrid_oracle_decode_preserves_wire_fields() {
             assert_eq!(got_invert, invert);
             assert_eq!(got_unit_scale, unit_scale);
             assert_eq!(got_conf, conf_filter_bps);
-            assert_eq!(got_feeds, feeds);
+            let mut i = 0;
+            let mut feeds_match = true;
+            while i < 3 {
+                let mut j = 0;
+                while j < 32 {
+                    feeds_match &= got_feeds[i][j] == feeds[i][j];
+                    j += 1;
+                }
+                i += 1;
+            }
+            assert!(feeds_match);
         }
         _ => unreachable!(),
     }
 }
 
 #[kani::proof]
+#[kani::unwind(34)]
 fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
     let asset_index: u16 = kani::any();
 

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -9,6 +9,58 @@ use percolator_prog::matcher_abi::{
 use percolator_prog::policy_v16;
 
 #[kani::proof]
+fn kani_v16_unsigned_lp_cohort_gate_is_side_exact_and_preserves_reductions() {
+    let current_q: i64 = kani::any();
+    let delta_q: i64 = kani::any();
+    let stale_long: bool = kani::any();
+    let stale_short: bool = kani::any();
+    let unresolved_negative: bool = kani::any();
+    let current_q = current_q as i128;
+    let delta_q = delta_q as i128;
+    let next_q = current_q + delta_q;
+
+    let current_long = current_q.max(0) as u128;
+    let current_short = current_q.min(0).unsigned_abs();
+    let next_long = next_q.max(0) as u128;
+    let next_short = next_q.min(0).unsigned_abs();
+    let adds_long = next_long > current_long;
+    let adds_short = next_short > current_short;
+    let expected = (adds_long && stale_short)
+        || (adds_short && stale_long)
+        || ((adds_long || adds_short) && unresolved_negative);
+
+    let blocked = policy_v16::unsigned_lp_adds_unsettled_cohort_exposure(
+        current_q,
+        delta_q,
+        stale_long,
+        stale_short,
+        unresolved_negative,
+    )
+    .unwrap();
+
+    kani::cover!(
+        !adds_long && !adds_short && (stale_long || stale_short || unresolved_negative),
+        "pure LP reduction remains live while historical settlement is pending"
+    );
+    kani::cover!(
+        adds_long && stale_short && !stale_long,
+        "fresh long exposure is bound to stale short counterparties"
+    );
+    kani::cover!(
+        adds_short && stale_long && !stale_short,
+        "fresh short exposure is bound to stale long counterparties"
+    );
+    kani::cover!(
+        (adds_long || adds_short) && unresolved_negative,
+        "the post-settlement pre-booking interval blocks fresh unsigned exposure"
+    );
+    assert_eq!(blocked, expected);
+    if !adds_long && !adds_short {
+        assert!(!blocked);
+    }
+}
+
+#[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {
     let mark_raw: u16 = kani::any();
     let index_raw: u16 = kani::any();

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -1487,6 +1487,7 @@ fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_unknown_or_truncated_tags_reject() {
     let tag: u8 = kani::any();
     kani::assume(tag != 0);

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -1178,6 +1178,7 @@ fn kani_v16_ewma_mark_decode_preserves_wire_fields() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_decode_rejects_trailing_bytes() {
     let extra: u8 = kani::any();
     let data = [1u8, extra];
@@ -1191,6 +1192,7 @@ fn assert_rejects_trailing_byte(ix: Instruction, extra: u8) {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_init_market_payload_rejects_trailing_byte() {
     let extra: u8 = kani::any();
     assert_rejects_trailing_byte(
@@ -1223,6 +1225,7 @@ fn kani_v16_init_market_payload_rejects_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_custody_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1257,6 +1260,7 @@ fn kani_v16_custody_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1292,6 +1296,7 @@ fn kani_v16_trade_and_crank_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1366,6 +1371,7 @@ fn kani_v16_admin_policy_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1437,6 +1443,7 @@ fn kani_v16_oracle_asset_payloads_reject_trailing_byte() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_resolved_recovery_payloads_reject_trailing_byte() {
     let extra: u8 = kani::any();
 
@@ -1535,6 +1542,7 @@ fn kani_v16_unknown_or_truncated_tags_reject() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_refine_resolved_bound_tag_is_not_public() {
     let decrease_num: u128 = kani::any();
     let mut data = [0u8; 17];
@@ -1551,6 +1559,7 @@ fn kani_v16_zero_length_decode_rejects() {
 }
 
 #[kani::proof]
+#[kani::unwind(18)]
 fn kani_v16_every_active_payload_rejects_one_byte_truncation() {
     let init_market = [0u8; 80];
     assert!(Instruction::decode(&init_market).is_err());


### PR DESCRIPTION
## Finding

An unsigned matcher LP could accept fresh exposure after the opposite-side K/F
cohort became stale. A winning account could therefore realize source-backed PnL
first, novate its position onto a fresh LP, and leave the later bankruptcy/social
loss booking on that LP.

The LiteSVM reproduction uses only public instructions and ordinary initialized
accounts:

1. Open an attacker-controlled winning long against a thin losing short.
2. Move the authenticated mark and crank only the winner.
3. Attempt to move fresh long exposure onto an unsigned matcher LP through both
   `TradeCpi` and `BatchTradeCpi`.
4. Crank the loser and all remaining work to terminal state.

At the exact pre-fix parent, the batch matcher route succeeds and the regression
test fails. With this patch, both unsigned CPI routes reject before invoking the
matcher, state and matcher context roll back exactly, signed `TradeNoCpi`
novation remains available, pure LP reductions remain live, and honest cranks
reach the expected terminal payouts.

## Fix

- Pin engine PR aeyakovenko/percolator#162, which tracks monotonic per-side K/F
  settlement cohorts and conservatively locks stale source-backed claims.
- At the unsigned matcher boundary, reject only LP exposure increases that can
  inherit a stale opposite-side cohort or unresolved negative PnL.
- Subtract both atomically settled trade accounts from each pending aggregate.
  A locally curable negative-PnL account can therefore still exit through CPI;
  only an external pending account blocks new unsigned LP exposure.
- Scan the LP portfolio once for the whole matcher batch. The 14-leg CPI test is
  1,238,049 CU versus 1,222,481 CU at the parent.
- Prove the side mapping and the reduction-liveness exception with Kani.

## TDD evidence

- Test-only commit: `2890daf337f8d7d71706d06fc579b5f21f4faadd`
- Exact old engine pin: `143e68c4917ed0400a27b952f036a5677047cd84`
- Pre-fix result: RED at the public `BatchTradeCpi` assertion
- Fixed engine pin: `d81b86252c028d7977c14bcf75c06eb199a61b2b`
- Fixed result: GREEN for single CPI, batch CPI, signed escape, rollback,
  progress, reset, and terminal-value assertions
- Local-negative liveness test-only commit: `d26c970a`
- Exact pre-fix policy result: RED with `EngineLockActive` before matcher CPI
  after 22,200 CU
- Local-negative fixed commit: `6acc341c`
- Local-negative fixed result: GREEN; inline settlement clears the local
  negative PnL and the trade closes both positions

## Verification

- `cargo build-sbf --tools-version v1.52`
- Targeted LiteSVM exploit: pass
- Full runtime suite: 6 unit tests and 567 LiteSVM/BPF/CU tests passed
- Targeted 14-leg CPI CU test: pass at 1,238,049 CU
- Targeted wrapper Kani proof: 35/35 assertions and 7/7 covers
- Full wrapper Kani roster: 41/41 harnesses verified, 0 failures
- Checked decoder proof bounds: the symbolic vector cap is 16; every added
  unwind assertion remains enabled, and the 3-by-32 Hybrid feed comparison is
  explicit rather than hidden behind a 96-byte `memcmp`

## Deployment compatibility

Engine commit `d81b8625` advances `V16_LAYOUT_DISCRIMINATOR` from 17 to 18 and
adds settlement-cohort fields. This branch is suitable for fresh/predeployment
markets; an existing live layout-17 market requires a coordinated migration
before deployment.
