### PR TITLE
[BLOCKER LoF] Carry fractional oracle caps across max-dt cranks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=ccd834a7610a70d96127109ce9bc098517187b62#ccd834a7610a70d96127109ce9bc098517187b62"
+source = "git+https://github.com/aeyakovenko/percolator?rev=c8ea5cc6e4b56b744d8595d5c30eafe5f911b549#c8ea5cc6e4b56b744d8595d5c30eafe5f911b549"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a8b8877e784e34fbef7bfd16ce7228130219904b#a8b8877e784e34fbef7bfd16ce7228130219904b"
+source = "git+https://github.com/aeyakovenko/percolator?rev=ccd834a7610a70d96127109ce9bc098517187b62#ccd834a7610a70d96127109ce9bc098517187b62"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a8b8877e784e34fbef7bfd16ce7228130219904b" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ccd834a7610a70d96127109ce9bc098517187b62" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a8b8877e784e34fbef7bfd16ce7228130219904b" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ccd834a7610a70d96127109ce9bc098517187b62" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ccd834a7610a70d96127109ce9bc098517187b62" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8ea5cc6e4b56b744d8595d5c30eafe5f911b549" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "ccd834a7610a70d96127109ce9bc098517187b62" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "c8ea5cc6e4b56b744d8595d5c30eafe5f911b549" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4098,20 +4098,6 @@ pub mod oracle_v16 {
             core::cmp::max(target, p_last.saturating_sub(max_delta))
         }
     }
-
-    pub fn effective_price_from_target(
-        anchor: u64,
-        target: u64,
-        max_change_bps: u64,
-        dt_slots: u64,
-        exposed: bool,
-    ) -> u64 {
-        if exposed {
-            clamp_toward_engine_dt(anchor, target, max_change_bps, dt_slots)
-        } else {
-            target
-        }
-    }
 }
 
 pub mod policy_v16 {
@@ -10922,14 +10908,7 @@ pub mod processor {
             return Err(PercolatorError::OracleInvalid.into());
         }
         let current = asset.effective_price.get();
-        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-        let next = oracle_v16::effective_price_from_target(
-            current,
-            target,
-            group.header.config.max_price_move_bps_per_slot.get(),
-            dt,
-            exposed,
-        );
+        let next = capped_effective_price_for_asset_view(group, asset_index, target, dt)?;
         if next != current {
             return Err(PercolatorError::EngineNonProgress.into());
         }
@@ -11474,6 +11453,32 @@ pub mod processor {
         ))
     }
 
