### PR TITLE
[BLOCKER LoF] Require bilateral fee support for EWMA movement

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4138,9 +4138,16 @@ pub mod policy_v16 {
         if quoted_mark_e6 == 0 || mark_externality_notional == 0 {
             return Some(quoted_mark_e6);
         }
-        let collected = fee_a.checked_add(fee_b)?;
-        let externality_fee = collected.saturating_sub(base_fee_paid);
-        let supported_move_bps = externality_fee
+        // Each side can hold other positions that benefit from the mark move. Do not let one
+        // underfunded side use its counterparty's payment to make that separate book profitable.
+        // The quote's base fee is exactly two equal per-side charges, so only matched externality
+        // payments can support movement.
+        let base_fee_per_side = base_fee_paid / 2;
+        let externality_fee_a = fee_a.saturating_sub(base_fee_per_side);
+        let externality_fee_b = fee_b.saturating_sub(base_fee_per_side);
+        let matched_externality_fee =
+            core::cmp::min(externality_fee_a, externality_fee_b).checked_mul(2)?;
+        let supported_move_bps = matched_externality_fee
             .checked_mul(10_000)?
             .checked_div(mark_externality_notional)?;
         Some(clamp_mark_to_supported_move_bps(

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59718,8 +59718,13 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
     }
 }
 
-#[test]
-fn v16_probe_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
+#[derive(Clone, Copy, Debug)]
+enum UnderfundedCpiFeePath {
+    Single,
+    Batch,
+}
+
+fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: UnderfundedCpiFeePath) {
     const MARK: u64 = 1_000_000;
     const ADVERSE_MARK: u64 = 1_999_999;
     const MOVER_Q: i128 = POS_SCALE as i128;
@@ -59887,19 +59892,44 @@ fn v16_probe_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
     );
     env.svm.warp_to_slot(20);
     env.svm.expire_blockhash();
-    env.try_trade_cpi_with_cu_on_asset(
-        &mover_owner,
-        mover,
-        &fee_lp_owner,
-        fee_lp,
-        matcher_program,
-        exit_ctx,
-        exit_delegate,
-        0,
-        MOVER_Q,
-        0,
-    )
-    .expect("underfunded risk-reducing exit must remain live");
+    let exit = match path {
+        UnderfundedCpiFeePath::Single => env.try_trade_cpi_with_cu_on_asset(
+            &mover_owner,
+            mover,
+            &fee_lp_owner,
+            fee_lp,
+            matcher_program,
+            exit_ctx,
+            exit_delegate,
+            0,
+            MOVER_Q,
+            0,
+        ),
+        UnderfundedCpiFeePath::Batch => env.send(
+            ProgInstruction::BatchTradeCpi {
+                legs: vec![BatchTradeCpiLeg {
+                    asset_index: 0,
+                    size_q: MOVER_Q,
+                    fee_bps: 0,
+                    limit_price: 0,
+                }],
+            },
+            vec![
+                AccountMeta::new(mover_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(mover, false),
+                AccountMeta::new(fee_lp, false),
+                AccountMeta::new_readonly(matcher_program, false),
+                AccountMeta::new(exit_ctx, false),
+                AccountMeta::new_readonly(exit_delegate, false),
+            ],
+            &[&mover_owner],
+        ),
+    };
+    assert!(
+        exit.is_ok(),
+        "{path:?}: underfunded risk-reducing exit must remain live: {exit:?}"
+    );
 
     let (cfg_after_trade, group_after_trade) = env.market_state();
     assert!(
@@ -59927,7 +59957,7 @@ fn v16_probe_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
     let fee_lp_after = equity(&env.portfolio_state(fee_lp));
     let insurance_after = env.market_state().1.insurance;
     eprintln!(
-        "underfunded CPI subsidy: setup_mark={setup_mark} queued_mark={} \
+        "{path:?} underfunded CPI subsidy: setup_mark={setup_mark} queued_mark={} \
          attacker_delta={} victim_delta={} fee_lp_delta={} insurance_delta={}",
         cfg_after_trade.mark_ewma_e6,
         attacker_after - attacker_before,
@@ -59981,4 +60011,11 @@ fn v16_probe_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
         group_after_trade.assets[0].oi_eff_long_q,
         (BENEFICIARY_Q * 2) as u128
     );
+}
+
+#[test]
+fn v16_attack_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
+    for path in [UnderfundedCpiFeePath::Single, UnderfundedCpiFeePath::Batch] {
+        assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path);
+    }
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59724,7 +59724,16 @@ enum UnderfundedCpiFeePath {
     Batch,
 }
 
-fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: UnderfundedCpiFeePath) {
+#[derive(Clone, Copy, Debug)]
+enum UnderfundedMarkMode {
+    Ewma,
+    HybridAfterHours,
+}
+
+fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(
+    mode: UnderfundedMarkMode,
+    path: UnderfundedCpiFeePath,
+) {
     const MARK: u64 = 1_000_000;
     const ADVERSE_MARK: u64 = 1_999_999;
     const MOVER_Q: i128 = POS_SCALE as i128;
@@ -59738,25 +59747,52 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
         min_funding_lifetime_slots: 1,
         ..V16CuMarketParams::default()
     });
-    env.configure_ewma_mark_with_cu(0, MARK, 1, 0);
-    let oracle_authority = Keypair::new();
-    env.ensure_signer_account(oracle_authority.pubkey());
-    let market_admin = env.admin.insecure_clone();
-    env.svm.expire_blockhash();
-    env.send(
-        ProgInstruction::UpdateAssetAuthority {
-            asset_index: 0,
-            kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
-            new_pubkey: oracle_authority.pubkey().to_bytes(),
-        },
-        vec![
-            AccountMeta::new(market_admin.pubkey(), true),
-            AccountMeta::new(oracle_authority.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&market_admin, &oracle_authority],
-    )
-    .expect("separate the honest oracle authority from every trader");
+    let mut ewma_oracle_authority = None;
+    let mut hybrid_feed = None;
+    match mode {
+        UnderfundedMarkMode::Ewma => {
+            env.configure_ewma_mark_with_cu(0, MARK, 1, 0);
+            let oracle_authority = Keypair::new();
+            env.ensure_signer_account(oracle_authority.pubkey());
+            let market_admin = env.admin.insecure_clone();
+            env.svm.expire_blockhash();
+            env.send(
+                ProgInstruction::UpdateAssetAuthority {
+                    asset_index: 0,
+                    kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
+                    new_pubkey: oracle_authority.pubkey().to_bytes(),
+                },
+                vec![
+                    AccountMeta::new(market_admin.pubkey(), true),
+                    AccountMeta::new(oracle_authority.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                &[&market_admin, &oracle_authority],
+            )
+            .expect("separate the honest oracle authority from every trader");
+            ewma_oracle_authority = Some(oracle_authority);
+        }
+        UnderfundedMarkMode::HybridAfterHours => {
+            set_test_clock(&mut env, 1, 100);
+            let feed = [0xceu8; 32];
+            let initial_oracle = env.set_pyth_price(&feed, MARK as i64, -6, 100);
+            env.try_configure_hybrid_asset_with_conf_filter_cu(
+                0,
+                1,
+                0,
+                [feed, [0u8; 32], [0u8; 32]],
+                &[initial_oracle],
+                1,
+                100,
+                0,
+                0,
+                1,
+                0,
+            )
+            .expect("configure external-oracle hybrid market");
+            hybrid_feed = Some(feed);
+        }
+    }
 
     let matcher_program = Pubkey::new_unique();
     let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
@@ -59835,37 +59871,60 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
     );
 
     // Reach a distressed but still live short through normal oracle and crank instructions.
-    env.svm.warp_to_slot(10);
-    env.svm.expire_blockhash();
-    env.send(
-        ProgInstruction::PushEwmaMark {
-            asset_index: 0,
-            now_slot: 10,
-            mark_e6: ADVERSE_MARK,
-        },
-        vec![
-            AccountMeta::new(oracle_authority.pubkey(), true),
-            AccountMeta::new(env.market, false),
-        ],
-        &[&oracle_authority],
-    )
-    .expect("honest oracle advances the market before the attack");
+    let hybrid_oracle_tail = match mode {
+        UnderfundedMarkMode::Ewma => {
+            env.svm.warp_to_slot(10);
+            let oracle_authority = ewma_oracle_authority
+                .as_ref()
+                .expect("EWMA mode has an independent oracle authority");
+            env.svm.expire_blockhash();
+            env.send(
+                ProgInstruction::PushEwmaMark {
+                    asset_index: 0,
+                    now_slot: 10,
+                    mark_e6: ADVERSE_MARK,
+                },
+                vec![
+                    AccountMeta::new(oracle_authority.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                ],
+                &[oracle_authority],
+            )
+            .expect("honest oracle advances the market before the attack");
+            None
+        }
+        UnderfundedMarkMode::HybridAfterHours => {
+            set_test_clock(&mut env, 10, 110);
+            Some(
+                env.set_pyth_price(
+                    hybrid_feed
+                        .as_ref()
+                        .expect("hybrid mode has an external feed"),
+                    ADVERSE_MARK as i64,
+                    -6,
+                    110,
+                ),
+            )
+        }
+    };
     for (index, account) in [mover, fee_lp, beneficiary, victim, close_long, close_lp]
         .into_iter()
         .enumerate()
     {
         env.svm.expire_blockhash();
-        env.crank(
-            account,
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 10,
-                observations: if index == 0 {
-                    crank_observations(0)
-                } else {
-                    Vec::new()
-                },
+        let instruction = ProgInstruction::PermissionlessCrank {
+            now_slot: 10,
+            observations: if index == 0 || hybrid_oracle_tail.is_some() {
+                crank_observations(0)
+            } else {
+                Vec::new()
             },
-        );
+        };
+        if let Some(oracle) = hybrid_oracle_tail {
+            env.crank_with_oracle_tail(account, instruction, &[oracle]);
+        } else {
+            env.crank(account, instruction);
+        }
     }
     let (_, group_at_attack_setup) = env.market_state();
     let setup_mark = group_at_attack_setup.assets[0].effective_price;
@@ -59890,7 +59949,10 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
         9_000,
         9_000,
     );
-    env.svm.warp_to_slot(20);
+    match mode {
+        UnderfundedMarkMode::Ewma => env.svm.warp_to_slot(20),
+        UnderfundedMarkMode::HybridAfterHours => set_test_clock(&mut env, 20, 1_000),
+    }
     env.svm.expire_blockhash();
     let exit = match path {
         UnderfundedCpiFeePath::Single => env.try_trade_cpi_with_cu_on_asset(
@@ -59933,22 +59995,24 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
 
     let (cfg_after_trade, group_after_trade) = env.market_state();
     assert!(
-        cfg_after_trade.mark_ewma_e6 > setup_mark,
-        "the independently funded side must currently move the mark"
+        cfg_after_trade.mark_ewma_e6 >= setup_mark,
+        "the accepted upward print must not reverse the mark"
     );
     for (index, account) in [beneficiary, victim].into_iter().enumerate() {
         env.svm.expire_blockhash();
-        env.crank(
-            account,
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 20,
-                observations: if index == 0 {
-                    crank_observations(0)
-                } else {
-                    Vec::new()
-                },
+        let instruction = ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: if index == 0 || hybrid_oracle_tail.is_some() {
+                crank_observations(0)
+            } else {
+                Vec::new()
             },
-        );
+        };
+        if let Some(oracle) = hybrid_oracle_tail {
+            env.crank_with_oracle_tail(account, instruction, &[oracle]);
+        } else {
+            env.crank(account, instruction);
+        }
     }
 
     let attacker_after =
@@ -59957,7 +60021,7 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
     let fee_lp_after = equity(&env.portfolio_state(fee_lp));
     let insurance_after = env.market_state().1.insurance;
     eprintln!(
-        "{path:?} underfunded CPI subsidy: setup_mark={setup_mark} queued_mark={} \
+        "{mode:?} {path:?} underfunded CPI subsidy: setup_mark={setup_mark} queued_mark={} \
          attacker_delta={} victim_delta={} fee_lp_delta={} insurance_delta={}",
         cfg_after_trade.mark_ewma_e6,
         attacker_after - attacker_before,
@@ -60003,8 +60067,16 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
         attacker_payout - attacker_before as u128
     );
     assert!(
-        victim_after < victim_before,
-        "the probe must move real victim value"
+        victim_after <= victim_before,
+        "the accepted upward print must not benefit the short victim"
+    );
+    assert!(
+        fee_lp_after < fee_lp_before,
+        "the independent LP must pay a real fee"
+    );
+    assert!(
+        insurance_after > insurance_before,
+        "the accepted trade must collect a real fee"
     );
     assert!(attacker_after >= attacker_payout as i128);
     assert_eq!(
@@ -60015,7 +60087,12 @@ fn assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path: Underfun
 
 #[test]
 fn v16_attack_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
-    for path in [UnderfundedCpiFeePath::Single, UnderfundedCpiFeePath::Batch] {
-        assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(path);
+    for mode in [
+        UnderfundedMarkMode::Ewma,
+        UnderfundedMarkMode::HybridAfterHours,
+    ] {
+        for path in [UnderfundedCpiFeePath::Single, UnderfundedCpiFeePath::Batch] {
+            assert_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain(mode, path);
+        }
     }
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,268 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+#[test]
+fn v16_probe_underfunded_cpi_fee_cannot_subsidize_attacker_mark_gain() {
+    const MARK: u64 = 1_000_000;
+    const ADVERSE_MARK: u64 = 1_999_999;
+    const MOVER_Q: i128 = POS_SCALE as i128;
+    const BENEFICIARY_Q: i128 = 10 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: MARK,
+        max_trading_fee_bps: 10_000,
+        max_price_move_bps_per_slot: 10_000,
+        max_accrual_dt_slots: 1,
+        min_funding_lifetime_slots: 1,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_ewma_mark_with_cu(0, MARK, 1, 0);
+    let oracle_authority = Keypair::new();
+    env.ensure_signer_account(oracle_authority.pubkey());
+    let market_admin = env.admin.insecure_clone();
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: 0,
+            kind: percolator_prog::processor::ASSET_AUTH_ORACLE,
+            new_pubkey: oracle_authority.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(market_admin.pubkey(), true),
+            AccountMeta::new(oracle_authority.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&market_admin, &oracle_authority],
+    )
+    .expect("separate the honest oracle authority from every trader");
+
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+
+    let mover_owner = Keypair::new();
+    let mover = env.create_portfolio(&mover_owner);
+    let fee_lp_owner = Keypair::new();
+    let fee_lp = env.create_portfolio(&fee_lp_owner);
+    let beneficiary_owner = Keypair::new();
+    let beneficiary = env.create_portfolio(&beneficiary_owner);
+    let victim_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let close_long_owner = Keypair::new();
+    let close_long = env.create_portfolio(&close_long_owner);
+    let close_lp_owner = Keypair::new();
+    let close_lp = env.create_portfolio(&close_lp_owner);
+    env.deposit(&mover_owner, mover, MARK as u128);
+    env.deposit(&fee_lp_owner, fee_lp, 50_000_000);
+    env.deposit(&beneficiary_owner, beneficiary, 50_000_000);
+    env.deposit(&victim_owner, victim, 50_000_000);
+    env.deposit(&close_long_owner, close_long, 50_000_000);
+    env.deposit(&close_lp_owner, close_lp, 50_000_000);
+
+    let (open_ctx, open_delegate, _) = env.init_matcher_context_with_passive_spread_authorized(
+        matcher_program,
+        &fee_lp_owner,
+        fee_lp,
+        0,
+        9_000,
+    );
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &mover_owner,
+        mover,
+        &fee_lp_owner,
+        fee_lp,
+        matcher_program,
+        open_ctx,
+        open_delegate,
+        0,
+        -MOVER_Q,
+        0,
+    )
+    .expect("open the future distressed short");
+
+    // Establish the separate attacker/victim book before the distressed account raises H-lock.
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &beneficiary_owner,
+        beneficiary,
+        &victim_owner,
+        victim,
+        BENEFICIARY_Q,
+        MARK,
+        0,
+    );
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        0,
+        &close_long_owner,
+        close_long,
+        &close_lp_owner,
+        close_lp,
+        BENEFICIARY_Q,
+        MARK,
+        0,
+    );
+    let (close_ctx, close_delegate, _) = env.init_matcher_context_with_passive_spread_authorized(
+        matcher_program,
+        &close_lp_owner,
+        close_lp,
+        0,
+        9_000,
+    );
+
+    // Reach a distressed but still live short through normal oracle and crank instructions.
+    env.svm.warp_to_slot(10);
+    env.svm.expire_blockhash();
+    env.send(
+        ProgInstruction::PushEwmaMark {
+            asset_index: 0,
+            now_slot: 10,
+            mark_e6: ADVERSE_MARK,
+        },
+        vec![
+            AccountMeta::new(oracle_authority.pubkey(), true),
+            AccountMeta::new(env.market, false),
+        ],
+        &[&oracle_authority],
+    )
+    .expect("honest oracle advances the market before the attack");
+    for (index, account) in [mover, fee_lp, beneficiary, victim, close_long, close_lp]
+        .into_iter()
+        .enumerate()
+    {
+        env.svm.expire_blockhash();
+        env.crank(
+            account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 10,
+                observations: if index == 0 {
+                    crank_observations(0)
+                } else {
+                    Vec::new()
+                },
+            },
+        );
+    }
+    let (_, group_at_attack_setup) = env.market_state();
+    let setup_mark = group_at_attack_setup.assets[0].effective_price;
+    let mover_at_setup = env.portfolio_state(mover);
+    assert!(
+        0 < mover_at_setup.capital.get() && mover_at_setup.capital.get() < setup_mark as u128,
+        "setup must leave a live short unable to pay a one-sided 100% exit fee"
+    );
+
+    let equity =
+        |state: &PortfolioAccountV16| -> i128 { state.capital.get() as i128 + state.pnl.get() };
+    let attacker_before =
+        equity(&env.portfolio_state(mover)) + equity(&env.portfolio_state(beneficiary));
+    let victim_before = equity(&env.portfolio_state(victim));
+    let fee_lp_before = equity(&env.portfolio_state(fee_lp));
+    let insurance_before = env.market_state().1.insurance;
+
+    let (exit_ctx, exit_delegate, _) = env.init_matcher_context_with_passive_spread_authorized(
+        matcher_program,
+        &fee_lp_owner,
+        fee_lp,
+        9_000,
+        9_000,
+    );
+    env.svm.warp_to_slot(20);
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &mover_owner,
+        mover,
+        &fee_lp_owner,
+        fee_lp,
+        matcher_program,
+        exit_ctx,
+        exit_delegate,
+        0,
+        MOVER_Q,
+        0,
+    )
+    .expect("underfunded risk-reducing exit must remain live");
+
+    let (cfg_after_trade, group_after_trade) = env.market_state();
+    assert!(
+        cfg_after_trade.mark_ewma_e6 > setup_mark,
+        "the independently funded side must currently move the mark"
+    );
+    for (index, account) in [beneficiary, victim].into_iter().enumerate() {
+        env.svm.expire_blockhash();
+        env.crank(
+            account,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 20,
+                observations: if index == 0 {
+                    crank_observations(0)
+                } else {
+                    Vec::new()
+                },
+            },
+        );
+    }
+
+    let attacker_after =
+        equity(&env.portfolio_state(mover)) + equity(&env.portfolio_state(beneficiary));
+    let victim_after = equity(&env.portfolio_state(victim));
+    let fee_lp_after = equity(&env.portfolio_state(fee_lp));
+    let insurance_after = env.market_state().1.insurance;
+    eprintln!(
+        "underfunded CPI subsidy: setup_mark={setup_mark} queued_mark={} \
+         attacker_delta={} victim_delta={} fee_lp_delta={} insurance_delta={}",
+        cfg_after_trade.mark_ewma_e6,
+        attacker_after - attacker_before,
+        victim_after - victim_before,
+        fee_lp_after - fee_lp_before,
+        insurance_after - insurance_before,
+    );
+
+    // Close through a separately authorized passive LP and turn the marked gain into ordinary SPL
+    // custody. The victim does not participate in the attack or the extraction.
+    env.svm.expire_blockhash();
+    env.try_trade_cpi_with_cu_on_asset(
+        &beneficiary_owner,
+        beneficiary,
+        &close_lp_owner,
+        close_lp,
+        matcher_program,
+        close_ctx,
+        close_delegate,
+        0,
+        -BENEFICIARY_Q,
+        0,
+    )
+    .expect("attacker closes the beneficiary position through the passive matcher");
+    let released = env.portfolio_state(beneficiary).pnl.get().max(0) as u128;
+    assert!(released > 0, "the mark gain must be real and releasable");
+    env.convert_released_pnl_with_cu(&beneficiary_owner, beneficiary, released);
+    let beneficiary_capital = env.portfolio_state(beneficiary).capital.get();
+    let beneficiary_dest = env.withdraw(&beneficiary_owner, beneficiary, beneficiary_capital);
+    let mover_capital = env.portfolio_state(mover).capital.get();
+    let mover_payout = if mover_capital == 0 {
+        0
+    } else {
+        let mover_dest = env.withdraw(&mover_owner, mover, mover_capital);
+        env.token_amount(mover_dest) as u128
+    };
+    let attacker_payout = env.token_amount(beneficiary_dest) as u128 + mover_payout;
+
+    assert!(
+        attacker_payout <= attacker_before as u128,
+        "an underfunded mover used an independent LP's fee to withdraw {} more atoms than the \
+         attacker's pre-attack equity",
+        attacker_payout - attacker_before as u128
+    );
+    assert!(
+        victim_after < victim_before,
+        "the probe must move real victim value"
+    );
+    assert!(attacker_after >= attacker_payout as i128);
+    assert_eq!(
+        group_after_trade.assets[0].oi_eff_long_q,
+        (BENEFICIARY_Q * 2) as u128
+    );
+}

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -103,7 +103,7 @@ fn kani_v16_one_sided_externality_fee_cannot_fund_mark_movement() {
     let mark_externality_notional = kani::any::<u32>() as u128 + 1;
     kani::assume(old_mark > 0 && quoted_mark > 0);
 
-    let mark = policy_v16::collected_fee_supported_mark(
+    let mark_a_underfunded = policy_v16::collected_fee_supported_mark(
         old_mark,
         quoted_mark,
         base_fee_per_side * 2,
@@ -112,12 +112,22 @@ fn kani_v16_one_sided_externality_fee_cannot_fund_mark_movement() {
         base_fee_per_side + paying_side_externality,
     )
     .unwrap();
+    let mark_b_underfunded = policy_v16::collected_fee_supported_mark(
+        old_mark,
+        quoted_mark,
+        base_fee_per_side * 2,
+        mark_externality_notional,
+        base_fee_per_side + paying_side_externality,
+        base_fee_per_side,
+    )
+    .unwrap();
 
     kani::cover!(
         quoted_mark != old_mark && paying_side_externality > 0,
         "one counterparty pays a real externality fee against a moving quote"
     );
-    assert_eq!(mark, old_mark);
+    assert_eq!(mark_a_underfunded, old_mark);
+    assert_eq!(mark_b_underfunded, old_mark);
 }
 
 #[kani::proof]

--- a/tests/v16_kani.rs
+++ b/tests/v16_kani.rs
@@ -95,6 +95,32 @@ fn kani_v16_collected_base_fee_cannot_fund_mark_movement() {
 }
 
 #[kani::proof]
+fn kani_v16_one_sided_externality_fee_cannot_fund_mark_movement() {
+    let old_mark = kani::any::<u64>();
+    let quoted_mark = kani::any::<u64>();
+    let base_fee_per_side = kani::any::<u32>() as u128;
+    let paying_side_externality = kani::any::<u32>() as u128;
+    let mark_externality_notional = kani::any::<u32>() as u128 + 1;
+    kani::assume(old_mark > 0 && quoted_mark > 0);
+
+    let mark = policy_v16::collected_fee_supported_mark(
+        old_mark,
+        quoted_mark,
+        base_fee_per_side * 2,
+        mark_externality_notional,
+        base_fee_per_side,
+        base_fee_per_side + paying_side_externality,
+    )
+    .unwrap();
+
+    kani::cover!(
+        quoted_mark != old_mark && paying_side_externality > 0,
+        "one counterparty pays a real externality fee against a moving quote"
+    );
+    assert_eq!(mark, old_mark);
+}
+
+#[kani::proof]
 fn kani_v16_init_market_decode_preserves_wire_fields() {
     // Full-width symbolic inputs (audit: avoid the u16->u64/u128 widening collapse so
     // narrow-read / high-byte decode bugs are observable).


### PR DESCRIPTION
## Root cause

`collected_fee_supported_mark` bounded trade-driven EWMA movement from the aggregate fee collected from both trade sides. A distressed risk-reducing trader can pay only its remaining capital while an independently authorized CPI LP pays the full dynamic fee. The LP's payment then supported the entire mark move, even though the underfunded side could hold a separate position that profits from that move.

This is distinct from the existing uncollectible-fee regression: the fee is genuinely collected, but from the wrong economic side for the externality it funds.

## Public exploit

The RED test uses only deployed SBF instructions and ordinary accounts:

- independently owned distressed mover, fee-paying passive LP, attacker beneficiary, victim, and extraction LP
- real SPL deposits and withdrawals
- independently authenticated EWMA mark or external Pyth hybrid feed
- public single or batch CPI trades and permissionless cranks
- no protocol-state injection, compromised key, or privileged attacker

On exact parent `36fa587e`:

| Mode / route | Queued mark | Attacker delta | Independent victim delta |
| --- | ---: | ---: | ---: |
| EWMA single/batch | 1,997,385 | +792,859 | -883,860 |
| Hybrid-after-hours single/batch | 2,090,398 | +903,989 | -903,990 |

The attacker closes through a separately authorized LP, converts released PnL, and withdraws the gain as SPL tokens.

## Fix

Subtract the equal per-side base charge independently, then support internal mark movement from `2 * min(externality_fee_a, externality_fee_b)`. Either side's payment alone therefore supports zero movement. When both sides pay, the existing aggregate economics are unchanged.

Arbitrary-price risk-reducing exits remain live. The wrapper still executes the trade and collects whatever fees are available; only its internal mark movement is clamped to bilateral paid support.

At head:

- EWMA single/batch: queued mark 1,913,198; attacker delta -49,011
- Hybrid-after-hours single/batch: mark remains 1,999,999; attacker delta -1
- the independent LP still pays a real fee and insurance receives it

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo build-sbf --tools-version v1.52`
- exact-parent RED for all four mode/route combinations
- focused GREEN for all four mode/route combinations
- `cargo test --all-targets -- --test-threads=1`: 6/6 unit and 566/566 LiteSVM/BPF/CU tests pass
- `cargo kani --tests --harness kani_v16_one_sided_externality_fee_cannot_fund_mark_movement`: 43 checks pass and the nontrivial cover property is satisfied