### PR TITLE
[BLOCKER LoF] Reconcile expired backing in Recovery forfeits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=0928823d3cb883c762042e7348677944044ef429#0928823d3cb883c762042e7348677944044ef429"
+source = "git+https://github.com/aeyakovenko/percolator?rev=0af8bf28ab9013ea3bd55dc7f56ede6feaa9b1b5#0af8bf28ab9013ea3bd55dc7f56ede6feaa9b1b5"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0928823d3cb883c762042e7348677944044ef429" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0af8bf28ab9013ea3bd55dc7f56ede6feaa9b1b5" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0928823d3cb883c762042e7348677944044ef429" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0af8bf28ab9013ea3bd55dc7f56ede6feaa9b1b5" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8477,10 +8477,74 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
+            reject_lapsed_source_backing_for_recovery_forfeit_view(
+                group,
+                portfolio,
+                asset_index as usize,
+                authenticated_market_slot_or_fallback_view(group),
+            )?;
             group
                 .forfeit_recovery_leg_not_atomic(portfolio, asset_index as usize, b_delta_budget)
                 .map(|_| ())
         })
+    }
+
+    fn reject_lapsed_source_backing_for_recovery_forfeit_view(
+        group: &state::MarketViewMutV16<'_>,
+        portfolio: &percolator::PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        authenticated_slot: u64,
+    ) -> Result<(), V16Error> {
+        if asset_index >= group.header.config.max_market_slots.get() as usize
+            || asset_index >= group.markets.len()
+        {
+            return Err(V16Error::InvalidLeg);
+        }
+        let market_id = group.markets[asset_index].engine.asset.market_id.get();
+        let mut leg_side = None;
+        for leg in portfolio.header.legs.iter() {
+            let leg = leg.try_to_runtime()?;
+            if leg.active && leg.asset_index as usize == asset_index && leg.market_id == market_id {
+                if leg_side.replace(leg.side).is_some() {
+                    return Err(V16Error::HiddenLeg);
+                }
+            }
+        }
+        let Some(leg_side) = leg_side else {
+            return Ok(());
+        };
+        let source_domain = asset_index
+            .checked_mul(2)
+            .and_then(|domain| domain.checked_add(usize::from(leg_side == SideV16::Long)))
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let source =
+            portfolio.header.source_domains.iter().find(|source| {
+                source.is_occupied() && source.domain.get() as usize == source_domain
+            });
+        let Some(source) = source else {
+            return Ok(());
+        };
+        let claim_floor = source.active_leg_claim_floor_num.get();
+        let locked_claim = source
+            .source_claim_liened_num
+            .get()
+            .checked_add(source.source_claim_impaired_num.get())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if claim_floor == 0 || locked_claim <= claim_floor {
+            return Ok(());
+        }
+        let engine_slot = &group.markets[source_domain / 2].engine;
+        let bucket = if source_domain % 2 == 0 {
+            engine_slot.backing_long.try_to_runtime()?
+        } else {
+            engine_slot.backing_short.try_to_runtime()?
+        };
+        if bucket.status == percolator::BackingBucketStatusV16::Fresh
+            && bucket.expiry_slot <= authenticated_slot
+        {
+            return Err(V16Error::Stale);
+        }
+        Ok(())
     }
 
     #[inline(never)]

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8477,74 +8477,15 @@ pub mod processor {
             if group.header.mode == 0 && permissionless_resolve_matured_now_view(cfg, group) {
                 return Err(V16Error::LockActive);
             }
-            reject_lapsed_source_backing_for_recovery_forfeit_view(
-                group,
-                portfolio,
-                asset_index as usize,
-                authenticated_market_slot_or_fallback_view(group),
-            )?;
             group
-                .forfeit_recovery_leg_not_atomic(portfolio, asset_index as usize, b_delta_budget)
+                .forfeit_recovery_leg_at_slot_not_atomic(
+                    portfolio,
+                    asset_index as usize,
+                    b_delta_budget,
+                    authenticated_market_slot_or_fallback_view(group),
+                )
                 .map(|_| ())
         })
