### PR TITLE
[BLOCKER DoS] Keep winner-first Recovery forfeits live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=143e68c4917ed0400a27b952f036a5677047cd84#143e68c4917ed0400a27b952f036a5677047cd84"
+source = "git+https://github.com/aeyakovenko/percolator?rev=a9a8588483ac6ecccd5d94bcbc80e116cf5487a8#a9a8588483ac6ecccd5d94bcbc80e116cf5487a8"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9a8588483ac6ecccd5d94bcbc80e116cf5487a8" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "143e68c4917ed0400a27b952f036a5677047cd84" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9a8588483ac6ecccd5d94bcbc80e116cf5487a8" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59725,6 +59725,9 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
 fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
     const PRICE: u64 = 1_000_000;
     const ASSET: u16 = 1;
+    const WINNER_SOURCE_DOMAIN: u16 = ASSET * 2;
+    const BACKING: u128 = 100_000;
+    const BASE_RISK_Q: i128 = POS_SCALE as i128 * 3 / 2;
 
     let mut params = production_risk_params();
     params.max_portfolio_assets = 2;
@@ -59736,10 +59739,14 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
 
     let loser_owner = Keypair::new();
     let winner_owner = Keypair::new();
+    let base_counterparty_owner = Keypair::new();
     let loser = env.create_portfolio(&loser_owner);
     let winner = env.create_portfolio(&winner_owner);
+    let base_counterparty = env.create_portfolio(&base_counterparty_owner);
     env.deposit(&loser_owner, loser, 51_000);
     env.deposit(&winner_owner, winner, 100_000);
+    env.deposit(&base_counterparty_owner, base_counterparty, 100_000);
+    env.top_up_backing_bucket(WINNER_SOURCE_DOMAIN, BACKING, 10_000);
     env.trade_asset_with_cu(
         ASSET,
         &loser_owner,
@@ -59751,7 +59758,33 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
         0,
     );
 
-    for (slot, mark) in [(20, 952_000), (25, 940_000), (30, 940_576)] {
+    env.svm.warp_to_slot(20);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 20, 952_000);
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(ASSET),
+        },
+    );
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &base_counterparty_owner,
+        base_counterparty,
+        BASE_RISK_Q,
+        PRICE,
+        0,
+    );
+    let winner_with_lien = env.portfolio_state(winner);
+    let lien = state::portfolio_source_domain(&winner_with_lien, WINNER_SOURCE_DOMAIN as usize);
+    assert!(
+        lien.source_lien_counterparty_backing_num.get() > 0,
+        "public cross-margin risk increase must create a real backing lien"
+    );
+
+    for (slot, mark) in [(25, 940_000), (30, 940_576)] {
         env.svm.warp_to_slot(slot);
         env.push_auth_mark_for_asset_as_admin(ASSET, slot, mark);
         env.crank(
@@ -59775,6 +59808,19 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
         "winner-first Recovery loser forfeit",
         loser_forfeit_cu,
         CUSTODY_CU_LIMIT,
+    );
+    let (_, after_forfeits) = env.market_state();
+    assert_eq!(
+        after_forfeits.source_backing_buckets[WINNER_SOURCE_DOMAIN as usize]
+            .valid_liened_backing_num,
+        0,
+        "winner forfeit must release its selected-domain backing lien"
+    );
+    assert_eq!(
+        after_forfeits.source_backing_buckets[WINNER_SOURCE_DOMAIN as usize]
+            .fresh_unliened_backing_num,
+        BACKING * BOUND_SCALE,
+        "released lien must return all provider principal"
     );
 
     let loser_after = env.portfolio_state(loser);
@@ -59842,6 +59888,16 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
         CUSTODY_CU_LIMIT,
     );
 
+    env.trade_asset_with_cu(
+        0,
+        &winner_owner,
+        winner,
+        &base_counterparty_owner,
+        base_counterparty,
+        -BASE_RISK_Q,
+        PRICE,
+        0,
+    );
     let winner_capital = env.portfolio_state(winner).capital.get();
     assert!(
         winner_capital > 0,
@@ -59854,6 +59910,22 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
         "the detached winner can withdraw"
     );
     env.close_portfolio_with_cu(&winner_owner, winner);
