### PR TITLE
[PRIVILEGED LoF] Prevent asset-admin seizure of funded roles

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -8739,6 +8739,43 @@ pub mod processor {
         state::write_wrapper_config(&mut data, &cfg_after)
     }
 
+    fn asset_role_holds_funded_value_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+        kind: u8,
+    ) -> Result<bool, ProgramError> {
+        let long_domain = asset_index
+            .checked_mul(2)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        let short_domain = long_domain
+            .checked_add(1)
+            .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+        if matches!(kind, ASSET_AUTH_INSURANCE | ASSET_AUTH_INSURANCE_OPERATOR) {
+            return Ok(domain_budget_remaining_view(group, long_domain)? != 0
+                || domain_budget_remaining_view(group, short_domain)? != 0);
+        }
+        if kind != ASSET_AUTH_BACKING_BUCKET {
+            return Ok(false);
+        }
+        for domain in [long_domain, short_domain] {
+            let (source, bucket) = backing_domain_parts_view(group, domain)?;
+            if bucket.fresh_unliened_backing_num != 0
+                || bucket.valid_liened_backing_num != 0
+                || bucket.consumed_liened_backing_num != 0
+                || bucket.impaired_liened_backing_num != 0
+                || bucket.utilization_fee_earnings != 0
+                || source.fresh_reserved_backing_num != 0
+                || source.spent_backing_num != 0
+                || source.provider_receivable_num != 0
+                || source.valid_liened_backing_num != 0
+                || source.impaired_liened_backing_num != 0
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     #[inline(never)]
     fn handle_update_asset_authority<'a>(
         program_id: &Pubkey,
@@ -8786,6 +8823,14 @@ pub mod processor {
             ASSET_AUTH_ORACLE => profile.oracle_authority,
             _ => return Err(PercolatorError::InvalidInstruction.into()),
         };
+        // The cold admin can repair an empty role, but cannot redirect value already funded under
+        // an independent holder. A funded holder can still self-rotate through this same endpoint.
+        if admin_signed
+            && current_value != current.key.to_bytes()
+            && asset_role_holds_funded_value_view(&group, asset_index, kind)?
+        {
+            return Err(PercolatorError::EngineLockActive.into());
+        }
         // Required domain authorities must stay live after activation. A zero insurance/backing/oracle
         // authority can strand funds or oracle liveness during wind-down; only the cold-storage
         // asset_admin may be intentionally burned.

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59427,6 +59427,251 @@ fn v16_attack_update_authority_handoff_rekeys_asset0_lifecycle_admin() {
     );
 }
 
+// Bounded-admin LoF: an asset admin may recover empty role assignments, but it must not replace a
+// backing authority after an independent provider has funded that role. Otherwise the replacement
+// can withdraw the provider's principal without the incumbent provider ever signing the handoff.
+#[test]
+fn v16_attack_asset_admin_cannot_seize_funded_backing_role() {
+    let mut env = V16CuEnv::new();
+    let marketauth = env.admin.insecure_clone();
+    let asset_admin = Keypair::new();
+    let provider = Keypair::new();
+    let replacement = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &marketauth,
+        Some(&asset_admin),
+        0,
+        processor::ASSET_AUTH_ADMIN,
+        asset_admin.pubkey().to_bytes(),
+    )
+    .expect("market authority delegates the separate cold asset-admin role");
+    env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&provider),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        provider.pubkey().to_bytes(),
+    )
+    .expect("empty backing role can be handed to the provider");
+    let provider_source = env.top_up_backing_bucket_with_authority(&provider, 0, 500, 100_000);
+    assert_eq!(
+        env.token_amount(provider_source),
+        0,
+        "independent provider actually committed 500 tokens"
+    );
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[0].fresh_unliened_backing_num,
+        500 * BOUND_SCALE,
+        "provider principal is live in the backing bucket"
+    );
+
+    env.svm.expire_blockhash();
+    let takeover = env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&replacement),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        replacement.pubkey().to_bytes(),
+    );
+
+    let replacement_gain = if takeover.is_ok() {
+        let replacement_dest = env.token_account(replacement.pubkey(), 0);
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::WithdrawBackingBucket {
+                domain: 0,
+                amount: 500,
+            },
+            vec![
+                AccountMeta::new(replacement.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(replacement_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&replacement],
+        )
+        .expect("replacement authority drains the seized provider principal");
+        env.token_amount(replacement_dest)
+    } else {
+        0
+    };
+    assert_eq!(
+        replacement_gain, 0,
+        "asset admin replaced a funded backing role and transferred {replacement_gain} provider tokens to the replacement"
+    );
+
+    let provider_successor = Keypair::new();
+    env.svm.expire_blockhash();
+    env.try_update_per_asset_authority_with_cu(
+        &provider,
+        Some(&provider_successor),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        provider_successor.pubkey().to_bytes(),
+    )
+    .expect("incumbent provider can still rotate its own funded role");
+    let provider_dest = env.token_account(provider_successor.pubkey(), 0);
+    env.svm.expire_blockhash();
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawBackingBucket {
+            domain: 0,
+            amount: 500,
+        },
+        vec![
+            AccountMeta::new(provider_successor.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(provider_dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&provider_successor],
+    )
+    .expect("provider-approved successor retains the funded withdrawal path");
+    assert_eq!(env.token_amount(provider_dest), 500);
+}
+
+// The same funded-role invariant applies to the live insurance operator: asset-admin recovery of an
+// empty role is useful, but an admin must not redirect an independent funder's live reserve without
+// the incumbent role holder's consent.
+#[test]
+fn v16_attack_asset_admin_cannot_seize_funded_insurance_operator_role() {
+    let mut env = V16CuEnv::new();
+    let marketauth = env.admin.insecure_clone();
+    let asset_admin = Keypair::new();
+    let funder = Keypair::new();
+    let replacement = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &marketauth,
+        Some(&asset_admin),
+        0,
+        processor::ASSET_AUTH_ADMIN,
+        asset_admin.pubkey().to_bytes(),
+    )
+    .expect("market authority delegates the separate cold asset-admin role");
+    for kind in [
+        processor::ASSET_AUTH_INSURANCE,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+    ] {
+        env.try_update_per_asset_authority_with_cu(
+            &asset_admin,
+            Some(&funder),
+            0,
+            kind,
+            funder.pubkey().to_bytes(),
+        )
+        .expect("empty insurance role can be handed to the independent funder");
+    }
+    let funder_source = env.top_up_insurance_domain_with_authority(&funder, 0, 500);
+    assert_eq!(
+        env.token_amount(funder_source),
+        0,
+        "independent funder actually committed 500 tokens"
+    );
+    assert_eq!(
+        env.market_state().1.insurance_domain_budget[0],
+        500,
+        "the independent reserve is live before the takeover"
+    );
+
+    env.svm.expire_blockhash();
+    let takeover = env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&replacement),
+        0,
+        processor::ASSET_AUTH_INSURANCE_OPERATOR,
+        replacement.pubkey().to_bytes(),
+    );
+    let replacement_gain = if takeover.is_ok() {
+        let (replacement_dest, _) = env
+            .try_withdraw_insurance_asset_with_authority(&replacement, 0, 500)
+            .expect("replacement operator drains the seized insurance reserve");
+        env.token_amount(replacement_dest)
+    } else {
+        0
+    };
+    assert_eq!(
+        replacement_gain, 0,
+        "asset admin replaced a funded insurance role and transferred {replacement_gain} funder tokens to the replacement"
+    );
+
+    let (funder_dest, _) = env
+        .try_withdraw_insurance_asset_with_authority(&funder, 0, 500)
+        .expect("incumbent insurance operator retains the funded withdrawal path");
+    assert_eq!(env.token_amount(funder_dest), 500);
+}
+
+// Terminal insurance belongs to the configured insurance authority. Replacing that funded role is
+// the delayed form of the same attack: an honest market authority can resolve normally, after which
+// the admin-appointed replacement would otherwise withdraw the independent funder's reserve.
+#[test]
+fn v16_attack_asset_admin_cannot_seize_funded_insurance_authority_role() {
+    let mut env = V16CuEnv::new();
+    let marketauth = env.admin.insecure_clone();
+    let asset_admin = Keypair::new();
+    let funder = Keypair::new();
+    let replacement = Keypair::new();
+
+    env.try_update_per_asset_authority_with_cu(
+        &marketauth,
+        Some(&asset_admin),
+        0,
+        processor::ASSET_AUTH_ADMIN,
+        asset_admin.pubkey().to_bytes(),
+    )
+    .expect("market authority delegates the separate cold asset-admin role");
+    env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&funder),
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+        funder.pubkey().to_bytes(),
+    )
+    .expect("empty terminal insurance role can be handed to the independent funder");
+    let funder_source = env.top_up_insurance_domain_with_authority(&funder, 0, 500);
+    assert_eq!(env.token_amount(funder_source), 0);
+    assert_eq!(env.market_state().1.insurance_domain_budget[0], 500);
+
+    env.svm.expire_blockhash();
+    let takeover = env.try_update_per_asset_authority_with_cu(
+        &asset_admin,
+        Some(&replacement),
+        0,
+        processor::ASSET_AUTH_INSURANCE,
+        replacement.pubkey().to_bytes(),
+    );
+
+    env.resolve();
+    let replacement_gain = if takeover.is_ok() {
+        let (replacement_dest, _) =
+            env.withdraw_terminal_insurance_with_authority(&replacement, 500);
+        env.token_amount(replacement_dest)
+    } else {
+        0
+    };
+    assert_eq!(
+        replacement_gain, 0,
+        "asset admin replaced the funded terminal insurance authority and transferred {replacement_gain} funder tokens to the replacement"
+    );
+
+    let (funder_dest, _) = env.withdraw_terminal_insurance_with_authority(&funder, 500);
+    assert_eq!(
+        env.token_amount(funder_dest),
+        500,
+        "incumbent funder retains the terminal withdrawal path"
+    );
+}
+
 #[test]
 fn v16_attack_update_authority_handoff_rekeys_asset0_default_runtime_authorities() {
     let mut env = V16CuEnv::new();


### PR DESCRIPTION
## Impact

A separately delegated per-asset cold admin could replace an independent funded backing authority, live insurance operator, or terminal insurance authority without the incumbent signing. The replacement could then withdraw the incumbent provider/funder's tokens. This is a bounded privileged-role LoF, not a permissionless attack and not an initialization footgun.

## Fix

- Permit asset-admin recovery while the affected backing/insurance role is empty.
- Require a funded incumbent role holder to self-rotate.
- Preserve existing market-authority cascade behavior, oracle/admin rotation, and all public withdrawal paths.

## Public-interface TDD

Against exact parent `36fa587e1424a8c7fdde2c701c10938188a51876`, all three public LiteSVM probes fail and transfer 500 tokens to the replacement:

- funded backing-provider takeover and withdrawal
- funded live-insurance-operator takeover and withdrawal
- funded terminal-insurance-authority takeover and withdrawal after normal resolution

At this head, all three takeovers reject while incumbent withdrawals and provider-approved self-rotation succeed. No account bytes are injected or mutated by the tests.

## Verification

- `cargo fmt --check`
- `cargo test --lib --quiet` (6/6)
- `cargo test --test v16_cu --quiet` (568/568)
- engine pin unchanged (`143e68c...`)
