### PR TITLE
[REAL LoF] Order matcher config mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,9 @@ Authority fields are split by scope:
 - **`AssetOracleProfileV16.asset_admin`**: per-asset cold key that rotates that asset's scoped authorities
 - **`AssetOracleProfileV16.insurance_authority` / `insurance_operator` / `backing_bucket_authority` / `oracle_authority`**: per-asset operational authorities
 
-Matcher requests do not use a persisted market nonce. The wrapper invokes the matcher and requires the response to echo the request id, LP identity, asset index, oracle price, and requested size/sign constraints.
+Matcher requests do not use a persisted market nonce. The wrapper invokes the matcher and requires
+the response to echo the request id, LP identity, asset index, oracle price, and requested size/sign
+constraints. Matcher-config mutations use a separate portfolio-local sequence.
 
 ### Vault token account (market collateral)
 - SPL Token account holding collateral for this market
@@ -355,6 +357,12 @@ Unsigned LP matcher fills require an enabled matcher config stored directly on t
 `SetMatcherConfig` (tag 68) is signed by the LP owner and writes:
 
 `matcher_program, matcher_context, matcher_delegate, enabled`
+
+Its payload also carries `expected_sequence`. The caller reads the current portfolio matcher
+sequence, signs that exact value, and each successful enable or disable increments it. A legacy
+portfolio with no matcher tail, or a legacy tail whose enabled word is 0/1, starts at sequence 0.
+This ordering prevents a retained older signed transaction from restoring a matcher after the LP
+revokes or replaces it.
 
 During `TradeCpi` / `BatchTradeCpi`, Percolator reads this LP-account config and requires the
 instruction's matcher program, matcher context, and matcher delegate PDA to match it byte-for-byte.
