### PR TITLE
[BLOCKER LoF] Make retired-slot activation intents one-shot

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4334,6 +4334,16 @@ pub mod processor {
         Clock::get().map(|c| c.slot).unwrap_or(fallback_slot)
     }
 
+    #[doc(hidden)]
+    #[inline]
+    pub fn activation_intent_slot_is_fresh(
+        intent_slot: u64,
+        authenticated_slot: u64,
+        retired_slot: u64,
+    ) -> bool {
+        intent_slot != 0 && intent_slot <= authenticated_slot && intent_slot > retired_slot
+    }
+
     fn authenticated_market_slot_or_fallback_view(group: &state::MarketViewMutV16<'_>) -> u64 {
         core::cmp::max(
             Clock::get()
@@ -9170,6 +9180,15 @@ pub mod processor {
                         {
                             return Err(PercolatorError::EngineLockActive.into());
                         }
+                        let retired_slot =
+                            group.markets[asset_index].engine.asset.retired_slot.get();
+                        if !activation_intent_slot_is_fresh(
+                            now_slot,
+                            authenticated_slot,
+                            retired_slot,
+                        ) {
+                            return Err(PercolatorError::InvalidInstruction.into());
+                        }
                         // Reject zero domain authorities, mirroring the append path
                         // (activate_dynamic_asset_slot, ~line 1475). A zero
                         // insurance_authority makes that domain's insurance budget
@@ -9368,6 +9387,17 @@ pub mod processor {
                     }
                     let was_retired = group.markets[asset_index].engine.asset.lifecycle
                         == ASSET_LIFECYCLE_RETIRED;
+                    if was_retired {
+                        let retired_slot =
+                            group.markets[asset_index].engine.asset.retired_slot.get();
+                        if !activation_intent_slot_is_fresh(
+                            now_slot,
+                            authenticated_slot,
+                            retired_slot,
+                        ) {
+                            return Err(PercolatorError::InvalidInstruction.into());
+                        }
+                    }
                     let preserved_policy_count =
                         backing_fee_policy_count_from_profile(&existing_profile);
                     group

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,102 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// LoF sweep: a permissionless retired-slot activation is an owner-signed value intent. Two
+// fee-bump variants may share the same semantic activation while having distinct transaction
+// signatures. Once one variant activates generation N, a retained variant must not become valid
+// again after that generation is retired; otherwise an unprivileged relayer can charge the creator
+// a second init fee and reinstall stale price/authority material.
+#[test]
+fn v16_attack_retained_reuse_activation_cannot_debit_next_generation() {
+    const FEE: u128 = 500;
+    const ASSET_INDEX: u16 = 1;
+
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(FEE);
+
+    // Bootstrap and retire slot 1 so the honest creator's signed request exercises the
+    // permissionless reuse path rather than first-time market growth.
+    env.svm.warp_to_slot(1);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        processor::ASSET_ACTION_ACTIVATE,
+        ASSET_INDEX,
+        1,
+        100,
+    );
+    env.svm.warp_to_slot(2);
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_RETIRE, ASSET_INDEX, 2, 0);
+
+    let creator = Keypair::new();
+    env.ensure_signer_account(creator.pubkey());
+    let source = env.token_account(creator.pubkey(), (2 * FEE) as u64);
+    env.svm.warp_to_slot(3);
+    env.svm.expire_blockhash();
+    let blockhash = env.svm.latest_blockhash();
+    let activate_ix = Instruction {
+        program_id: env.program_id,
+        accounts: vec![
+            AccountMeta::new(creator.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(source, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        data: ProgInstruction::UpdateAssetLifecycle {
+            action: processor::ASSET_ACTION_ACTIVATE,
+            asset_index: ASSET_INDEX,
+            now_slot: 3,
+            initial_price: 100,
+            insurance_authority: creator.pubkey().to_bytes(),
+            insurance_operator: creator.pubkey().to_bytes(),
+            backing_bucket_authority: creator.pubkey().to_bytes(),
+            oracle_authority: creator.pubkey().to_bytes(),
+        }
+        .encode(),
+    };
+    let intended = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), activate_ix.clone()],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &creator],
+        blockhash,
+    );
+    let retained = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            activate_ix,
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &creator],
+        blockhash,
+    );
+    env.svm
+        .send_transaction(intended)
+        .expect("the creator's intended reuse activation lands");
+    assert_eq!(env.token_amount(source), FEE as u64);
+    let first_generation = env.market_state().1.assets[ASSET_INDEX as usize].market_id;
+
+    // Normal lifecycle progress makes the same slot reusable again while the retained blockhash
+    // variant remains valid.
+    env.svm.warp_to_slot(4);
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_RETIRE, ASSET_INDEX, 4, 0);
+    assert_eq!(
+        env.market_state().1.assets[ASSET_INDEX as usize].lifecycle,
+        AssetLifecycleV16::Retired
+    );
+    let source_before = env.svm.get_account(&source).unwrap();
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+
+    env.svm.warp_to_slot(5);
+    let replay = env.svm.send_transaction(retained);
+    assert!(
+        replay.is_err(),
+        "retained generation-{first_generation} reuse activation must reject instead of \
+         charging the creator twice and installing another asset generation"
+    );
+    assert_eq!(env.svm.get_account(&source).unwrap(), source_before);
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -4925,11 +4925,11 @@ fn v16_bpf_permissionless_reuse_activation_uses_authenticated_slot() {
         AssetLifecycleV16::Retired
     );
 