-    }
-
-    fn reject_lapsed_source_backing_for_recovery_forfeit_view(
-        group: &state::MarketViewMutV16<'_>,
-        portfolio: &percolator::PortfolioV16ViewMut<'_>,
-        asset_index: usize,
-        authenticated_slot: u64,
-    ) -> Result<(), V16Error> {
-        if asset_index >= group.header.config.max_market_slots.get() as usize
-            || asset_index >= group.markets.len()
-        {
-            return Err(V16Error::InvalidLeg);
-        }
-        let market_id = group.markets[asset_index].engine.asset.market_id.get();
-        let mut leg_side = None;
-        for leg in portfolio.header.legs.iter() {
-            let leg = leg.try_to_runtime()?;
-            if leg.active && leg.asset_index as usize == asset_index && leg.market_id == market_id {
-                if leg_side.replace(leg.side).is_some() {
-                    return Err(V16Error::HiddenLeg);
-                }
-            }
-        }
-        let Some(leg_side) = leg_side else {
-            return Ok(());
-        };
-        let source_domain = asset_index
-            .checked_mul(2)
-            .and_then(|domain| domain.checked_add(usize::from(leg_side == SideV16::Long)))
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        let source =
-            portfolio.header.source_domains.iter().find(|source| {
-                source.is_occupied() && source.domain.get() as usize == source_domain
-            });
-        let Some(source) = source else {
-            return Ok(());
-        };
-        let claim_floor = source.active_leg_claim_floor_num.get();
-        let locked_claim = source
-            .source_claim_liened_num
-            .get()
-            .checked_add(source.source_claim_impaired_num.get())
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if claim_floor == 0 || locked_claim <= claim_floor {
-            return Ok(());
-        }
-        let engine_slot = &group.markets[source_domain / 2].engine;
-        let bucket = if source_domain % 2 == 0 {
-            engine_slot.backing_long.try_to_runtime()?
-        } else {
-            engine_slot.backing_short.try_to_runtime()?
-        };
-        if bucket.status == percolator::BackingBucketStatusV16::Fresh
-            && bucket.expiry_slot <= authenticated_slot
-        {
-            return Err(V16Error::Stale);
-        }
-        Ok(())
     }
 
     #[inline(never)]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60782,6 +60782,112 @@ fn v16_attack_retained_recovery_forfeit_cannot_consume_expired_backing() {
         vault_before,
         "the stale retained transaction must preserve canonical custody"
     );
