### PR TITLE
[PRIVILEGED LoF] Escheat abandoned shutdown reserves

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10508,19 +10508,7 @@ pub mod processor {
         }
 
         let domain_usize = domain as usize;
-        let (bump, amount_u64) = verify_domain_withdrawal_preflight(
-            program_id,
-            market_ai,
-            authority,
-            dest_token,
-            vault_token,
-            vault_authority_ai,
-            domain_usize,
-            amount,
-            expected_market_id,
-            false,
-            DOMAIN_WITHDRAW_AUTH_BACKING,
-        )?;
+        let escheat_to_base_insurance;
 
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
@@ -10546,17 +10534,15 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
+            // Marketauth is a shutdown-progress submitter, not the provider's payout authority.
+            escheat_to_base_insurance = admin_shutdown_authorized && !local_authorized;
             let epoch_asset_index = if local_authorized {
                 domain_usize / 2
             } else {
                 0
             };
             require_authority_epoch_view(&group, epoch_asset_index, expected_authority_epoch)?;
-            let ledger_authority = if admin_shutdown_authorized && !local_authorized {
-                cfg.marketauth
-            } else {
-                authorities.backing_bucket_authority
-            };
+            let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
             if !policy_v16::backing_principal_withdrawal_is_fresh(
@@ -10589,6 +10575,9 @@ pub mod processor {
             group
                 .withdraw_fresh_counterparty_backing_not_atomic(domain_usize, amount)
                 .map_err(map_v16_error)?;
+            if escheat_to_base_insurance {
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_principal_atoms = ledger
                     .total_principal_atoms
@@ -10607,16 +10596,31 @@ pub mod processor {
             }
         }
 
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (bump, amount_u64) = verify_domain_withdrawal_preflight(
+                program_id,
+                market_ai,
+                authority,
+                dest_token,
+                vault_token,
+                vault_authority_ai,
+                domain_usize,
+                amount,
+                expected_market_id,
+                false,
+                DOMAIN_WITHDRAW_AUTH_BACKING,
+            )?;
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 
@@ -10649,19 +10653,7 @@ pub mod processor {
         }
 
         let domain_usize = domain as usize;
-        let (bump, amount_u64) = verify_domain_withdrawal_preflight(
-            program_id,
-            market_ai,
-            authority,
-            dest_token,
-            vault_token,
-            vault_authority_ai,
-            domain_usize,
-            amount,
-            expected_market_id,
-            false,
-            DOMAIN_WITHDRAW_AUTH_BACKING,
-        )?;
+        let escheat_to_base_insurance;
 
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
@@ -10687,17 +10679,15 @@ pub mod processor {
             if !local_authorized && !admin_shutdown_authorized {
                 return Err(PercolatorError::Unauthorized.into());
             }
+            // Marketauth is a shutdown-progress submitter, not the provider's payout authority.
+            escheat_to_base_insurance = admin_shutdown_authorized && !local_authorized;
             let epoch_asset_index = if local_authorized {
                 domain_usize / 2
             } else {
                 0
             };
             require_authority_epoch_view(&group, epoch_asset_index, expected_authority_epoch)?;
-            let ledger_authority = if admin_shutdown_authorized && !local_authorized {
-                cfg.marketauth
-            } else {
-                authorities.backing_bucket_authority
-            };
+            let ledger_authority = authorities.backing_bucket_authority;
 
             let (_, bucket) = backing_domain_parts_view(&group, domain_usize)?;
             if amount > bucket.utilization_fee_earnings || amount > group.header.vault.get() {
@@ -10715,6 +10705,9 @@ pub mod processor {
             group
                 .withdraw_backing_provider_earnings_not_atomic(domain_usize, amount)
                 .map_err(map_v16_error)?;
+            if escheat_to_base_insurance {
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             ledger.last_observed_bucket_earnings_atoms = ledger
                 .last_observed_bucket_earnings_atoms
                 .checked_sub(amount)
@@ -10727,16 +10720,31 @@ pub mod processor {
             write_or_init_backing_domain_ledger(&mut ledger_data, &ledger, initialized)?;
         }
 
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (bump, amount_u64) = verify_domain_withdrawal_preflight(
+                program_id,
+                market_ai,
+                authority,
+                dest_token,
+                vault_token,
+                vault_authority_ai,
+                domain_usize,
+                amount,
+                expected_market_id,
+                false,
+                DOMAIN_WITHDRAW_AUTH_BACKING,
+            )?;
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 
@@ -10837,30 +10845,8 @@ pub mod processor {
         let long_domain = asset_index
             .checked_mul(2)
             .ok_or(PercolatorError::EngineArithmeticOverflow)?;
-        let amount_u64 = amount_to_u64(amount)?;
-        {
-            let market_data = market_ai.try_borrow_data()?;
-            let (cfg, mode, _, market_id, _, _) =
-                state::read_market_trade_preflight(&market_data, asset_index)?;
-            if market_id != expected_market_id {
-                return Err(PercolatorError::AssetGenerationMismatch.into());
-            }
-            if mode != MarketModeV16::Live && mode != MarketModeV16::Resolved {
-                return Err(PercolatorError::InvalidInstruction.into());
-            }
-            let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
-            expect_key(vault_authority_ai, &vault_authority)?;
-            let vault_balance = verify_withdrawable_token_accounts(
-                dest_token,
-                operator.key,
-                vault_token,
-                &vault_authority,
-                &cfg,
-                false,
-            )?;
-            require_token_balance(vault_balance, amount_u64)?;
-        }
-        let (_, bump) = derive_vault_authority(program_id, market_ai.key);
+        let escheat_to_base_insurance;
+        let destination_owner;
         {
             let mut market_data = market_ai.try_borrow_mut_data()?;
             let (cfg, mut group) = state::market_view_mut(&mut market_data)?;
@@ -10875,24 +10861,22 @@ pub mod processor {
             }
             require_asset_generation_view(&group, asset_index, expected_market_id)?;
             let authorities = domain_authorities_from_view(&group, &cfg, long_domain)?;
+            let local_operator =
+                live_authority_matches(&authorities.insurance_operator, operator.key);
             let ledger_authority = if live_mode {
                 let shutdown_drain =
                     live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
-                let local_authorized =
-                    live_authority_matches(&authorities.insurance_operator, operator.key);
                 let admin_shutdown_authorized = asset_index != 0
                     && shutdown_drain
                     && live_authority_matches(&cfg.marketauth, operator.key);
-                if !local_authorized && !admin_shutdown_authorized {
+                if !local_operator && !admin_shutdown_authorized {
                     return Err(PercolatorError::Unauthorized.into());
                 }
-                let epoch_asset_index = if local_authorized { asset_index } else { 0 };
+                let epoch_asset_index = if local_operator { asset_index } else { 0 };
                 require_authority_epoch_view(&group, epoch_asset_index, expected_authority_epoch)?;
-                if admin_shutdown_authorized && !local_authorized {
-                    cfg.marketauth
-                } else {
-                    authorities.insurance_authority
-                }
+                // Marketauth is a shutdown-progress submitter, not the operator's payout authority.
+                escheat_to_base_insurance = admin_shutdown_authorized && !local_operator;
+                authorities.insurance_authority
             } else {
                 if group.header.materialized_portfolio_count.get() != 0
                     || group.header.c_tot.get() != 0
@@ -10906,7 +10890,13 @@ pub mod processor {
                 group
                     .recredit_terminal_claim_free_residual_for_asset_not_atomic(asset_index)
                     .map_err(map_v16_error)?;
+                escheat_to_base_insurance = false;
                 authorities.insurance_authority
+            };
+            destination_owner = if local_operator {
+                *operator.key
+            } else {
+                Pubkey::new_from_array(authorities.insurance_authority)
             };
             let available = market_insurance_withdraw_capacity_view(&group, asset_index)?;
             if amount > available
@@ -10935,6 +10925,9 @@ pub mod processor {
             // Atomic insurance/vault/budget withdraw through the engine (maintains the
             // insurance_domain_budget_remaining_total aggregate).
             debit_market_insurance_budget_view(&mut group, asset_index, amount)?;
+            if escheat_to_base_insurance {
+                deposit_market_zero_insurance_view(&mut group, amount)?;
+            }
             if let Some((ledger, _)) = ledger_state.as_mut() {
                 ledger.total_withdrawn_atoms = ledger
                     .total_withdrawn_atoms
@@ -10953,16 +10946,35 @@ pub mod processor {
                 write_or_init_insurance_ledger(data, ledger, *initialized)?;
             }
         }
-        let bump_arr = [bump];
-        let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
-        transfer_tokens_signed(
-            token_program,
-            vault_token,
-            dest_token,
-            vault_authority_ai,
-            amount_u64,
-            signer_seeds,
-        )?;
+        if !escheat_to_base_insurance {
+            let (vault_authority, bump) = derive_vault_authority(program_id, market_ai.key);
+            expect_key(vault_authority_ai, &vault_authority)?;
+            let amount_u64 = amount_to_u64(amount)?;
+            {
+                let market_data = market_ai.try_borrow_data()?;
+                let (cfg, _, _, _, _, _) =
+                    state::read_market_trade_preflight(&market_data, asset_index)?;
+                let vault_balance = verify_withdrawable_token_accounts(
+                    dest_token,
+                    &destination_owner,
+                    vault_token,
+                    &vault_authority,
+                    &cfg,
+                    false,
+                )?;
+                require_token_balance(vault_balance, amount_u64)?;
+            }
+            let bump_arr = [bump];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"vault", market_ai.key.as_ref(), &bump_arr]];
+            transfer_tokens_signed(
+                token_program,
+                vault_token,
+                dest_token,
+                vault_authority_ai,
+                amount_u64,
+                signer_seeds,
+            )?;
+        }
         Ok(())
     }
 

--- a/tests/invariants/cu/inv_005_authority_incarnation_binding.rs
+++ b/tests/invariants/cu/inv_005_authority_incarnation_binding.rs
@@ -3433,6 +3433,138 @@ fn v16_attack_market_admin_cannot_drain_foreign_asset_or_user_collateral() {
     );
 }
 
+// INV-005/INV-024/INV-034: marketauth may finish a mature shutdown when an asset provider is
+// unavailable, but that liveness fallback is not a transfer authorization. Provider-attributed
+// backing and insurance must stay in protocol custody and escheat to base insurance; they must
+// never become withdrawable by the marketauth signer.
+#[test]
+fn v16_attack_shutdown_cleanup_cannot_pay_foreign_reserves_to_marketauth() {
+    const INSURANCE: u128 = 300;
+    const BACKING: u128 = 500;
+    const RECLAIMED_INSURANCE: u128 = 100;
+    const RECLAIMED_BACKING: u128 = 200;
+
+    let mut env = V16CuEnv::new();
+    let marketauth = env.admin.insecure_clone();
+    env.configure_permissionless_resolve_with_cu(100, 2);
+    env.update_market_init_fee_policy_with_cu(10);
+
+    let provider = Keypair::new();
+    let provider_key = provider.pubkey();
+    env.svm.warp_to_slot(1);
+    env.activate_permissionless_asset_with_fee(
+        &provider,
+        1,
+        1,
+        100,
+        provider_key,
+        provider_key,
+        provider_key,
+        provider_key,
+        10,
+    );
+    env.top_up_insurance_domain_with_authority(&provider, 2, INSURANCE);
+    env.top_up_backing_bucket_with_authority(&provider, 2, BACKING, 100);
+
+    let funded = env.market_state().1;
+    assert_eq!(funded.insurance_domain_budget[2], INSURANCE);
+    assert_eq!(
+        funded.source_backing_buckets[2].fresh_unliened_backing_num,
+        BACKING * BOUND_SCALE
+    );
+
+    env.svm.warp_to_slot(4);
+    env.try_shutdown_asset_with_authority(&marketauth, 1, 4)
+        .expect("marketauth may initiate bounded asset shutdown");
+    env.svm.warp_to_slot(7);
+
+    let (provider_insurance_dest, provider_insurance_cu) = env
+        .try_withdraw_insurance_asset_with_authority(&provider, 1, RECLAIMED_INSURANCE)
+        .expect("present insurance operator reclaims its own reserve");
+    assert_cu_within(
+        "shutdown provider insurance reclaim",
+        provider_insurance_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.token_amount(provider_insurance_dest),
+        RECLAIMED_INSURANCE as u64
+    );
+
+    let provider_backing_dest = env.token_account(provider_key, 0);
+    let provider_backing_cu = env
+        .send(
+            ProgInstruction::WithdrawBackingBucket {
+                domain: 2,
+                market_id: env.asset_market_id(1),
+                authority_epoch: env.withdrawal_authority_epoch(provider_key, 1, false),
+                amount: RECLAIMED_BACKING,
+            },
+            vec![
+                AccountMeta::new(provider_key, true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(provider_backing_dest, false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&provider],
+        )
+        .expect("present backing provider reclaims its own principal");
+    assert_cu_within(
+        "shutdown provider backing reclaim",
+        provider_backing_cu,
+        CUSTODY_CU_LIMIT,
+    );
+    assert_eq!(
+        env.token_amount(provider_backing_dest),
+        RECLAIMED_BACKING as u64
+    );
+
+    let admin_dest = env.token_account(marketauth.pubkey(), 0);
+    let base_insurance_before = {
+        let group = env.market_state().1;
+        group.insurance_domain_budget[0] + group.insurance_domain_budget[1]
+    };
+    let vault_tokens_before = env.token_amount(env.vault);
+    let header_vault_before = env.market_state().1.vault;
+
+    let abandoned_insurance = INSURANCE - RECLAIMED_INSURANCE;
+    let abandoned_backing = BACKING - RECLAIMED_BACKING;
+    let insurance_cu =
+        env.withdraw_insurance_domain_to_admin_token_with_cu(admin_dest, 2, abandoned_insurance);
+    assert_cu_within("shutdown insurance escheat", insurance_cu, CUSTODY_CU_LIMIT);
+    let backing_cu =
+        env.withdraw_backing_bucket_to_admin_token_with_cu(admin_dest, 2, abandoned_backing);
+    assert_cu_within("shutdown backing escheat", backing_cu, CUSTODY_CU_LIMIT);
+
+    assert_eq!(
+        env.token_amount(admin_dest),
+        0,
+        "shutdown progress cannot turn marketauth into the reserve beneficiary"
+    );
+    assert_eq!(
+        env.token_amount(env.vault),
+        vault_tokens_before,
+        "escheat is custody-neutral"
+    );
+    let after = env.market_state().1;
+    assert_eq!(
+        after.vault, header_vault_before,
+        "engine vault is unchanged"
+    );
+    assert_eq!(after.insurance_domain_budget[2], 0);
+    assert_eq!(
+        after.source_backing_buckets[2].fresh_unliened_backing_num,
+        0
+    );
+    assert_eq!(
+        after.insurance_domain_budget[0] + after.insurance_domain_budget[1],
+        base_insurance_before + abandoned_insurance + abandoned_backing,
+        "abandoned provider reserves escheat exactly to base insurance"
+    );
+}
+
 // Regression for percolator-cli#82 (fixed by 05a8f845): UpdateAssetLifecycle(Activate) must NOT let a
 // non-admin install attacker-controlled per-asset authorities. Exact exploit shape: a non-admin calls
 // Activate on a slot with ITSELF as oracle/insurance/operator/backing authority (written verbatim from

--- a/tests/invariants/cu/inv_078_permissionless_recovery_coverage.rs
+++ b/tests/invariants/cu/inv_078_permissionless_recovery_coverage.rs
@@ -468,19 +468,14 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
     }
     assert_eq!(
         env.token_amount(admin_recovery),
-        55,
-        "admin must recover asset-domain insurance and backing funds"
-    );
-    assert_eq!(env.token_amount(env.vault), 2_000_025);
-
-    env.top_up_insurance_from_admin_token_with_cu(admin_recovery, 10);
-    env.top_up_backing_bucket_from_admin_token_with_cu(admin_recovery, 0, 45, 20);
-    assert_eq!(
-        env.token_amount(admin_recovery),
         0,
-        "recovered funds should be re-deposited into market-0 buckets"
+        "shutdown cleanup must not pay provider-attributed reserves to marketauth"
     );
-    assert_eq!(env.token_amount(env.vault), 2_000_080);
+    assert_eq!(
+        env.token_amount(env.vault),
+        2_000_080,
+        "cleanup must reattribute reserves without moving custody"
+    );
     let market_data = env.svm.get_account(&env.market).unwrap().data;
     let (_, recovered_group) = state::read_market(&market_data).unwrap();
     assert_eq!(recovered_group.insurance_domain_budget[2], 0);
@@ -493,11 +488,11 @@ fn v16_bpf_permissionless_market_shutdown_force_closes_recovers_and_reuses_slot(
         recovered_group.source_backing_buckets[3].fresh_unliened_backing_num,
         0
     );
-    assert_eq!(recovered_group.insurance_domain_budget[0], 17);
-    assert_eq!(recovered_group.insurance_domain_budget[1], 18);
+    assert_eq!(recovered_group.insurance_domain_budget[0], 39);
+    assert_eq!(recovered_group.insurance_domain_budget[1], 41);
     assert_eq!(
         recovered_group.source_backing_buckets[0].fresh_unliened_backing_num,
-        45 * BOUND_SCALE
+        0
     );
 
     env.update_asset_lifecycle_as_admin_with_cu(


### PR DESCRIPTION
## Impact

A market authority could shut down a permissionlessly created asset, wait for the public cleanup delay, then use the shutdown fallback in `WithdrawInsuranceAsset`, `WithdrawBackingBucket`, and `WithdrawBackingBucketEarnings` to send another provider's attributed reserves to an admin-owned SPL account.

The current-main public LiteSVM trace deposits 300 insurance atoms and 500 backing atoms from a distinct provider. Before this fix, the normal shutdown path transfers all 800 atoms to marketauth. No program-owned account bytes are modified out of band.

## Fix

Treat marketauth as a shutdown-progress submitter, not a payout authority. Provider-signed cleanup still pays the provider. Marketauth-only cleanup debits the abandoned source bucket and recredits the same amount to asset-0 insurance without moving SPL tokens. Provider ledger identity remains bound to the provider.

## TDD evidence

- Pre-fix: `v16_attack_shutdown_cleanup_cannot_pay_foreign_reserves_to_marketauth` fails with admin balance `800` instead of `0`.
- Post-fix: the same test passes, including provider reclaim-first controls and exact vault/base-insurance reconciliation.
- The existing end-to-end shutdown/force-close/retire/reuse test now requires vault-neutral escheat instead of trusting the admin to redeposit the funds.

## Verification

- `cargo build-sbf --tools-version v1.52`
- `cargo test --lib`: 8/8
- INV-005 module: 43/43
- INV-064 module: 10/10
- Targeted backing-earnings, shutdown lifecycle, and three SPL rollback tests: green
- Full `v16_cu`: 957/962. The five failures reproduce stale merged-main invariant metadata/expectations unrelated to these handlers: RestartAssetOracle replay roster, three missing caller-input fields / field count, shifted Kani inventory lines, and duplicate Recovery-hint semantics.