+    fn capped_effective_price_for_asset_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        target: u64,
+        dt: u64,
+    ) -> Result<u64, ProgramError> {
+        let asset = group.markets[asset_index].engine.asset;
+        if asset.oi_eff_long_q.get() == 0 && asset.oi_eff_short_q.get() == 0 {
+            return Ok(target);
+        }
+        let remainder_num = if target == asset.raw_oracle_target_price.get() {
+            asset.retired_slot.get()
+        } else {
+            0
+        };
+        percolator::capped_oracle_price_step_v16(
+            asset.effective_price.get(),
+            target,
+            group.header.config.max_price_move_bps_per_slot.get(),
+            dt,
+            remainder_num,
+        )
+        .map(|(price, _)| price)
+        .map_err(map_v16_error)
+    }
+
     #[derive(Clone, Copy)]
     struct HybridTradeFeeQuote {
         fee_bps: u64,
@@ -11738,15 +11743,12 @@ pub mod processor {
             if target == 0 {
                 return Err(PercolatorError::OracleInvalid.into());
             }
-            let asset = group.markets[asset_index].engine.asset;
-            let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-            let price = oracle_v16::effective_price_from_target(
-                asset.effective_price.get(),
+            let price = capped_effective_price_for_asset_view(
+                group,
+                asset_index,
                 target,
-                group.header.config.max_price_move_bps_per_slot.get(),
                 asset_segment_dt_view(group, asset_index, now_slot)?,
-                exposed,
-            );
+            )?;
             profile.oracle_target_price_e6 = target;
             return Ok(price);
         }
@@ -11797,15 +11799,12 @@ pub mod processor {
         if target == 0 {
             return Err(PercolatorError::OracleInvalid.into());
         }
-        let asset = group.markets[asset_index].engine.asset;
-        let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
-        let price = oracle_v16::effective_price_from_target(
-            asset.effective_price.get(),
+        let price = capped_effective_price_for_asset_view(
+            group,
+            asset_index,
             target,
-            group.header.config.max_price_move_bps_per_slot.get(),
             asset_segment_dt_view(group, asset_index, now_slot)?,
-            exposed,
-        );
+        )?;
         profile.oracle_target_price_e6 = target;
         if !oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot) {
             profile.mark_ewma_e6 = price;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -11463,13 +11463,18 @@ pub mod processor {
         if asset.oi_eff_long_q.get() == 0 && asset.oi_eff_short_q.get() == 0 {
             return Ok(target);
         }
-        let remainder_num = if target == asset.raw_oracle_target_price.get() {
+        let anchor = asset.effective_price.get();
+        let old_target = asset.raw_oracle_target_price.get();
+        let target_changed = target != old_target;
+        let target_direction_preserved =
+            (old_target > anchor && target > anchor) || (old_target < anchor && target < anchor);
+        let remainder_num = if !target_changed || target_direction_preserved {
             asset.retired_slot.get()
         } else {
             0
         };
         percolator::capped_oracle_price_step_v16(
-            asset.effective_price.get(),
+            anchor,
             target,
             group.header.config.max_price_move_bps_per_slot.get(),
             dt,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59720,9 +59720,9 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     }
 }
 
-// A percentage price cap can round a one-slot move below one price atom. Permissionless callers
-// must not consume those zero-delta slots and reset the elapsed interval forever: failed calls
-// preserve state until enough time has accumulated for a representable target-directed move.
+// A percentage price cap can round a one-slot move below one price atom. Each bounded crank must
+// carry that fraction forward, so callers cannot discard it and the effective price still reaches
+// the authenticated target after finitely many successful calls.
 #[test]
 fn v16_attack_permissionless_micro_price_cranks_cannot_pin_oracle_progress() {
     const PRICE: u64 = 100;
@@ -59775,66 +59775,194 @@ fn v16_attack_permissionless_micro_price_cranks_cannot_pin_oracle_progress() {
         )
     };
 
-    for slot in 1..5u64 {
-        let market_before = env.svm.get_account(&env.market).unwrap();
-        let crank = crank_once(&mut env, slot);
-        assert!(
-            matches!(&crank, Err(err) if err.contains("Custom(22)")),
-            "slot {slot} zero-delta crank must return engine NonProgress: {crank:?}"
-        );
-        assert_eq!(
-            env.svm.get_account(&env.market).unwrap(),
-            market_before,
-            "slot {slot} rejected crank is byte-stable under SVM rollback"
-        );
-        let asset = env.market_state().1.assets[0];
-        assert_eq!(asset.slot_last, 0, "slot {slot} was not consumed");
-        assert_eq!(
-            asset.effective_price, PRICE,
-            "zero-delta rejection preserves the effective price"
-        );
-        assert_eq!(
-            asset.raw_oracle_target_price, PRICE,
-            "the engine target copy rolls back with the rejected crank"
-        );
-        assert_eq!(
-            env.market_state().0.oracle_target_price_e6,
-            TARGET,
-            "the separately committed authenticated wrapper target remains pending"
-        );
+    let mut saw_fraction_only_progress = false;
+    let mut saw_price_move = false;
+    for slot in 1..=10u64 {
+        let before = env.market_state().1.assets[0];
+        let cu = crank_once(&mut env, slot).expect("fractional-cap crank must commit progress");
+        assert_cu_within("fractional-cap PermissionlessCrank", cu, CRANK_CU_LIMIT);
+        let after = env.market_state().1.assets[0];
+        assert_eq!(after.slot_last, slot);
+        assert_eq!(after.raw_oracle_target_price, TARGET);
+        assert!(after.effective_price >= before.effective_price);
+        assert!(after.effective_price <= TARGET);
+        if after.effective_price == before.effective_price {
+            saw_fraction_only_progress = true;
+            assert!(
+                after.retired_slot > before.retired_slot,
+                "a sub-atom segment carries cap numerator forward"
+            );
+        } else {
+            saw_price_move = true;
+        }
     }
+    let after = env.market_state().1.assets[0];
+    assert!(saw_fraction_only_progress);
+    assert!(saw_price_move);
+    assert_eq!(after.effective_price, PRICE + 2);
+}
 
-    let first_cu = crank_once(&mut env, 5).expect("five accumulated slots move one price atom");
-    assert!(
-        first_cu <= CRANK_CU_LIMIT,
-        "representable progress stays within crank CU budget: {first_cu}"
+// Fractional budget belongs only to the authenticated target that earned it. If the target reverses
+// before a whole price atom is available, the wrapper and engine must both reset the old-direction
+// carry so the first new-direction crank remains executable.
+#[test]
+fn v16_attack_micro_price_target_reversal_resets_fractional_cap_budget() {
+    const PRICE: u64 = 100;
+    const CAP_BPS: u64 = 24;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(0);
+    env.configure_auth_mark_with_cu(0, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        PRICE,
+        0,
     );
-    let first = env.market_state().1.assets[0];
-    assert_eq!(first.slot_last, 5);
-    assert_eq!(first.effective_price, PRICE + 1);
-    assert_eq!(first.raw_oracle_target_price, TARGET);
 
-    for slot in 6..10u64 {
-        let market_before = env.svm.get_account(&env.market).unwrap();
-        let crank = crank_once(&mut env, slot);
-        assert!(
-            matches!(&crank, Err(err) if err.contains("Custom(22)")),
-            "slot {slot} zero-delta crank must return engine NonProgress: {crank:?}"
-        );
-        assert_eq!(
-            env.svm.get_account(&env.market).unwrap(),
-            market_before,
-            "slot {slot} rejected crank is byte-stable under SVM rollback"
-        );
+    let crank_once = |env: &mut V16CuEnv, slot: u64| {
+        env.svm.warp_to_slot(slot);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+            ],
+            &[],
+        )
+    };
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, 200);
+    crank_once(&mut env, 4).expect("old-direction fractional progress");
+    let before_reversal = env.market_state().1.assets[0];
+    assert_eq!(before_reversal.effective_price, PRICE);
+    assert_eq!(before_reversal.retired_slot, 9_600);
+
+    env.svm.warp_to_slot(5);
+    env.push_auth_mark_with_cu(5, 1);
+    let cu = crank_once(&mut env, 5).expect("target reversal remains crankable");
+    assert_cu_within("target-reversal PermissionlessCrank", cu, CRANK_CU_LIMIT);
+    let after_reversal = env.market_state().1.assets[0];
+    assert_eq!(after_reversal.effective_price, PRICE);
+    assert_eq!(after_reversal.raw_oracle_target_price, 1);
+    assert_eq!(
+        after_reversal.retired_slot, 2_400,
+        "old-direction carry must not subsidize the reversed target"
+    );
+}
+
+// Regression for the max-dt endpoint: price 100 -> 1 used to stall forever at 20 even after the
+// zero-delta caller fix. Fractional cap carry must reach the target before stale resolution, so
+// terminal payouts use the honest authenticated mark.
+#[test]
+fn v16_attack_max_dt_price_floor_cannot_underpay_honest_settlement() {
+    const OPEN_PRICE: u64 = 100;
+    const TARGET_PRICE: u64 = 1;
+    const CAP_BPS: u64 = 24;
+    const MAX_DT: u64 = 20;
+    const DEPOSIT: u128 = 1_000_000;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: OPEN_PRICE,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: MAX_DT,
+        min_funding_lifetime_slots: MAX_DT,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_permissionless_resolve_with_cu(10_000, 1);
+    env.svm.warp_to_slot(0);
+    env.configure_auth_mark_with_cu(0, OPEN_PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, DEPOSIT);
+    env.deposit(&short_owner, short, DEPOSIT);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        OPEN_PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, TARGET_PRICE);
+
+    let crank_once = |env: &mut V16CuEnv, slot: u64| {
+        env.svm.warp_to_slot(slot);
+        env.svm.expire_blockhash();
+        env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(short, false),
+            ],
+            &[],
+        )
+    };
+
+    let mut slot = MAX_DT;
+    let mut saw_fraction_only_progress = false;
+    for _ in 0..200 {
+        let before = env.market_state().1.assets[0];
+        let cu = crank_once(&mut env, slot).expect("each max-dt crank commits bounded progress");
+        assert_cu_within("max-dt fractional-cap crank", cu, CRANK_CU_LIMIT);
+        let after = env.market_state().1.assets[0];
+        if after.effective_price == before.effective_price {
+            saw_fraction_only_progress = true;
+            assert!(after.retired_slot > before.retired_slot);
+        }
+        if after.effective_price == TARGET_PRICE {
+            break;
+        }
+        slot += MAX_DT;
     }