+
+    // Keep the base market healthy after the asset-local force-close delay. Global resolution is
+    // not a valid escape hatch for one lapsed backing domain in an otherwise live market.
+    let retry_slot = EXPIRY_SLOT + 10;
+    env.svm.warp_to_slot(retry_slot);
+    env.push_auth_mark_for_asset_as_admin(0, retry_slot, PRICE);
+    env.svm.expire_blockhash();
+    let global_resolve = env.send(
+        ProgInstruction::ResolveStalePermissionless {
+            now_slot: retry_slot,
+        },
+        vec![AccountMeta::new(env.market, false)],
+        &[],
+    );
+    assert!(
+        global_resolve.is_err(),
+        "a fresh base market must not be globally resolved to free one expired backing lien"
+    );
+
+    // The opposite leg was validly forfeited before expiry, so pair-close cannot make progress.
+    let cranker = Keypair::new();
+    let pair_close = env.try_force_close_abandoned_asset_with_cu(
+        &cranker, victim, attacker, ASSET, retry_slot, POS_SCALE,
+    );
+    assert!(
+        pair_close.is_err(),
+        "the remaining owner has no opposite Recovery leg to pair-close against"
+    );
+
+    env.svm.expire_blockhash();
+    let crank = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: retry_slot,
+            observations: crank_observations(ASSET),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[],
+    );
+    assert!(
+        crank.is_err(),
+        "ordinary account refresh cannot reconcile an asset already in Recovery"
+    );
+
+    env.svm.expire_blockhash();
+    let reduce = env.send(
+        ProgInstruction::RebalanceReduce {
+            asset_index: ASSET,
+            reduce_q: POS_SCALE,
+        },
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    );
+    assert!(
+        reduce.is_err(),
+        "owner reduction is not the unilateral dead-leg exit"
+    );
+
+    // A freshly signed forfeit is the remaining bounded exit. It must observe expiry, impair the
+    // source-backed claim instead of capitalizing it, and detach the dead leg so deposited capital
+    // is not held hostage to a global market shutdown.
+    env.svm.expire_blockhash();
+    let fresh_forfeit = env.send(
+        ProgInstruction::ForfeitRecoveryLeg {
+            asset_index: ASSET,
+            b_delta_budget: u128::MAX,
+        },
+        vec![
+            AccountMeta::new(victim_owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[&victim_owner],
+    );
+    assert!(
+        fresh_forfeit.is_ok(),
+        "expired backing must not permanently block the only unilateral Recovery exit: {fresh_forfeit:?}"
+    );
+    let recovered = env.portfolio_state(victim);
+    assert!(
+        !has_active_leg_for_asset(&recovered, ASSET as usize),
+        "the dead leg must detach after bounded expiry reconciliation"
+    );
+    assert_eq!(
+        recovered.capital.get(),
+        RETAINED_CAPITAL,
+        "expired provider principal must not be capitalized"
+    );
+    assert_eq!(
+        recovered.pnl.get(),
+        (historical_claim / BOUND_SCALE) as i128,
+        "the earlier claim remains impaired rather than trapping deposited capital"
+    );
+    let (deposit_destination, _) = env.withdraw_with_cu(&victim_owner, victim, RETAINED_CAPITAL);
+    assert_eq!(
+        env.token_amount(deposit_destination),
+        RETAINED_CAPITAL as u64,
+        "the owner recovers the deposited capital after the dead leg detaches"
+    );
 }
 
 #[test]

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60734,138 +60734,30 @@ fn v16_attack_retained_recovery_forfeit_cannot_consume_expired_backing() {
         &[&env.payer, &victim_owner],
         env.svm.latest_blockhash(),
     );
-    let market_before = env.svm.get_account(&env.market).unwrap();
-    let victim_before = env.svm.get_account(&victim).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
 
     // Only authenticated wall-clock time changes. The engine's cached slot and every protocol
     // account remain at the state where the transaction was signed.
     env.svm.warp_to_slot(EXPIRY_SLOT + 1);
     let delayed = env.svm.send_transaction(retained_forfeit);
-
-    let mut extracted = 0u64;
-    if delayed.is_ok() {
-        let withdrawable = env.portfolio_state(victim).capital.get();
-        let (destination, _) = env.withdraw_with_cu(&victim_owner, victim, withdrawable);
-        extracted = env.token_amount(destination);
-    }
-    let (_, after) = env.market_state();
-    let consumed_provider_principal = after.source_backing_buckets[SOURCE_DOMAIN as usize]
-        .consumed_liened_backing_num
-        / BOUND_SCALE;
-    let extracted_provider_principal = extracted.saturating_sub(RETAINED_CAPITAL as u64);
     assert!(
-        delayed.is_err(),
-        "retained Recovery forfeit landed at wall-clock slot {}, past provider expiry {}, while engine slot stayed {}; it consumed {} provider atoms and the user withdrew {} atoms of provider principal",
-        EXPIRY_SLOT + 1,
-        EXPIRY_SLOT,
-        after.current_slot,
-        consumed_provider_principal,
-        extracted_provider_principal,
-    );
-    assert_eq!(
-        extracted_provider_principal, 0,
-        "no expired backing principal may reach user custody"
-    );
-    assert_eq!(
-        env.svm.get_account(&env.market).unwrap(),
-        market_before,
-        "the stale retained transaction must preserve market bytes"
-    );
-    assert_eq!(
-        env.svm.get_account(&victim).unwrap(),
-        victim_before,
-        "the stale retained transaction must preserve victim bytes"
+        delayed.is_ok(),
+        "the authenticated forfeit must reconcile expiry instead of consuming backing or stranding the dead leg: {delayed:?}"
     );
     assert_eq!(
         env.svm.get_account(&env.vault).unwrap(),
         vault_before,
-        "the stale retained transaction must preserve canonical custody"
+        "expiry reconciliation and dead-leg detach move no SPL custody"
     );
 
-    // Keep the base market healthy after the asset-local force-close delay. Global resolution is
-    // not a valid escape hatch for one lapsed backing domain in an otherwise live market.
-    let retry_slot = EXPIRY_SLOT + 10;
-    env.svm.warp_to_slot(retry_slot);
-    env.push_auth_mark_for_asset_as_admin(0, retry_slot, PRICE);
-    env.svm.expire_blockhash();
-    let global_resolve = env.send(
-        ProgInstruction::ResolveStalePermissionless {
-            now_slot: retry_slot,
-        },
-        vec![AccountMeta::new(env.market, false)],
-        &[],
-    );
-    assert!(
-        global_resolve.is_err(),
-        "a fresh base market must not be globally resolved to free one expired backing lien"
-    );
-
-    // The opposite leg was validly forfeited before expiry, so pair-close cannot make progress.
-    let cranker = Keypair::new();
-    let pair_close = env.try_force_close_abandoned_asset_with_cu(
-        &cranker, victim, attacker, ASSET, retry_slot, POS_SCALE,
-    );
-    assert!(
-        pair_close.is_err(),
-        "the remaining owner has no opposite Recovery leg to pair-close against"
-    );
-
-    env.svm.expire_blockhash();
-    let crank = env.send(
-        ProgInstruction::PermissionlessCrank {
-            now_slot: retry_slot,
-            observations: crank_observations(ASSET),
-        },
-        vec![
-            AccountMeta::new(env.payer.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(victim, false),
-        ],
-        &[],
-    );
-    assert!(
-        crank.is_err(),
-        "ordinary account refresh cannot reconcile an asset already in Recovery"
-    );
-
-    env.svm.expire_blockhash();
-    let reduce = env.send(
-        ProgInstruction::RebalanceReduce {
-            asset_index: ASSET,
-            reduce_q: POS_SCALE,
-        },
-        vec![
-            AccountMeta::new(victim_owner.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(victim, false),
-        ],
-        &[&victim_owner],
-    );
-    assert!(
-        reduce.is_err(),
-        "owner reduction is not the unilateral dead-leg exit"
-    );
-
-    // A freshly signed forfeit is the remaining bounded exit. It must observe expiry, impair the
-    // source-backed claim instead of capitalizing it, and detach the dead leg so deposited capital
-    // is not held hostage to a global market shutdown.
-    env.svm.expire_blockhash();
-    let fresh_forfeit = env.send(
-        ProgInstruction::ForfeitRecoveryLeg {
-            asset_index: ASSET,
-            b_delta_budget: u128::MAX,
-        },
-        vec![
-            AccountMeta::new(victim_owner.pubkey(), true),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(victim, false),
-        ],
-        &[&victim_owner],
-    );
-    assert!(
-        fresh_forfeit.is_ok(),
-        "expired backing must not permanently block the only unilateral Recovery exit: {fresh_forfeit:?}"
+    let (_, after) = env.market_state();
+    let bucket_after = after.source_backing_buckets[SOURCE_DOMAIN as usize];
+    assert_eq!(after.current_slot, 40);
+    assert_eq!(bucket_after.status, BackingBucketStatusV16::Impaired);
+    assert_eq!(bucket_after.valid_liened_backing_num, 0);
+    assert_eq!(
+        bucket_after.consumed_liened_backing_num, 0,
+        "expiry must impair provider backing rather than consume it into senior capital"
     );
     let recovered = env.portfolio_state(victim);
     assert!(
@@ -60882,6 +60774,10 @@ fn v16_attack_retained_recovery_forfeit_cannot_consume_expired_backing() {
         (historical_claim / BOUND_SCALE) as i128,
         "the earlier claim remains impaired rather than trapping deposited capital"
     );
+    let source = state::portfolio_source_domain(&recovered, SOURCE_DOMAIN as usize);
+    assert_eq!(source.source_claim_bound_num.get(), historical_claim);
+    assert_eq!(source.source_claim_impaired_num.get(), historical_claim);
+
     let (deposit_destination, _) = env.withdraw_with_cu(&victim_owner, victim, RETAINED_CAPITAL);
     assert_eq!(
         env.token_amount(deposit_destination),

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -60563,3 +60563,287 @@ fn v16_attack_retained_recovery_forfeit_haircut_preserves_prior_same_domain_clai
         "the public fixed path pays every preserved atom through canonical custody"
     );
 }
+
+// Recovery can capitalize an older claim while releasing a reopened leg's overlapping source
+// lien. A transaction signed while that backing is live must not consume the provider's principal
+// when an unprivileged relayer lands it after the provider's signed wall-clock expiry.
+#[test]
+fn v16_attack_retained_recovery_forfeit_cannot_consume_expired_backing() {
+    const PRICE: u64 = 1_000_000;
+    const FIRST_PROFIT_MARK: u64 = 952_000;
+    const SECOND_PROFIT_MARK: u64 = 932_000;
+    const ASSET: u16 = 1;
+    const SOURCE_DOMAIN: u16 = ASSET * 2;
+    const INITIAL_CAPITAL: u128 = 1_000_000;
+    const RETAINED_CAPITAL: u128 = 5_000;
+    const BACKING: u128 = 100_000;
+    const EXPIRY_SLOT: u64 = 41;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_for_asset_as_admin(0, 0, PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, PRICE);
+
+    let admin = env.admin.insecure_clone();
+    let backing_provider = Keypair::new();
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&backing_provider),
+        ASSET,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        backing_provider.pubkey().to_bytes(),
+    )
+    .expect("rotate the asset to an independent backing provider");
+    let provider_source = env.top_up_backing_bucket_with_authority(
+        &backing_provider,
+        SOURCE_DOMAIN,
+        BACKING,
+        EXPIRY_SLOT,
+    );
+    assert_eq!(
+        env.token_amount(provider_source),
+        0,
+        "the independent provider funds the expiring bucket"
+    );
+
+    let victim_owner = Keypair::new();
+    let first_counterparty_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let first_counterparty = env.create_portfolio(&first_counterparty_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&first_counterparty_owner, first_counterparty),
+        (&attacker_owner, attacker),
+    ] {
+        env.deposit(owner, portfolio, INITIAL_CAPITAL);
+    }
+
+    // Episode one earns and fully closes a real 48,000-atom provider-backed claim.
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+    env.svm.warp_to_slot(20);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 20, FIRST_PROFIT_MARK);
+    env.crank(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 20,
+            observations: crank_observations(ASSET),
+        },
+    );
+    env.trade_asset_with_cu(
+        ASSET,
+        &first_counterparty_owner,
+        first_counterparty,
+        &victim_owner,
+        victim,
+        -(POS_SCALE as i128),
+        FIRST_PROFIT_MARK,
+        0,
+    );
+    let historical_claim =
+        state::portfolio_source_domain(&env.portfolio_state(victim), SOURCE_DOMAIN as usize)
+            .source_claim_bound_num
+            .get();
+    assert_eq!(historical_claim, 48_000 * BOUND_SCALE);
+
+    // Reopening the same side creates a claim suffix and then liens across the historical floor.
+    env.withdraw(&victim_owner, victim, INITIAL_CAPITAL - RETAINED_CAPITAL);
+    env.trade_asset_with_cu(
+        ASSET,
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        FIRST_PROFIT_MARK,
+        0,
+    );
+    env.svm.warp_to_slot(40);
+    env.push_auth_mark_for_asset_as_admin(ASSET, 40, SECOND_PROFIT_MARK);
+    for portfolio in [victim, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 40,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+    env.trade_asset_with_cu(
+        ASSET,
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        (POS_SCALE / 2) as i128,
+        SECOND_PROFIT_MARK,
+        0,
+    );
+    let source =
+        state::portfolio_source_domain(&env.portfolio_state(victim), SOURCE_DOMAIN as usize);
+    assert!(source.source_claim_bound_num.get() > historical_claim);
+    assert!(source.source_claim_liened_num.get() > historical_claim);
+
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_SHUTDOWN, ASSET, 40, 0);
+    env.forfeit_recovery_leg_with_cu(&attacker_owner, attacker, ASSET, u128::MAX);
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(attacker), ASSET as usize),
+        "the opposite leg is gone before the retained transaction is signed"
+    );
+    let (_, before_signing) = env.market_state();
+    let bucket_before = before_signing.source_backing_buckets[SOURCE_DOMAIN as usize];
+    assert_eq!(before_signing.current_slot, 40);
+    assert_eq!(bucket_before.expiry_slot, EXPIRY_SLOT);
+    assert_eq!(bucket_before.status, BackingBucketStatusV16::Fresh);
+    assert!(
+        bucket_before.valid_liened_backing_num >= historical_claim,
+        "the historical claim remains backed when the victim signs"
+    );
+
+    let retained_forfeit = Transaction::new_signed_with_payer(
+        &[
+            heap_ix(),
+            cu_ix(),
+            Instruction {
+                program_id: env.program_id,
+                accounts: vec![
+                    AccountMeta::new(victim_owner.pubkey(), true),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(victim, false),
+                ],
+                data: ProgInstruction::ForfeitRecoveryLeg {
+                    asset_index: ASSET,
+                    b_delta_budget: u128::MAX,
+                }
+                .encode(),
+            },
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &victim_owner],
+        env.svm.latest_blockhash(),
+    );
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+
+    // Only authenticated wall-clock time changes. The engine's cached slot and every protocol
+    // account remain at the state where the transaction was signed.
+    env.svm.warp_to_slot(EXPIRY_SLOT + 1);
+    let delayed = env.svm.send_transaction(retained_forfeit);
+
+    let mut extracted = 0u64;
+    if delayed.is_ok() {
+        let withdrawable = env.portfolio_state(victim).capital.get();
+        let (destination, _) = env.withdraw_with_cu(&victim_owner, victim, withdrawable);
+        extracted = env.token_amount(destination);
+    }
+    let (_, after) = env.market_state();
+    let consumed_provider_principal = after.source_backing_buckets[SOURCE_DOMAIN as usize]
+        .consumed_liened_backing_num
+        / BOUND_SCALE;
+    let extracted_provider_principal = extracted.saturating_sub(RETAINED_CAPITAL as u64);
+    assert!(
+        delayed.is_err(),
+        "retained Recovery forfeit landed at wall-clock slot {}, past provider expiry {}, while engine slot stayed {}; it consumed {} provider atoms and the user withdrew {} atoms of provider principal",
+        EXPIRY_SLOT + 1,
+        EXPIRY_SLOT,
+        after.current_slot,
+        consumed_provider_principal,
+        extracted_provider_principal,
+    );
+    assert_eq!(
+        extracted_provider_principal, 0,
+        "no expired backing principal may reach user custody"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.market).unwrap(),
+        market_before,
+        "the stale retained transaction must preserve market bytes"
+    );
+    assert_eq!(
+        env.svm.get_account(&victim).unwrap(),
+        victim_before,
+        "the stale retained transaction must preserve victim bytes"
+    );
+    assert_eq!(
+        env.svm.get_account(&env.vault).unwrap(),
+        vault_before,
+        "the stale retained transaction must preserve canonical custody"
+    );
+}
+
+#[test]
+fn v16_recovery_expired_backing_claim_free_forfeit_remains_live() {
+    const PRICE: u64 = 1_000_000;
+    const ASSET: u16 = 1;
+    const VICTIM_SOURCE_DOMAIN: u16 = ASSET * 2;
+    const EXPIRY_SLOT: u64 = 2;
+
+    let mut params = production_risk_params();
+    params.max_portfolio_assets = 2;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, 0, PRICE);
+    env.top_up_backing_bucket(VICTIM_SOURCE_DOMAIN, 100_000, EXPIRY_SLOT);
+
+    let counterparty_owner = Keypair::new();
+    let victim_owner = Keypair::new();
+    let counterparty = env.create_portfolio(&counterparty_owner);
+    let victim = env.create_portfolio(&victim_owner);
+    env.deposit(&counterparty_owner, counterparty, 100_000);
+    env.deposit(&victim_owner, victim, 100_000);
+    env.trade_asset_with_cu(
+        ASSET,
+        &counterparty_owner,
+        counterparty,
+        &victim_owner,
+        victim,
+        POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+    assert!(
+        env.portfolio_state(victim)
+            .source_domains
+            .iter()
+            .all(|source| !source.is_occupied()),
+        "the zero-PnL control has no preserved source claim"
+    );
+    env.svm.warp_to_slot(1);
+    env.update_asset_lifecycle_as_admin_with_cu(processor::ASSET_ACTION_SHUTDOWN, ASSET, 1, 0);
+
+    env.svm.warp_to_slot(EXPIRY_SLOT + 1);
+    let (_, before) = env.market_state();
+    assert!(before.current_slot < EXPIRY_SLOT);
+    assert_eq!(
+        before.source_backing_buckets[VICTIM_SOURCE_DOMAIN as usize].status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert_eq!(
+        before.source_backing_buckets[VICTIM_SOURCE_DOMAIN as usize].expiry_slot,
+        EXPIRY_SLOT
+    );
+
+    let cu = env.forfeit_recovery_leg_with_cu(&victim_owner, victim, ASSET, u128::MAX);
+    assert_cu_within(
+        "claim-free Recovery forfeit after unrelated backing expiry",
+        cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert!(
+        !has_active_leg_for_asset(&env.portfolio_state(victim), ASSET as usize),
+        "wall-clock expiry must not block a forfeit that cannot consume backing"
+    );
+}


### PR DESCRIPTION
## Impact

A victim can retain an honestly signed `ForfeitRecoveryLeg` transaction before a backing bucket expires and an unprivileged relayer can land it afterward. On the exact parent (`32faddebec5909c71dab414a6a0da44e54319257`), the transition capitalized a historical Recovery claim with lapsed external backing: 48,000 atoms of an independent provider's 100,000-atom principal became withdrawable by the victim.

## Root cause

The wrapper authenticated maturity-sensitive actions with `Clock`, but Recovery forfeit called an engine transition that neither received that execution slot nor reconciled source-bucket expiry. Retained transactions could therefore cross the expiry boundary while the engine still used a cached pre-expiry slot.

## Change

- Pin the engine to aeyakovenko/percolator#169 (`0af8bf28ab9013ea3bd55dc7f56ede6feaa9b1b5`).
- Pass the authenticated execution slot into the Recovery forfeit transition.
- Reconcile only the selected source domain atomically: expired backing is impaired, never capitalized.
- Preserve the user's historical 48,000-atom impaired claim, detach the dead leg, and return exactly the user's own 5,000-atom deposit.

The first reject-only guard was intentionally superseded. Its exact-parent RED returned `Custom(19)` after expiry and permanently stranded the local Recovery exit whenever another healthy market prevented global resolution. The final transition preserves both fund safety and liveness.

This adds no custody path, admin authority, DAO authority, or ability to move user/provider funds.

## Validation

- Exact-parent LoF RED: retained transaction consumed 48,000 atoms of expired provider principal.
- Exact reject-only RED: final safe-exit test fails with `Custom(19)` and leaves the Recovery leg stranded.
- Fixed public LiteSVM/SBF regression: retained transaction lands after expiry, consumes 0 provider principal, detaches the leg, preserves the 48,000-atom impaired claim, and returns exactly the 5,000-atom user deposit.
- Claim-free post-expiry liveness control.
- Wrapper suite: 6 unit + 571 LiteSVM/BPF tests, 0 failures.
- Engine suite: 136 tests; Kani closure proof: 326 checks, 0 failures.
- Production SBF rebuilt with the exact engine pin.
- `cargo fmt --all -- --check` and `git diff --check`.