### PR TITLE
[BLOCKER DoS] Prevent expired partial recovery from locking market

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=d7b29edb943ebf490ac8ea3d95798cf9b44deba3#d7b29edb943ebf490ac8ea3d95798cf9b44deba3"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d7b29edb943ebf490ac8ea3d95798cf9b44deba3" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d7b29edb943ebf490ac8ea3d95798cf9b44deba3" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -15908,6 +15908,70 @@ fn v16_probe_expired_recovery_forfeit_cannot_globally_lock_unrelated_user() {
     assert_eq!(env.portfolio_state(victim_account).capital.get(), 0);
 }
 
+// Upgrade regression only: model a Recovery state committed by the previous engine revision, then
+// require the wrapper's sole public crank to classify and complete its value-neutral transition.
+// The public exploit reachability proof itself is the preceding test and does not inject state.
+#[test]
+fn v16_upgrade_committed_recovery_resolves_through_permissionless_crank() {
+    let mut env = V16CuEnv::new();
+    let owner = Keypair::new();
+    let portfolio = env.create_portfolio(&owner);
+    env.deposit(&owner, portfolio, 100);
+    env.mutate_market(|_, group| {
+        group.mode = MarketModeV16::Recovery;
+        group.recovery_reason =
+            Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress);
+    });
+
+    env.svm.warp_to_slot(1);
+    env.svm.expire_blockhash();
+    let crank_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 0,
+                observations: Vec::new(),
+            },
+            vec![
+                AccountMeta::new_readonly(env.payer.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolio, false),
+            ],
+            &[],
+        )
+        .expect("the sole public crank must resolve a persisted Recovery state");
+    assert_cu_within(
+        "PermissionlessCrank persisted Recovery migration",
+        crank_cu,
+        CRANK_CU_LIMIT,
+    );
+    let (_, resolved) = env.market_state();
+    assert_eq!(resolved.mode, MarketModeV16::Resolved);
+    assert_eq!(
+        resolved.recovery_reason,
+        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)
+    );
+
+    let destination = env.token_account(owner.pubkey(), 0);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::CloseResolved {
+            fee_rate_per_slot: 0,
+        },
+        vec![
+            AccountMeta::new_readonly(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+            AccountMeta::new(destination, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&owner],
+    )
+    .expect("the owner can exit real custody after the migration crank");
+    assert_eq!(env.token_amount(destination), 100);
+}
+
 // security.md sweep — cross-margin (#22/#32): one portfolio holds positions on TWO assets.
 // Probe aggregate conservation and per-asset OI balance under shared-capital cross-margin.
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -15754,6 +15754,160 @@ fn v16_attack_auto_crank_expired_close_uses_authenticated_slot_not_stale_market_
     );
 }
 
+// Public-interface DoS probe: an asset-recovery owner can leave a chunked forfeit ledger
+// unfinished until it expires. The expiry crank must not turn that account-local condition into
+// an irreversible global market mode that strands an unrelated flat user's principal.
+#[test]
+fn v16_probe_expired_recovery_forfeit_cannot_globally_lock_unrelated_user() {
+    let mut params = production_risk_params();
+    params.max_bankrupt_close_lifetime_slots = 1;
+    params.public_b_chunk_atoms = 8_000;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_with_cu(0, 1_000_000);
+
+    let attacker = Keypair::new();
+    let counterparty = Keypair::new();
+    let victim = Keypair::new();
+    let attacker_account = env.create_portfolio(&attacker);
+    let counterparty_account = env.create_portfolio(&counterparty);
+    let victim_account = env.create_portfolio(&victim);
+    env.deposit(&attacker, attacker_account, 51_000);
+    env.deposit(&counterparty, counterparty_account, 100_000);
+    env.deposit(&victim, victim_account, 100);
+
+    env.trade_asset_with_cu(
+        0,
+        &attacker,
+        attacker_account,
+        &counterparty,
+        counterparty_account,
+        POS_SCALE as i128,
+        1_000_000,
+        0,
+    );
+
+    env.svm.warp_to_slot(20);
+    env.push_auth_mark_with_cu(20, 952_000);
+    env.crank(
+        counterparty_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(25);
+    env.push_auth_mark_with_cu(25, 940_000);
+    env.crank(
+        counterparty_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 25,
+            observations: crank_observations(0),
+        },
+    );
+    env.svm.warp_to_slot(30);
+    env.push_auth_mark_with_cu(30, 940_576);
+    env.crank(
+        counterparty_account,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 30,
+            observations: crank_observations(0),
+        },
+    );
+    env.update_asset_lifecycle_as_admin_with_cu(
+        percolator_prog::processor::ASSET_ACTION_SHUTDOWN,
+        0,
+        30,
+        0,
+    );
+
+    env.svm.expire_blockhash();
+    let partial_forfeit = env.send(
+        ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: 0,
+            b_delta_budget: percolator::MAX_VAULT_TVL,
+        },
+        vec![
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_account, false),
+        ],
+        &[&attacker],
+    );
+    assert!(
+        partial_forfeit.is_ok(),
+        "public recovery forfeit must commit one bounded residual chunk: {partial_forfeit:?}"
+    );
+
+    let partial = env.portfolio_state(attacker_account);
+    let ledger = close_progress(&partial);
+    assert!(
+        ledger.active && ledger.residual_remaining > 0,
+        "public recovery forfeit must leave a genuine bounded residual for the expiry probe: \
+         capital={} pnl={} ledger={ledger:?}",
+        partial.capital.get(),
+        partial.pnl.get(),
+    );
+    assert_eq!(env.market_state().1.mode, MarketModeV16::Live);
+
+    env.svm.warp_to_slot(ledger.max_close_slot + 1);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: Vec::new(),
+        },
+        vec![
+            AccountMeta::new_readonly(env.payer.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(attacker_account, false),
+        ],
+        &[],
+    )
+    .expect("expired public forfeit ledger selects terminal recovery");
+    let (_, terminal) = env.market_state();
+    assert_eq!(
+        terminal.mode,
+        MarketModeV16::Resolved,
+        "an expired account-local close must enter the bounded resolved-exit path, not a global \
+         Recovery sink"
+    );
+    assert_eq!(
+        terminal.recovery_reason,
+        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        "terminal resolution retains the recovery reason for audit"
+    );
+
+    let victim_dest = env.token_account(victim.pubkey(), 0);
+    let vault_tokens_before = env.token_amount(env.vault);
+    env.svm.expire_blockhash();
+    let close_cu = env
+        .send(
+            ProgInstruction::CloseResolved {
+                fee_rate_per_slot: 0,
+            },
+            vec![
+                AccountMeta::new_readonly(victim.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim_account, false),
+                AccountMeta::new(victim_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&victim],
+        )
+        .expect("unrelated flat owner retains a real custody exit after terminal recovery");
+    assert_cu_within(
+        "CloseResolved after expired account-local recovery",
+        close_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(env.token_amount(victim_dest), 100);
+    assert_eq!(env.token_amount(env.vault), vault_tokens_before - 100);
+    assert_eq!(env.portfolio_state(victim_account).capital.get(), 0);
+}
+
 // security.md sweep — cross-margin (#22/#32): one portfolio holds positions on TWO assets.
 // Probe aggregate conservation and per-asset OI balance under shared-capital cross-margin.
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -15681,22 +15681,22 @@ fn v16_attack_auto_crank_expired_close_recovery_not_blocked_by_stale_oracle() {
     );
 
     let (_, group_after) = env.market_state();
-    assert_eq!(group_after.mode, MarketModeV16::Recovery);
+    assert_eq!(group_after.mode, MarketModeV16::Resolved);
     assert_eq!(
         group_after.recovery_reason,
         Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)
     );
     assert_eq!(
         group_after.vault, vault_before,
-        "recovery declaration moves no custody"
+        "terminal recovery resolution moves no custody"
     );
     assert_eq!(
         group_after.c_tot, c_tot_before,
-        "recovery declaration mints no capital"
+        "terminal recovery resolution mints no capital"
     );
     assert_eq!(
         group_after.insurance, insurance_before,
-        "recovery declaration spends no insurance"
+        "terminal recovery resolution spends no insurance"
     );
 }
 
