### PR TITLE
[BLOCKER LoF] Observe backing expiry before PnL conversion

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8374,6 +8374,39 @@ pub mod processor {
         Ok(())
     }
 
+    fn reject_lapsed_source_backing_for_conversion_view(
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        authenticated_slot: u64,
+    ) -> Result<(), V16Error> {
+        let max_market_slots = group.header.config.max_market_slots.get() as usize;
+        if max_market_slots > group.markets.len() {
+            return Err(V16Error::InvalidConfig);
+        }
+        for source in portfolio.header.source_domains.iter() {
+            if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+                continue;
+            }
+            let domain = source.domain.get() as usize;
+            let asset_index = domain / 2;
+            if asset_index >= max_market_slots {
+                return Err(V16Error::InvalidConfig);
+            }
+            let engine_slot = &group.markets[asset_index].engine;
+            let bucket = if domain % 2 == 0 {
+                engine_slot.backing_long.try_to_runtime()?
+            } else {
+                engine_slot.backing_short.try_to_runtime()?
+            };
+            if bucket.status == percolator::BackingBucketStatusV16::Fresh
+                && bucket.expiry_slot <= authenticated_slot
+            {
+                return Err(V16Error::Stale);
+            }
+        }
+        Ok(())
+    }
+
     #[inline(never)]
     fn handle_convert_released_pnl<'a>(
         program_id: &Pubkey,
@@ -8390,6 +8423,11 @@ pub mod processor {
             if permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
+            reject_lapsed_source_backing_for_conversion_view(
+                group,
+                portfolio,
+                authenticated_market_slot_or_fallback_view(group),
+            )?;
             // The v16 engine converts the currently released residual-bounded
             // amount atomically. Preserve the wrapper caller cap by staging the
             // conversion and only committing it when the converted amount fits.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,137 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Authenticated wall-clock expiry must be observed before released
+// source-backed PnL can consume and withdraw provider principal.
+#[test]
+fn v16_attack_released_pnl_cannot_consume_backing_after_wall_clock_expiry() {
+    const INITIAL_PRICE: u64 = 100;
+    const WINNING_MARK: u64 = 105;
+    const SIZE_Q: i128 = 20 * POS_SCALE as i128;
+    const EXPECTED_PNL: u128 = 100;
+    const WINNING_DOMAIN: usize = 1;
+    const EXPIRY_SLOT: u64 = 3;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 1_000, 500);
+    env.svm.warp_to_slot(1);
+    env.configure_auth_mark_for_asset_as_admin(0, 1, INITIAL_PRICE);
+    let admin = env.admin.insecure_clone();
+    let backing_provider = Keypair::new();
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&backing_provider),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        backing_provider.pubkey().to_bytes(),
+    )
+    .expect("rotate to an independent backing provider");
+    let provider_source = env.top_up_backing_bucket_with_authority(
+        &backing_provider,
+        WINNING_DOMAIN as u16,
+        150,
+        EXPIRY_SLOT,
+    );
+    assert_eq!(
+        env.token_amount(provider_source),
+        0,
+        "the independent provider funds the expiring bucket"
+    );
+
+    let winner_owner = Keypair::new();
+    let loser_owner = Keypair::new();
+    let winner = env.create_portfolio(&winner_owner);
+    let loser = env.create_portfolio(&loser_owner);
+    env.deposit(&winner_owner, winner, 1_000);
+    env.deposit(&loser_owner, loser, 1_000);
+    env.trade_with_cu(
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        SIZE_Q,
+        INITIAL_PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, WINNING_MARK);
+    for portfolio in [loser, winner] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    env.trade_with_cu(
+        &winner_owner,
+        winner,
+        &loser_owner,
+        loser,
+        -SIZE_Q,
+        WINNING_MARK,
+        0,
+    );
+
+    let winner_before = env.portfolio_state(winner);
+    assert_eq!(winner_before.pnl.get(), EXPECTED_PNL as i128);
+    assert!(
+        !has_active_leg_for_asset(&winner_before, 0),
+        "precondition: the PnL is released before expiry"
+    );
+    let (_, market_before) = env.market_state();
+    assert_eq!(market_before.current_slot, 2);
+    assert_eq!(
+        market_before.source_backing_buckets[WINNING_DOMAIN].consumed_liened_backing_num,
+        0
+    );
+    let winner_capital_before = winner_before.capital.get();
+    let market_account_before = env.svm.get_account(&env.market).unwrap();
+    let portfolio_account_before = env.svm.get_account(&winner).unwrap();
+    let custody_before = env.token_amount(env.vault);
+
+    env.svm.warp_to_slot(EXPIRY_SLOT + 1);
+    let conversion = env.send(
+        ProgInstruction::ConvertReleasedPnl {
+            amount: EXPECTED_PNL,
+        },
+        vec![
+            AccountMeta::new(winner_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(winner, false),
+        ],
+        &[&winner_owner],
+    );
+
+    let mut extracted = 0u64;
+    if conversion.is_ok() {
+        let (dest, _) = env.withdraw_with_cu(&winner_owner, winner, EXPECTED_PNL);
+        extracted = env.token_amount(dest);
+    }
+    let winner_after = env.portfolio_state(winner);
+    let (_, market_after) = env.market_state();
+    assert!(
+        conversion.is_err(),
+        "released PnL converted at authenticated slot {} after backing expiry {} while engine slot stayed {}; capital {} -> {}, extracted {} SPL atoms",
+        EXPIRY_SLOT + 1,
+        EXPIRY_SLOT,
+        market_after.current_slot,
+        winner_capital_before,
+        winner_after.capital.get(),
+        extracted,
+    );
+    assert_eq!(extracted, 0, "no post-expiry backing may be withdrawn");
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_account_before,
+        "rejected conversion preserves market state"
+    );
+    assert_eq!(
+        env.svm.get_account(&winner).unwrap(),
+        portfolio_account_before,
+        "rejected conversion preserves portfolio state"
+    );
+    assert_eq!(env.token_amount(env.vault), custody_before);
+}