-    env.svm.warp_to_slot(4);
+    env.svm.warp_to_slot(5);
     env.activate_permissionless_asset_with_fee(
         &attacker,
         1,
-        u64::MAX,
+        4,
         250,
         attacker.pubkey(),
         attacker.pubkey(),
@@ -4940,17 +4940,17 @@ fn v16_bpf_permissionless_reuse_activation_uses_authenticated_slot() {
 
     let (_, group) = env.market_state();
     assert_eq!(
-        group.current_slot, 4,
+        group.current_slot, 5,
         "permissionless reuse activation must authenticate now_slot against Clock"
     );
-    assert_eq!(group.assets[1].slot_last, 4);
+    assert_eq!(group.assets[1].slot_last, 5);
 
     let cranker = Keypair::new();
     let cranker_portfolio = env.create_portfolio(&cranker);
     env.crank(
         cranker_portfolio,
         ProgInstruction::PermissionlessCrank {
-            now_slot: 4,
+            now_slot: 5,
             observations: crank_observations(0),
         },
     );
@@ -4999,27 +4999,27 @@ fn v16_bpf_privileged_reactivate_uses_authenticated_slot() {
         0,
     );
 
-    env.svm.warp_to_slot(4);
+    env.svm.warp_to_slot(5);
     env.update_asset_lifecycle_as_admin_with_cu(
         percolator_prog::processor::ASSET_ACTION_ACTIVATE,
         1,
-        u64::MAX,
+        4,
         250,
     );
 
     let (_, group) = env.market_state();
     assert_eq!(
-        group.current_slot, 4,
+        group.current_slot, 5,
         "privileged reactivation must authenticate now_slot against Clock"
     );
-    assert_eq!(group.assets[1].slot_last, 4);
+    assert_eq!(group.assets[1].slot_last, 5);
 
     let cranker = Keypair::new();
     let cranker_portfolio = env.create_portfolio(&cranker);
     env.crank(
         cranker_portfolio,
         ProgInstruction::PermissionlessCrank {
-            now_slot: 4,
+            now_slot: 5,
             observations: crank_observations(0),
         },
     );
@@ -59809,8 +59809,9 @@ fn v16_attack_retained_reuse_activation_cannot_debit_next_generation() {
     let replay = env.svm.send_transaction(retained);
     assert!(
         replay.is_err(),
-        "retained generation-{first_generation} reuse activation must reject instead of \
-         charging the creator twice and installing another asset generation"
+        "retained generation-{} reuse activation must reject instead of charging the creator \
+         twice and installing another asset generation",
+        first_generation
     );
     assert_eq!(env.svm.get_account(&source).unwrap(), source_before);
     assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -6,7 +6,29 @@ use percolator_prog::ix::{CrankObservationHint, Instruction};
 use percolator_prog::matcher_abi::{
     validate_matcher_return, MatcherReturn, FLAG_PARTIAL_OK, FLAG_REJECTED, FLAG_VALID,
 };
-use percolator_prog::policy_v16;
+use percolator_prog::{policy_v16, processor};
+
+#[kani::proof]
+fn kani_v16_retired_activation_intent_cannot_cross_next_retirement() {
+    let intent_slot: u64 = kani::any();
+    let first_authenticated_slot: u64 = kani::any();
+    let prior_retired_slot: u64 = kani::any();
+    let next_retired_slot: u64 = kani::any();
+    let replay_authenticated_slot: u64 = kani::any();
+
+    kani::assume(processor::activation_intent_slot_is_fresh(
+        intent_slot,
+        first_authenticated_slot,
+        prior_retired_slot,
+    ));
+    kani::assume(next_retired_slot >= first_authenticated_slot);
+
+    assert!(!processor::activation_intent_slot_is_fresh(
+        intent_slot,
+        replay_authenticated_slot,
+        next_retired_slot,
+    ));
+}
 
 #[kani::proof]
 fn kani_v16_premium_funding_rate_is_clamped_and_signed() {


### PR DESCRIPTION
## What changed

Bind every retired-slot `ACTIVATE` intent to the lifecycle retirement that made the slot reusable. The signed intent slot must be nonzero, no later than the authenticated Clock slot, and strictly later than the asset's recorded retirement slot. The guard runs before fee transfer or state mutation for both permissionless reuse and privileged/marketauth reactivation.

This is wire-compatible and does not change persisted layouts.

## Public exploit

An honest creator could sign two fee-bump transaction variants carrying the same permissionless activation intent. After one variant landed and paid the activation fee, the asset could be retired normally. A relayer could then land the retained variant during the recent-blockhash window, charging the creator a second time and installing stale authority/price material into a new asset generation.

The LiteSVM regression uses only public instructions, real SPL token accounts, normal lifecycle transitions, and retained signed transaction bytes. On exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`, RED commit `3ec400f7bc690a7949976ce37409b58d2f9b9c43` reproduces the second debit. Fix commit `21a7f09f` rejects it atomically while preserving delayed/out-of-order landing within the intended retired generation.

This is distinct from mutable fee consent (#314) and shutdown generation binding (#315): it prevents replay of the same valid activation consent across successive asset generations.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 LiteSVM/CU tests pass
- Focused public replay regression passes
- All 41 Kani harnesses pass with unwinding checks enabled: 36 at checked bound 17, 4 aggregate decode harnesses at 34, and the 3x32-byte hybrid decode harness at 98
- Program and all matcher SBF fixtures build
- `cargo fmt --check`
- `git diff --check`