@@ -15747,7 +15747,7 @@ fn v16_attack_auto_crank_expired_close_uses_authenticated_slot_not_stale_market_
     );
 
     let (_, group_after) = env.market_state();
-    assert_eq!(group_after.mode, MarketModeV16::Recovery);
+    assert_eq!(group_after.mode, MarketModeV16::Resolved);
     assert_eq!(
         group_after.recovery_reason,
         Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)


### PR DESCRIPTION
## Impact

A public portfolio owner can turn an account-local, partially completed recovery forfeit into a permanent global market lock after a legitimate asset shutdown. An unrelated flat user's real SPL principal becomes unreachable even with an honest cranker supplying the correct transaction.

## Public TDD reproduction

The regression uses only normal accounts and public instructions:

1. Initialize a production-risk market and three portfolios.
2. Open a normal long/short pair and fund an unrelated flat victim.
3. Move the authenticated mark through bounded public updates.
4. Shut down the asset through the public lifecycle instruction.
5. Owner-sign `ForfeitRecoveryLeg`, which commits one bounded chunk and leaves a real nonzero residual.
6. After its deadline, submit unsigned `PermissionlessCrank`.

Against exact parent `36fa587e1424a8c7fdde2c701c10938188a51876` with engine `143e68c4917ed0400a27b952f036a5677047cd84`, step 6 commits `MarketModeV16::Recovery`, creating the global sink. No protocol state is injected in this exploit test.

With engine PR aeyakovenko/percolator#165, the same crank reaches `Resolved` atomically and the unrelated owner withdraws exactly 100 real SPL tokens through the bounded `CloseResolved` path.

A separate, explicitly marked migration regression injects only a pre-upgrade persisted `Recovery` fixture and proves the wrapper's sole public `PermissionlessCrank` resolves it. It is supplemental upgrade coverage, not the exploit reachability evidence.

## Changes

- Add the public-interface LiteSVM exploit/regression.
- Add the persisted-state auto-crank migration regression.
- Update existing terminal-recovery expectations from `Recovery` to `Resolved`.
- Pin engine `d7b29edb943ebf490ac8ea3d95798cf9b44deba3` from aeyakovenko/percolator#165.

No wrapper program source is changed.

## Verification

- `cargo build-sbf --tools-version v1.52`: passed.
- `cargo test --all-targets -- --test-threads=1`: 567/567 LiteSVM/CU tests and 6/6 wrapper unit tests passed.
- Engine runtime: 130/130 passed.
- Engine Kani: 4,543-check direct resolution proof and 14,839-check whole auto-crank proof passed.

## Known dependency

The regression here proves that the unrelated flat user regains a custody exit. Complete wind-down of the loss-side cohort for this small valid B budget also requires engine #155, which fixes the independent loss-atom/B-index unit mismatch. This PR intentionally does not duplicate that existing finding.