### PR TITLE
[BLOCKER LoF] Preserve prior same-domain claim across Recovery forfeit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=a9a8588483ac6ecccd5d94bcbc80e116cf5487a8#a9a8588483ac6ecccd5d94bcbc80e116cf5487a8"
+source = "git+https://github.com/aeyakovenko/percolator?rev=58c085d6c521a98788ee123809c34980d54958e5#58c085d6c521a98788ee123809c34980d54958e5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=58c085d6c521a98788ee123809c34980d54958e5#58c085d6c521a98788ee123809c34980d54958e5"
+source = "git+https://github.com/aeyakovenko/percolator?rev=d3133a93cf2cf219b69e0072cb4079d24a07f4f6#d3133a93cf2cf219b69e0072cb4079d24a07f4f6"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "58c085d6c521a98788ee123809c34980d54958e5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d3133a93cf2cf219b69e0072cb4079d24a07f4f6" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "58c085d6c521a98788ee123809c34980d54958e5" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "d3133a93cf2cf219b69e0072cb4079d24a07f4f6" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9a8588483ac6ecccd5d94bcbc80e116cf5487a8" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "58c085d6c521a98788ee123809c34980d54958e5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "a9a8588483ac6ecccd5d94bcbc80e116cf5487a8" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "58c085d6c521a98788ee123809c34980d54958e5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60136,3 +60136,165 @@ fn v16_attack_reopened_recovery_forfeit_preserves_prior_same_domain_claim() {
         "the fixed path pays the preserved value through canonical custody"
     );
 }
+
+// Episode attribution must remain live when the later episode uses part of its newly earned claim
+// as source-backed initial margin. The Recovery exit must atomically preserve the older claim's
+// economic value; returning LockActive or releasing its backing for a provider race is not enough.
+#[test]
+fn v16_attack_reopened_recovery_forfeit_capitalizes_prior_claim_past_lien_overlap() {
+    const PRICE: u64 = 1_000_000;
+    const FIRST_PROFIT_MARK: u64 = 952_000;
+    const SECOND_PROFIT_MARK: u64 = 932_000;
+    const ASSET: u16 = 1;
+    const SOURCE_DOMAIN: u16 = ASSET * 2;
+    const INITIAL_CAPITAL: u128 = 1_000_000;
+    const RETAINED_CAPITAL: u128 = 5_000;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, PRICE);
+    env.top_up_backing_bucket(SOURCE_DOMAIN, 100_000, 10_000);
+
+    let victim_owner = Keypair::new();
+    let first_counterparty_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let first_counterparty = env.create_portfolio(&first_counterparty_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&first_counterparty_owner, first_counterparty),
+        (&attacker_owner, attacker),
+    ] {
+        env.deposit(owner, portfolio, INITIAL_CAPITAL);
+    }
+
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+    env.svm.warp_to_slot(20);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 20, FIRST_PROFIT_MARK);
+    env.crank(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(ASSET),
+        },
+    );
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        -(POS_SCALE as i128),
+        FIRST_PROFIT_MARK,
+        0,
+    );
+    let historical_claim =
+        state::portfolio_source_domain(&env.portfolio_state(victim), SOURCE_DOMAIN as usize)
+            .source_claim_bound_num
+            .get();
+    assert_eq!(historical_claim, 48_000 * BOUND_SCALE);
+
+    env.withdraw(&victim_owner, victim, INITIAL_CAPITAL - RETAINED_CAPITAL);
+    env.trade_asset_with_cu(
+        ASSET,
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        FIRST_PROFIT_MARK,
+        0,
+    );
+
+    // Episode two earns a new claim, then increases risk enough to lien beyond the attach-time
+    // historical floor. This is the overlap branch that a zero-PnL reopen does not exercise.
+    env.svm.warp_to_slot(40);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 40, SECOND_PROFIT_MARK);
+    for portfolio in [victim, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+    env.trade_asset_with_cu(
+        ASSET,
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        (POS_SCALE / 2) as i128,
+        SECOND_PROFIT_MARK,
+        0,
+    );
+    let before_shutdown = env.portfolio_state(victim);
+    let source = state::portfolio_source_domain(&before_shutdown, SOURCE_DOMAIN as usize);
+    assert!(
+        source.source_claim_bound_num.get() > historical_claim,
+        "episode two must add a new same-domain claim suffix"
+    );
+    assert!(
+        source.source_claim_liened_num.get() > historical_claim,
+        "risk increase must lien part of episode two above the historical floor"
+    );
+
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_SHUTDOWN, ASSET, 40, 0);
+    env.forfeit_recovery_leg_with_cu(&attacker_owner, attacker, ASSET, u128::MAX);
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(attacker), ASSET as usize),
+        "the attacker must remove the only opposite leg before the victim exits"
+    );
+    env.forfeit_recovery_leg_with_cu(&victim_owner, victim, ASSET, u128::MAX);
+
+    let after_forfeit = env.portfolio_state(victim);
+    assert!(
+        !has_active_leg_for_asset(&after_forfeit, ASSET as usize),
+        "the owner must retain a bounded unilateral Recovery exit"
+    );
+    assert_eq!(
+        after_forfeit.capital.get(),
+        RETAINED_CAPITAL + historical_claim / BOUND_SCALE,
+        "the forfeit must atomically capitalize episode one's backed value"
+    );
+    assert_eq!(
+        after_forfeit.pnl.get(),
+        0,
+        "the historical claim is capitalized while episode-two PnL is waived"
+    );
+
+    // The provider may immediately reclaim every unconsumed backing atom. This transaction must
+    // not race the victim because the preserved claim is already senior capital.
+    let provider_withdrawable = env.market_state().1.source_backing_buckets[SOURCE_DOMAIN as usize]
+        .fresh_unliened_backing_num
+        / BOUND_SCALE;
+    if provider_withdrawable != 0 {
+        let provider_destination = env.token_account(env.admin.pubkey(), 0);
+        env.withdraw_backing_bucket_to_admin_token_with_cu(
+            provider_destination,
+            SOURCE_DOMAIN,
+            provider_withdrawable,
+        );
+    }
+    let withdrawable = env.portfolio_state(victim).capital.get();
+    let (destination, _) = env.withdraw_with_cu(&victim_owner, victim, withdrawable);
+    assert_eq!(
+        env.token_amount(destination) as u128,
+        RETAINED_CAPITAL + historical_claim / BOUND_SCALE,
+        "the older claim remains fully withdrawable despite the later lien overlap"
+    );
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59932,3 +59932,207 @@ fn v16_attack_winner_first_recovery_forfeit_cannot_strand_loser() {
         "both Recovery users can dematerialize"
     );
 }