+    let converged = env.market_state().1.assets[0];
+    assert!(saw_fraction_only_progress);
+    assert_eq!(converged.effective_price, TARGET_PRICE);
+    assert_eq!(converged.raw_oracle_target_price, TARGET_PRICE);
+    assert_eq!(converged.retired_slot, 0);
 
-    let second_cu = crank_once(&mut env, 10).expect("next five-slot interval also progresses");
-    assert!(
-        second_cu <= CRANK_CU_LIMIT,
-        "repeated representable progress stays within crank CU budget: {second_cu}"
-    );
-    let second = env.market_state().1.assets[0];
-    assert_eq!(second.slot_last, 10);
-    assert_eq!(second.effective_price, PRICE + 2);
-    assert_eq!(second.raw_oracle_target_price, TARGET);
+    let resolve_slot = slot + 1_000 * MAX_DT + 1;
+    env.resolve_stale_permissionless_with_cu(resolve_slot);
+    env.svm.warp_to_slot(resolve_slot + 1);
+    let long_dest = env.close_resolved(&long_owner, long);
+    let short_dest = env.close_resolved(&short_owner, short);
+    let long_payout = env.token_amount(long_dest);
+    let short_payout = env.token_amount(short_dest);
+    assert_eq!(long_payout, DEPOSIT as u64 - (OPEN_PRICE - TARGET_PRICE));
+    assert_eq!(short_payout, DEPOSIT as u64 + (OPEN_PRICE - TARGET_PRICE));
+    assert_eq!(long_payout + short_payout, 2 * DEPOSIT as u64);
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59874,6 +59874,74 @@ fn v16_attack_micro_price_target_reversal_resets_fractional_cap_budget() {
     );
 }
 