### PR DESCRIPTION
## Public exploit

`ConvertReleasedPnl` did not authenticate backing expiry against the SVM `Clock`. It delegated to the engine, whose source-ledger freshness check compares `expiry_slot` only with the engine's stored `header.current_slot`.

The public LiteSVM reproduction uses ordinary initialized state and no protocol-account mutation:

1. An independent backing authority deposits 150 atoms into the winning source domain with signed expiry slot 3.
2. Two users deposit, trade at 100, and an authenticated mark move to 105 creates 100 atoms of real source-backed PnL.
3. The winner flattens before expiry, making the PnL publicly convertible.
4. No crank advances the engine after slot 2. At authenticated SVM slot 4, the winner calls `ConvertReleasedPnl`.
5. On exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`, conversion succeeds against the expired bucket and the winner immediately withdraws 100 real SPL atoms. The engine still reports slot 2.

This is a public ordering-dependent loss of funds: the backing provider's signed support term has ended, but a claimant can consume and withdraw that principal before an honest expiry crank lands.

## Fix

Before favorable PnL conversion, the wrapper scans the portfolio's bounded source-domain roster and compares every live claim's `Fresh` bucket expiry with the authenticated SVM slot. A lapsed bucket returns engine `Stale` before value mutation, so SVM rollback preserves market, portfolio, and custody bytes.

The check is wrapper-specific because this is where authenticated `Clock` is available. It does not advance global engine time without asset accrual and does not change the engine pin.

The existing expired-source liveness fix remains tracked by wrapper #214 / engine #112. This PR closes the value-extraction race; #214 supplies the bounded permissionless reconciliation route after the safe rejection.

## TDD

- Exact-parent RED: `11d381ec` extracts 100 SPL atoms after expiry.
- Fixed GREEN: `17223602` rejects atomically and preserves market, portfolio, and vault state.

## Verification

- `cargo build-sbf --tools-version v1.52`
- rebuilt auth and hostile matcher SBF fixtures
- focused exploit regression: green
- adjacent conversion authorization, caller-cap, isolation, resolve-maturity, and backing-expiry regressions: green
- `cargo test --all-targets -- --test-threads=1`: 6 unit + 566 LiteSVM/BPF/CU tests passed
- `cargo fmt --all -- --check`
- `git diff --check`