@@ -448,7 +456,8 @@ This section describes intent and operational ordering, not argument-by-argument
     legs (the matcher's return-data cap).
 - **SetMatcherConfig** (tag 68)
   - LP-owner-signed opt-in/out for unsigned LP matcher fills. This writes the matcher config tail
-    on the LP portfolio: matcher program, matcher context, matcher delegate, and enabled flag.
+    on the LP portfolio: matcher program, matcher context, matcher delegate, enabled flag, and
+    monotonic mutation sequence. The payload must carry the current `expected_sequence`.
 
 ### Oracle / mark management
 - External-oracle markets authenticate configured oracle account(s) in the oracle configuration/crank
@@ -761,7 +770,8 @@ Call `InitMarket` with:
   - deploy or choose matcher program
   - create matcher context account owned by matcher program
   - create a portfolio with `InitPortfolio`
-  - call `SetMatcherConfig` with the LP owner signing the exact matcher program/context/delegate tuple
+  - read the portfolio matcher sequence and call `SetMatcherConfig` with the LP owner signing the
+    exact matcher program/context/delegate tuple and current `expected_sequence`
   - deposit collateral with `Deposit`
 - User:
   - create a portfolio with `InitPortfolio`

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -658,6 +658,8 @@ pub mod state {
         pub matcher_program: [u8; 32],
         pub matcher_context: [u8; 32],
         pub matcher_delegate: [u8; 32],
+        // On disk, bit 0 is enabled and bits 1..=63 are the mutation sequence.
+        // Public readers normalize this field back to 0 or 1.
         pub enabled: u64,
     }
 
@@ -758,15 +760,27 @@ pub mod state {
         check_header(data, KIND_PORTFOLIO)?;
         let bytes = matcher_config_bytes(data)?;
         let config_len = core::mem::size_of::<PortfolioMatcherConfigV16>();
-        let cfg: PortfolioMatcherConfigV16 = bytemuck::pod_read_unaligned(
+        let mut cfg: PortfolioMatcherConfigV16 = bytemuck::pod_read_unaligned(
             bytes
                 .get(..config_len)
                 .ok_or(PercolatorError::InvalidAccountLen)?,
         );
-        if cfg.enabled > 1 {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        cfg.enabled &= 1;
         Ok(cfg)
+    }
+
+    #[inline]
+    pub fn read_portfolio_matcher_config_sequence(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        if data.len() < PORTFOLIO_MATCHER_CONFIG_OFF + PORTFOLIO_MATCHER_CONFIG_LEN {
+            return Ok(0);
+        }
+        let bytes = matcher_config_bytes(data)?;
+        let word = read_u64(
+            bytes,
+            core::mem::size_of::<PortfolioMatcherConfigV16>() - core::mem::size_of::<u64>(),
+        )?;
+        Ok(word >> 1)
     }
 
     #[inline]
@@ -774,8 +788,18 @@ pub mod state {
         data: &mut [u8],
         cfg: &PortfolioMatcherConfigV16,
     ) -> Result<(), ProgramError> {
+        let sequence = read_portfolio_matcher_config_sequence(data)?;
+        write_portfolio_matcher_config_at_sequence(data, cfg, sequence)
+    }
+
+    #[inline]
+    pub(crate) fn write_portfolio_matcher_config_at_sequence(
+        data: &mut [u8],
+        cfg: &PortfolioMatcherConfigV16,
+        sequence: u64,
+    ) -> Result<(), ProgramError> {
         check_header(data, KIND_PORTFOLIO)?;
-        if cfg.enabled > 1 {
+        if cfg.enabled > 1 || sequence > (u64::MAX >> 1) {
             return Err(ProgramError::InvalidAccountData);
         }
         let bytes = matcher_config_bytes_mut(data)?;
@@ -783,10 +807,12 @@ pub mod state {
             *b = 0;
         }
         let config_len = core::mem::size_of::<PortfolioMatcherConfigV16>();
+        let mut encoded = *cfg;
+        encoded.enabled = (sequence << 1) | cfg.enabled;
         bytes
             .get_mut(..config_len)
             .ok_or(PercolatorError::InvalidAccountLen)?
-            .copy_from_slice(bytemuck::bytes_of(cfg));
+            .copy_from_slice(bytemuck::bytes_of(&encoded));
         Ok(())
     }
 
@@ -2509,6 +2535,8 @@ pub mod ix {
         },
         SetMatcherConfig {
             enabled: u8,
+            /// Must equal the portfolio tail's current monotonic matcher mutation sequence.
+            expected_sequence: u64,
         },
         ClosePortfolio,
         TopUpInsurance {
@@ -2776,6 +2804,7 @@ pub mod ix {
                 }
                 68 => Self::SetMatcherConfig {
                     enabled: read_u8(&mut rest)?,
+                    expected_sequence: read_u64(&mut rest)?,
                 },
                 8 => Self::ClosePortfolio,
                 9 => Self::TopUpInsurance {
@@ -3063,9 +3092,13 @@ pub mod ix {
                         push_u64(&mut out, leg.limit_price);
                     }
                 }
-                Self::SetMatcherConfig { enabled } => {
+                Self::SetMatcherConfig {
+                    enabled,
+                    expected_sequence,
+                } => {
                     out.push(68);
                     out.push(enabled);
+                    push_u64(&mut out, expected_sequence);
                 }
                 Self::ClosePortfolio => out.push(8),
                 Self::TopUpInsurance { amount } => {
@@ -5255,9 +5288,10 @@ pub mod processor {
             Instruction::BatchTradeCpi { legs } => {
                 handle_batch_trade_cpi(program_id, accounts, &legs)
             }
-            Instruction::SetMatcherConfig { enabled } => {
-                handle_set_matcher_config(program_id, accounts, enabled)
-            }
+            Instruction::SetMatcherConfig {
+                enabled,
+                expected_sequence,
+            } => handle_set_matcher_config(program_id, accounts, enabled, expected_sequence),
             Instruction::ClosePortfolio => handle_close_portfolio(program_id, accounts),
             Instruction::TopUpInsurance { amount } => {
                 handle_top_up_insurance(program_id, accounts, amount)
@@ -6711,6 +6745,7 @@ pub mod processor {
         program_id: &Pubkey,
         accounts: &'a [AccountInfo<'a>],
         enabled: u8,
+        expected_sequence: u64,
     ) -> ProgramResult {
         if enabled > 1 {
             return Err(PercolatorError::InvalidInstruction.into());
@@ -6734,6 +6769,15 @@ pub mod processor {
         if lp_portfolio_ai.data_len() < required_len {
             lp_portfolio_ai.realloc(required_len, true)?;
         }
+        let current_sequence =
+            state::read_portfolio_matcher_config_sequence(&lp_portfolio_ai.try_borrow_data()?)?;
+        if current_sequence != expected_sequence {
+            return Err(PercolatorError::InvalidInstruction.into());
+        }
+        let next_sequence = current_sequence
+            .checked_add(1)
+            .filter(|sequence| *sequence <= (u64::MAX >> 1))
+            .ok_or(PercolatorError::InvalidInstruction)?;
         let cfg = if enabled == 0 {
             state::PortfolioMatcherConfigV16::default()
         } else {
@@ -6764,7 +6808,11 @@ pub mod processor {
                 enabled: 1,
             }
         };
-        state::write_portfolio_matcher_config(&mut lp_portfolio_ai.try_borrow_mut_data()?, &cfg)
+        state::write_portfolio_matcher_config_at_sequence(
+            &mut lp_portfolio_ai.try_borrow_mut_data()?,
+            &cfg,
+            next_sequence,
+        )
     }
 
     /// Maximum legs in a single matcher batch CPI: the matcher returns N*64 bytes via

--- a/tests/v16_cu.rs
+++ b/tests/v16_cu.rs
@@ -2022,8 +2022,15 @@ impl V16CuEnv {
                 AccountMeta::new_readonly(matcher_delegate, false),
             ]);
         }
+        let expected_sequence = state::read_portfolio_matcher_config_sequence(
+            &self.svm.get_account(&maker_account).unwrap().data,
+        )
+        .expect("read matcher config sequence");
         self.send(
-            ProgInstruction::SetMatcherConfig { enabled },
+            ProgInstruction::SetMatcherConfig {
+                enabled,
+                expected_sequence,
+            },
             accounts,
             &[maker_owner],
         )?;
@@ -20553,6 +20560,129 @@ fn v16_attack_disabled_lp_matcher_config_blocks_cpi_fills() {
 }
 
 #[test]
+fn v16_matcher_config_sequence_rejects_withheld_enable_after_revoke() {
+    let mut env = V16CuEnv::new();
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(auth_matcher_program_path()).expect("read auth matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+    let lp_owner = Keypair::new();
+    let lp = env.create_portfolio(&lp_owner);
+    let matcher_context = Pubkey::new_unique();
+    let matcher_delegate = matcher_delegate_key(
+        &env.program_id,
+        &env.market,
+        &lp,
+        &lp_owner.pubkey(),
+        &matcher_program,
+        &matcher_context,
+    );
+    env.try_init_auth_matcher_context_with_delegate(
+        matcher_program,
+        &lp_owner,
+        lp,
+        matcher_context,
+        matcher_delegate,
+    )
+    .expect("initialize matcher context without configuring the LP");
+
+    let program_id = env.program_id;
+    let market = env.market;
+    let config_accounts = || {
+        vec![
+            AccountMeta::new(lp_owner.pubkey(), true),
+            AccountMeta::new_readonly(market, false),
+            AccountMeta::new(lp, false),
+            AccountMeta::new_readonly(matcher_program, false),
+            AccountMeta::new_readonly(matcher_context, false),
+            AccountMeta::new_readonly(matcher_delegate, false),
+        ]
+    };
+    let enable_at = |expected_sequence| Instruction {
+        program_id,
+        accounts: config_accounts(),
+        data: ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            expected_sequence,
+        }
+        .encode(),
+    };
+    env.svm.expire_blockhash();
+    let retained_blockhash = env.svm.latest_blockhash();
+    let enable_a = Transaction::new_signed_with_payer(
+        &[
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            enable_at(0),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &lp_owner],
+        retained_blockhash,
+    );
+    let enable_b = Transaction::new_signed_with_payer(
+        &[
+            ComputeBudgetInstruction::set_compute_unit_price(2),
+            enable_at(0),
+        ],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, &lp_owner],
+        retained_blockhash,
+    );
+    env.svm
+        .send_transaction(enable_a)
+        .expect("first relayed enable");
+    assert_eq!(
+        state::read_portfolio_matcher_config_sequence(&env.svm.get_account(&lp).unwrap().data)
+            .unwrap(),
+        1,
+    );
+
+    env.send(
+        ProgInstruction::SetMatcherConfig {
+            enabled: 0,
+            expected_sequence: 1,
+        },
+        vec![
+            AccountMeta::new(lp_owner.pubkey(), true),
+            AccountMeta::new_readonly(env.market, false),
+            AccountMeta::new(lp, false),
+        ],
+        &[&lp_owner],
+    )
+    .expect("owner revokes matcher");
+    let lp_after_revoke = env.svm.get_account(&lp).unwrap();
+    assert_eq!(env.portfolio_matcher_config(lp).enabled, 0);
+    assert_eq!(
+        state::read_portfolio_matcher_config_sequence(&lp_after_revoke.data).unwrap(),
+        2,
+    );
+
+    assert!(
+        env.svm.send_transaction(enable_b).is_err(),
+        "a withheld sequence-0 enable must not cross the sequence-1 revoke",
+    );
+    assert_eq!(
+        env.svm.get_account(&lp).unwrap(),
+        lp_after_revoke,
+        "stale matcher mutation must roll back atomically",
+    );
+
+    env.send(
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            expected_sequence: 2,
+        },
+        config_accounts(),
+        &[&lp_owner],
+    )
+    .expect("fresh post-revoke enable remains live");
+    assert_eq!(env.portfolio_matcher_config(lp).enabled, 1);
+    assert_eq!(
+        state::read_portfolio_matcher_config_sequence(&env.svm.get_account(&lp).unwrap().data)
+            .unwrap(),
+        3,
+    );
+}
+
+#[test]
 fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
     let mut env = V16CuEnv::new();
     let matcher_program = Pubkey::new_unique();
@@ -20573,7 +20703,10 @@ fn v16_attack_non_owner_cannot_change_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let revoke = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 0,
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(attacker.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -20638,7 +20771,10 @@ fn v16_attack_cross_lp_cannot_overwrite_lp_matcher_config() {
 
     env.svm.expire_blockhash();
     let overwrite = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 0 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 0,
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(attacker_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21003,7 +21139,10 @@ fn v16_attack_set_lp_matcher_config_cannot_target_protocol_accounts() {
     let send_with_lp_account = |env: &mut V16CuEnv, lp_account: Pubkey| {
         env.svm.expire_blockhash();
         env.send(
-            ProgInstruction::SetMatcherConfig { enabled: 1 },
+            ProgInstruction::SetMatcherConfig {
+                enabled: 1,
+                expected_sequence: 0,
+            },
             vec![
                 AccountMeta::new(lp_owner.pubkey(), true),
                 AccountMeta::new_readonly(env.market, false),
@@ -21077,7 +21216,10 @@ fn v16_attack_matcher_config_and_fills_reject_self_program_context() {
     let lp_before_config = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let self_config = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -21333,7 +21475,10 @@ fn v16_attack_set_matcher_config_bad_legacy_context_rolls_back_realloc() {
     let lp_before = env.svm.get_account(&lp).unwrap();
     env.svm.expire_blockhash();
     let rejected = env.send(
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(lp_owner.pubkey(), true),
             AccountMeta::new_readonly(env.market, false),
@@ -30540,7 +30685,10 @@ fn v16_attack_trade_paths_reject_cross_market_portfolio_substitution() {
         &mut env.svm,
         env.program_id,
         &env.payer,
-        ProgInstruction::SetMatcherConfig { enabled: 1 },
+        ProgInstruction::SetMatcherConfig {
+            enabled: 1,
+            expected_sequence: 0,
+        },
         vec![
             AccountMeta::new(cpi_lp.pubkey(), true),
             AccountMeta::new_readonly(market_b, false),


### PR DESCRIPTION
## Classification

REAL LoF through public `SetMatcherConfig`, `TradeCpi`, oracle, crank, conversion, and withdrawal paths. Fixes #392.

This PR is limited to same-portfolio-incarnation mutation ordering. PR #304 covers the separate close/reinitialize incarnation boundary.

## Public RED

A clean-room Meta LiteSVM test against pinned Percolator SBF SHA-256 `74ce6b85576fcbcb7596fdc7a774ff92661853d50ca9eb9475fcba7b1b7f40a4` proves:

1. an LP signs two fee variants of matcher enable at one blockhash;
2. variant A lands and the LP revokes the matcher;
3. the withheld variant restores it without a fresh LP signature;
4. a public attacker opens and flattens against the LP around an already-known independent oracle update;
5. ordinary cranks crystallize 250 atoms of LP loss;
6. the attacker converts and withdraws 1,000,250 atoms after depositing 1,000,000.

The market is initialized through public instructions, handed to the constrained controller, and uses real SPL collateral movement plus an authenticated external matcher fixture. No initialized Percolator state is injected.

## Fix

- Reuse the existing 104-byte portfolio matcher tail; no account offsets move.
- Pack a monotonic 63-bit sequence into the existing final word while retaining bit 0 as `enabled`.
- Decode deployed legacy words 0/1 and absent legacy tails as sequence 0.
- Add `expected_sequence` to tag 68 and reject old unbound payloads.
- Check exact equality and increment on every successful enable or disable.
- Preserve the sequence in ordinary matcher-config storage helpers.
- Document the new client flow.

This adds no signer, authority, PDA, admin, custody, token-transfer, recipient, or withdrawal surface.

## Verification

- Exact-parent public Meta exploit: RED with attacker withdrawal `1,000,250`, deposit `1,000,000`, LP crystallized loss `250`.
- Fixed public Meta exploit: GREEN; stale retry rejects and LP state is byte-identical.
- Upstream matcher-config LiteSVM compatibility batch: 10/10 GREEN.
- Regression proves fresh enable at the current post-revoke sequence remains live.
- Legacy-tail realloc and failed-context rollback tests remain GREEN.
- `rustfmt --check`: clean.
- `git diff --check`: clean.
- Fixed SBF SHA-256: `bfdbd77c26aa5aefa978a5f31c9a6d99ef607431f4252d3ef0ce0e55d2d962bc`.

Commit: `48ccf9a`.