### PR TITLE
[BLOCKER LoF] Crystallize flat fees before first open

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -6802,25 +6802,6 @@ pub mod processor {
         collect_maintenance_fee_to_slot_before_value_debit_view(cfg, group, portfolio, now_slot)
     }
 
-    fn collect_maintenance_fee_before_trade_view(
-        cfg: &WrapperConfigV16,
-        group: &mut state::MarketViewMutV16<'_>,
-        portfolio: &mut percolator::PortfolioV16ViewMut<'_>,
-    ) -> Result<u128, ProgramError> {
-        let active_bitmap = portfolio
-            .header
-            .active_bitmap
-            .map(percolator::V16PodU64::get);
-        if percolator::active_bitmap_is_empty(active_bitmap) {
-            // Opening a first leg does not debit an existing exposure. Leave flat-account fee
-            // realization to SyncMaintenanceFee/Withdraw instead of advancing its cursor ahead of
-            // the loss-current anchor immediately before it becomes nonflat.
-            return Ok(0);
-        }
-        let now_slot = authenticated_market_slot_or_fallback_view(group);
-        collect_maintenance_fee_to_slot_before_value_debit_view(cfg, group, portfolio, now_slot)
-    }
-
     fn require_asset_active_for_oracle_reconfiguration_view(
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
@@ -8081,8 +8062,8 @@ pub mod processor {
                 &account_b,
                 core::slice::from_ref(&req),
             )?;
-            collect_maintenance_fee_before_trade_view(&cfg, &mut group, &mut account_a)?;
-            collect_maintenance_fee_before_trade_view(&cfg, &mut group, &mut account_b)?;
+            collect_maintenance_fee_before_value_debit_view(&cfg, &mut group, &mut account_a)?;
+            collect_maintenance_fee_before_value_debit_view(&cfg, &mut group, &mut account_b)?;
             let account_a_needs_source_capacity =
                 trade_delta_may_require_source_domain_capacity(account_a_position, size_q)?;
             let account_b_needs_source_capacity =
@@ -8444,8 +8425,8 @@ pub mod processor {
                     &group, &account_a, &account_b, &requests,
                 )?;
             }
-            collect_maintenance_fee_before_trade_view(&cfg, &mut group, &mut account_a)?;
-            collect_maintenance_fee_before_trade_view(&cfg, &mut group, &mut account_b)?;
+            collect_maintenance_fee_before_value_debit_view(&cfg, &mut group, &mut account_a)?;
+            collect_maintenance_fee_before_value_debit_view(&cfg, &mut group, &mut account_b)?;
             if needs_source_domain_capacity {
                 let mut admitted_source_domains_a =
                     occupied_source_domains_snapshot_for_trade_view(&account_a)?;

--- a/tests/invariants/README.md
+++ b/tests/invariants/README.md
@@ -2956,8 +2956,11 @@ generators now reauthorize explicitly after an external position mutation instea
 stale fixture capability. The wrapper also closes issue 408's maintenance-debt seniority gap.
 Collectible maintenance is now crystallized
 before withdrawals, existing-exposure trades, force-close transfers, and eligible auto-crank
-actions; flat first opens remain available, and liquidation rewards snapshot insurance only after
-the maintenance credit. Two public issue408 worlds prove that neither an unsigned standing matcher
+actions; flat first opens remain available only when fee-net capital passes admission, and
+liquidation rewards snapshot insurance only after the maintenance credit. A public first-open
+regression ages a flat attacker portfolio, proves stale gross capital cannot back a 20x position,
+and closes the prior 457,999-atom independent-insurance drain. Two public issue408 worlds prove
+that neither an unsigned standing matcher
 nor a permissionless liquidator can spend the aged obligation first, while exact fee attribution,
 subsequent exposure reduction/recovery progress, and the maximum 14-leg CU paths remain live. The
 stateful withdrawal reference now separately reconciles `capital debit = SPL payout + maintenance`

--- a/tests/invariants/cu/inv_027_protected_principal_seniority.rs
+++ b/tests/invariants/cu/inv_027_protected_principal_seniority.rs
@@ -83,6 +83,27 @@ fn v16_attack_flat_fee_debt_cannot_back_first_open_or_spend_independent_insuranc
         assert_eq!(env.svm.get_account(&aged).unwrap(), aged_before);
         assert_eq!(env.svm.get_account(&fresh).unwrap(), fresh_before);
         assert_eq!(env.token_amount(env.vault), vault_before);
+
+        env.deposit(&aged_owner, aged, 1_000_000);
+        env.svm.expire_blockhash();
+        let open_cu = env.trade_asset_with_cu(
+            0,
+            &fresh_owner,
+            fresh,
+            &aged_owner,
+            aged,
+            LOTS * POS_SCALE as i128,
+            PRICE,
+            0,
+        );
+        assert_cu_within("fee-net flat first-open", open_cu, TRADE_CU_LIMIT);
+        let aged_after = env.portfolio_state(aged);
+        assert_eq!(aged_after.last_fee_slot.get(), AGED_SLOT);
+        assert_eq!(aged_after.capital.get(), ATTACKER_DEPOSIT_PER_ACCOUNT);
+        assert_eq!(
+            env.market_state().1.insurance,
+            INSURANCE + AGED_SLOT as u128 * FEE_PER_SLOT,
+        );
         return;
     }
 

