### PR TITLE
[BLOCKER DoS] Keep fresh insurance withdrawable after asset restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,15 @@ There are two different insurance withdrawal surfaces:
 - live `WithdrawInsuranceAsset`, which is a per-asset operator path bounded by that asset's funded
   long+short insurance budget
 
-Live insurance withdrawal is intentionally stricter. It is expected to be allowed only when the live market is flat or loss-current, target/effective-lag-free, stress-free, h-lock-free, and has non-negative senior residual. In other words, live insurance can be withdrawn from an empty or fully healthy market, but not while the insurance fund is still protecting unresolved loss or bankruptcy work.
+Live insurance withdrawal is intentionally stricter. It is expected to be allowed only when the
+live market is flat or loss-current, target/effective-lag-free, stress-free, and has non-negative
+senior residual. A bankruptcy h-lock remains an unconditional blocker for backing withdrawals and
+for an insurance asset with any local position, stale account, pending obligation, loss state,
+generation spend, or loss barrier. The per-asset insurance operator may bypass only a historical
+market-wide h-lock after that target asset has restarted Active with an empty local generation.
+Per-domain budgets and global/source reservation capacity still prevent that path from consuming
+insurance assigned to another asset. Threshold stress, loss staleness, and recovery reason remain
+unconditional blockers.
 
 ### Product intuition
 

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -4515,6 +4515,7 @@ pub mod processor {
         group: &state::MarketViewMutV16<'_>,
         domain: usize,
         allow_asset0_local_backing_recovery: bool,
+        allow_empty_asset_historical_bankruptcy: bool,
     ) -> Result<bool, ProgramError> {
         let asset_index = domain / 2;
         if shutdown_asset_empty_and_matured_now_view(cfg, group, asset_index).is_ok() {
@@ -4531,7 +4532,9 @@ pub mod processor {
             }
         }
         reject_permissionless_resolve_matured_live_view(cfg, group)?;
-        if group.header.bankruptcy_hlock_active != 0
+        let historical_bankruptcy_isolated = allow_empty_asset_historical_bankruptcy
+            && asset_is_active_without_local_insurance_risk_view(group, asset_index);
+        if (group.header.bankruptcy_hlock_active != 0 && !historical_bankruptcy_isolated)
             || group.header.threshold_stress_active != 0
             || group.header.loss_stale_active != 0
             || group
@@ -4548,6 +4551,19 @@ pub mod processor {
         }
         reject_exposed_target_effective_lag_view(group, asset_index)?;
         Ok(false)
+    }
+
+    fn asset_is_active_without_local_insurance_risk_view(
+        group: &state::MarketViewMutV16<'_>,
+        asset_index: usize,
+    ) -> bool {
+        let Some(slot) = group.markets.get(asset_index) else {
+            return false;
+        };
+        slot.engine.asset.lifecycle == ASSET_LIFECYCLE_ACTIVE
+            && slot.engine.insurance_domain_spent_long.get() == 0
+            && slot.engine.insurance_domain_spent_short.get() == 0
+            && !asset_local_has_position_or_loss_state_view(group, asset_index)
     }
 
     fn asset_local_loss_stale_view(
@@ -7733,9 +7749,13 @@ pub mod processor {
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain_usize)?;
             let shutdown_drain = match group.header.mode {
-                0 => {
-                    live_domain_withdraw_health_or_shutdown_view(&cfg, &group, domain_usize, true)?
-                }
+                0 => live_domain_withdraw_health_or_shutdown_view(
+                    &cfg,
+                    &group,
+                    domain_usize,
+                    true,
+                    false,
+                )?,
                 1 => {
                     if group.header.materialized_portfolio_count.get() != 0
                         || group.header.c_tot.get() != 0
@@ -7860,9 +7880,13 @@ pub mod processor {
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
             let authorities = domain_authorities_from_view(&group, &cfg, domain_usize)?;
             let shutdown_drain = match group.header.mode {
-                0 => {
-                    live_domain_withdraw_health_or_shutdown_view(&cfg, &group, domain_usize, true)?
-                }
+                0 => live_domain_withdraw_health_or_shutdown_view(
+                    &cfg,
+                    &group,
+                    domain_usize,
+                    true,
+                    false,
+                )?,
                 1 => {
                     if group.header.materialized_portfolio_count.get() != 0
                         || group.header.c_tot.get() != 0
@@ -8188,8 +8212,13 @@ pub mod processor {
             }
             let authorities = domain_authorities_from_view(&group, &cfg, long_domain)?;
             let ledger_authority = if live_mode {
-                let shutdown_drain =
-                    live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain, false)?;
+                let shutdown_drain = live_domain_withdraw_health_or_shutdown_view(
+                    &cfg,
+                    &group,
+                    long_domain,
+                    false,
+                    true,
+                )?;
                 let local_authorized =
                     live_authority_matches(&authorities.insurance_operator, operator.key);
                 let admin_shutdown_authorized = asset_index != 0
@@ -11437,6 +11466,8 @@ pub mod processor {
             || asset.stored_pos_count_short.get() != 0
             || asset.stale_account_count_long.get() != 0
             || asset.stale_account_count_short.get() != 0
+            || asset.pending_obligation_count_long.get() != 0
+            || asset.pending_obligation_count_short.get() != 0
             || asset.b_long_num.get() != 0
             || asset.b_short_num.get() != 0
             || asset.b_epoch_start_long_num.get() != 0

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -6543,6 +6543,40 @@ fn v16_bpf_asset0_bankruptcy_recovery_lets_only_backing_provider_drain() {
     )
     .expect("the recorded provider can drain mature, empty asset-0 recovery backing");
     assert_eq!(env.token_amount(provider_dest) as u128, principal);
+
+    // A completed asset restart creates a fresh insurance generation. The historical
+    // market-wide bankruptcy lock must remain active for unrelated accounts, but it
+    // cannot permanently strand this empty asset's newly funded domain budget.
+    env.enable_live_insurance_withdrawal();
+    let old_market_id = env.market_state().1.assets[0].market_id;
+    env.svm.warp_to_slot(4);
+    env.try_restart_asset_oracle_with_authority(&marketauth, 0, 4, 399)
+        .expect("the cleaned loss generation restarts");
+    let restarted = env.market_state().1;
+    assert_ne!(restarted.assets[0].market_id, old_market_id);
+    assert_eq!(restarted.assets[0].lifecycle, AssetLifecycleV16::Active);
+    assert!(
+        restarted.bankruptcy_hlock_active,
+        "asset restart must not clear the market-wide historical lock",
+    );
+    assert_eq!(restarted.insurance_domain_spent[0], 0);
+    assert_eq!(restarted.insurance_domain_spent[1], 0);
+
+    env.top_up_insurance_domain_with_authority(&marketauth, 0, 2);
+    let before_withdrawal = env.market_state().1;
+    env.try_withdraw_insurance_asset_with_authority(&marketauth, 0, 1)
+        .expect("fresh empty-generation insurance remains withdrawable");
+    let after_withdrawal = env.market_state().1;
+    assert!(after_withdrawal.bankruptcy_hlock_active);
+    assert_eq!(after_withdrawal.insurance, before_withdrawal.insurance - 1,);
+    assert_eq!(
+        after_withdrawal.insurance_domain_budget[0],
+        before_withdrawal.insurance_domain_budget[0] - 1,
+    );
+    assert_eq!(
+        after_withdrawal.insurance_domain_budget[1],
+        before_withdrawal.insurance_domain_budget[1],
+    );
 }
 
 #[test]
@@ -35699,16 +35733,9 @@ fn v16_attack_live_insurance_withdraw_rejects_exposed_target_effective_lag() {
     );
 }
 
-// security.md sweep — live insurance withdrawal must reject while insurance is still protecting
-// unresolved loss (SOL-021/SOL-022 terminal/encumbered gating). live_domain_withdraw_health_or_shutdown
-// _view (v16_program 4812) blocks WithdrawInsuranceAsset on a live market whenever bankruptcy_hlock_active
-// / threshold_stress_active / loss_stale_active / recovery_reason is set — exactly the states where the
-// fund is the users' backstop for in-flight loss/bankruptcy work. If an operator could drain insurance
-// then, users lose their protection (LOF). The exposed target/effective lag branch is covered by
-// v16_attack_live_insurance_withdraw_rejects_exposed_target_effective_lag; the DISTINCT stress/h-lock/
-// loss-stale OR-branch (4822-4831) was untested. This sets each flag on an otherwise-healthy FLAT market
-// (where the same withdrawal demonstrably succeeds) and asserts the withdrawal rejects with insurance +
-// domain budget byte-unchanged — proving the stress flag is the sole blocker (non-vacuous).
+// Live insurance withdrawal must reject while insurance is still protecting unresolved loss.
+// Threshold/loss-stale flags remain unconditional. A bankruptcy h-lock may be historical for an
+// unrelated empty asset, but it must still block the exact asset as soon as fresh exposure exists.
 #[test]
 fn v16_attack_live_insurance_withdraw_rejects_while_stressed_or_hlocked() {
     let mut env = V16CuEnv::new_with_market_params_and_price_move(1, 10_000, 10_000, 24);
@@ -35725,11 +35752,8 @@ fn v16_attack_live_insurance_withdraw_rejects_while_stressed_or_hlocked() {
     env.try_withdraw_insurance_asset_with_authority(&admin, 0, 100)
         .expect("flat healthy live insurance withdrawal must succeed");
 
-    // Each engine "insurance still protecting loss" flag must independently block the withdrawal.
-    let cases: [(&str, fn(&mut MarketGroupV16, bool)); 3] = [
-        ("bankruptcy_hlock_active", |g, v| {
-            g.bankruptcy_hlock_active = v
-        }),
+    // These global states remain unconditional blockers even while the asset is empty.
+    let cases: [(&str, fn(&mut MarketGroupV16, bool)); 2] = [
         ("threshold_stress_active", |g, v| {
             g.threshold_stress_active = v
         }),
@@ -35756,6 +35780,62 @@ fn v16_attack_live_insurance_withdraw_rejects_while_stressed_or_hlocked() {
         // clear the flag so the next iteration tests its flag in isolation.
         env.mutate_market(|_cfg, group| set(group, false));
     }
+
+    env.mutate_market(|_cfg, group| {
+        group.bankruptcy_hlock_active = true;
+        group.assets[0].pending_obligation_count_long = 1;
+    });
+    let pending_before = env.market_state().1;
+    env.svm.expire_blockhash();
+    assert!(
+        env.try_withdraw_insurance_asset_with_authority(&admin, 0, 100)
+            .is_err(),
+        "the historical-lock exception must not cross a pending local obligation",
+    );
+    let pending_after = env.market_state().1;
+    assert_eq!(pending_after.insurance, pending_before.insurance);
+    assert_eq!(
+        pending_after.insurance_domain_budget[0],
+        pending_before.insurance_domain_budget[0],
+    );
+    env.mutate_market(|_cfg, group| {
+        group.bankruptcy_hlock_active = false;
+        group.assets[0].pending_obligation_count_long = 0;
+    });
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    env.deposit(&long_owner, long, 1_000_000_000);
+    env.deposit(&short_owner, short, 1_000_000_000);
+    env.trade_with_cu(
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        100_000_000,
+        0,
+    );
+
+    env.svm.expire_blockhash();
+    env.try_withdraw_insurance_asset_with_authority(&admin, 0, 100)
+        .expect("healthy current exposure alone does not block its bounded insurance operator");
+    env.mutate_market(|_cfg, group| group.bankruptcy_hlock_active = true);
+    let before = env.market_state().1;
+    env.svm.expire_blockhash();
+    assert!(
+        env.try_withdraw_insurance_asset_with_authority(&admin, 0, 100)
+            .is_err(),
+        "a bankruptcy h-lock must protect the freshly exposed generation",
+    );
+    let after = env.market_state().1;
+    assert_eq!(after.insurance, before.insurance);
+    assert_eq!(
+        after.insurance_domain_budget[0],
+        before.insurance_domain_budget[0],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Finding

After a real asset-0 bankruptcy is fully settled and its recovered backing is drained, `RestartAssetOracle` starts a fresh asset generation and resets the asset-local insurance-spent counters. The market-wide `bankruptcy_hlock_active` bit intentionally remains durable, however, so every subsequent live `WithdrawInsuranceAsset` still failed with `EngineLockActive` (`Custom(21)`).

That permanently prevented TWAP from consuming fresh post-restart protocol insurance and could strand new external insurance deposits in an otherwise healthy live generation.

## Fix

The durable lock is not cleared. Only the per-asset `WithdrawInsuranceAsset` path may treat it as historical, and only when the exact target asset:

- is `Active`;
- has zero long and short generation-spent counters; and
- has no local OI, stored/stale accounts, pending obligations, B/loss state, or pending loss barriers.

Backing withdrawals retain the unconditional h-lock gate. Threshold stress, loss staleness, recovery reason, target/effective lag, per-domain budgets, and global/source reservation capacity remain unchanged. No authority, recipient, amount, or custody-transfer surface is added.

## TDD evidence

Exact-parent RED on `867ca977b907272e63538b3ea18a204da0d46355`:

- real bankruptcy and backing recovery completed;
- asset restart completed;
- fresh domain insurance top-up completed;
- the one-atom live withdrawal failed with `Custom(21)`.

Fixed GREEN against the real LiteSVM/SBF path:

- `v16_bpf_asset0_bankruptcy_recovery_lets_only_backing_provider_drain`
- `v16_attack_live_insurance_withdraw_rejects_while_stressed_or_hlocked`

The second regression proves pending local obligations and fresh balanced exposure keep the h-lock protective, while threshold and loss-stale flags remain unconditional blockers.

## Verification

Built the final stacked SBF against engine `5d608a8653a4d2535b3ff7d3a011ccc8f4accc23` with `cargo build-sbf --tools-version v1.52`.

- 6 unit tests passed
- 567 LiteSVM/CU tests passed
- SBF SHA-256: `619773eb0931e23682383ff0ce544e99dd0d6bb312704140963caeb20d2809c9`

Stacked on #379, #283, and #376.