### PR TITLE
[BLOCKER LoF] Preserve funding across prospective EWMA updates

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -2322,7 +2322,16 @@ pub mod state {
         check_header(data, KIND_MARKET)?;
         write_wrapper_config_to_bytes(data, config)?;
         if config.oracle_mode != ORACLE_MODE_MANUAL {
-            let base_profile = asset_oracle_profile_from_config(config);
+            let existing_profile = read_asset_oracle_profile(data, 0)?;
+            let mut base_profile = asset_oracle_profile_from_config(config);
+            base_profile.insurance_authority = existing_profile.insurance_authority;
+            base_profile.insurance_operator = existing_profile.insurance_operator;
+            base_profile.backing_bucket_authority = existing_profile.backing_bucket_authority;
+            base_profile.oracle_authority = existing_profile.oracle_authority;
+            base_profile.asset_admin = existing_profile.asset_admin;
+            base_profile.funding_mark_e6 = existing_profile.funding_mark_e6;
+            base_profile.funding_mark_pending_e6 = existing_profile.funding_mark_pending_e6;
+            base_profile.funding_mark_pending_slot = existing_profile.funding_mark_pending_slot;
             write_asset_oracle_profile(data, 0, &base_profile)?;
         }
         write_market_wire(data, group)?;

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -47,7 +47,7 @@ pub mod constants {
 
     pub const HEADER_LEN: usize = 16;
     pub const WRAPPER_CONFIG_LEN: usize = 448;
-    pub const ASSET_ORACLE_PROFILE_LEN: usize = 400;
+    pub const ASSET_ORACLE_PROFILE_LEN: usize = 424;
     pub const ASSET_ORACLE_WRAPPER_LEN: usize = 512;
     pub const MARKET_GROUP_LEN: usize = size_of::<MarketGroupV16HeaderAccount>();
     pub const MARKET_ASSET_SLOT_LEN: usize = size_of::<Market<[u8; ASSET_ORACLE_WRAPPER_LEN]>>();
@@ -589,7 +589,15 @@ pub mod state {
         // (insurance/operator/backing/oracle) and itself, and can be burned (set to 0). Isolated:
         // it can never act on another asset. Set to the activator at creation.
         pub asset_admin: [u8; 32],
+        /// Mark whose premium applies at the engine asset's current `slot_last`.
+        /// Zero is the legacy, not-yet-initialized sentinel.
+        pub funding_mark_e6: u64,
+        /// First prospective mark that must not affect funding before its slot.
+        pub funding_mark_pending_e6: u64,
+        pub funding_mark_pending_slot: u64,
     }
+
+    const _: [(); ASSET_ORACLE_PROFILE_LEN] = [(); core::mem::size_of::<AssetOracleProfileV16>()];
 
     /// Aggregate backing-domain accounting for an authority-controlled vault.
     /// This intentionally contains no per-depositor state; external authority
@@ -1126,6 +1134,11 @@ pub mod state {
             || profile._padding0 != [0u8; 6]
             || profile.oracle_leg_count as usize > ORACLE_LEG_CAP
             || (profile.oracle_leg_flags & !ORACLE_LEG_FLAGS_MASK) != 0
+            || (profile.funding_mark_e6 != 0 && !valid_engine_oracle_price(profile.funding_mark_e6))
+            || ((profile.funding_mark_pending_e6 == 0) != (profile.funding_mark_pending_slot == 0))
+            || (profile.funding_mark_pending_e6 != 0
+                && (!valid_engine_oracle_price(profile.funding_mark_pending_e6)
+                    || profile.funding_mark_e6 == 0))
         {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -1232,6 +1245,9 @@ pub mod state {
             oracle_leg_prices_e6: [0u64; ORACLE_LEG_CAP],
             oracle_leg_publish_times: [0i64; ORACLE_LEG_CAP],
             asset_admin: [0u8; 32],
+            funding_mark_e6: initial_price,
+            funding_mark_pending_e6: 0,
+            funding_mark_pending_slot: 0,
         }
     }
 
@@ -1269,6 +1285,9 @@ pub mod state {
             oracle_leg_prices_e6: config.oracle_leg_prices_e6,
             oracle_leg_publish_times: config.oracle_leg_publish_times,
             asset_admin: config.marketauth,
+            funding_mark_e6: config.mark_ewma_e6,
+            funding_mark_pending_e6: 0,
+            funding_mark_pending_slot: 0,
         }
     }
 
@@ -9304,6 +9323,9 @@ pub mod processor {
                             .map_err(map_v16_error)?;
                         profile.mark_ewma_e6 = frozen_mark;
                         profile.mark_ewma_last_slot = authenticated_slot;
+                        profile.funding_mark_e6 = frozen_mark;
+                        profile.funding_mark_pending_e6 = 0;
+                        profile.funding_mark_pending_slot = 0;
                         profile.oracle_target_price_e6 = frozen_mark;
                         profile.oracle_target_publish_time = 0;
                         profile.last_good_oracle_slot = authenticated_slot;
@@ -9873,6 +9895,9 @@ pub mod processor {
                 oracle_leg_feeds,
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
+                funding_mark_e6: 0,
+                funding_mark_pending_e6: 0,
+                funding_mark_pending_slot: 0,
             };
 
             let (price, publish_time, advanced) = oracle_v16::read_external_price_e6_profile(
@@ -9888,6 +9913,7 @@ pub mod processor {
             profile.oracle_target_publish_time = publish_time;
             profile.mark_ewma_e6 = price;
             profile.mark_ewma_last_slot = authenticated_slot;
+            profile.funding_mark_e6 = price;
             reset_empty_asset_oracle_anchor_view(
                 &mut group,
                 asset_index_usize,
@@ -9999,6 +10025,9 @@ pub mod processor {
                 oracle_leg_feeds: [[0u8; 32]; constants::ORACLE_LEG_CAP],
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
+                funding_mark_e6: initial_mark_e6,
+                funding_mark_pending_e6: 0,
+                funding_mark_pending_slot: 0,
             };
 
             reset_empty_asset_oracle_anchor_view(
@@ -10107,6 +10136,9 @@ pub mod processor {
                 oracle_leg_feeds: [[0u8; 32]; constants::ORACLE_LEG_CAP],
                 oracle_leg_prices_e6: [0u64; constants::ORACLE_LEG_CAP],
                 oracle_leg_publish_times: [0i64; constants::ORACLE_LEG_CAP],
+                funding_mark_e6: initial_mark_e6,
+                funding_mark_pending_e6: 0,
+                funding_mark_pending_slot: 0,
             };
 
             reset_empty_asset_oracle_anchor_view(
@@ -10206,8 +10238,21 @@ pub mod processor {
             if next_mark == 0 || next_mark > percolator::MAX_ORACLE_PRICE {
                 return Err(PercolatorError::OracleInvalid.into());
             }
-            profile.mark_ewma_e6 = next_mark;
-            profile.mark_ewma_last_slot = authenticated_slot;
+            if next_mark != profile.mark_ewma_e6 {
+                let asset_slot = group.markets[asset_index_usize]
+                    .engine
+                    .asset
+                    .slot_last
+                    .get();
+                record_funding_mark_transition_view(
+                    &mut profile,
+                    asset_slot,
+                    next_mark,
+                    authenticated_slot,
+                )?;
+                profile.mark_ewma_e6 = next_mark;
+                profile.mark_ewma_last_slot = authenticated_slot;
+            }
             profile.oracle_target_price_e6 = next_mark;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
@@ -10270,8 +10315,21 @@ pub mod processor {
             {
                 return Err(PercolatorError::EngineStale.into());
             }
-            profile.mark_ewma_e6 = mark_e6;
-            profile.mark_ewma_last_slot = authenticated_slot;
+            if mark_e6 != profile.mark_ewma_e6 {
+                let asset_slot = group.markets[asset_index_usize]
+                    .engine
+                    .asset
+                    .slot_last
+                    .get();
+                record_funding_mark_transition_view(
+                    &mut profile,
+                    asset_slot,
+                    mark_e6,
+                    authenticated_slot,
+                )?;
+                profile.mark_ewma_e6 = mark_e6;
+                profile.mark_ewma_last_slot = authenticated_slot;
+            }
             profile.oracle_target_price_e6 = mark_e6;
             profile.oracle_target_publish_time = 0;
             profile.last_good_oracle_slot = authenticated_slot;
@@ -10600,6 +10658,7 @@ pub mod processor {
                     &oracle_profile,
                     &group,
                     asset_index,
+                    authenticated_now_slot,
                     crank_price,
                 )?;
                 group
@@ -10614,7 +10673,6 @@ pub mod processor {
                         oracle_profile.last_good_oracle_slot,
                     );
                 }
-                write_oracle_profile_to_view(&mut group, asset_index, &oracle_profile)?;
                 if asset_index == 0 && oracle_v16::profile_is_price_managed(&oracle_profile) {
                     cfg.oracle_mode = oracle_profile.oracle_mode;
                     cfg.oracle_leg_count = oracle_profile.oracle_leg_count;
@@ -10643,10 +10701,20 @@ pub mod processor {
                         true,
                     )
                     .map_err(map_v16_error)?;
+                let asset_slot_after = group.markets[asset_index].engine.asset.slot_last.get();
+                advance_funding_mark_checkpoint_view(&mut oracle_profile, asset_slot_after);
+                let next_funding_rate_e9 = permissionless_funding_rate_e9_view(
+                    &oracle_profile,
+                    &group,
+                    asset_index,
+                    authenticated_now_slot,
+                    crank_price,
+                )?;
+                write_oracle_profile_to_view(&mut group, asset_index, &oracle_profile)?;
                 observations.push(AutoCrankObservationV16 {
                     asset_index,
                     effective_price: crank_price,
-                    funding_rate_e9: computed_funding_rate_e9,
+                    funding_rate_e9: next_funding_rate_e9,
                 });
             }
             if !oracle_tail.is_empty() {
@@ -10683,6 +10751,13 @@ pub mod processor {
                 Err(V16Error::NonProgress) if !observations.is_empty() => None,
                 Err(err) => return Err(map_v16_error(err)),
             };
+            for observation in observations.iter() {
+                let asset_index = observation.asset_index;
+                let mut profile = read_oracle_profile_from_view(&group, &cfg, asset_index)?;
+                let asset_slot = group.markets[asset_index].engine.asset.slot_last.get();
+                advance_funding_mark_checkpoint_view(&mut profile, asset_slot);
+                write_oracle_profile_to_view(&mut group, asset_index, &profile)?;
+            }
 
             let selected_fee_asset = match result.as_ref().map(|r| &r.selected) {
                 Some(AutoCrankPlanV16::RefreshAccount {
@@ -11725,6 +11800,8 @@ pub mod processor {
         if asset_index >= group.header.config.max_market_slots.get() as usize {
             return Err(PercolatorError::InvalidInstruction.into());
         }
+        let asset_slot = group.markets[asset_index].engine.asset.slot_last.get();
+        advance_funding_mark_checkpoint_view(profile, asset_slot);
         if oracle_v16::profile_is_ewma_mark(profile) || oracle_v16::profile_is_auth_mark(profile) {
             let target = profile.mark_ewma_e6;
             if target == 0 {
@@ -11799,7 +11876,10 @@ pub mod processor {
             exposed,
         );
         profile.oracle_target_price_e6 = target;
-        if !oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot) {
+        if !oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot)
+            && price != profile.mark_ewma_e6
+        {
+            record_funding_mark_transition_view(profile, asset_slot, price, now_slot)?;
             profile.mark_ewma_e6 = price;
             profile.mark_ewma_last_slot = now_slot;
         }
@@ -11810,6 +11890,7 @@ pub mod processor {
         profile: &state::AssetOracleProfileV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
+        now_slot: u64,
         effective_price: u64,
     ) -> Result<i128, ProgramError> {
         if !oracle_v16::profile_is_price_managed(profile) {
@@ -11825,11 +11906,93 @@ pub mod processor {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let asset = group.markets[asset_index].engine.asset;
-        if profile.mark_ewma_last_slot > asset.slot_last.get() {
+        let asset_slot = asset.slot_last.get();
+        let active_mark = if profile.funding_mark_e6 != 0 {
+            profile.funding_mark_e6
+        } else if profile.mark_ewma_last_slot <= asset_slot {
+            profile.mark_ewma_e6
+        } else {
+            // Legacy profiles have no recoverable mark history while a prospective update is
+            // pending. Preserve the old non-retroactive behavior until the engine catches up.
             return Ok(0);
-        }
-        policy_v16::premium_funding_rate_e9(profile.mark_ewma_e6, effective_price, max_abs_rate)
+        };
+        let segment_dt = asset_segment_dt_view(group, asset_index, now_slot)?;
+        let has_pending =
+            profile.funding_mark_pending_e6 != 0 && profile.funding_mark_pending_slot > asset_slot;
+        // A mark published after asset.slot_last is prospective. Keep the entire bounded accrual
+        // segment on the last committed funding checkpoint, including a counterfactual index that
+        // the prospective target cannot rewrite. The oldest pending mark becomes active only after
+        // this segment commits; later updates are coalesced into the next checkpoint.
+        let funding_index = if has_pending {
+            let exposed = asset.oi_eff_long_q.get() != 0 || asset.oi_eff_short_q.get() != 0;
+            oracle_v16::effective_price_from_target(
+                asset.effective_price.get(),
+                active_mark,
+                group.header.config.max_price_move_bps_per_slot.get(),
+                segment_dt,
+                exposed,
+            )
+        } else {
+            effective_price
+        };
+        policy_v16::premium_funding_rate_e9(active_mark, funding_index, max_abs_rate)
             .ok_or(PercolatorError::EngineArithmeticOverflow.into())
+    }
+
+    fn advance_funding_mark_checkpoint_view(
+        profile: &mut state::AssetOracleProfileV16,
+        asset_slot: u64,
+    ) {
+        if profile.funding_mark_e6 == 0 && profile.mark_ewma_last_slot <= asset_slot {
+            profile.funding_mark_e6 = profile.mark_ewma_e6;
+        }
+        if profile.funding_mark_pending_e6 != 0 && profile.funding_mark_pending_slot <= asset_slot {
+            let activated_slot = profile.funding_mark_pending_slot;
+            profile.funding_mark_e6 = profile.funding_mark_pending_e6;
+            profile.funding_mark_pending_e6 = 0;
+            profile.funding_mark_pending_slot = 0;
+            if profile.mark_ewma_last_slot > activated_slot {
+                if profile.mark_ewma_last_slot <= asset_slot {
+                    profile.funding_mark_e6 = profile.mark_ewma_e6;
+                } else {
+                    profile.funding_mark_pending_e6 = profile.mark_ewma_e6;
+                    profile.funding_mark_pending_slot = profile.mark_ewma_last_slot;
+                }
+            }
+        }
+    }
+
+    fn record_funding_mark_transition_view(
+        profile: &mut state::AssetOracleProfileV16,
+        asset_slot: u64,
+        next_mark_e6: u64,
+        mark_slot: u64,
+    ) -> ProgramResult {
+        advance_funding_mark_checkpoint_view(profile, asset_slot);
+        if profile.funding_mark_e6 == 0 {
+            // A legacy profile can already have a prospective mark when the upgraded program
+            // first sees it, so its prior checkpoint is unrecoverable. Keep trades live and retain
+            // the legacy zero-funding behavior until a crank reaches the latest visible mark.
+            return Ok(());
+        }
+        if profile.funding_mark_pending_e6 != 0 {
+            if mark_slot < profile.funding_mark_pending_slot {
+                return Err(PercolatorError::EngineStale.into());
+            }
+            if mark_slot == profile.funding_mark_pending_slot {
+                profile.funding_mark_pending_e6 = next_mark_e6;
+            }
+            // The profile itself retains the latest transition. Keeping the first pending
+            // boundary prevents later fills from postponing already-owed funding.
+            return Ok(());
+        }
+        if mark_slot <= asset_slot {
+            profile.funding_mark_e6 = next_mark_e6;
+        } else {
+            profile.funding_mark_pending_e6 = next_mark_e6;
+            profile.funding_mark_pending_slot = mark_slot;
+        }
+        Ok(())
     }
 
     fn update_hybrid_mark_after_trade_view(
@@ -11853,6 +12016,8 @@ pub mod processor {
         }
         let old = profile.mark_ewma_e6;
         if post_trade_mark_e6 != old {
+            let asset_slot = group.markets[asset_index].engine.asset.slot_last.get();
+            record_funding_mark_transition_view(profile, asset_slot, post_trade_mark_e6, now_slot)?;
             profile.mark_ewma_e6 = post_trade_mark_e6;
             profile.mark_ewma_last_slot = now_slot;
         }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -59717,3 +59717,179 @@ fn v16_attack_underfunded_exit_cannot_move_ewma_with_uncollectible_fee() {
         assert_underfunded_ewma_exit_uses_collected_fee(path);
     }
 }
+
+// A trade-driven EWMA update is prospective: a risk-reducing exit that lands before a bounded
+// catch-up crank must not erase funding already attributable to the prior committed premium.
+#[test]
+fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
+    const PRICE: u64 = 1_000_000;
+    const DEPOSIT: u128 = 100_000_000;
+    const MARK_HALFLIFE: u64 = 1_000_000;
+    const PREP_SLOT: u64 = 1_000;
+    const CATCHUP_SLOT: u64 = 1_101;
+    const PUSH_TARGET: u64 = 556_555_556;
+
+    fn run(
+        path: NoCpiReportedPricePath,
+        stamp_before_catchup: bool,
+    ) -> (u128, u128, u128, u128, u64, u64, i128) {
+        let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+            initial_price: PRICE,
+            max_price_move_bps_per_slot: 1,
+            max_accrual_dt_slots: PREP_SLOT,
+            max_abs_funding_e9_per_slot: 10_000,
+            min_funding_lifetime_slots: PREP_SLOT,
+            ..V16CuMarketParams::default()
+        });
+        env.configure_ewma_mark_with_cu(0, PRICE, MARK_HALFLIFE, 0);
+
+        let attacker = Keypair::new();
+        let victim = Keypair::new();
+        let stamper_long = Keypair::new();
+        let stamper_short = Keypair::new();
+        let attacker_portfolio = env.create_portfolio(&attacker);
+        let victim_portfolio = env.create_portfolio(&victim);
+        let stamper_long_portfolio = env.create_portfolio(&stamper_long);
+        let stamper_short_portfolio = env.create_portfolio(&stamper_short);
+        env.deposit(&attacker, attacker_portfolio, DEPOSIT);
+        env.deposit(&victim, victim_portfolio, DEPOSIT);
+        env.deposit(&stamper_long, stamper_long_portfolio, DEPOSIT);
+        env.deposit(&stamper_short, stamper_short_portfolio, DEPOSIT);
+        try_no_cpi_reported_price_trade_with_cu(
+            &mut env,
+            path,
+            &attacker,
+            attacker_portfolio,
+            &victim,
+            victim_portfolio,
+            POS_SCALE as i128,
+            PRICE,
+            0,
+        )
+        .unwrap_or_else(|err| panic!("{path:?}: primary setup trade failed: {err}"));
+        try_no_cpi_reported_price_trade_with_cu(
+            &mut env,
+            path,
+            &stamper_long,
+            stamper_long_portfolio,
+            &stamper_short,
+            stamper_short_portfolio,
+            POS_SCALE as i128,
+            PRICE,
+            0,
+        )
+        .unwrap_or_else(|err| panic!("{path:?}: stamper setup trade failed: {err}"));
+
+        // Bring the engine clock current while mark == effective, then publish an honest premium.
+        env.svm.warp_to_slot(PREP_SLOT);
+        env.crank(
+            victim_portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: PREP_SLOT,
+                observations: crank_observations(0),
+            },
+        );
+        env.push_ewma_mark_with_cu(PREP_SLOT, PUSH_TARGET);
+        let (cfg_after_push, group_after_push) = env.market_state();
+        assert_eq!(cfg_after_push.mark_ewma_e6, 1_500_000);
+        assert_eq!(cfg_after_push.mark_ewma_last_slot, PREP_SLOT);
+        assert_eq!(group_after_push.assets[0].effective_price, PRICE);
+        assert_eq!(group_after_push.assets[0].slot_last, PREP_SLOT);
+
+        env.svm.warp_to_slot(CATCHUP_SLOT);
+        let insurance_before_stamp = env.market_state().1.insurance;
+        let stamp = |env: &mut V16CuEnv| {
+            try_no_cpi_reported_price_trade_with_cu(
+                env,
+                path,
+                &stamper_long,
+                stamper_long_portfolio,
+                &stamper_short,
+                stamper_short_portfolio,
+                -(POS_SCALE as i128),
+                1_010_100,
+                0,
+            )
+            .unwrap_or_else(|err| panic!("{path:?}: risk-reducing stamp failed: {err}"));
+        };
+        let catchup = |env: &mut V16CuEnv| {
+            env.crank(
+                victim_portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: CATCHUP_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+        };
+        if stamp_before_catchup {
+            stamp(&mut env);
+            catchup(&mut env);
+        } else {
+            catchup(&mut env);
+            stamp(&mut env);
+        }
+
+        let (cfg_after, group_after) = env.market_state();
+        let stamp_fee = group_after.insurance - insurance_before_stamp;
+        assert_eq!(cfg_after.mark_ewma_e6, 1_499_952);
+        assert_eq!(cfg_after.mark_ewma_last_slot, CATCHUP_SLOT);
+        assert_eq!(group_after.assets[0].effective_price, 1_010_100);
+        assert_eq!(group_after.assets[0].slot_last, CATCHUP_SLOT);
+
+        env.resolve();
+        let close_total = |env: &mut V16CuEnv, owner: &Keypair, portfolio: Pubkey| {
+            let mut paid = 0u128;
+            for _ in 0..3 {
+                let dest = env.close_resolved(owner, portfolio);
+                paid += env.token_amount(dest) as u128;
+                let account = env.portfolio_state(portfolio);
+                if account.capital.get() == 0
+                    && account.pnl.get() == 0
+                    && (resolved_receipt(&account).finalized || !resolved_receipt(&account).present)
+                {
+                    break;
+                }
+            }
+            paid
+        };
+        // Settle the price-losing shorts first so the residual is present before long winners claim.
+        let stamper_short_paid = close_total(&mut env, &stamper_short, stamper_short_portfolio);
+        let victim_paid = close_total(&mut env, &victim, victim_portfolio);
+        let attacker_paid = close_total(&mut env, &attacker, attacker_portfolio);
+        let stamper_long_paid = close_total(&mut env, &stamper_long, stamper_long_portfolio);
+        (
+            attacker_paid + stamper_long_paid,
+            stamper_short_paid,
+            victim_paid,
+            stamp_fee,
+            cfg_after.mark_ewma_e6,
+            group_after.assets[0].effective_price,
+            group_after.assets[0].f_short_num,
+        )
+    }
+
+    for path in [
+        NoCpiReportedPricePath::Single,
+        NoCpiReportedPricePath::Batch,
+    ] {
+        let control = run(path, false);
+        let attack = run(path, true);
+        assert_eq!(attack.3, control.3, "{path:?}: same stamp fee");
+        assert_eq!(attack.4, control.4, "{path:?}: same final mark");
+        assert_eq!(attack.5, control.5, "{path:?}: same final index");
+        assert!(control.6 > 0, "{path:?}: control accrues funding");
+        assert_eq!(
+            attack.6, control.6,
+            "{path:?}: trade ordering must not erase catch-up funding: control={control:?} attack={attack:?}"
+        );
+        assert_eq!(
+            attack.2, control.2,
+            "{path:?}: independent victim SPL payout must be order-independent: control={control:?} attack={attack:?}"
+        );
+        assert_eq!(
+            attack.0 + attack.1,
+            control.0 + control.1,
+            "{path:?}: attacker-controlled SPL payouts must not gain: control={control:?} attack={attack:?}"
+        );
+    }
+}

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -4310,6 +4310,27 @@ fn v16_host_write_market_round_trips_source_fresh_backing_total() {
     );
 }
 
+#[test]
+fn v16_host_write_market_preserves_funding_mark_checkpoint() {
+    let mut data = init_host_market_data_for_serializer_probe();
+    let (mut cfg, group) = state::read_market(&data).unwrap();
+    cfg.oracle_mode = percolator_prog::constants::ORACLE_MODE_EWMA_MARK;
+    cfg.mark_ewma_e6 = 101;
+    cfg.mark_ewma_last_slot = 7;
+
+    let mut profile = state::asset_oracle_profile_from_config(&cfg);
+    profile.funding_mark_e6 = 100;
+    profile.funding_mark_pending_e6 = 101;
+    profile.funding_mark_pending_slot = 7;
+    state::write_asset_oracle_profile(&mut data, 0, &profile).unwrap();
+
+    state::write_market(&mut data, &cfg, &group).unwrap();
+    let after = state::read_asset_oracle_profile(&data, 0).unwrap();
+    assert_eq!(after.funding_mark_e6, 100);
+    assert_eq!(after.funding_mark_pending_e6, 101);
+    assert_eq!(after.funding_mark_pending_slot, 7);
+}
+
 fn crank_portfolio_on_market(
     env: &mut V16CuEnv,
     market: Pubkey,
@@ -17624,6 +17645,13 @@ fn v16_attack_crank_future_now_slot_does_not_overaccrue() {
             &[],
         );
     }
+    env.crank(
+        lo,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: LIE,
+            observations: vec![],
+        },
+    );
     let a = state::read_portfolio(&env.svm.get_account(&lo).unwrap().data).unwrap();
     let b = state::read_portfolio(&env.svm.get_account(&sh).unwrap().data).unwrap();
     let (_, g) = env.market_state();
@@ -17646,8 +17674,8 @@ fn v16_attack_crank_future_now_slot_does_not_overaccrue() {
         (a.capital.get() as i128 + a.pnl.get()) + (b.capital.get() as i128 + b.pnl.get());
     assert_eq!(g.vault, 2 * DEPOSIT, "no tokens created/destroyed");
     assert!(
-        total_equity + g.insurance as i128 <= g.vault as i128 + 1,
-        "no over-distribution beyond the pinned engine's one-atom settlement remainder"
+        total_equity + g.insurance as i128 <= g.vault as i128,
+        "no over-distribution after bounded account settlement"
     );
     assert!(
         g.vault >= g.c_tot + g.insurance,
@@ -59732,6 +59760,9 @@ fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
     fn run(
         path: NoCpiReportedPricePath,
         stamp_before_catchup: bool,
+        stamp_slot: u64,
+        mark_halflife: u64,
+        stamp_exec_price: u64,
     ) -> (u128, u128, u128, u128, u64, u64, i128) {
         let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
             initial_price: PRICE,
@@ -59741,7 +59772,7 @@ fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
             min_funding_lifetime_slots: PREP_SLOT,
             ..V16CuMarketParams::default()
         });
-        env.configure_ewma_mark_with_cu(0, PRICE, MARK_HALFLIFE, 0);
+        env.configure_ewma_mark_with_cu(0, PRICE, mark_halflife, 0);
 
         let attacker = Keypair::new();
         let victim = Keypair::new();
@@ -59791,12 +59822,14 @@ fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
         );
         env.push_ewma_mark_with_cu(PREP_SLOT, PUSH_TARGET);
         let (cfg_after_push, group_after_push) = env.market_state();
-        assert_eq!(cfg_after_push.mark_ewma_e6, 1_500_000);
+        if mark_halflife == MARK_HALFLIFE {
+            assert_eq!(cfg_after_push.mark_ewma_e6, 1_500_000);
+        }
         assert_eq!(cfg_after_push.mark_ewma_last_slot, PREP_SLOT);
         assert_eq!(group_after_push.assets[0].effective_price, PRICE);
         assert_eq!(group_after_push.assets[0].slot_last, PREP_SLOT);
 
-        env.svm.warp_to_slot(CATCHUP_SLOT);
+        env.svm.warp_to_slot(stamp_slot);
         let insurance_before_stamp = env.market_state().1.insurance;
         let stamp = |env: &mut V16CuEnv| {
             try_no_cpi_reported_price_trade_with_cu(
@@ -59807,33 +59840,39 @@ fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
                 &stamper_short,
                 stamper_short_portfolio,
                 -(POS_SCALE as i128),
-                1_010_100,
+                stamp_exec_price,
                 0,
             )
             .unwrap_or_else(|err| panic!("{path:?}: risk-reducing stamp failed: {err}"));
         };
-        let catchup = |env: &mut V16CuEnv| {
+        let catchup = |env: &mut V16CuEnv, slot: u64| {
             env.crank(
                 victim_portfolio,
                 ProgInstruction::PermissionlessCrank {
-                    now_slot: CATCHUP_SLOT,
+                    now_slot: slot,
                     observations: crank_observations(0),
                 },
             );
         };
         if stamp_before_catchup {
             stamp(&mut env);
-            catchup(&mut env);
+            catchup(&mut env, stamp_slot);
         } else {
-            catchup(&mut env);
+            catchup(&mut env, stamp_slot);
             stamp(&mut env);
+        }
+        if stamp_slot < CATCHUP_SLOT {
+            env.svm.warp_to_slot(CATCHUP_SLOT);
+            catchup(&mut env, CATCHUP_SLOT);
         }
 
         let (cfg_after, group_after) = env.market_state();
         let stamp_fee = group_after.insurance - insurance_before_stamp;
-        assert_eq!(cfg_after.mark_ewma_e6, 1_499_952);
-        assert_eq!(cfg_after.mark_ewma_last_slot, CATCHUP_SLOT);
-        assert_eq!(group_after.assets[0].effective_price, 1_010_100);
+        if stamp_slot == CATCHUP_SLOT && mark_halflife == MARK_HALFLIFE {
+            assert_eq!(cfg_after.mark_ewma_e6, 1_499_952);
+            assert_eq!(cfg_after.mark_ewma_last_slot, CATCHUP_SLOT);
+            assert_eq!(group_after.assets[0].effective_price, 1_010_100);
+        }
         assert_eq!(group_after.assets[0].slot_last, CATCHUP_SLOT);
 
         env.resolve();
@@ -59868,28 +59907,41 @@ fn v16_attack_risk_reducing_trade_cannot_erase_catchup_funding() {
         )
     }
 
-    for path in [
-        NoCpiReportedPricePath::Single,
-        NoCpiReportedPricePath::Batch,
-    ] {
-        let control = run(path, false);
-        let attack = run(path, true);
-        assert_eq!(attack.3, control.3, "{path:?}: same stamp fee");
-        assert_eq!(attack.4, control.4, "{path:?}: same final mark");
-        assert_eq!(attack.5, control.5, "{path:?}: same final index");
-        assert!(control.6 > 0, "{path:?}: control accrues funding");
+    fn assert_order_invariant(
+        path: NoCpiReportedPricePath,
+        label: &str,
+        control: (u128, u128, u128, u128, u64, u64, i128),
+        attack: (u128, u128, u128, u128, u64, u64, i128),
+    ) {
+        assert_eq!(attack.3, control.3, "{path:?} {label}: same stamp fee");
+        assert_eq!(attack.4, control.4, "{path:?} {label}: same final mark");
+        assert_eq!(attack.5, control.5, "{path:?} {label}: same final index");
+        assert!(control.6 > 0, "{path:?} {label}: control accrues funding");
         assert_eq!(
             attack.6, control.6,
-            "{path:?}: trade ordering must not erase catch-up funding: control={control:?} attack={attack:?}"
+            "{path:?} {label}: trade ordering must not erase catch-up funding: control={control:?} attack={attack:?}"
         );
         assert_eq!(
             attack.2, control.2,
-            "{path:?}: independent victim SPL payout must be order-independent: control={control:?} attack={attack:?}"
+            "{path:?} {label}: independent victim SPL payout must be order-independent: control={control:?} attack={attack:?}"
         );
         assert_eq!(
             attack.0 + attack.1,
             control.0 + control.1,
-            "{path:?}: attacker-controlled SPL payouts must not gain: control={control:?} attack={attack:?}"
+            "{path:?} {label}: attacker-controlled SPL payouts must not gain: control={control:?} attack={attack:?}"
         );
+    }
+
+    for path in [
+        NoCpiReportedPricePath::Single,
+        NoCpiReportedPricePath::Batch,
+    ] {
+        let control = run(path, false, CATCHUP_SLOT, MARK_HALFLIFE, 1_010_100);
+        let attack = run(path, true, CATCHUP_SLOT, MARK_HALFLIFE, 1_010_100);
+        assert_order_invariant(path, "endpoint", control, attack);
+
+        let midpoint_control = run(path, false, 1_050, 100_000, 1_005_000);
+        let midpoint_attack = run(path, true, 1_050, 100_000, 1_005_000);
+        assert_order_invariant(path, "midpoint", midpoint_control, midpoint_attack);
     }
 }

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -17646,8 +17646,8 @@ fn v16_attack_crank_future_now_slot_does_not_overaccrue() {
         (a.capital.get() as i128 + a.pnl.get()) + (b.capital.get() as i128 + b.pnl.get());
     assert_eq!(g.vault, 2 * DEPOSIT, "no tokens created/destroyed");
     assert!(
-        total_equity + g.insurance as i128 <= g.vault as i128,
-        "no over-distribution"
+        total_equity + g.insurance as i128 <= g.vault as i128 + 1,
+        "no over-distribution beyond the pinned engine's one-atom settlement remainder"
     );
     assert!(
         g.vault >= g.c_tot + g.insurance,


### PR DESCRIPTION
## Summary

Prevent a fee-supported EWMA trade from retroactively erasing funding that accrued before the trade landed.

The wrapper now persists an active funding mark plus the oldest prospective mark boundary inside the existing 512-byte per-asset wrapper allocation. Permissionless crank funding uses the active checkpoint until the engine asset reaches that boundary, then advances the checkpoint. Trades remain live at every reported price; this changes only internal funding/mark accounting.

## Public exploit

Exact-parent RED commit: `03018bf84a01279189fe3a226a9a8123dbe862d2`.

The LiteSVM reproducer uses only public instructions and production SBF, with no account/state injection:

1. Two independent users hold opposite positions while an attacker controls a second balanced pair.
2. An honest EWMA premium exists for 101 elapsed slots.
3. Immediately before the permissionless catch-up crank, the attacker risk-reduces the balanced pair at a valid nonzero reported price. The fill pays the same 406-atom fee and reaches the same final mark and effective index as the control ordering.
4. Before the fix, that trade advances `mark_ewma_last_slot`, so the subsequent crank returns zero funding for the elapsed interval.
5. At full SPL resolution, the attacker-controlled accounts receive 1,020 more collateral atoms and the independent victim receives 1,020 fewer.

Pre-fix endpoint results:

```text
control=(200017957, 99990717, 99990920, 406, 1499952, 1010100, 1020000000000000000)
attack =(200009897, 99999797, 99989900, 406, 1499952, 1010100, 0)
```

The economic delta scales with position size and elapsed funding; it is not a dust-only assertion.

## Fix

- Extend `AssetOracleProfileV16` from 400 to 424 bytes within its unchanged 512-byte reserved wrapper slot.
- Persist `funding_mark_e6`, `funding_mark_pending_e6`, and `funding_mark_pending_slot`.
- Record trade, authenticated-mark, and hybrid-oracle mark changes as prospective transitions when the engine asset is behind.
- Compute historical funding from the active checkpoint and a counterfactual bounded index that a later mark cannot rewrite.
- Advance the checkpoint after each bounded asset accrual, including the auto-crank continuation.
- Preserve the new profile-only fields in the host `read_market`/`write_market` round trip.

`TradeCpi` delegates to the same single-trade execution path, and `BatchTradeCpi` delegates to the same batch execution path, so the production update logic is shared across all four trade entrypoints. The public exploit directly covers `TradeNoCpi` and `BatchTradeNoCpi`; existing real-matcher tests cover both CPI dispatch paths.

## Coverage

- Endpoint trade-before-crank versus crank-before-trade, single and batch.
- Mid-segment prospective boundary with the exact same public calls in opposite order, single and batch.
- Independent victim SPL payout and attacker-controlled aggregate SPL payout equality.
- Same fee, final mark, final effective index, and funding accumulator.
- Strict vault/equity conservation after bounded account settlement.
- Host serializer checkpoint persistence.

## Compatibility

The account allocation and dynamic market-slot size do not change; the new fields consume 24 previously reserved zero bytes. For a legacy profile already in the vulnerable state (`mark_ewma_last_slot > asset.slot_last`) at upgrade time, the prior mark is not recoverable from persisted state. Such a profile retains the old zero-funding behavior only until bounded cranks catch the engine up, after which checkpoints initialize normally.

Engine pin: `143e68c4917ed0400a27b952f036a5677047cd84` (unchanged).

## Verification

- `cargo build-sbf --no-default-features`
- `cargo test --test v16_cu`: 567 passed
- `cargo test --lib`: 6 passed
- `cargo test --test v16_kani`: harness target compiles
- `cargo check --all-targets`
- Max-shape CU: 14-leg refresh 657,537; 14-leg liquidation 1,127,276 (below 1.4M)
- `cargo fmt --check`
- `git diff --check`