+// A fresh oracle report commonly changes the target every slot. Same-direction target updates must
+// retain fractional cap budget; otherwise an honest moving feed can reset the fraction forever and
+// pin the effective price without any stale or malicious report.
+#[test]
+fn v16_attack_moving_micro_price_target_cannot_reset_fractional_cap_budget() {
+    const PRICE: u64 = 100;
+    const CAP_BPS: u64 = 24;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: CAP_BPS,
+        max_accrual_dt_slots: 20,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.svm.warp_to_slot(0);
+    env.configure_auth_mark_with_cu(0, PRICE);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000);
+    env.deposit(&short_owner, short, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    for slot in 1..=10 {
+        let target = 200 + slot;
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_with_cu(slot, target);
+        env.svm.expire_blockhash();
+        let cu = env
+            .send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+                vec![
+                    AccountMeta::new(env.payer.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(long, false),
+                ],
+                &[],
+            )
+            .expect("same-direction moving target remains crankable");
+        assert_cu_within("moving-target PermissionlessCrank", cu, CRANK_CU_LIMIT);
+        let asset = env.market_state().1.assets[0];
+        assert_eq!(asset.raw_oracle_target_price, target);
+        assert!(asset.effective_price >= PRICE);
+        assert!(asset.effective_price <= target);
+    }
+
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        PRICE + 2,
+        "same-direction reports must accumulate enough fractional budget to move"
+    );
+}
+
 // Regression for the max-dt endpoint: price 100 -> 1 used to stall forever at 20 even after the
 // zero-delta caller fix. Fractional cap carry must reach the target before stale resolution, so
 // terminal payouts use the honest authenticated mark.