+
+// A Recovery forfeit is scoped to the selected position episode. A counterparty that forfeits a
+// newly reopened leg first must not force the remaining owner to burn already-materialized,
+// provider-backed PnL earned by an earlier, fully closed position on the same asset and side.
+#[test]
+fn v16_attack_reopened_recovery_forfeit_preserves_prior_same_domain_claim() {
+    const PRICE: u64 = 1_000_000;
+    const PROFIT_MARK: u64 = 952_000;
+    const ASSET: u16 = 1;
+    const VICTIM_SOURCE_DOMAIN: u16 = ASSET * 2;
+    const BACKING: u128 = 100_000;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, PRICE);
+    env.top_up_backing_bucket(VICTIM_SOURCE_DOMAIN, BACKING, 10_000);
+
+    let victim_owner = Keypair::new();
+    let first_counterparty_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let first_counterparty = env.create_portfolio(&first_counterparty_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&first_counterparty_owner, first_counterparty),
+        (&attacker_owner, attacker),
+    ] {
+        env.deposit(owner, portfolio, 1_000_000);
+    }
+
+    // Episode one: the victim is short, earns a bounded authenticated-mark profit, and closes the
+    // position completely while retaining the materialized source-domain claim.
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+    env.svm.warp_to_slot(20);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 20, PROFIT_MARK);
+    env.crank(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(ASSET),
+        },
+    );
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        -(POS_SCALE as i128),
+        PROFIT_MARK,
+        0,
+    );
+
+    let after_first_episode = env.portfolio_state(victim);
+    assert!(
+        !has_active_leg_for_asset(&after_first_episode, ASSET as usize),
+        "the profitable first position episode must be fully closed"
+    );
+    let historical_pnl = after_first_episode.pnl.get();
+    let historical_claim =
+        state::portfolio_source_domain(&after_first_episode, VICTIM_SOURCE_DOMAIN as usize)
+            .source_claim_bound_num
+            .get();
+    assert_eq!(
+        historical_pnl, 48_000,
+        "the bounded authenticated mark creates the expected independent-victim claim"
+    );
+    assert!(
+        historical_pnl > 0 && historical_claim > 0,
+        "the closed episode must leave real materialized, source-attributed PnL"
+    );
+
+    // Episode two reuses the same asset and side at the current mark, adding no PnL. After normal
+    // shutdown, the new counterparty maliciously forfeits first and removes the pair-close route.
+    env.trade_asset_with_cu(
+        ASSET,
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        PROFIT_MARK,
+        0,
+    );
+    assert_eq!(
+        env.portfolio_state(victim).pnl.get(),
+        historical_pnl,
+        "reopening at the current mark must not create the historical profit"
+    );
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_SHUTDOWN, ASSET, 20, 0);
+    env.forfeit_recovery_leg_with_cu(&attacker_owner, attacker, ASSET, u128::MAX);
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(attacker), ASSET as usize),
+        "the attacker removes the only opposite leg"
+    );
+
+    // The historical claim is real and backed, but every non-destructive public exit is gone.
+    env.svm.expire_blockhash();
+    let convert = env.send(
+        ProgInstruction::ConvertReleasedPnl {
+            amount: historical_pnl as u128,
+        },
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    );
+    assert!(
+        convert.is_err(),
+        "Recovery must reproduce the blocked direct conversion path"
+    );
+    env.svm.expire_blockhash();
+    let reduce = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: ASSET,
+            reduce_q: POS_SCALE,
+        },
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    );
+    assert!(
+        reduce.is_err(),
+        "Recovery must reproduce the blocked unilateral reduction path"
+    );
+    // Keep the unrelated base current beyond the global stale-resolution horizon. The victim
+    // cannot escape by waiting for whole-market resolution while honest base cranking continues.
+    env.svm.warp_to_slot(1_000);
+    env.push_auth_mark_for_asset_as_admin(0, 1_000, PRICE);
+    env.crank(
+        first_counterparty,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1_000,
+            observations: crank_observations(0),
+        },
+    );
+    assert_eq!(
+        env.market_state().1.mode,
+        MarketModeV16::Live,
+        "fresh base observations keep the unaffected market live"
+    );
+    let cranker = Keypair::new();
+    assert!(
+        env.try_force_close_abandoned_asset_with_cu(
+            &cranker, attacker, victim, ASSET, 1_000, POS_SCALE,
+        )
+        .is_err(),
+        "the attacker has no leg left for permissionless pair close"
+    );
+
+    env.forfeit_recovery_leg_with_cu(&victim_owner, victim, ASSET, u128::MAX);
+    let after_forfeit = env.portfolio_state(victim);
+    assert_eq!(
+        after_forfeit.pnl.get(),
+        historical_pnl,
+        "forfeiting episode two must preserve episode one's materialized PnL"
+    );
+    assert_eq!(
+        state::portfolio_source_domain(&after_forfeit, VICTIM_SOURCE_DOMAIN as usize)
+            .source_claim_bound_num
+            .get(),
+        historical_claim,
+        "forfeiting episode two must preserve episode one's source claim"
+    );
+
+    env.crank(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1_000,
+            observations: crank_observations(0),
+        },
+    );
+    env.convert_released_pnl_with_cu(&victim_owner, victim, historical_pnl as u128);
+    assert_eq!(
+        env.portfolio_state(victim).capital.get(),
+        1_000_000 + historical_pnl as u128,
+        "the preserved claim must remain convertible into senior capital"
+    );
+    let withdrawable = env.portfolio_state(victim).capital.get();
+    let (destination, _) = env.withdraw_with_cu(&victim_owner, victim, withdrawable);
+    assert_eq!(
+        env.token_amount(destination) as u128,
+        withdrawable,
+        "the fixed path pays the preserved value through canonical custody"
+    );
+}