--- a/tests/invariants/cu/inv_027_protected_principal_seniority.rs
+++ b/tests/invariants/cu/inv_027_protected_principal_seniority.rs
@@ -23,6 +23,105 @@ const ISSUE408_AGED_SLOT: u64 = 500;
 const ISSUE408_MOVE_SLOT: u64 = 542;
 const ISSUE408_LOTS: i128 = 10;
 
+#[test]
+fn v16_attack_flat_fee_debt_cannot_back_first_open_or_spend_independent_insurance() {
+    const PRICE: u64 = 1_000_000;
+    const AGED_SLOT: u64 = 500;
+    const MOVE_SLOT: u64 = 542;
+    const FEE_PER_SLOT: u128 = 2_000;
+    const INSURANCE: u128 = 1_000_000;
+    const ATTACKER_DEPOSIT_PER_ACCOUNT: u128 = 1_100_000;
+    const LOTS: i128 = 20;
+
+    let mut params = production_risk_params();
+    params.maintenance_fee_per_slot = FEE_PER_SLOT;
+    let mut env = V16CuEnv::new_with_init_params(params);
+    env.update_liquidation_fee_policy_with_cu(0);
+    env.top_up_insurance(INSURANCE);
+    env.configure_auth_mark_with_cu(0, PRICE);
+
+    let aged_owner = Keypair::new();
+    let aged = env.create_portfolio(&aged_owner);
+    env.deposit(&aged_owner, aged, ATTACKER_DEPOSIT_PER_ACCOUNT);
+
+    let empty_owner = Keypair::new();
+    let empty = env.create_portfolio(&empty_owner);
+    for slot in (20..=AGED_SLOT).step_by(20) {
+        env.svm.warp_to_slot(slot);
+        env.push_auth_mark_for_asset_as_admin(0, slot, PRICE);
+        env.crank(
+            empty,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: slot,
+                observations: crank_observations(0),
+            },
+        );
+    }
+    assert_eq!(env.portfolio_state(aged).last_fee_slot.get(), 0);
+
+    let fresh_owner = Keypair::new();
+    let fresh = env.create_portfolio(&fresh_owner);
+    env.deposit(&fresh_owner, fresh, ATTACKER_DEPOSIT_PER_ACCOUNT);
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let aged_before = env.svm.get_account(&aged).unwrap();
+    let fresh_before = env.svm.get_account(&fresh).unwrap();
+    let vault_before = env.token_amount(env.vault);
+    let open = env.try_trade_asset_with_cu(
+        0,
+        &fresh_owner,
+        fresh,
+        &aged_owner,
+        aged,
+        LOTS * POS_SCALE as i128,
+        PRICE,
+        0,
+    );
+
+    if open.is_err() {
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&aged).unwrap(), aged_before);
+        assert_eq!(env.svm.get_account(&fresh).unwrap(), fresh_before);
+        assert_eq!(env.token_amount(env.vault), vault_before);
+        return;
+    }
+
+    env.svm.warp_to_slot(MOVE_SLOT);
+    env.push_auth_mark_with_cu(MOVE_SLOT, 1_100_000);
+    for _ in 0..64 {
+        for portfolio in [aged, fresh] {
+            let _ = env.crank_if_actionable(
+                portfolio,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: MOVE_SLOT,
+                    observations: crank_observations(0),
+                },
+            );
+        }
+    }
+
+    env.close_portfolio_with_cu(&aged_owner, aged);
+    env.resolve();
+    let fresh_dest = env.close_resolved(&fresh_owner, fresh);
+    let coalition_out = env.token_amount(fresh_dest) as u128;
+    let independent_insurance_after = env.market_state().1.insurance;
+    let attacker_deposits = 2 * ATTACKER_DEPOSIT_PER_ACCOUNT;
+
+    assert!(
+        coalition_out <= attacker_deposits,
+        "stale first-open extracted {} atoms from independent insurance: attacker deposits={}, payout={}, insurance {} -> {}",
+        coalition_out - attacker_deposits,
+        attacker_deposits,
+        coalition_out,
+        INSURANCE,
+        independent_insurance_after,
+    );
+    assert!(
+        independent_insurance_after >= INSURANCE,
+        "attacker-backed first-open must not consume pre-existing insurance"
+    );
+}
+
 fn issue408_advance_market_without_target_refresh(
     env: &mut V16CuEnv,
     empty: Pubkey,

--- a/tests/invariants/cu/inv_077_bounded_work_and_maximum_shape_compute.rs
+++ b/tests/invariants/cu/inv_077_bounded_work_and_maximum_shape_compute.rs
@@ -4357,10 +4357,25 @@ fn v16_attack_public_recovery_kf_progress_survives_stale_42_feed_tail_at_max_sha
 
 #[test]
 fn v16_attack_max_source_maintenance_sync_stays_bounded() {
-    let (mut env, _taker_owner, _lp_owner, _taker, lp, _slot) = setup_max_source_live_pair(1, 1);
+    let (mut env, taker_owner, lp_owner, taker, lp, _slot) = setup_max_source_live_pair(1, 1);
+    let final_asset = MAX_SOURCE_LIVE_ASSETS - 1;
+    let close_mark = env.market_state().1.assets[usize::from(final_asset)].effective_price;
+    env.svm.expire_blockhash();
+    env.trade_asset_with_cu(
+        final_asset,
+        &taker_owner,
+        taker,
+        &lp_owner,
+        lp,
+        -MAX_SOURCE_LIVE_SIZE_Q,
+        close_mark,
+        0,
+    );
     let before = env.portfolio_state(lp);
-    let group_before = env.market_state().1;
-    let custody_before = env.token_amount(env.vault);
+    assert!(
+        percolator::active_bitmap_is_empty(active_bitmap(&before)),
+        "max-source fee benchmark must leave a flat account so authenticated clock progress alone advances its fee anchor"
+    );
     let charge_slot = before
         .last_fee_slot
         .get()
@@ -4368,6 +4383,8 @@ fn v16_attack_max_source_maintenance_sync_stays_bounded() {
         .expect("maintenance charge slot");
 
     env.svm.warp_to_slot(charge_slot);
+    let group_before = env.market_state().1;
+    let custody_before = env.token_amount(env.vault);
     env.svm.expire_blockhash();
     let cu = env.sync_maintenance_fee_with_cu(lp, None, charge_slot);
     println!("v16 28-source-domain SyncMaintenanceFee CU: {cu}");

--- a/tests/invariants/public_sbf/inv_036_fee_destination_and_policy_version_integrity.rs
+++ b/tests/invariants/public_sbf/inv_036_fee_destination_and_policy_version_integrity.rs
@@ -98,8 +98,12 @@ fn v16_program_pr223_unsigned_lp_backing_fee_requires_matcher_consent() {
         u128::from(protection.extracted_tokens)
     );
     // The zero-cap close pays no backing fee. Its only capital delta is the
-    // exact four-slot maintenance charge collected before the value change.
-    assert_eq!(protection.attacker_capital_delta, -120);
+    // maintenance debt implied by the authenticated fee-cursor movement.
+    assert!(protection.attacker_maintenance_fee > 0);
+    assert_eq!(
+        protection.attacker_capital_delta,
+        -i128::try_from(protection.attacker_maintenance_fee).unwrap()
+    );
     assert!(protection.zero_cap_risk_reduction_landed);
     assert!(protection.max_route_cu < support::v16_svm::TX_CU_LIMIT);
     assert!(protection.token_supply_conserved);

--- a/tests/invariants/stateful/inv_036_fee_destination_and_policy_version_integrity.rs
+++ b/tests/invariants/stateful/inv_036_fee_destination_and_policy_version_integrity.rs
@@ -147,7 +147,11 @@ proptest! {
         prop_assert_eq!(protection.lp_capital_loss, protection.provider_earnings);
         prop_assert!(protection.provider_earnings > 0);
         prop_assert_eq!(protection.provider_earnings, u128::from(protection.extracted_tokens));
-        prop_assert_eq!(protection.attacker_capital_delta, -120);
+        prop_assert!(protection.attacker_maintenance_fee > 0);
+        prop_assert_eq!(
+            protection.attacker_capital_delta,
+            -i128::try_from(protection.attacker_maintenance_fee).unwrap()
+        );
         prop_assert!(protection.zero_cap_risk_reduction_landed);
         prop_assert!(protection.max_route_cu < crate::support::v16_svm::TX_CU_LIMIT);
         prop_assert!(protection.token_supply_conserved);

--- a/tests/support/fuzz_model.rs
+++ b/tests/support/fuzz_model.rs
@@ -249,6 +249,7 @@ pub struct CpiBackingFeeProtection {
     pub earnings_spl_vault_debit: u128,
     pub earnings_accounted_vault_debit: u128,
     pub attacker_capital_delta: i128,
+    pub attacker_maintenance_fee: u128,
     pub zero_cap_risk_reduction_landed: bool,
     pub max_route_cu: u64,
     pub token_supply_conserved: bool,
@@ -22561,7 +22562,7 @@ pub fn verify_cpi_backing_fee_consent(
     const LOSING_SIZE_Q: i128 = 100 * POS_SCALE as i128;
     const INCREASE_Q: i128 = 20 * POS_SCALE as i128;
     const WINNING_DOMAIN: u16 = 3;
-    const EXPECTED_ATTACKER_MAINTENANCE_FEE: i128 = 120;
+    const MAINTENANCE_FEE_PER_SLOT: u128 = 30;
 
     let mut env = V16Svm::new(
         seed,
@@ -22571,7 +22572,7 @@ pub fn verify_cpi_backing_fee_consent(
             initial_margin_bps: 1_000,
             max_price_move_bps_per_slot: 500,
             max_accrual_dt_slots: 1,
-            maintenance_fee_per_slot: 30,
+            maintenance_fee_per_slot: MAINTENANCE_FEE_PER_SLOT,
             actor_deposits: [
                 ATTACKER_DEPOSIT,
                 ATTACKER_DEPOSIT,
@@ -22668,6 +22669,19 @@ pub fn verify_cpi_backing_fee_consent(
         ));
     }
 
+    let attacker_before_maintenance = env.primary_portfolio(0).capital.get();
+    let attacker_fee_slot_before = env.primary_portfolio(0).last_fee_slot.get();
+    env.sync_maintenance_fee(0, 5)
+        .map_err(|error| format!("sync flat attacker maintenance fee: {error}"))?;
+    for actor in [0] {
+        crank_adapter_steps_with_observations(
+            &mut env,
+            actor,
+            5,
+            complete_lp_observations.clone(),
+            8,
+        )?;
+    }
     let lp_before = env.primary_portfolio(2).capital.get();
     let attacker_before = env.primary_portfolio(0).capital.get();
     let provider_before = env.primary_market_state().1.source_backing_buckets
@@ -22676,7 +22690,6 @@ pub fn verify_cpi_backing_fee_consent(
     let provider_destination_before = env.token_amount(env.actors[0].destination_token);
     let supply_before = env.token_supply_observed();
 
-    env.warp_to_slot(6);
     let before_rejection = tracked_economic_accounts(&env);
     let rejection = match env.trade_cpi(0, 2, 0, -INCREASE_Q, 0, 0) {
         Ok(_) => return Err("zero-cap matcher accepted an LP backing fee".into()),
@@ -22739,11 +22752,23 @@ pub fn verify_cpi_backing_fee_consent(
         .utilization_fee_earnings
         == earnings_before_reduction;
     let attacker_after = env.primary_portfolio(0).capital.get();
+    let attacker_fee_slot_after = env.primary_portfolio(0).last_fee_slot.get();
+    let attacker_maintenance_fee = u128::from(
+        attacker_fee_slot_after
+            .checked_sub(attacker_fee_slot_before)
+            .ok_or("attacker maintenance fee cursor moved backward")?,
+    )
+    .checked_mul(MAINTENANCE_FEE_PER_SLOT)
+    .ok_or("attacker maintenance fee overflow")?;
+    let expected_attacker_capital_delta = i128::try_from(attacker_maintenance_fee)
+        .map_err(|_| "attacker maintenance fee does not fit i128")?
+        .checked_neg()
+        .ok_or("attacker maintenance fee negation overflow")?;
     let attacker_capital_delta = i128::try_from(attacker_after)
-        .and_then(|after| i128::try_from(attacker_before).map(|before| after - before))
+        .and_then(|after| i128::try_from(attacker_before_maintenance).map(|before| after - before))
         .map_err(|_| "attacker capital does not fit i128")?;
     if !zero_cap_risk_reduction_landed
-        || attacker_capital_delta != -EXPECTED_ATTACKER_MAINTENANCE_FEE
+        || attacker_capital_delta != expected_attacker_capital_delta
         || observed_positions(&env.primary_portfolio(0))?[0] != 0
     {
         return Err(format!(
@@ -22793,6 +22818,7 @@ pub fn verify_cpi_backing_fee_consent(
         earnings_spl_vault_debit,
         earnings_accounted_vault_debit,
         attacker_capital_delta,
+        attacker_maintenance_fee,
         zero_cap_risk_reduction_landed,
         max_route_cu,
         token_supply_conserved,


### PR DESCRIPTION
## Impact

A flat portfolio could age a maintenance-fee liability while retaining its gross capital, then use that gross capital to pass initial margin on its first open. Once the deferred liability became current, public liquidation could consume pre-existing insurance.

The public LiteSVM trace uses production-like 5% IM/MM and authenticated AuthMark updates. Two attacker-controlled accounts deposit 2,200,000 atoms, the stale flat account opens 20,000,000 atoms of notional, and the coalition later withdraws 2,657,999 atoms while independent insurance falls from 1,000,000 to 542,000: a 457,999-atom extraction. No program-owned bytes are injected.

## Fix

Use the existing value-debit maintenance collector before all single and batch trade routes, including empty-to-nonempty first opens. Fee-net undercollateralized opens reject atomically; after adding the exact missing capital, the same first open lands within the CU limit and credits the debt to insurance. The obsolete flat-account exception is removed, reducing production source by 19 lines.

## TDD evidence

- Exact vulnerable base: `d5e2ec6fa727a1049a62851c3be19c638815b4e2`
- RED commit: `349e1801e0536d9105e6774c9197ef3a85401deb`
- RED SBF SHA-256: `230b6db1278dbff258c84f9a3df78c7d9decc6f8653fe06c46fa5ea9834afb20`
- Fixed commit: `1c52f510`
- Fixed SBF SHA-256: `0032c667d904341a4e648303049ef9c3adeb6f0a0be3937e0a6b16608e3e7099`
- Regression: `v16_attack_flat_fee_debt_cannot_back_first_open_or_spend_independent_insurance`
- Maximum 28-source maintenance sync: 569,464 CU
- Dependency-affected PR223 public and stateful tests pass against the fixed SBF; the adapted public test also passes against the exact parent SBF.

The full stateful inventory is still running. One observed failure is the pre-existing matcher-position-episode counterexample tracked by #412; it reproduces unchanged on the exact parent SBF.