### PR DESCRIPTION
## What changed

- Pin the engine to the fractional oracle-cap carry implementation from engine PR #164.
- Route AuthMark, EWMA-mark, Hybrid, and pending-observation price checks through the engine's shared capped-price helper.
- Preserve carry across same-direction target updates and reset it on convergence or direction reversal.
- Replace the old rejection-only micro-price regression with successful finite-progress coverage.
- Add public LiteSVM regressions for moving targets, target reversal, and max-dt settlement value.

## Root cause and impact

The percentage cap used:

`floor(effective_price * cap_bps_per_slot * min(dt, max_dt) / 10_000)`

and discarded the fractional numerator after every successful segment. PR #246 prevents a caller from consuming a zero-delta slot before enough elapsed time exists, but elapsed time saturates at `max_accrual_dt_slots`. At sufficiently small prices, even the saturated segment budget remains below one price atom forever.

The exact-parent public repro initializes an ordinary AuthMark market, opens balanced one-unit long/short positions at price 100 between independent owners, accepts an honest target of 1, and uses a 24 bps/slot cap with max dt 20. Permissionless cranks deterministically stall at effective price 20. A later public stale resolution pays the long/short owners `999,920 / 1,000,080`, rather than target-valued `999,901 / 1,000,099`, shifting 19 real SPL atoms from the independent short to the long.

This is reachable without state injection, a compromised admin, or a dishonest oracle mark. It is classified `[BLOCKER LoF]`.

## Fix

The engine carries the sub-atom cap numerator across bounded accrual segments and commits that carry as progress. Once a whole atom is representable, a no-move submission still rejects. Reaching the target or reversing direction resets the carry; fresh reports that keep moving the target on the same side preserve it.

The wrapper computes the same target-directed step before calling engine accrual. It applies the same directional rule, preventing both a reversal-induced `RecoveryRequired` stall and a continuously advancing honest feed from discarding every fraction.

This does not round the cap up and does not permit movement beyond accumulated cap budget.

PR #255's pending-target resolution guard is complementary: it prevents resolution while a target is pending, while this PR guarantees the pending target can actually converge in finite bounded cranks.

## Validation

- Exact-parent RED: wrapper `89d95619` pinned to engine `a8b8877e` stalls at 20 and produces the stale `999,920 / 1,000,080` payouts.
- Reversal RED: the pre-correction SBF rejects the first reversed-target crank with `EngineRecoveryRequired`; fixed SBF succeeds and resets carry to the new direction's `2,400` numerator.
- Moving-feed RED: resetting carry on every fresh target leaves effective price at 100 after ten same-direction reports; fixed head reaches 102.
- Engine: 133/133 tests pass (50 unit, 9 backing fuzz, 2 resolved fuzz, 72 v16 spec).
- `cargo build-sbf --tools-version v1.52`
- Wrapper: 6/6 unit and 569/569 LiteSVM/BPF/CU tests pass.

Depends on engine PR #164 and is stacked on wrapper PR #246.