### PR TITLE
[PRIVILEGED LoF] Bind retained single-CPI taker fee consent

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -9242,8 +9242,9 @@ pub mod processor {
         if stale_matured {
             return Err(PercolatorError::OracleStale.into());
         }
-        let fee_floor_pre = core::cmp::max(fee_bps, cfg_pre.trade_fee_base_bps);
-        if fee_floor_pre > max_trading_fee_bps {
+        // The taker signs `fee_bps` before the matcher runs. A later policy update cannot raise
+        // the base fee above that retained consent; the unsigned LP is bounded separately below.
+        if cfg_pre.trade_fee_base_bps > fee_bps || fee_bps > max_trading_fee_bps {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         if backing_fee_cap_bps > 10_000 {

--- a/tests/invariants/cu/inv_036_fee_destination_and_policy_version_integrity.rs
+++ b/tests/invariants/cu/inv_036_fee_destination_and_policy_version_integrity.rs
@@ -2,7 +2,7 @@
 //!
 //! Normative obligation: Charged fees reach only the authorized destination under the bound policy version.
 //!
-//! Evidence in this file (I/C plus invariant-specific M assertions): `v16_program_signed_direction_route_matrix_preserves_side_attribution_and_terminal_value`, `v16_program_mixed_direction_fee_allocation_matches_independent_side_ledger`, `v16_attack_mixed_direction_batch_fees_conserve_by_asset`. These tests exercise the deployed public
+//! Evidence in this file (I/C plus invariant-specific M assertions): `v16_program_signed_direction_route_matrix_preserves_side_attribution_and_terminal_value`, `v16_program_mixed_direction_fee_allocation_matches_independent_side_ledger`, `v16_attack_mixed_direction_batch_fees_conserve_by_asset`, `v16_attack_retained_single_cpi_trade_rejects_increased_taker_base_fee`. These tests exercise the deployed public
 //! wrapper with real SBF/LiteSVM account construction and assert economic state, token,
 //! rollback, liveness, or compute outcomes appropriate to the invariant.
 //!
@@ -15,6 +15,74 @@
 //! destination helper, engine pin, or loss of a public witness reopens the current-surface closure.
 
 use super::*;
+use crate::support::v16_svm::{MarketConfig, V16Svm, INITIAL_PRICE};
+
+#[test]
+fn v16_attack_retained_single_cpi_trade_rejects_increased_taker_base_fee() {
+    const VICTIM: usize = 1;
+    const LP: usize = 2;
+    const FEE_BPS: u64 = 500;
+    const SIZE_Q: i128 = POS_SCALE as i128;
+    const FEE_PER_SIDE: u128 = 50_000;
+
+    let mut env = V16Svm::new([0x41; 32], MarketConfig::default());
+    env.begin_public_trace();
+    env.set_matcher_config_with_trade_fee_cap(LP, 1, FEE_BPS as u16)
+        .expect("LP consents to the future fee independently of the taker");
+    let retained =
+        env.build_retained_cpi_trade_with_fee_caps(VICTIM, LP, 0, SIZE_Q, INITIAL_PRICE, 0, 0);
+    env.update_trade_fee_policy(FEE_BPS)
+        .expect("privileged fee authority raises the live base fee");
+
+    let victim_before = env.primary_portfolio(VICTIM).capital.get();
+    let lp_before = env.primary_portfolio(LP).capital.get();
+    let insurance_before = env.primary_market_state().1.insurance;
+    let retained_result = env.land_retained(retained);
+
+    assert!(
+        retained_result.is_err(),
+        "a retained CPI trade must not debit the taker above its signed fee_bps bound"
+    );
+    assert_eq!(env.primary_portfolio(VICTIM).capital.get(), victim_before);
+    assert_eq!(env.primary_portfolio(LP).capital.get(), lp_before);
+    assert_eq!(env.primary_market_state().1.insurance, insurance_before);
+
+    let authorized = env.build_retained_cpi_trade_with_fee_caps(
+        VICTIM,
+        LP,
+        0,
+        SIZE_Q,
+        INITIAL_PRICE,
+        FEE_BPS,
+        0,
+    );
+    env.land_retained(authorized)
+        .expect("a freshly authorized CPI trade remains available");
+    assert_eq!(
+        victim_before - env.primary_portfolio(VICTIM).capital.get(),
+        FEE_PER_SIDE
+    );
+    assert_eq!(
+        lp_before - env.primary_portfolio(LP).capital.get(),
+        FEE_PER_SIDE
+    );
+    assert_eq!(
+        env.primary_market_state().1.insurance - insurance_before,
+        FEE_PER_SIDE * 2
+    );
+
+    let fee_destination_before = env.token_amount(env.provider_destination_token);
+    env.withdraw_insurance_asset_as_admin(0, FEE_PER_SIDE * 2)
+        .expect("the fee authority may withdraw only the freshly authorized fees");
+    assert_eq!(
+        env.token_amount(env.provider_destination_token) - fee_destination_before,
+        (FEE_PER_SIDE * 2) as u64
+    );
+
+    env.finish_public_trace()
+        .validate_public_execution()
+        .expect("fee-consent regression uses only valid public SBF instructions");
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct DirectionalFeeTerminalOutcome {

--- a/tests/support/fuzz_model.rs
+++ b/tests/support/fuzz_model.rs
@@ -22407,7 +22407,14 @@ pub fn verify_cpi_base_fee_consent(
     let send_fill = |env: &mut V16Svm, size_q: i128| {
         let market_id = env.primary_market_state().1.assets[ASSET as usize].market_id;
         match route {
-            TradeRoute::Cpi => env.trade_cpi(BENEFICIARY, LP, ASSET, size_q, 0, 0),
+            TradeRoute::Cpi => env.trade_cpi(
+                BENEFICIARY,
+                LP,
+                ASSET,
+                size_q,
+                INSTALLED_FEE_BPS,
+                0,
+            ),
             TradeRoute::BatchCpi => env.batch_trade_cpi(
                 BENEFICIARY,
                 LP,

--- a/tests/support/v16_svm.rs
+++ b/tests/support/v16_svm.rs
@@ -4418,6 +4418,27 @@ impl V16Svm {
         limit_price: u64,
         backing_fee_cap_bps: u16,
     ) -> Transaction {
+        self.build_retained_cpi_trade_with_fee_caps(
+            taker,
+            maker,
+            asset_index,
+            size_q,
+            limit_price,
+            0,
+            backing_fee_cap_bps,
+        )
+    }
+
+    pub fn build_retained_cpi_trade_with_fee_caps(
+        &mut self,
+        taker: usize,
+        maker: usize,
+        asset_index: u16,
+        size_q: i128,
+        limit_price: u64,
+        fee_bps: u64,
+        backing_fee_cap_bps: u16,
+    ) -> Transaction {
         let market_id = self.primary_market_state().1.assets[asset_index as usize].market_id;
         let account_a_portfolio_id = self.primary_portfolio_id(taker);
         let account_a_position_epoch = self.primary_portfolio_position_epoch(taker);
@@ -4436,7 +4457,7 @@ impl V16Svm {
                 asset_index,
                 market_id,
                 size_q,
-                fee_bps: 0,
+                fee_bps,
                 limit_price,
                 backing_fee_cap_bps,
             },


### PR DESCRIPTION
## Impact
A retained `TradeCpi` signed by the taker with `fee_bps = 0` could land after the asset-0 insurance authority raised `trade_fee_base_bps`, provided the LP had independently allowed the new fee. On the pre-fix SBF, a one-unit public trade debited the victim and LP by 50,000 quote atoms each, credited 100,000 atoms to insurance, and the privileged fee authority withdrew all 100,000 through `WithdrawInsuranceAsset`. No program-owned state was injected.

This is a privileged LoF: a compromised or malicious fee authority can extract value from an already-signed taker transaction beyond its retained base-fee consent.

## Fix
Reject single-CPI execution when the current base fee exceeds the taker-signed `fee_bps`. The LP matcher cap and protocol maximum remain independent. A newly signed transaction at the current fee still executes.

## TDD evidence
- Parent `c74209f3`: the production-SBF LiteSVM regression fails because the stale zero-cap trade lands.
- Head: stale trade rejects with exact rollback; a fresh 500 bps trade succeeds and the authorized fee is withdrawable.

## Verification
- `cargo build-sbf --tools-version v1.52`
- exact INV-036 regression: pass
- deterministic PR313 CPI fee-consent route test: pass
- PR313 stateful fuzz, 4 cases: pass
- `cargo test --lib`: 8/8 pass

A broader INV-036 relink was attempted but the host filesystem ran out of space during linking; it did not produce a test failure.