### PR TITLE
[REAL DoS] Preserve source capacity in combined engine pin (restacked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=3db81b0b0484754dffb8a9c10e8d86076e969c8d#3db81b0b0484754dffb8a9c10e8d86076e969c8d"
+source = "git+https://github.com/aeyakovenko/percolator?rev=5d608a8653a4d2535b3ff7d3a011ccc8f4accc23#5d608a8653a4d2535b3ff7d3a011ccc8f4accc23"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3db81b0b0484754dffb8a9c10e8d86076e969c8d" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5d608a8653a4d2535b3ff7d3a011ccc8f4accc23" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "3db81b0b0484754dffb8a9c10e8d86076e969c8d" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "5d608a8653a4d2535b3ff7d3a011ccc8f4accc23" }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
## Impact

The prior combined pin could silently omit the engine's reserved-source-capacity repair. A publicly admitted position could then consume every source slot and leave normal crank/trade/recovery continuations unable to allocate the source domain they require.

## Fix

Pin the wrapper to engine commit `5d608a8653a4d2535b3ff7d3a011ccc8f4accc23`, which contains the source-capacity repair, terminal source-payout monotonicity, and empty-asset reuse fix. This PR changes dependency metadata only and adds no authority or fund-moving surface.

This is the current-stack replacement for merged PR #378, whose former base was rewritten during dependency restacking.

## Dependencies

- aeyakovenko/percolator#142
- aeyakovenko/percolator#145
- aeyakovenko/percolator#123
- #283

## Verification

Built the exact SBF with `cargo build-sbf --tools-version v1.52` and ran the wrapper suite against it:

- 6 unit tests passed
- 567 LiteSVM/CU tests passed
- terminal one-unit source-backing payout passed
- post-restart insurance withdrawal passed