### PR TITLE
[BLOCKER LoF] Reject post-expiry backing liens

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -5864,14 +5864,8 @@ pub mod processor {
                 &account_b,
                 core::slice::from_ref(&req),
             )?;
-            let backing_before = if cfg.backing_trade_fee_policy_count == 0 {
-                None
-            } else {
-                Some((
-                    source_counterparty_backing_snapshot_view(&account_a)?,
-                    source_counterparty_backing_snapshot_view(&account_b)?,
-                ))
-            };
+            let backing_before_a = source_counterparty_backing_snapshot_view(&account_a)?;
+            let backing_before_b = source_counterparty_backing_snapshot_view(&account_b)?;
             let source_lien_before_a =
                 source_lien_effective_reserved_snapshot_for_trade_view(&account_a)?;
             let source_lien_before_b =
@@ -5893,7 +5887,15 @@ pub mod processor {
                     )
                     .map_err(map_v16_error)?
             };
-            if let Some((backing_before_a, backing_before_b)) = backing_before {
+            ensure_new_counterparty_backed_liens_fresh_for_trade_view(
+                &group,
+                authenticated_market_slot_or_fallback_view(&group),
+                backing_before_a.as_ref(),
+                &account_a,
+                backing_before_b.as_ref(),
+                &account_b,
+            )?;
+            if cfg.backing_trade_fee_policy_count != 0 {
                 apply_backing_domain_fees_after_trade_view(
                     &cfg,
                     &mut group,
@@ -6116,6 +6118,8 @@ pub mod processor {
                 &group, &account_a, &account_b, &requests,
             )?;
 
+            let backing_before_a = source_counterparty_backing_snapshot_view(&account_a)?;
+            let backing_before_b = source_counterparty_backing_snapshot_view(&account_b)?;
             let source_lien_before_a =
                 source_lien_effective_reserved_snapshot_for_trade_view(&account_a)?;
             let source_lien_before_b =
@@ -6128,6 +6132,14 @@ pub mod processor {
                     &requests,
                 )
                 .map_err(map_v16_error)?;
+            ensure_new_counterparty_backed_liens_fresh_for_trade_view(
+                &group,
+                authenticated_market_slot_or_fallback_view(&group),
+                backing_before_a.as_ref(),
+                &account_a,
+                backing_before_b.as_ref(),
+                &account_b,
+            )?;
 
             // The engine reports one collected-fee aggregate per account. Allocate each aggregate
             // against requested fees in request order. This deterministic wrapper policy conserves
@@ -6322,6 +6334,38 @@ pub mod processor {
                     ensure_source_credit_full_rate_for_domain_view(group, domain as usize)?;
                 }
                 i += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_new_counterparty_backed_liens_fresh_for_trade_view(
+        group: &state::MarketViewMutV16<'_>,
+        authenticated_slot: u64,
+        before_a: &[(u32, u128)],
+        account_a: &percolator::PortfolioV16ViewMut<'_>,
+        before_b: &[(u32, u128)],
+        account_b: &percolator::PortfolioV16ViewMut<'_>,
+    ) -> ProgramResult {
+        // A retained transaction can land after the engine's cached slot and a provider's signed
+        // backing expiry. Only newly-created counterparty-backed liens need this landing-time
+        // check; insurance-backed liens and trades that do not increase a lien remain live.
+        for (account, before) in [(account_a, before_a), (account_b, before_b)] {
+            for source in account.header.source_domains.iter() {
+                if !source.is_occupied() {
+                    continue;
+                }
+                let domain = source.domain.get();
+                let after = source.source_lien_counterparty_backing_num.get();
+                if after <= sparse_domain_value_lookup(before, domain) {
+                    continue;
+                }
+                let (_, bucket) = backing_domain_parts_view(group, domain as usize)?;
+                if bucket.status != percolator::BackingBucketStatusV16::Fresh
+                    || bucket.expiry_slot <= authenticated_slot
+                {
+                    return Err(PercolatorError::EngineStale.into());
+                }
             }
         }
         Ok(())

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,147 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A trade that lands after the backing provider's signed expiry must not create a
+// new source lien and charge the trader for support that has already lapsed.
+#[test]
+fn v16_probe_post_expiry_trade_cannot_charge_backing_fee() {
+    const PRICE: u64 = 100;
+    const WINNING_MARK: u64 = 105;
+    const OPEN_Q: i128 = 1_000 * POS_SCALE as i128;
+    const INCREASE_Q: i128 = 50 * POS_SCALE as i128;
+    const WINNING_DOMAIN: usize = 1;
+    const EXPIRY_SLOT: u64 = 2;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 1_000, 5_000, 500);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, PRICE);
+    env.update_backing_fee_policy_with_cu(WINNING_DOMAIN as u16, 5_000, 0);
+    env.top_up_backing_bucket(WINNING_DOMAIN as u16, 100_000, EXPIRY_SLOT);
+
+    let trader_owner = Keypair::new();
+    let counterparty_owner = Keypair::new();
+    let trader = env.create_portfolio(&trader_owner);
+    let counterparty = env.create_portfolio(&counterparty_owner);
+    env.deposit(&trader_owner, trader, 52_501);
+    env.deposit(&counterparty_owner, counterparty, 1_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &trader_owner,
+        trader,
+        &counterparty_owner,
+        counterparty,
+        OPEN_Q,
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_for_asset_as_admin(0, 1, WINNING_MARK);
+    for portfolio in [counterparty, trader] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 1,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    assert_eq!(env.portfolio_state(trader).pnl.get(), 5_000);
+    let (_, before) = env.market_state();
+    assert_eq!(before.current_slot, 1);
+    assert_eq!(
+        before.source_backing_buckets[WINNING_DOMAIN].expiry_slot,
+        EXPIRY_SLOT
+    );
+    let trader_capital_before = env.portfolio_state(trader).capital.get();
+    let provider_earnings_before =
+        before.source_backing_buckets[WINNING_DOMAIN].utilization_fee_earnings;
+    let market_account_before = env.svm.get_account(&env.market).unwrap();
+    let trader_account_before = env.svm.get_account(&trader).unwrap();
+    let counterparty_account_before = env.svm.get_account(&counterparty).unwrap();
+
+    env.svm.expire_blockhash();
+    let retained_trade = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(trader_owner.pubkey(), true),
+                    AccountMeta::new(counterparty_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(trader, false),
+                    AccountMeta::new(counterparty, false),
+                ],
+                data: ProgInstruction::TradeNoCpi {
+                    asset_index: 0,
+                    size_q: INCREASE_Q,
+                    exec_price: WINNING_MARK,
+                    fee_bps: 0,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &trader_owner, &counterparty_owner],
+        env.svm.latest_blockhash(),
+    );
+
+    env.svm.warp_to_slot(EXPIRY_SLOT + 1);
+    let trade = env.svm.send_transaction(retained_trade);
+
+    let trader_after = env.portfolio_state(trader);
+    let (_, after) = env.market_state();
+    let provider_earnings_after =
+        after.source_backing_buckets[WINNING_DOMAIN].utilization_fee_earnings;
+    let charged = provider_earnings_after - provider_earnings_before;
+    let mut extracted = 0;
+    if charged != 0 {
+        let ledger = env.backing_domain_ledger_account();
+        let provider_dest = env.token_account(env.admin.pubkey(), 0);
+        env.withdraw_backing_bucket_earnings_to_admin_token_with_cu(
+            ledger,
+            provider_dest,
+            WINNING_DOMAIN as u16,
+            charged,
+        );
+        extracted = env.token_amount(provider_dest);
+    }
+    assert!(
+        trade.is_err(),
+        "retained post-expiry trade charged {charged} backing-fee atoms, extracted {extracted} real SPL atoms, and reduced trader capital {} -> {} while authenticated slot {} exceeded expiry {} and engine slot stayed {}",
+        trader_capital_before,
+        trader_after.capital.get(),
+        EXPIRY_SLOT + 1,
+        EXPIRY_SLOT,
+        after.current_slot,
+    );
+    assert_eq!(extracted, 0, "expired support may not earn a trade fee");
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_account_before,
+        "the rejected stale trade must roll back the market"
+    );
+    assert_eq!(
+        env.svm.get_account(&trader).unwrap(),
+        trader_account_before,
+        "the rejected stale trade must roll back the trader"
+    );
+    assert_eq!(
+        env.svm.get_account(&counterparty).unwrap(),
+        counterparty_account_before,
+        "the rejected stale trade must roll back the counterparty"
+    );
+
+    env.trade_asset_with_cu(
+        0,
+        &trader_owner,
+        trader,
+        &counterparty_owner,
+        counterparty,
+        -INCREASE_Q,
+        WINNING_MARK,
+        0,
+    );
+}


### PR DESCRIPTION
## Summary

- Reject a trade only when it creates a new counterparty-backed source lien against a bucket that is no longer fresh at the authenticated SVM landing slot.
- Apply the invariant to the shared single/CPI executor and both batch executors.
- Preserve insurance-backed liens, trades with no new lien, and risk-reducing exits.

## Root cause

The engine correctly checks backing expiry against its cached `current_slot`, but a retained transaction can land after that slot and after the provider's signed backing expiry. The wrapper previously did not reconcile a newly-created lien with authenticated `Clock::slot` before charging backing-domain fees.

A normally initialized public LiteSVM reproduction signs a valid `TradeNoCpi` at slot 1, with backing expiring at slot 2, then submits the retained bytes at slot 3 while the engine remains at slot 1. On the exact pre-fix program the trade succeeds, charges the trader 1,312 atoms, credits those atoms to provider earnings, and the provider withdraws 1,312 real SPL atoms. Trader capital falls from 52,501 to 51,189. No protocol state injection, dishonest oracle, or compromised key is used.

## Fix

Snapshot each account's sparse counterparty-backed source liens before the engine trade. After execution, any domain whose counterparty-backed lien increased must have a `Fresh` bucket with `expiry_slot > max(Clock::slot, engine current_slot)`. Otherwise the instruction returns `EngineStale`; SVM rollback restores the engine mutations. The check occurs before backing-fee accounting.

## Validation

- Exact pre-fix red: 1,312 SPL atoms extractable; trader capital `52,501 -> 51,189`.
- Fixed head green: delayed transaction rejects, market and both portfolios roll back byte-for-byte, and a post-expiry risk-reducing trade still succeeds.
- `cargo test --lib`: 6/6 passed.
- Full LiteSVM suite: 566/566 passed.
- Max-shape guard overhead: about 6,945 CU.
- Highest full-suite trade observation: 14-leg `BatchTradeCpi` at 1,236,926 / 1,400,000 CU, leaving 163,074 CU headroom.