### PR TITLE
[BLOCKER DoS] Reject retained backing top-ups after signed expiry

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -7586,6 +7586,11 @@ pub mod processor {
             {
                 return Err(PercolatorError::EngineLockActive.into());
             }
+            if amount != 0
+                && expiry_slot <= authenticated_slot_or_fallback(group.header.current_slot.get())
+            {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
             require_domain_accepts_live_topup_view(&group, domain_usize)?;
             let profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
             let authorities = domain_authorities_from_profile(&cfg, &profile, asset_index);
@@ -7603,6 +7608,9 @@ pub mod processor {
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
             if group.header.mode != 0 {
                 return Err(PercolatorError::EngineLockActive.into());
+            }
+            if expiry_slot <= authenticated_slot_or_fallback(group.header.current_slot.get()) {
+                return Err(PercolatorError::InvalidInstruction.into());
             }
             reject_permissionless_resolve_matured_live_view(&cfg, &group)?;
             require_domain_accepts_live_topup_view(&group, domain_usize)?;

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,259 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+struct DelayedBackingTopupOutcome {
+    topup_accepted: bool,
+    provider_source: u64,
+    winner_payout: u64,
+    loser_payout: u64,
+    winner_terminal: bool,
+    loser_terminal: bool,
+    provider_recovery: u64,
+    provider_withdraw_succeeded: bool,
+}
+
+fn run_delayed_backing_topup_after_expiry(submit_retained: bool) -> DelayedBackingTopupOutcome {
+    const BACKING: u128 = 500;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+    const ASSET_INDEX: u16 = 1;
+    const WINNING_DOMAIN: u16 = 3;
+    const EXPIRY_SLOT: u64 = 6;
+    const SETTLED_SLOT: u64 = 3;
+    const LANDING_SLOT: u64 = 7;
+    const RESOLVE_SLOT: u64 = 13;
+
+    let mut env = V16CuEnv::new();
+    let provider = Keypair::new();
+    env.activate_asset_with_authorities(
+        ASSET_INDEX,
+        1,
+        100,
+        env.admin.pubkey(),
+        env.admin.pubkey(),
+        provider.pubkey(),
+        env.admin.pubkey(),
+    );
+    env.ensure_signer_account(provider.pubkey());
+    env.configure_auth_mark_for_asset_as_admin(ASSET_INDEX, 1, 100);
+    env.configure_permissionless_resolve_with_cu(RESOLVE_SLOT - SETTLED_SLOT, 1);
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let publisher_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    let publisher = env.create_portfolio(&publisher_owner);
+    env.deposit(&winner_owner, winner, 1_000);
+    env.deposit(&loser_owner, loser, 1_000);
+    env.trade_asset_with_cu(
+        ASSET_INDEX,
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q,
+        100,
+        0,
+    );
+
+    for (slot, mark) in [(2, 200), (SETTLED_SLOT, 350)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(ASSET_INDEX, slot, mark);
+        env.crank(
+            publisher,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(ASSET_INDEX),
+            },
+        );
+    }
+    assert_eq!(
+        env.market_state().1.assets[ASSET_INDEX as usize].effective_price,
+        350,
+        "the adverse public mark must be committed before the provider signs"
+    );
+
+    let source = env.token_account(provider.pubkey(), BACKING as u64);
+    env.svm.expire_blockhash();
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(provider.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(source, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                data: ProgInstruction::TopUpBackingBucket {
+                    domain: WINNING_DOMAIN,
+                    amount: BACKING,
+                    expiry_slot: EXPIRY_SLOT,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &provider],
+        env.svm.latest_blockhash(),
+    );
+
+    // A relayer retains the honestly signed transaction until after the provider's
+    // explicit risk window. No market instruction advances the engine slot first.
+    env.svm.warp_to_slot(LANDING_SLOT);
+    let topup_accepted = if submit_retained {
+        let result = env.svm.send_transaction(retained);
+        result.is_ok()
+    } else {
+        false
+    };
+    assert_eq!(
+        env.svm.get_sysvar::<Clock>().slot,
+        LANDING_SLOT,
+        "the transaction is submitted after its signed expiry"
+    );
+
+    env.resolve_stale_permissionless_with_cu(RESOLVE_SLOT);
+    env.svm.warp_to_slot(RESOLVE_SLOT + 1);
+    let winner_dest = env.token_account(winner_owner.pubkey(), 0);
+    let loser_dest = env.token_account(loser_owner.pubkey(), 0);
+    let is_terminal = |portfolio: &PortfolioAccountV16| {
+        portfolio.capital.get() == 0
+            && portfolio.pnl.get() == 0
+            && percolator::active_bitmap_is_empty(active_bitmap(portfolio))
+            && portfolio
+                .source_domains
+                .iter()
+                .all(|source| source.source_claim_bound_num.get() == 0)
+    };
+    let mut close_successes = 0usize;
+    let mut close_errors = 0usize;
+    for _ in 0..64 {
+        for (owner, portfolio, dest) in [
+            (&loser_owner, loser, loser_dest),
+            (&winner_owner, winner, winner_dest),
+        ] {
+            if is_terminal(&env.portfolio_state(portfolio)) {
+                continue;
+            }
+            env.svm.expire_blockhash();
+            let result = env.send(
+                ProgInstruction::CloseResolved {
+                    fee_rate_per_slot: 0,
+                },
+                vec![
+                    AccountMeta::new_readonly(owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolio, false),
+                    AccountMeta::new(dest, false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                &[owner],
+            );
+            if result.is_ok() {
+                close_successes += 1;
+            } else {
+                close_errors += 1;
+            }
+        }
+        if is_terminal(&env.portfolio_state(winner)) && is_terminal(&env.portfolio_state(loser)) {
+            break;
+        }
+    }
+    let winner_terminal = is_terminal(&env.portfolio_state(winner));
+    let loser_terminal = is_terminal(&env.portfolio_state(loser));
+    let provider_dest = env.token_account(provider.pubkey(), 0);
+    let provider_withdraw_succeeded = if topup_accepted {
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain: WINNING_DOMAIN,
+                amount: BACKING,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&provider],
+        )
+        .is_ok()
+    } else {
+        false
+    };
+    println!(
+        "delayed-topup terminal summary: accepted={topup_accepted} closes_ok={close_successes} \
+         closes_err={close_errors} winner_terminal={winner_terminal} \
+         loser_terminal={loser_terminal} provider_source={} provider_recovery={} \
+         winner_payout={} loser_payout={}",
+        env.token_amount(source),
+        env.token_amount(provider_dest),
+        env.token_amount(winner_dest),
+        env.token_amount(loser_dest),
+    );
+
+    DelayedBackingTopupOutcome {
+        topup_accepted,
+        provider_source: env.token_amount(source),
+        winner_payout: env.token_amount(winner_dest),
+        loser_payout: env.token_amount(loser_dest),
+        winner_terminal,
+        loser_terminal,
+        provider_recovery: env.token_amount(provider_dest),
+        provider_withdraw_succeeded,
+    }
+}
+
+// A backing provider's signed expiry is a custody boundary, not a hint. A relayer
+// must not be able to land the retained top-up after that slot and route the
+// provider's atoms into an already-profitable independent account.
+#[test]
+fn v16_attack_retained_backing_topup_cannot_land_after_signed_expiry() {
+    let control = run_delayed_backing_topup_after_expiry(false);
+    let delayed = run_delayed_backing_topup_after_expiry(true);
+
+    assert!(
+        !delayed.topup_accepted,
+        "expired retained top-up landed: provider source {} -> {}, recovery={}, \
+         winner payout {} -> {}, terminal={}; loser terminal={}",
+        control.provider_source,
+        delayed.provider_source,
+        delayed.provider_recovery,
+        control.winner_payout,
+        delayed.winner_payout,
+        delayed.winner_terminal,
+        delayed.loser_terminal,
+    );
+    assert!(
+        delayed.winner_terminal && delayed.loser_terminal,
+        "the stale transaction must not strand terminal users (winner={}, loser={})",
+        delayed.winner_terminal,
+        delayed.loser_terminal,
+    );
+    assert_eq!(
+        delayed.provider_source + delayed.provider_recovery,
+        control.provider_source + control.provider_recovery,
+        "rejected stale top-up preserves provider custody"
+    );
+    assert!(
+        !delayed.topup_accepted || delayed.provider_withdraw_succeeded,
+        "accepted stale top-up must remain publicly recoverable by its provider"
+    );
+    assert_eq!(
+        delayed.winner_payout, control.winner_payout,
+        "an expired provider signature cannot increase an independent payout"
+    );
+    assert_eq!(
+        delayed.loser_payout, control.loser_payout,
+        "the stale transaction cannot alter terminal loss allocation"
+    );
+}


### PR DESCRIPTION
## Root cause

`TopUpBackingBucket` treated `expiry_slot` as fresh relative only to the engine's stored `header.current_slot`. A relayer could retain an honestly signed provider transaction and land it after the signed expiry while no market instruction had advanced that stored slot. The wrapper did not compare the expiry with the authenticated SVM `Clock`.

## Public exploit

The LiteSVM regression uses only public instructions and ordinary external account fixtures:

1. Initialize a live market and permissionless asset with an independent backing provider.
2. Open public long/short positions and move the honest authenticated mark from 100 to 350.
3. At slot 3, have the provider sign a 500-atom domain top-up expiring at slot 6.
4. Let an unprivileged relayer retain it and submit it at authenticated slot 7, within the blockhash lifetime.
5. Resolve permissionlessly and repeatedly submit owner-signed `CloseResolved` calls.

On exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`, test-only commit `fcb4af76` is RED:

- control: top-up rejected/not submitted, 16 successful close steps, both users terminal, winner payout 2,000, provider source 500
- delayed submission: top-up accepted, provider source 500 -> 0, 64 successful and 64 failed close attempts, both users remain nonterminal, both payouts 0, and the provider cannot withdraw the resolved backing

This is a persistent public terminal-progress DoS, not an init footgun or injected protocol state.

## Fix

For every nonzero backing top-up, both preflight and commit now require:

```text
expiry_slot > authenticated SVM Clock slot
```

The existing zero-amount expired no-op behavior is preserved. No engine code or engine pin changes are included.

## Verification

- Exact-parent RED repro: `fcb4af76`
- Fixed GREEN: `v16_attack_retained_backing_topup_cannot_land_after_signed_expiry`
- Adjacent backing input/expiry tests: green
- `cargo build-sbf --tools-version v1.52`: green
- Full runtime suite with all program/matcher fixtures: 6 unit + 566 LiteSVM/BPF/CU tests, 0 failures
- Kani: all 40 harnesses verified; 36 completed in the full sequence, then the pathological symbolic-tag decoder and its three successors completed explicitly with `--unwind 18` and unwinding assertions enabled (the decoder observation loop is production-bounded at 16)
- `git diff --check`: clean