### PR TITLE
[BLOCKER LoF] Round composite oracle prices once

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -3658,22 +3658,6 @@ pub mod oracle_v16 {
         feeds[2] != [0u8; 32] && feeds[2] != feeds[0] && feeds[2] != feeds[1]
     }
 
-    fn leg_divides(config: &WrapperConfigV16, idx: usize) -> bool {
-        match idx {
-            1 => (config.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
-            2 => (config.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
-            _ => false,
-        }
-    }
-
-    fn profile_leg_divides(profile: &AssetOracleProfileV16, idx: usize) -> bool {
-        match idx {
-            1 => (profile.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
-            2 => (profile.oracle_leg_flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
-            _ => false,
-        }
-    }
-
     pub fn read_pyth_price_e6(
         price_ai: &AccountInfo,
         expected_feed_id: &[u8; 32],
@@ -3914,48 +3898,77 @@ pub mod oracle_v16 {
         }
     }
 
-    fn apply_transform(raw_price: u64, invert: u8, unit_scale: u32) -> Result<u64, ProgramError> {
-        let mut price = raw_price;
-        // Guard zero BEFORE the invert divide: a multi-leg `compose` with a divide leg can floor the
-        // accumulator to 0, and `1e12 / 0` would panic. A zero price is always OracleInvalid anyway
-        // (the post-transform check below already rejects it), so this only converts the panic into
-        // the same graceful error — no valid behavior changes (valid oracle prices are nonzero).
-        if price == 0 {
+    fn compose_price_e6(
+        prices_e6: &[u64],
+        flags: u8,
+        invert: u8,
+        unit_scale: u32,
+    ) -> Result<u64, ProgramError> {
+        if prices_e6.is_empty()
+            || prices_e6.len() > ORACLE_LEG_CAP
+            || invert > 1
+            || (flags & !ORACLE_LEG_FLAGS_MASK) != 0
+            || (prices_e6.len() == 1 && flags != 0)
+            || (prices_e6.len() == 2 && (flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0)
+        {
+            return Err(PercolatorError::EngineInvalidConfig.into());
+        }
+        if prices_e6
+            .iter()
+            .any(|price| *price == 0 || *price > percolator::MAX_ORACLE_PRICE)
+        {
             return Err(PercolatorError::OracleInvalid.into());
         }
-        if invert != 0 {
-            price = (1_000_000_000_000u128 / price as u128)
-                .try_into()
-                .map_err(|_| PercolatorError::OracleInvalid)?;
-        }
-        if unit_scale > 1 {
-            price /= unit_scale as u64;
-        }
-        if price == 0 || price > percolator::MAX_ORACLE_PRICE {
-            return Err(PercolatorError::OracleInvalid.into());
-        }
-        Ok(price)
-    }
 
-    fn compose(acc_e6: u64, leg_e6: u64, divide: bool) -> Result<u64, ProgramError> {
-        if leg_e6 == 0 {
+        // At most three MAX_ORACLE_PRICE-bounded E6 legs keep both products within u128.
+        let mut numerator = prices_e6[0] as u128;
+        let mut denominator = 1u128;
+        let mut i = 1usize;
+        while i < prices_e6.len() {
+            let divide = match i {
+                1 => (flags & ORACLE_LEG_FLAG_DIVIDE_LEG2) != 0,
+                2 => (flags & ORACLE_LEG_FLAG_DIVIDE_LEG3) != 0,
+                _ => false,
+            };
+            if divide {
+                numerator = numerator
+                    .checked_mul(1_000_000)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                denominator = denominator
+                    .checked_mul(prices_e6[i] as u128)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            } else {
+                numerator = numerator
+                    .checked_mul(prices_e6[i] as u128)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+                denominator = denominator
+                    .checked_mul(1_000_000)
+                    .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            }
+
+            // Preserve the per-leg validity gate without discarding the rational remainder.
+            let intermediate = numerator / denominator;
+            if intermediate == 0 || intermediate > percolator::MAX_ORACLE_PRICE as u128 {
+                return Err(PercolatorError::OracleInvalid.into());
+            }
+            i += 1;
+        }
+
+        if invert != 0 {
+            let inverted_numerator = denominator
+                .checked_mul(1_000_000_000_000)
+                .ok_or(PercolatorError::EngineArithmeticOverflow)?;
+            denominator = numerator;
+            numerator = inverted_numerator;
+        }
+        let mut price = numerator / denominator;
+        if unit_scale > 1 {
+            price /= unit_scale as u128;
+        }
+        if price == 0 || price > percolator::MAX_ORACLE_PRICE as u128 {
             return Err(PercolatorError::OracleInvalid.into());
         }
-        let next = if divide {
-            (acc_e6 as u128)
-                .checked_mul(1_000_000)
-                .ok_or(PercolatorError::EngineArithmeticOverflow)?
-                / leg_e6 as u128
-        } else {
-            (acc_e6 as u128)
-                .checked_mul(leg_e6 as u128)
-                .ok_or(PercolatorError::EngineArithmeticOverflow)?
-                / 1_000_000
-        };
-        if next == 0 || next > percolator::MAX_ORACLE_PRICE as u128 {
-            return Err(PercolatorError::OracleInvalid.into());
-        }
-        Ok(next as u64)
+        Ok(price as u64)
     }
 
     pub fn read_external_price_e6(
@@ -3977,7 +3990,7 @@ pub mod oracle_v16 {
         ) {
             return Err(PercolatorError::EngineInvalidConfig.into());
         }
-        let mut acc = 0u64;
+        let mut prices = [0u64; ORACLE_LEG_CAP];
         let mut advanced = false;
         let mut max_publish_time = i64::MIN;
         let mut i = 0usize;
@@ -4005,15 +4018,16 @@ pub mod oracle_v16 {
                 advanced = true;
             }
             max_publish_time = core::cmp::max(max_publish_time, publish_time);
-            acc = if i == 0 {
-                price
-            } else {
-                compose(acc, price, leg_divides(config, i))?
-            };
+            prices[i] = price;
             i += 1;
         }
         Ok((
-            apply_transform(acc, config.invert, config.unit_scale)?,
+            compose_price_e6(
+                &prices[..count],
+                config.oracle_leg_flags,
+                config.invert,
+                config.unit_scale,
+            )?,
             max_publish_time,
             advanced,
         ))
@@ -4038,7 +4052,7 @@ pub mod oracle_v16 {
         ) {
             return Err(PercolatorError::EngineInvalidConfig.into());
         }
-        let mut acc = 0u64;
+        let mut prices = [0u64; ORACLE_LEG_CAP];
         let mut advanced = false;
         let mut max_publish_time = i64::MIN;
         let mut i = 0usize;
@@ -4066,15 +4080,16 @@ pub mod oracle_v16 {
                 advanced = true;
             }
             max_publish_time = core::cmp::max(max_publish_time, publish_time);
-            acc = if i == 0 {
-                price
-            } else {
-                compose(acc, price, profile_leg_divides(profile, i))?
-            };
+            prices[i] = price;
             i += 1;
         }
         Ok((
-            apply_transform(acc, profile.invert, profile.unit_scale)?,
+            compose_price_e6(
+                &prices[..count],
+                profile.oracle_leg_flags,
+                profile.invert,
+                profile.unit_scale,
+            )?,
             max_publish_time,
             advanced,
         ))

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -54549,6 +54549,165 @@ fn v16_bpf_oracle_composite_divide_legs_produce_correct_cross_rate() {
     );
 }
 
+// A composite update with an unchanged exact cross-rate must not create liquidation work. The two
+// feed tuples below both equal 1.002000, but sequential E6 flooring turns the second tuple into
+// 1.000000. At production risk settings, that false 20-bps move can liquidate an exactly margined
+// long and pay a permissionless cranker in withdrawable collateral.
+#[test]
+fn v16_attack_composite_rounding_cannot_false_liquidate_and_pay_cranker() {
+    const EXACT_MARK: u64 = 1_002_000;
+    const SIZE_Q: u128 = 1_000 * POS_SCALE;
+    const INITIAL_MARGIN: u128 = 50_100_000;
+
+    let initial_prices = [501u128, 1_000_000, 500];
+    let fresh_prices = [501u128, 500_000_000, 1];
+    let exact_composite = |prices: [u128; 3]| {
+        prices[0].checked_mul(1_000_000_000_000).unwrap()
+            / prices[1].checked_mul(prices[2]).unwrap()
+    };
+    assert_eq!(exact_composite(initial_prices), EXACT_MARK as u128);
+    assert_eq!(exact_composite(fresh_prices), EXACT_MARK as u128);
+
+    let mut params = production_risk_params();
+    params.initial_price = EXACT_MARK;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.update_liquidation_fee_policy_with_cu(5_000);
+    set_test_clock(&mut env, 1, 100);
+
+    let feeds = [[0xe1u8; 32], [0xe2u8; 32], [0xe3u8; 32]];
+    let initial_oracles = [
+        env.set_pyth_price_with_conf(&feeds[0], initial_prices[0] as i64, -6, 0, 100),
+        env.set_pyth_price_with_conf(&feeds[1], initial_prices[1] as i64, -6, 0, 100),
+        env.set_pyth_price_with_conf(&feeds[2], initial_prices[2] as i64, -6, 0, 100),
+    ];
+    env.try_configure_hybrid_with_cu(
+        3,
+        ORACLE_LEG_FLAG_DIVIDE_LEG2 | ORACLE_LEG_FLAG_DIVIDE_LEG3,
+        feeds,
+        &initial_oracles,
+        1,
+        100,
+        0,
+        0,
+        3,
+    )
+    .expect("configure exact composite");
+
+    let (configured, configured_group) = env.market_state();
+    assert_eq!(configured.oracle_target_price_e6, EXACT_MARK);
+    assert_eq!(configured_group.assets[0].effective_price, EXACT_MARK);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let cranker_owner = Keypair::new();
+    let long = env.create_portfolio(&long_owner);
+    let short = env.create_portfolio(&short_owner);
+    let cranker = env.create_portfolio(&cranker_owner);
+    env.deposit(&long_owner, long, INITIAL_MARGIN);
+    env.deposit(&short_owner, short, INITIAL_MARGIN);
+    env.deposit(&cranker_owner, cranker, 1);
+    env.trade_asset_with_cu(
+        0,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        SIZE_Q as i128,
+        EXACT_MARK,
+        0,
+    );
+
+    let (_, group_before) = env.market_state();
+    let long_before = env.portfolio_state(long);
+    let cranker_before = env.portfolio_state(cranker).capital.get();
+    assert_eq!(cranker_before, 1);
+    assert_eq!(health_cert(&long_before).certified_liq_deficit, 0);
+
+    set_test_clock(&mut env, 2, 101);
+    let fresh_oracles = [
+        env.set_pyth_price_with_conf(&feeds[0], fresh_prices[0] as i64, -6, 0, 101),
+        env.set_pyth_price_with_conf(&feeds[1], fresh_prices[1] as i64, -6, 0, 101),
+        env.set_pyth_price_with_conf(&feeds[2], fresh_prices[2] as i64, -6, 0, 101),
+    ];
+    env.svm.expire_blockhash();
+    send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 2,
+            observations: crank_observations_with_accounts(0, 3),
+        },
+        vec![
+            AccountMeta::new(env.payer.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(long, false),
+            AccountMeta::new_readonly(fresh_oracles[0], false),
+            AccountMeta::new_readonly(fresh_oracles[1], false),
+            AccountMeta::new_readonly(fresh_oracles[2], false),
+        ],
+        &[],
+    )
+    .expect("permissionless composite refresh");
+
+    let post_refresh = env.portfolio_state(long);
+    if health_cert(&post_refresh).certified_liq_deficit != 0 {
+        env.svm.expire_blockhash();
+        send_tx(
+            &mut env.svm,
+            env.program_id,
+            &env.payer,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations_with_accounts(0, 3),
+            },
+            vec![
+                AccountMeta::new(cranker_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(long, false),
+                AccountMeta::new_readonly(fresh_oracles[0], false),
+                AccountMeta::new_readonly(fresh_oracles[1], false),
+                AccountMeta::new_readonly(fresh_oracles[2], false),
+                AccountMeta::new(cranker, false),
+            ],
+            &[&cranker_owner],
+        )
+        .expect("permissionless false-price liquidation");
+    }
+
+    let (refreshed, group_after) = env.market_state();
+    let long_after = env.portfolio_state(long);
+    let cranker_after = env.portfolio_state(cranker).capital.get();
+    let cranker_destination = env.withdraw(&cranker_owner, cranker, cranker_after);
+    let cranker_withdrawn = env.token_amount(cranker_destination);
+    assert_eq!(
+        cranker_withdrawn, cranker_after as u64,
+        "every credited cranker atom must reach the attacker's SPL account"
+    );
+
+    assert!(
+        refreshed.oracle_target_price_e6 == EXACT_MARK
+            && group_after.assets[0].effective_price == EXACT_MARK
+            && group_after.assets[0].oi_eff_long_q == group_before.assets[0].oi_eff_long_q
+            && long_after.capital.get() == long_before.capital.get()
+            && group_after.insurance == group_before.insurance
+            && cranker_after == cranker_before,
+        "unchanged rational cross-rate caused target={}, mark={}, long_oi {}->{}, \
+         victim_capital {}->{}, insurance {}->{}, cranker_capital {}->{}, withdrawn={}",
+        refreshed.oracle_target_price_e6,
+        group_after.assets[0].effective_price,
+        group_before.assets[0].oi_eff_long_q,
+        group_after.assets[0].oi_eff_long_q,
+        long_before.capital.get(),
+        long_after.capital.get(),
+        group_before.insurance,
+        group_after.insurance,
+        cranker_before,
+        cranker_after,
+        cranker_withdrawn
+    );
+}
+
 // ForfeitRecoveryLeg owner-gating + input guard (sibling of v16_attack_rebalance_reduce_owner_gated, which
 // was tested while ForfeitRecoveryLeg was not). handle_forfeit_recovery_leg uses with_one_portfolio_view
 // (owner_must_sign=true), so a non-owner forfeiting a victim's recovery leg -- which would force the victim


### PR DESCRIPTION
## What changed

- evaluate all configured oracle legs as one checked rational expression
- retain each intermediate remainder while preserving the existing per-leg zero/range gates
- apply inversion and unit scaling to the retained rational only once
- add a real-SBF LiteSVM regression covering false liquidation, fee routing, and attacker withdrawal

Closes #327 when merged.

## Public exploit

The exact-parent regression uses normal hybrid-oracle configuration, deposits, `TradeNoCpi`, two permissionless cranks, liquidation reward routing, and `Withdraw`. Two authenticated three-leg feed tuples both have the exact cross-rate `1.002000`, but the old sequential E6 arithmetic stores `1.000000` for the second tuple.

At the configured production 24 bps movement cap, that false 20 bps move is accepted in one slot. On exact parent `a232b13e3924aa2271f153e06f50a8051920ff15`:

- long OI falls from `1,000,000,000` to `961,616,179`
- victim capital falls from `50,100,000` to `48,080,808`
- insurance receives `9,596`
- the permissionless cranker grows from `1` to `9,597` atoms and withdraws all `9,597` to its SPL account

The mathematical cross-rate never changes and the victim is healthy at that exact price.

## Fix invariant

For up to three E6 legs, numerator and denominator are accumulated with checked `u128` arithmetic. Range validation may inspect `floor(numerator / denominator)` after each leg, but that rounded value is never used as the next accumulator. The final price is rounded exactly once after optional inversion and unit scaling.

No instruction, account layout, signer, authority, destination, custody route, or administrator surface changes.

## TDD and validation

- RED: `947893d5` on exact parent `a232b13e`
- GREEN: `557f15ba`
- SBF SHA-256: `74ce6b85576fcbcb7596fdc7a774ff92661853d50ca9eb9475fcba7b1b7f40a4`
- 6/6 unit tests passed
- 568/568 LiteSVM tests passed
- focused hybrid, composite range, inversion, and production-risk matrices passed
- `cargo fmt -- --check`
- `git diff --check`