### PR TITLE
[BLOCKER LoF] Gate liquidation on pending later-leg accrual

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10660,10 +10660,18 @@ pub mod processor {
             let summary = group
                 .build_actionable_summary(&portfolio.as_view())
                 .map_err(map_v16_error)?;
-            if let Some(asset_index) =
+            if summary.liquidatable && !summary.b_stale {
+                reject_missing_pending_liquidation_observations_view(
+                    &cfg,
+                    &group,
+                    &portfolio,
+                    authenticated_now_slot,
+                    observations.as_slice(),
+                )?;
+            } else if let Some(asset_index) =
                 auto_crank_selected_asset_that_accrues_view(&portfolio, &summary)?
             {
-                reject_missing_pending_selected_observation_view(
+                reject_missing_observation_that_changes_accrual_view(
                     &cfg,
                     &group,
                     asset_index,
@@ -10848,6 +10856,51 @@ pub mod processor {
         Ok(())
     }
 
+    fn reject_missing_pending_liquidation_observations_view(
+        cfg: &WrapperConfigV16,
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        now_slot: u64,
+        observations: &[AutoCrankObservationV16],
+    ) -> ProgramResult {
+        let active_bitmap = portfolio
+            .header
+            .active_bitmap
+            .map(percolator::V16PodU64::get);
+        let mut seen_assets = [u32::MAX; percolator::V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut seen_asset_count = 0usize;
+        let mut slot = 0usize;
+        while slot < percolator::V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = portfolio.header.legs[slot]
+                .try_to_runtime()
+                .map_err(map_v16_error)?;
+            let bit = percolator::active_bitmap_get(active_bitmap, slot);
+            if bit != leg.active {
+                return Err(PercolatorError::EngineHiddenLeg.into());
+            }
+            if bit {
+                let mut seen = 0usize;
+                while seen < seen_asset_count {
+                    if seen_assets[seen] == leg.asset_index {
+                        return Err(PercolatorError::EngineHiddenLeg.into());
+                    }
+                    seen += 1;
+                }
+                seen_assets[seen_asset_count] = leg.asset_index;
+                seen_asset_count += 1;
+                reject_missing_observation_that_changes_accrual_view(
+                    cfg,
+                    group,
+                    leg.asset_index as usize,
+                    now_slot,
+                    observations,
+                )?;
+            }
+            slot += 1;
+        }
+        Ok(())
+    }
+
     fn first_active_asset_from_portfolio_view(
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
     ) -> Result<Option<usize>, ProgramError> {
@@ -10885,7 +10938,7 @@ pub mod processor {
         Ok(None)
     }
 
-    fn reject_missing_pending_selected_observation_view(
+    fn reject_missing_observation_that_changes_accrual_view(
         cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
@@ -10922,7 +10975,8 @@ pub mod processor {
             dt,
             exposed,
         );
-        if next != current {
+        let funding_rate = permissionless_funding_rate_e9_view(&profile, group, asset_index, next)?;
+        if next != current || funding_rate != 0 {
             return Err(PercolatorError::EngineNonProgress.into());
         }
         Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10493,6 +10493,207 @@ fn v16_attack_pending_selected_mark_requires_observation() {
     );
 }
 
+// A stale-account refresh must not omit funding on a later active leg merely
+// because that leg's capped effective-price movement rounds to zero. Otherwise
+// the refresh can certify and liquidate the account before its authenticated
+// rescue funding is booked.
+#[test]
+fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
+    const ADVERSE_PRICE: u64 = 1_000_000;
+    const ADVERSE_TARGET: u64 = 997_600;
+    const RESCUE_PRICE: u64 = 100;
+    const RESCUE_MARK: u64 = 99;
+    const OPEN_SLOT: u64 = 1;
+    const PRIME_SLOT: u64 = 2;
+    const ATTACK_SLOT: u64 = 3;
+    const ADVERSE_SIZE_Q: i128 = (50 * POS_SCALE) as i128;
+    const RESCUE_SIZE_Q: i128 = (100_000 * POS_SCALE) as i128;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    params.max_accrual_dt_slots = 1;
+    params.max_abs_funding_e9_per_slot = 10_000;
+    params.min_funding_lifetime_slots = 1;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.svm.warp_to_slot(OPEN_SLOT);
+    env.configure_auth_mark_for_asset_as_admin(0, OPEN_SLOT, RESCUE_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(1, OPEN_SLOT, ADVERSE_PRICE);
+
+    let user = Keypair::new();
+    let counterparty = Keypair::new();
+    let observer_owner = Keypair::new();
+    let user_account = env.create_portfolio(&user);
+    let counterparty_account = env.create_portfolio(&counterparty);
+    let observer = env.create_portfolio(&observer_owner);
+    env.deposit(&user, user_account, 3_115_000);
+    env.deposit(&counterparty, counterparty_account, 50_000_000);
+
+    // The adverse long is first. The funding-receiving long deliberately
+    // occupies a later slot, outside the wrapper's selected-leg check.
+    env.trade_asset_with_cu(
+        1,
+        &user,
+        user_account,
+        &counterparty,
+        counterparty_account,
+        ADVERSE_SIZE_Q,
+        ADVERSE_PRICE,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &user,
+        user_account,
+        &counterparty,
+        counterparty_account,
+        RESCUE_SIZE_Q,
+        RESCUE_PRICE,
+        0,
+    );
+    let opened = env.portfolio_state(user_account);
+    assert_eq!(leg(&opened, 0).asset_index, 1);
+    assert_eq!(leg(&opened, 1).asset_index, 0);
+    let adverse_position_before = active_leg_for_asset(&opened, 1).basis_pos_q.unsigned_abs();
+
+    // Prime the later leg at the low price. Its 24-bps movement cap rounds to
+    // zero, and the first observed segment intentionally has no funding.
+    env.svm.warp_to_slot(PRIME_SLOT);
+    env.push_auth_mark_for_asset_as_admin(0, PRIME_SLOT, RESCUE_MARK);
+    env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: PRIME_SLOT,
+            observations: crank_observations(0),
+        },
+    );
+    let (_, primed) = env.market_state();
+    assert_eq!(primed.assets[0].effective_price, RESCUE_PRICE);
+    assert_eq!(primed.assets[0].slot_last, PRIME_SLOT);
+    assert_eq!(primed.assets[0].f_long_num, 0);
+
+    // Commit the first leg's adverse move. This makes the user's certificate
+    // stale while the later leg has one segment of negative-premium long funding.
+    env.svm.warp_to_slot(ATTACK_SLOT);
+    env.push_auth_mark_for_asset_as_admin(1, ATTACK_SLOT, ADVERSE_TARGET);
+    env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: crank_observations(1),
+        },
+    );
+    let (_, stale_group) = env.market_state();
+    assert_eq!(stale_group.assets[0].effective_price, RESCUE_PRICE);
+    assert_eq!(stale_group.assets[0].slot_last, PRIME_SLOT);
+    assert!(
+        health_cert(&env.portfolio_state(user_account)).cert_oracle_epoch
+            < stale_group.oracle_epoch
+    );
+    let market_before_omission = env.svm.get_account(&env.market).unwrap();
+    let user_before_omission = env.svm.get_account(&user_account).unwrap();
+    let insurance_before = stale_group.insurance;
+
+    env.svm.expire_blockhash();
+    let omitted = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(user_account, false),
+        ],
+        &[],
+    );
+    if omitted.is_ok() {
+        let stale = env.portfolio_state(user_account);
+        assert!(
+            health_cert(&stale).certified_liq_deficit > 0,
+            "omitting later-leg rescue funding must reproduce a liquidatable certificate: {:?}",
+            health_cert(&stale)
+        );
+        let stale_position = active_leg_for_asset(&stale, 1).basis_pos_q.unsigned_abs();
+        env.svm.expire_blockhash();
+        let liquidation = env.send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: ATTACK_SLOT,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new(env.payer.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(user_account, false),
+            ],
+            &[],
+        );
+        assert!(
+            liquidation.is_ok(),
+            "omitted funding must reach public liquidation: {liquidation:?}"
+        );
+        let liquidated = env.portfolio_state(user_account);
+        let liquidated_position = if has_active_leg_for_asset(&liquidated, 1) {
+            active_leg_for_asset(&liquidated, 1)
+                .basis_pos_q
+                .unsigned_abs()
+        } else {
+            0
+        };
+        assert!(liquidated_position < stale_position);
+        assert!(env.market_state().1.insurance > insurance_before);
+        panic!(
+            "omitted later-leg rescue funding reduced user position {stale_position}->{liquidated_position} and charged insurance {}->{}",
+            insurance_before,
+            env.market_state().1.insurance
+        );
+    }
+
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before_omission
+    );
+    assert_eq!(
+        env.svm.get_account(&user_account).unwrap(),
+        user_before_omission
+    );
+
+    // Supplying the later-leg observation books the rescue funding and leaves
+    // the same account healthy without charging a liquidation fee.
+    env.svm.expire_blockhash();
+    env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: crank_observations(0),
+        },
+    );
+    assert!(env.market_state().1.assets[0].f_long_num > 0);
+    env.svm.expire_blockhash();
+    env.crank(
+        counterparty_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: vec![],
+        },
+    );
+    env.svm.expire_blockhash();
+    env.crank(
+        user_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: vec![],
+        },
+    );
+    let healthy = env.portfolio_state(user_account);
+    assert_eq!(health_cert(&healthy).certified_liq_deficit, 0);
+    assert_eq!(
+        active_leg_for_asset(&healthy, 1).basis_pos_q.unsigned_abs(),
+        adverse_position_before
+    );
+    assert_eq!(env.market_state().1.insurance, insurance_before);
+}
+
 #[test]
 fn v16_bpf_no_cranker_liquidation_rejects_invalid_final_market_shape() {
     let mut env = V16CuEnv::new();

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -10493,10 +10493,10 @@ fn v16_attack_pending_selected_mark_requires_observation() {
     );
 }
 