### PR DESCRIPTION
## Impact

A normally initialized, provider-backed market can erase or strand an independent user's settled profit from an earlier position episode.

The public LiteSVM reproduction uses only wrapper instructions:

1. The victim earns exactly 48,000 atoms on asset 1 and fully closes that position.
2. The victim reopens the same asset and side at the current authenticated mark.
3. The asset enters normal Recovery and the new counterparty forfeits first.
4. Conversion, unilateral reduction, and abandoned-asset pair close cannot remove the victim's leg. Asset 0 remains honestly refreshed, so global resolution does not rescue it.
5. On exact parent engine `a9a8588483ac6ecccd5d94bcbc80e116cf5487a8`, the victim's unilateral forfeit burns the earlier claim.

The strengthened case then earns episode-two PnL and increases risk until the source lien crosses the saved historical floor. The first fix aborted that public forfeit with `LockActive`, leaving the victim persistently stuck.

No market or portfolio bytes are injected. Every account, deposit, backing top-up, trade, mark update, shutdown, failed alternative, and forfeit is constructed through public SBF instructions.

## Fix and TDD

This PR pins engine #167 at `d3133a93cf2cf219b69e0072cb4079d24a07f4f6`.

The engine snapshots the claim bound present when a leg episode attaches. A Recovery forfeit waives only the current episode's suffix. If a later valid lien overlaps the historical floor, the same transaction realizes the older claim into capital before detaching, preventing both `LockActive` and a provider-withdrawal race.

The strengthened test proves:

- the attacker removes the only opposite leg first;
- the victim exits in one bounded public forfeit;
- exactly 48,000 historical atoms become senior capital while episode-two PnL is waived;
- the backing provider can immediately withdraw every unconsumed backing atom; and
- the victim still withdraws all 53,000 remaining atoms through canonical SPL custody.

This PR is intentionally stacked on wrapper #371 / engine #166.

## Verification

- Exact-parent public LiteSVM: RED
- Fixed-head focused Recovery suite: 3/3 passed
- `cargo test --all-targets -- --test-threads=1`: 568 LiteSVM tests passed
- Full CU/max-shape suite included in those 568 tests
- `cargo build-sbf --tools-version v1.52`
- `cargo check --tests`
- `cargo fmt --all -- --check`