+
+    let base_counterparty_capital = env.portfolio_state(base_counterparty).capital.get();
+    env.withdraw(
+        &base_counterparty_owner,
+        base_counterparty,
+        base_counterparty_capital,
+    );
+    env.close_portfolio_with_cu(&base_counterparty_owner, base_counterparty);
+
+    let backing_dest = env.token_account(env.admin.pubkey(), 0);
+    env.withdraw_backing_bucket_to_admin_token_with_cu(backing_dest, WINNER_SOURCE_DOMAIN, BACKING);
+    assert_eq!(
+        env.token_amount(backing_dest),
+        BACKING as u64,
+        "the released backing remains fully withdrawable by its provider"
+    );
     assert_eq!(
         env.market_state().1.materialized_portfolio_count,
         0,

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,146 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// Probe: after a normal asset shutdown, public forfeit order must not strand the last losing leg.
+// The winning side is allowed to forfeit first; the remaining owner still needs a bounded public
+// route that commits progress even when no opposing social-loss weight remains.
+#[test]
+fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
+    const PRICE: u64 = 1_000_000;
+    const ASSET: u16 = 1;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    params.public_b_chunk_atoms = 8_000;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, PRICE);
+
+    let loser_owner = Keypair::new();
+    let winner_owner = Keypair::new();
+    let loser = env.create_portfolio(&loser_owner);
+    let winner = env.create_portfolio(&winner_owner);
+    env.deposit(&loser_owner, loser, 51_000);
+    env.deposit(&winner_owner, winner, 100_000);
+    env.trade_asset_with_cu(
+        ASSET,
+        &loser_owner,
+        loser,
+        &winner_owner,
+        winner,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    for (slot, mark) in [(20, 952_000), (25, 940_000), (30, 940_576)] {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(ASSET, slot, mark);
+        env.crank(
+            winner,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_SHUTDOWN, ASSET, 30, 0);
+    env.forfeit_recovery_leg_with_cu(&winner_owner, winner, ASSET, u128::MAX);
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(winner), ASSET as usize),
+        "the winning counterparty must detach first"
+    );
+
+    let custody_before = env.token_amount(env.vault);
+    let loser_forfeit_cu = env.forfeit_recovery_leg_with_cu(&loser_owner, loser, ASSET, u128::MAX);
+    assert_cu_within(
+        "winner-first Recovery loser forfeit",
+        loser_forfeit_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let loser_after = env.portfolio_state(loser);
+    assert!(
+        !has_active_leg_for_asset(&loser_after, ASSET as usize),
+        "the losing owner must detach after the winner forfeits first"
+    );
+    assert_eq!(
+        loser_after.capital.get(),
+        0,
+        "the bankrupt owner has no remaining capital"
+    );
+    assert_eq!(
+        loser_after.pnl.get(),
+        0,
+        "the explicit claim-free residual must be finalized"
+    );
+    let ledger = close_progress(&loser_after);
+    assert!(
+        ledger.finalized && ledger.residual_remaining == 0,
+        "no pending close residual may survive the successful forfeit"
+    );
+
+    let (_, group_after) = env.market_state();
+    assert_eq!(
+        group_after.mode,
+        MarketModeV16::Live,
+        "a secondary-asset shutdown must not resolve the live market"
+    );
+    assert_eq!(
+        group_after.assets[ASSET as usize].lifecycle,
+        AssetLifecycleV16::Recovery
+    );
+    assert_eq!(group_after.assets[ASSET as usize].oi_eff_long_q, 0);
+    assert_eq!(group_after.assets[ASSET as usize].oi_eff_short_q, 0);
+    assert_eq!(group_after.assets[ASSET as usize].loss_weight_sum_long, 0);
+    assert_eq!(group_after.assets[ASSET as usize].loss_weight_sum_short, 0);
+    assert_eq!(
+        env.token_amount(env.vault),
+        custody_before,
+        "forfeiting recovery legs must not move SPL custody"
+    );
+
+    // Keep the unrelated base current beyond the stale-resolution horizon. Progress must complete
+    // without resolving an otherwise-live market.
+    env.svm.warp_to_slot(1_000);
+    env.push_auth_mark_for_asset_as_admin(0, 1_000, PRICE);
+    env.crank(
+        winner,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1_000,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.market_state().1.mode,
+        MarketModeV16::Live,
+        "honest base cranking keeps the market live"
+    );
+
+    let loser_close_cu = env.close_portfolio_with_cu(&loser_owner, loser);
+    assert_cu_within(
+        "ClosePortfolio after winner-first Recovery forfeit",
+        loser_close_cu,
+        CUSTODY_CU_LIMIT,
+    );
+
+    let winner_capital = env.portfolio_state(winner).capital.get();
+    assert!(
+        winner_capital > 0,
+        "the winner retains only its independently withdrawable capital"
+    );
+    let winner_dest = env.withdraw(&winner_owner, winner, winner_capital);
+    assert_eq!(
+        env.token_amount(winner_dest),
+        winner_capital as u64,
+        "the detached winner can withdraw"
+    );
+    env.close_portfolio_with_cu(&winner_owner, winner);
+    assert_eq!(
+        env.market_state().1.materialized_portfolio_count,
+        0,
+        "both Recovery users can dematerialize"
+    );
+}