-// A stale-account refresh must not omit funding on a later active leg merely
-// because that leg's capped effective-price movement rounds to zero. Otherwise
-// the refresh can certify and liquidate the account before its authenticated
-// rescue funding is booked.
+// Liquidation must not omit funding on a later active leg merely because that
+// leg's capped effective-price movement rounds to zero. An order-insensitive
+// stale refresh may land first, but the irreversible liquidation must wait for
+// every active leg whose authenticated accrual would change.
 #[test]
 fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
     const ADVERSE_PRICE: u64 = 1_000_000;
@@ -10527,6 +10527,7 @@ fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
     let observer = env.create_portfolio(&observer_owner);
     env.deposit(&user, user_account, 3_115_000);
     env.deposit(&counterparty, counterparty_account, 50_000_000);
+    env.top_up_backing_bucket(1, 200_000, 10);
 
     // The adverse long is first. The funding-receiving long deliberately
     // occupies a later slot, outside the wrapper's selected-leg check.
@@ -10590,8 +10591,6 @@ fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
         health_cert(&env.portfolio_state(user_account)).cert_oracle_epoch
             < stale_group.oracle_epoch
     );
-    let market_before_omission = env.svm.get_account(&env.market).unwrap();
-    let user_before_omission = env.svm.get_account(&user_account).unwrap();
     let insurance_before = stale_group.insurance;
 
     env.svm.expire_blockhash();
@@ -10607,31 +10606,33 @@ fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
         ],
         &[],
     );
-    if omitted.is_ok() {
-        let stale = env.portfolio_state(user_account);
-        assert!(
-            health_cert(&stale).certified_liq_deficit > 0,
-            "omitting later-leg rescue funding must reproduce a liquidatable certificate: {:?}",
-            health_cert(&stale)
-        );
-        let stale_position = active_leg_for_asset(&stale, 1).basis_pos_q.unsigned_abs();
-        env.svm.expire_blockhash();
-        let liquidation = env.send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: ATTACK_SLOT,
-                observations: vec![],
-            },
-            vec![
-                AccountMeta::new(env.payer.pubkey(), true),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(user_account, false),
-            ],
-            &[],
-        );
-        assert!(
-            liquidation.is_ok(),
-            "omitted funding must reach public liquidation: {liquidation:?}"
-        );
+    assert!(
+        omitted.is_ok(),
+        "ordinary stale refresh remains order-insensitive: {omitted:?}"
+    );
+    let stale = env.portfolio_state(user_account);
+    assert!(
+        health_cert(&stale).certified_liq_deficit > 0,
+        "omitting later-leg rescue funding must reproduce a liquidatable certificate: {:?}",
+        health_cert(&stale)
+    );
+    let stale_position = active_leg_for_asset(&stale, 1).basis_pos_q.unsigned_abs();
+    let market_before_liquidation = env.svm.get_account(&env.market).unwrap();
+    let user_before_liquidation = env.svm.get_account(&user_account).unwrap();
+    env.svm.expire_blockhash();
+    let liquidation = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: ATTACK_SLOT,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(user_account, false),
+        ],
+        &[],
+    );
+    if liquidation.is_ok() {
         let liquidated = env.portfolio_state(user_account);
         let liquidated_position = if has_active_leg_for_asset(&liquidated, 1) {
             active_leg_for_asset(&liquidated, 1)
@@ -10648,14 +10649,15 @@ fn v16_attack_pending_later_rounded_rescue_funding_requires_observation() {
             env.market_state().1.insurance
         );
     }
-
     assert_eq!(
         env.svm.get_account(&env.market).unwrap(),
-        market_before_omission
+        market_before_liquidation,
+        "rejected stale-funding liquidation must roll back market state"
     );
     assert_eq!(
         env.svm.get_account(&user_account).unwrap(),
-        user_before_omission
+        user_before_liquidation,
+        "rejected stale-funding liquidation must roll back the victim"
     );
 
     // Supplying the later-leg observation books the rescue funding and leaves


### PR DESCRIPTION
## What changed

- Check every active portfolio leg immediately before the auto-crank dispatches liquidation.
- Reject with `EngineNonProgress` when an omitted observation would change that leg's bounded effective price or funding index.
- Keep ordinary stale refresh order-insensitive: only the selected leg is mandatory until the operation becomes an irreversible liquidation.

## Root cause and impact

The wrapper's missing-observation guard covered only the engine-selected first active leg. A public caller could advance an adverse first leg, omit a later backed negative-premium funding segment whose capped price movement rounded to zero, refresh the victim into a current liquidatable certificate, and then land another no-observation crank. The second crank liquidated the victim before the later rescue funding was booked.

The exact pre-fix parent reproduction reduces the independent victim's position from `50,000,000` to `47,995,187` q-units and credits `1,001` atoms to insurance. The correctly ordered control uses ordinary source-domain backing, settles the payer, preserves the full position, and charges no liquidation fee.

This composes the later-leg coverage of #220 with the rounded-funding coverage of #253 without forcing every stale refresh to carry all active-leg observations.

## Validation

- Exact parent: new public-interface LiteSVM test fails with the liquidation and fee evidence above.
- Fixed head: the same test passes and asserts rollback of the rejected liquidation.
- `cargo test --test v16_cu -- --test-threads=1`: **566 passed**.
- Max-shape CU: 14-leg refresh `690,376`; 14-leg liquidation `1,160,120`, both below the 1.4M transaction limit.
- `cargo fmt --all -- --check`
- `git diff --check`