### PR DESCRIPTION
## Impact

A normally initialized two-asset market could strand the bankrupt side of a secondary-asset shutdown permanently when the winning counterparty forfeited its Recovery leg first. The same sequence could leave provider backing permanently liened. The remaining loser had no successful public continuation while an unrelated fresh base asset kept the market live, so SVM rollback preserved the stuck state.

## Public reproduction

The LiteSVM regression uses only public program instructions and valid account state:

1. Initialize a production-risk two-asset market and three funded portfolios.
2. Fund asset 1's backing domain and trade one lot on asset 1.
3. Move the authenticated mark within configured bounds, materialize the winner's PnL, then open public cross-margin risk on asset 0 so the winner carries a real asset-1 provider-backing lien.
4. Continue bounded authenticated marks and cranks until the asset-1 long is bankrupt.
5. Shut down asset 1 through the normal admin lifecycle route.
6. Have the winning short owner call `ForfeitRecoveryLeg` first, then have the losing long owner do the same.

Against parent `36fa587e` pinned to engine `143e68c`, the loser's call returned `Custom(23)` (`RecoveryRequired`) at 77,366 CU. Rollback erased its attempted declaration/ledger progress, and the winner's exit left 22.6k atoms of provider backing liened. Retry, risk reduction, force close, and auto crank provided no successful exit; keeping asset 0 fresh also prevented global resolution from masking the bug.

## Root cause

The first owner could detach after materializing positive PnL and its matching source claim. The old forfeit path deleted that leg's social-loss weight without waiving the materialized claim or releasing the valid source lien. That contradicted the dead-leg rule: positive PnL must be valued at zero unless source backing is consumed. With no recipient weight left, the bankrupt counterparty could not settle its residual and every local exit reverted.

Engine PR aeyakovenko/percolator#166 fixes the accounting by burning the selected leg's materialized positive PnL/source claim, releasing its valid source liens without touching unrelated domains, and allowing claim-free terminal explicit loss. This wrapper PR contains the public TDD regression and pins engine commit `a9a8588483ac6ecccd5d94bcbc80e116cf5487a8`.

## Validation

- Parent-red public LiteSVM reproduction: loser forfeit fails with `Custom(23)` at 77,366 CU and 22.6k provider atoms remain liened.
- Fixed focused regression: all three portfolios close, all OI/loss weights clear, and the backing provider withdraws the full 100k principal.
- Wrapper full suite: 566/566 LiteSVM tests plus all unit/example targets pass.
- Engine full suite: 132/132 tests pass.
- Engine targeted Kani contracts: `kernel_terminal_explicit_loss_allowed` 211/211 and `kernel_bresidual_step` 147/147 pass.
- `cargo fmt --check` and `git diff --check` pass.