### PR TITLE
[PRIVILEGED LoF] Bind matcher grants to asset generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ Authority fields are split by scope:
 - **`AssetOracleProfileV16.asset_admin`**: per-asset cold key that rotates that asset's scoped authorities
 - **`AssetOracleProfileV16.insurance_authority` / `insurance_operator` / `backing_bucket_authority` / `oracle_authority`**: per-asset operational authorities
 
-Matcher requests do not use a persisted market nonce. The wrapper invokes the matcher and requires the response to echo the request id, LP identity, asset index, oracle price, and requested size/sign constraints.
+Matcher requests do not encode a persisted market nonce. The LP's wrapper-owned capability record
+snapshots the engine's monotonic `next_market_id` frontier, while the wrapper requires each response
+to echo the request id, LP identity, asset index, oracle price, and requested size/sign constraints.
 
 ### Vault token account (market collateral)
 - SPL Token account holding collateral for this market
@@ -363,6 +365,12 @@ The signed instruction carries `portfolio_id` and `expected_sequence`. It succee
 current portfolio incarnation and current sequence, then increments the sequence exactly once.
 This prevents a retained enable from crossing a later revoke. Prior-layout portfolios with a
 portfolio ID but no sequence tail read sequence zero and grow atomically on their first mutation.
+The portfolio capability tail also snapshots the current engine `next_market_id` frontier. A grant
+authorizes only nonzero asset generations below that frontier. Existing generations remain usable
+when an unrelated asset is appended, while an appended, retired-slot replacement, or Recovery
+restart generation requires fresh LP consent without scanning portfolios. The LP can reauthorize
+the same matcher tuple after an asset-generation change; the delegate PDA and matcher context stay
+stable. Legacy capability records without the frontier tail fail closed until reauthorized.
 
 During `TradeCpi` / `BatchTradeCpi`, Percolator reads this LP-account config and requires the
 instruction's matcher program, matcher context, and matcher delegate PDA to match it byte-for-byte.

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -83,8 +83,15 @@ pub mod constants {
         PORTFOLIO_MATCHER_SEQUENCE_OFF + PORTFOLIO_MATCHER_SEQUENCE_LEN;
     pub const PORTFOLIO_MATCHER_EXPIRY_LEN: usize = 8;
     pub const PORTFOLIO_PRE_EXPIRY_ACCOUNT_LEN: usize = PORTFOLIO_MATCHER_EXPIRY_OFF;
-    pub const PORTFOLIO_ACCOUNT_LEN: usize =
+    pub const PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF: usize =
         PORTFOLIO_MATCHER_EXPIRY_OFF + PORTFOLIO_MATCHER_EXPIRY_LEN;
+    pub const PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_OFF: usize =
+        PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF + 1;
+    pub const PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_LEN: usize = 9;
+    pub const PORTFOLIO_PRE_MATCHER_ASSET_GENERATION_FRONTIER_ACCOUNT_LEN: usize =
+        PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF;
+    pub const PORTFOLIO_ACCOUNT_LEN: usize = PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF
+        + PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_LEN;
     pub const MAX_MATCHER_TAIL_ACCOUNTS: usize = 32;
     pub const MATCHER_ABI_VERSION: u32 = 3;
     pub const MATCHER_CONTEXT_MIN_LEN: usize = 64;
@@ -184,10 +191,14 @@ pub mod state {
             ORACLE_MODE_AUTH_MARK, ORACLE_MODE_EWMA_MARK, ORACLE_MODE_HYBRID_AFTER_HOURS,
             ORACLE_MODE_MANUAL, PORTFOLIO_ACCOUNT_LEN, PORTFOLIO_ENGINE_ACCOUNT_LEN,
             PORTFOLIO_ID_LEN, PORTFOLIO_ID_OFF, PORTFOLIO_LEGACY_ACCOUNT_LEN,
-            PORTFOLIO_MATCHER_CONFIG_LEN, PORTFOLIO_MATCHER_CONFIG_OFF,
-            PORTFOLIO_MATCHER_CONTROL_OFF, PORTFOLIO_MATCHER_EXPIRY_LEN,
-            PORTFOLIO_MATCHER_EXPIRY_OFF, PORTFOLIO_MATCHER_SEQUENCE_LEN,
-            PORTFOLIO_MATCHER_SEQUENCE_OFF, PORTFOLIO_PRE_EXPIRY_ACCOUNT_LEN, PORTFOLIO_STATE_LEN,
+            PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_LEN,
+            PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_OFF,
+            PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF, PORTFOLIO_MATCHER_CONFIG_LEN,
+            PORTFOLIO_MATCHER_CONFIG_OFF, PORTFOLIO_MATCHER_CONTROL_OFF,
+            PORTFOLIO_MATCHER_EXPIRY_LEN, PORTFOLIO_MATCHER_EXPIRY_OFF,
+            PORTFOLIO_MATCHER_SEQUENCE_LEN, PORTFOLIO_MATCHER_SEQUENCE_OFF,
+            PORTFOLIO_PRE_EXPIRY_ACCOUNT_LEN,
+            PORTFOLIO_PRE_MATCHER_ASSET_GENERATION_FRONTIER_ACCOUNT_LEN, PORTFOLIO_STATE_LEN,
             VERSION, WRAPPER_CONFIG_LEN,
         },
         error::PercolatorError,
@@ -1042,6 +1053,49 @@ pub mod state {
     }
 
     #[inline]
+    pub fn read_portfolio_matcher_asset_generation_frontier(
+        data: &[u8],
+    ) -> Result<Option<u64>, ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        if data.len() <= PORTFOLIO_PRE_MATCHER_ASSET_GENERATION_FRONTIER_ACCOUNT_LEN {
+            return Ok(None);
+        }
+        match data[PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF] {
+            0 => Ok(None),
+            1 => Ok(Some(read_u64(
+                data,
+                PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_OFF,
+            )?)),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn write_portfolio_matcher_asset_generation_frontier(
+        data: &mut [u8],
+        frontier: Option<u64>,
+    ) -> Result<(), ProgramError> {
+        check_header(data, KIND_PORTFOLIO)?;
+        data.get_mut(
+            PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF
+                ..PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF
+                    + PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_LEN,
+        )
+        .ok_or(PercolatorError::InvalidAccountLen)?
+        .fill(0);
+        if let Some(frontier) = frontier {
+            data[PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_VALID_OFF] = 1;
+            data.get_mut(
+                PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_OFF
+                    ..PORTFOLIO_MATCHER_ASSET_GENERATION_FRONTIER_OFF + 8,
+            )
+            .ok_or(PercolatorError::InvalidAccountLen)?
+            .copy_from_slice(&frontier.to_le_bytes());
+        }
+        Ok(())
+    }
+
+    #[inline]
     pub fn matcher_capability_is_live(expiry_slot: u64, current_slot: u64) -> bool {
         expiry_slot != 0 && current_slot < expiry_slot
     }
@@ -1843,6 +1897,22 @@ pub mod state {
             engine_config.max_market_slots as usize,
             header.asset_slot_capacity.get() as usize,
         ))
+    }
+
+    #[inline]
+    pub fn read_asset_generation_frontier(data: &[u8]) -> Result<u64, ProgramError> {
+        check_header(data, KIND_MARKET)?;
+        validate_market_dynamic_len(data)?;
+        Ok(market_header(data)?.next_market_id.get())
+    }
+
+    #[inline]
+    pub fn matcher_asset_generation_frontier_authorizes(
+        authorized_frontier: Option<u64>,
+        current_market_id: u64,
+    ) -> bool {
+        current_market_id != 0
+            && authorized_frontier.is_some_and(|frontier| current_market_id < frontier)
     }
 
     pub fn read_asset_lifecycle_generation_preflight(
@@ -9104,12 +9174,15 @@ pub mod processor {
         matcher_prog_key: &Pubkey,
         matcher_ctx_key: &Pubkey,
         matcher_delegate_key: &Pubkey,
-    ) -> Result<(usize, u16), ProgramError> {
+    ) -> Result<(usize, u16, u64), ProgramError> {
         let account_b_data = account_b_ai.try_borrow_data()?;
         if state::read_portfolio_matcher_sequence(&account_b_data)? != expected_matcher_sequence {
             return Err(PercolatorError::EngineStale.into());
         }
         let cfg = state::read_portfolio_matcher_config(&account_b_data)?;
+        let asset_generation_frontier =
+            state::read_portfolio_matcher_asset_generation_frontier(&account_b_data)?
+                .ok_or(PercolatorError::Unauthorized)?;
         if !cfg.authorizes_matcher_tuple(
             &matcher_prog_key.to_bytes(),
             &matcher_ctx_key.to_bytes(),
@@ -9121,7 +9194,7 @@ pub mod processor {
         if !state::matcher_capability_is_live(expiry_slot, Clock::get()?.slot) {
             return Err(PercolatorError::Unauthorized.into());
         }
-        Ok((7, cfg.trade_fee_cap_bps()))
+        Ok((7, cfg.trade_fee_cap_bps(), asset_generation_frontier))
     }
 
     fn validate_matcher_tail<'a>(
@@ -9267,13 +9340,20 @@ pub mod processor {
             matcher_ctx.key,
         );
         expect_key(matcher_delegate, &delegate)?;
-        let (tail_start, lp_trade_fee_cap_bps) = matcher_tail_start_or_verify_lp_config(
-            account_b_ai,
-            account_b_matcher_sequence,
-            matcher_prog.key,
-            matcher_ctx.key,
-            matcher_delegate.key,
-        )?;
+        let (tail_start, lp_trade_fee_cap_bps, matcher_asset_generation_frontier) =
+            matcher_tail_start_or_verify_lp_config(
+                account_b_ai,
+                account_b_matcher_sequence,
+                matcher_prog.key,
+                matcher_ctx.key,
+                matcher_delegate.key,
+            )?;
+        if !state::matcher_asset_generation_frontier_authorizes(
+            Some(matcher_asset_generation_frontier),
+            market_id,
+        ) {
+            return Err(PercolatorError::Unauthorized.into());
+        }
         if cfg_pre.trade_fee_base_bps > u64::from(lp_trade_fee_cap_bps) {
             return Err(PercolatorError::InvalidInstruction.into());
         }
@@ -9439,6 +9519,8 @@ pub mod processor {
             return Err(PercolatorError::EngineStale.into());
         }
         state::next_portfolio_matcher_sequence(current_sequence, expected_sequence)?;
+        let matcher_asset_generation_frontier =
+            state::read_asset_generation_frontier(&market_ai.try_borrow_data()?)?;
         ensure_portfolio_storage_for_market_slots(lp_portfolio_ai, 0)?;
         let prior_control =
             state::read_portfolio_matcher_config(&lp_portfolio_ai.try_borrow_data()?)?.control;
@@ -9480,6 +9562,10 @@ pub mod processor {
         let mut data = lp_portfolio_ai.try_borrow_mut_data()?;
         state::write_portfolio_matcher_config(&mut data, &cfg)?;
         state::write_portfolio_matcher_expiry(&mut data, expiry_slot)?;
+        state::write_portfolio_matcher_asset_generation_frontier(
+            &mut data,
+            (enabled != 0).then_some(matcher_asset_generation_frontier),
+        )?;
         state::advance_portfolio_matcher_sequence(&mut data, expected_sequence)?;
         Ok(())
     }
@@ -9612,6 +9698,7 @@ pub mod processor {
             backing_fee_policy_active,
             fee_bounds_ok,
             cpi_fee_bps,
+            market_ids,
         ) = {
             let market_data = market_ai.try_borrow_data()?;
             let (
@@ -9657,6 +9744,7 @@ pub mod processor {
                 cfg_pre.backing_trade_fee_policy_count != 0,
                 fee_bounds_ok,
                 cfg_pre.trade_fee_base_bps,
+                market_ids,
             )
         };
         if mode_pre != MarketModeV16::Live {
@@ -9699,13 +9787,22 @@ pub mod processor {
             matcher_ctx.key,
         );
         expect_key(matcher_delegate, &delegate)?;
-        let (tail_start, lp_trade_fee_cap_bps) = matcher_tail_start_or_verify_lp_config(
-            account_b_ai,
-            account_b_matcher_sequence,
-            matcher_prog.key,
-            matcher_ctx.key,
-            matcher_delegate.key,
-        )?;
+        let (tail_start, lp_trade_fee_cap_bps, matcher_asset_generation_frontier) =
+            matcher_tail_start_or_verify_lp_config(
+                account_b_ai,
+                account_b_matcher_sequence,
+                matcher_prog.key,
+                matcher_ctx.key,
+                matcher_delegate.key,
+            )?;
+        if market_ids.iter().any(|market_id| {
+            !state::matcher_asset_generation_frontier_authorizes(
+                Some(matcher_asset_generation_frontier),
+                *market_id,
+            )
+        }) {
+            return Err(PercolatorError::Unauthorized.into());
+        }
         if cpi_fee_bps > u64::from(lp_trade_fee_cap_bps) {
             return Err(PercolatorError::InvalidInstruction.into());
         }
@@ -16198,6 +16295,46 @@ pub mod processor {
         }
 
         #[test]
+        fn pre_asset_generation_frontier_portfolio_tail_fails_closed_and_roundtrips_full_width() {
+            let mut data = vec![0u8; constants::PORTFOLIO_ACCOUNT_LEN];
+            state::init_portfolio_account_zero_copy(
+                &mut data, [1u8; 32], [2u8; 32], [3u8; 32], 0, 1, 7,
+            )
+            .expect("initialize portfolio");
+            assert_eq!(
+                state::read_portfolio_matcher_asset_generation_frontier(&data).unwrap(),
+                None
+            );
+
+            for frontier in [0, 1, u64::MAX] {
+                state::write_portfolio_matcher_asset_generation_frontier(&mut data, Some(frontier))
+                    .unwrap();
+                assert_eq!(
+                    state::read_portfolio_matcher_asset_generation_frontier(&data).unwrap(),
+                    Some(frontier)
+                );
+            }
+            state::write_portfolio_matcher_asset_generation_frontier(&mut data, None).unwrap();
+            assert_eq!(
+                state::read_portfolio_matcher_asset_generation_frontier(&data).unwrap(),
+                None
+            );
+
+            data.truncate(constants::PORTFOLIO_PRE_MATCHER_ASSET_GENERATION_FRONTIER_ACCOUNT_LEN);
+            assert_eq!(
+                state::read_portfolio_matcher_asset_generation_frontier(&data).unwrap(),
+                None,
+                "a legacy enabled grant must not imply current-generation consent"
+            );
+            data.resize(constants::PORTFOLIO_ACCOUNT_LEN, 0);
+            assert_eq!(
+                state::read_portfolio_matcher_asset_generation_frontier(&data).unwrap(),
+                None,
+                "zero-initialized migration bytes must remain fail-closed"
+            );
+        }
+
+        #[test]
         fn portfolio_position_epoch_is_zero_initialized_checked_and_monotonic() {
             let mut data = vec![
                 0u8;
@@ -16211,7 +16348,7 @@ pub mod processor {
             assert_eq!(
                 data.len(),
                 constants::PORTFOLIO_ACCOUNT_LEN,
-                "the wrapper tail contains matcher config, portfolio ID, sequence, and expiry"
+                "the wrapper tail contains matcher config, portfolio ID, sequence, expiry, and asset-generation consent"
             );
             assert_eq!(state::read_portfolio_matcher_sequence(&data).unwrap(), 0);
             assert_eq!(state::read_portfolio_matcher_expiry(&data).unwrap(), 0);

--- a/tests/invariants/README.md
+++ b/tests/invariants/README.md
@@ -10032,6 +10032,19 @@ proves the exact enabled/fee/expiry predicate, decoder Kani preserves the new fi
 account length reads expiry as disabled and grows zero-initialized, and the measured config/CPI
 routes remain below their CU limits.
 
+INV-002/012 now also bind each retained LP matcher grant to the asset generations that existed when
+the LP consented. A public two-asset LiteSVM trace showed that a hostile asset administrator could
+retire an empty slot, reactivate it under a replacement generation, and use the LP's still-enabled
+old matcher grant to transfer 250,000 quote atoms from that independent LP. `SetMatcherConfig` now
+snapshots the engine's monotonic `next_market_id` frontier in a nine-byte wrapper-owned portfolio
+tail, and both CPI trade routes require every current nonzero asset generation to fall below it
+before matcher invocation. This preserves grants on unrelated existing assets while appended,
+retired-slot replacement, and Recovery-restart generations require fresh consent. The delegate PDA
+and external matcher context remain stable, so the LP can restore liquidity with one fresh
+authorization. Legacy grants without the tail fail closed. The regression covers stale single and
+batch CPI rollback, the independent-victim balance transfer on the exact parent, same-tuple
+reauthorization, replacement/restart-generation liveness, and full-width frontier binding.
+
 INV-037 is reconciled to the exact deployed `CloseProgressLedgerV16` rather than growing a wrapper
 mirror for an abstract category. Its exhaustive engine struct literal and pinned engine proof own
 `gross + drift = support + insurance + B + explicit + residual`; public continuation, cure,

--- a/tests/invariants/cu/inv_012_capability_and_delegate_scope.rs
+++ b/tests/invariants/cu/inv_012_capability_and_delegate_scope.rs
@@ -1966,3 +1966,118 @@ fn v16_bpf_tradecpi_permissionless_lp_fill_does_not_need_lp_owner_signature() {
         (10 * POS_SCALE) as i128
     );
 }
+
+#[test]
+fn v16_program_asset_slot_reuse_rejects_stale_lp_matcher_capability() {
+    const ASSET: u16 = 1;
+    const RETIRE_SLOT: u64 = 3;
+    const REUSE_SLOT: u64 = 5;
+    const MOVE_SLOT: u64 = 6;
+    const OPEN_PRICE: u64 = 100;
+    const CLOSE_PRICE: u64 = 105;
+    const DEPOSIT: u128 = 1_000_000;
+    const SIZE_Q: i128 = 50_000 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    let attacker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let attacker = env.create_portfolio(&attacker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&attacker_owner, attacker, DEPOSIT);
+    env.deposit(&lp_owner, lp, DEPOSIT);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp);
+    let old_market_id = env.asset_market_id(ASSET);
+    assert_eq!(env.portfolio_matcher_config(lp).enabled(), 1);
+
+    env.svm.warp_to_slot(RETIRE_SLOT);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        processor::ASSET_ACTION_RETIRE,
+        ASSET,
+        RETIRE_SLOT,
+        0,
+    );
+    env.svm.warp_to_slot(REUSE_SLOT);
+    env.activate_asset(ASSET, REUSE_SLOT, OPEN_PRICE);
+    env.configure_auth_mark_for_asset_as_admin(ASSET, REUSE_SLOT, OPEN_PRICE);
+    assert_ne!(env.asset_market_id(ASSET), old_market_id);
+    assert_eq!(
+        env.portfolio_matcher_config(lp).enabled(),
+        1,
+        "retiring an unrelated empty slot cannot scan and mutate every portfolio"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let attacker_before = env.svm.get_account(&attacker).unwrap();
+    let lp_before = env.svm.get_account(&lp).unwrap();
+    let matcher_before = env.svm.get_account(&matcher_context).unwrap();
+    env.svm.expire_blockhash();
+    let stale_open = env.try_trade_cpi_with_cu_on_asset(
+        &attacker_owner,
+        attacker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        ASSET,
+        SIZE_Q,
+        0,
+    );
+    if stale_open.is_err() {
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&attacker).unwrap(), attacker_before);
+        assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before);
+        assert_eq!(
+            env.svm.get_account(&matcher_context).unwrap(),
+            matcher_before
+        );
+        return;
+    }
+
+    env.svm.warp_to_slot(MOVE_SLOT);
+    env.push_auth_mark_for_asset_as_admin(ASSET, MOVE_SLOT, CLOSE_PRICE);
+    for portfolio in [lp, attacker] {
+        env.crank(
+            portfolio,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: MOVE_SLOT,
+                observations: crank_observations(ASSET),
+            },
+        );
+    }
+    env.trade_cpi_with_cu_on_asset(
+        &attacker_owner,
+        attacker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        ASSET,
+        -SIZE_Q,
+        0,
+    );
+    let released_pnl = env.portfolio_state(attacker).pnl.get();
+    assert!(
+        released_pnl > 0,
+        "replacement-asset trade must earn attacker PnL"
+    );
+    env.convert_released_pnl_with_cu(&attacker_owner, attacker, released_pnl as u128);
+    let attacker_capital = env.portfolio_state(attacker).capital.get();
+    let lp_capital = env.portfolio_state(lp).capital.get();
+    let (attacker_destination, _) =
+        env.withdraw_with_cu(&attacker_owner, attacker, attacker_capital);
+    assert_eq!(
+        env.token_amount(attacker_destination),
+        attacker_capital as u64
+    );
+    eprintln!(
+        "stale matcher asset-generation exploit: generation {old_market_id} -> {}, attacker {DEPOSIT} -> {attacker_capital}, LP {DEPOSIT} -> {lp_capital}",
+        env.asset_market_id(ASSET),
+    );
+    assert!(
+        attacker_capital <= DEPOSIT && lp_capital >= DEPOSIT,
+        "an old LP matcher grant must not transfer value on a replacement asset"
+    );
+}

--- a/tests/invariants/cu/inv_012_capability_and_delegate_scope.rs
+++ b/tests/invariants/cu/inv_012_capability_and_delegate_scope.rs
@@ -16,8 +16,11 @@
 //!
 //! INV-016 exhausts the complete delegate PDA seed tuple. INV-002/003/004 independently compose
 //! asset generation, portfolio incarnation, and position episode checks around both CPI routes.
-//! The capability authorizes only CPI trade matching, so a separate operation set is structurally
-//! inapplicable; per-leg asset scope is carried by the generation-bound trade request.
+//! The capability authorizes only CPI trade matching. Its wrapper-owned portfolio tail snapshots
+//! the engine's monotonic next-asset-generation frontier. Existing generations remain authorized,
+//! while appending, reactivating, or restarting an asset creates a generation outside that frontier
+//! and requires fresh LP authorization without changing the external matcher PDA. Each CPI leg
+//! additionally carries the current asset generation.
 //!
 //! Both retained CPI routes bind the persisted matcher-config incarnation and an authenticated,
 //! owner-selected expiry. Expiry is strict (`current_slot < expiry_slot`), uses the Clock sysvar,
@@ -91,6 +94,8 @@ fn v16_program_matcher_capability_route_roster_binds_every_current_scope() {
             "{route} must bind both portfolio incarnations and position episodes"
         );
         assert!(body.contains("derive_matcher_delegate("));
+        assert!(body.contains("matcher_asset_generation_frontier"));
+        assert!(body.contains("matcher_asset_generation_frontier_authorizes("));
         assert!(body.contains("matcher_tail_start_or_verify_lp_config("));
         assert!(body.contains("account_b_matcher_sequence,"));
         assert!(body.contains("account_a_header.portfolio_account_id"));
@@ -102,6 +107,8 @@ fn v16_program_matcher_capability_route_roster_binds_every_current_scope() {
     assert!(config.contains("portfolio_id != current_portfolio_id"));
     assert!(config.contains("expected_sequence != current_sequence"));
     assert!(config.contains("derive_matcher_delegate("));
+    assert!(config.contains("read_asset_generation_frontier("));
+    assert!(config.contains("write_portfolio_matcher_asset_generation_frontier("));
     assert!(config.contains("Clock::get()?.slot"));
     assert!(config.contains("matcher_capability_config_is_valid("));
     assert!(config.contains("write_portfolio_matcher_expiry(&mut data, expiry_slot)"));
@@ -109,11 +116,15 @@ fn v16_program_matcher_capability_route_roster_binds_every_current_scope() {
     assert!(matcher_guard.contains("!= expected_matcher_sequence"));
     assert!(matcher_guard.contains("PercolatorError::EngineStale"));
     assert!(matcher_guard.contains("read_portfolio_matcher_config(&account_b_data)?"));
+    assert!(matcher_guard.contains("read_portfolio_matcher_asset_generation_frontier"));
     assert!(matcher_guard.contains("read_portfolio_matcher_expiry(&account_b_data)?"));
     assert!(matcher_guard.contains("matcher_capability_is_live(expiry_slot, Clock::get()?.slot)"));
 
     let expiry_proof = include_str!("../kani/inv_012_capability_and_delegate_scope.rs");
     assert!(expiry_proof.contains("fn kani_v16_matcher_capability_config_is_exact_at_full_width("));
+    assert!(expiry_proof.contains(
+        "fn kani_v16_matcher_asset_generation_frontier_requires_prior_generation_consent("
+    ));
     assert!(include_str!("inv_012_capability_and_delegate_scope.rs")
         .contains("fn v16_program_matcher_capability_expiry_is_clock_bound_on_both_cpi_routes("));
 
@@ -2032,6 +2043,76 @@ fn v16_program_asset_slot_reuse_rejects_stale_lp_matcher_capability() {
             env.svm.get_account(&matcher_context).unwrap(),
             matcher_before
         );
+        env.svm.expire_blockhash();
+        let replacement_market_id = env.asset_market_id(ASSET);
+        let stale_batch = env.send(
+            env.batch_trade_cpi_ix(
+                attacker,
+                lp,
+                vec![
+                    BatchTradeCpiLeg {
+                        asset_index: 0,
+                        market_id: env.asset_market_id(0),
+                        size_q: POS_SCALE as i128,
+                        fee_bps: 0,
+                        limit_price: 0,
+                    },
+                    BatchTradeCpiLeg {
+                        asset_index: ASSET,
+                        market_id: replacement_market_id,
+                        size_q: SIZE_Q,
+                        fee_bps: 0,
+                        limit_price: 0,
+                    },
+                ],
+            ),
+            vec![
+                AccountMeta::new(attacker_owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(attacker, false),
+                AccountMeta::new(lp, false),
+                AccountMeta::new_readonly(matcher_program, false),
+                AccountMeta::new(matcher_context, false),
+                AccountMeta::new_readonly(matcher_delegate, false),
+            ],
+            &[&attacker_owner],
+        );
+        assert!(
+            stale_batch.is_err(),
+            "BatchTradeCpi must reject the same stale asset-set capability"
+        );
+        assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+        assert_eq!(env.svm.get_account(&attacker).unwrap(), attacker_before);
+        assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before);
+        assert_eq!(
+            env.svm.get_account(&matcher_context).unwrap(),
+            matcher_before
+        );
+        env.set_matcher_config(
+            matcher_program,
+            &lp_owner,
+            lp,
+            matcher_context,
+            matcher_delegate,
+            1,
+        );
+        env.trade_cpi_with_cu_on_asset(
+            &attacker_owner,
+            attacker,
+            &lp_owner,
+            lp,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            ASSET,
+            SIZE_Q,
+            0,
+        );
+        assert_eq!(
+            active_leg_for_asset(&env.portfolio_state(lp), ASSET as usize).market_id,
+            env.asset_market_id(ASSET),
+            "a fresh post-reuse LP grant must retain normal matcher liveness"
+        );
         return;
     }
 
@@ -2079,5 +2160,165 @@ fn v16_program_asset_slot_reuse_rejects_stale_lp_matcher_capability() {
     assert!(
         attacker_capital <= DEPOSIT && lp_capital >= DEPOSIT,
         "an old LP matcher grant must not transfer value on a replacement asset"
+    );
+}
+
+#[test]
+fn v16_program_recovery_restart_rejects_stale_lp_matcher_capability() {
+    const ASSET: u16 = 1;
+    const SHUTDOWN_SLOT: u64 = 3;
+    const RESTART_SLOT: u64 = 4;
+    const PRICE: u64 = 100;
+    const SIZE_Q: i128 = 10 * POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_market_params_and_price_move(2, 1_000, 1_000, 500);
+    env.configure_permissionless_resolve_with_cu(20, 2);
+    let taker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&taker_owner, taker, 1_000_000);
+    env.deposit(&lp_owner, lp, 1_000_000);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp);
+    let old_market_id = env.asset_market_id(ASSET);
+
+    env.svm.warp_to_slot(SHUTDOWN_SLOT);
+    env.update_asset_lifecycle_as_admin_with_cu(
+        processor::ASSET_ACTION_SHUTDOWN,
+        ASSET,
+        SHUTDOWN_SLOT,
+        0,
+    );
+    env.svm.warp_to_slot(RESTART_SLOT);
+    let asset_admin = env.admin.insecure_clone();
+    env.try_restart_asset_oracle_with_authority(&asset_admin, ASSET, RESTART_SLOT, PRICE)
+        .expect("empty Recovery asset restarts");
+    assert_ne!(env.asset_market_id(ASSET), old_market_id);
+    assert_eq!(
+        env.portfolio_matcher_config(lp).enabled(),
+        1,
+        "generation changes cannot scan every portfolio"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let taker_before = env.svm.get_account(&taker).unwrap();
+    let lp_before = env.svm.get_account(&lp).unwrap();
+    let matcher_before = env.svm.get_account(&matcher_context).unwrap();
+    env.svm.expire_blockhash();
+    assert!(
+        env.try_trade_cpi_with_cu_on_asset(
+            &taker_owner,
+            taker,
+            &lp_owner,
+            lp,
+            matcher_program,
+            matcher_context,
+            matcher_delegate,
+            ASSET,
+            SIZE_Q,
+            0,
+        )
+        .is_err(),
+        "an LP grant from the Recovery generation must not authorize its replacement"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&taker).unwrap(), taker_before);
+    assert_eq!(env.svm.get_account(&lp).unwrap(), lp_before);
+    assert_eq!(
+        env.svm.get_account(&matcher_context).unwrap(),
+        matcher_before
+    );
+
+    env.set_matcher_config(
+        matcher_program,
+        &lp_owner,
+        lp,
+        matcher_context,
+        matcher_delegate,
+        1,
+    );
+    env.trade_cpi_with_cu_on_asset(
+        &taker_owner,
+        taker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        ASSET,
+        SIZE_Q,
+        0,
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(lp), ASSET as usize).market_id,
+        env.asset_market_id(ASSET),
+        "fresh LP consent restores matcher liveness on the restarted generation"
+    );
+}
+
+#[test]
+fn v16_program_unrelated_asset_append_preserves_existing_generation_matcher_liveness() {
+    const EXISTING_ASSET: u16 = 0;
+    const APPENDED_ASSET: u16 = 1;
+    const APPEND_SLOT: u64 = 1;
+
+    let mut env = V16CuEnv::new();
+    let taker_owner = Keypair::new();
+    let lp_owner = Keypair::new();
+    let taker = env.create_portfolio(&taker_owner);
+    let lp = env.create_portfolio(&lp_owner);
+    env.deposit(&taker_owner, taker, 1_000_000);
+    env.deposit(&lp_owner, lp, 1_000_000);
+    let (matcher_program, matcher_context, matcher_delegate) =
+        auth_matcher_for_lp_via_system_create(&mut env, &lp_owner, lp);
+    let authorized_market_id = env.asset_market_id(EXISTING_ASSET);
+    let authorized_frontier = state::read_portfolio_matcher_asset_generation_frontier(
+        &env.svm.get_account(&lp).unwrap().data,
+    )
+    .unwrap()
+    .expect("enabled matcher grant stores an asset-generation frontier");
+    assert_eq!(
+        authorized_frontier,
+        state::read_asset_generation_frontier(&env.svm.get_account(&env.market).unwrap().data)
+            .unwrap(),
+        "SetMatcherConfig snapshots the current engine frontier"
+    );
+
+    env.update_market_init_fee_policy_with_cu(1);
+    let creator = Keypair::new();
+    env.svm.warp_to_slot(APPEND_SLOT);
+    env.activate_permissionless_asset_with_fee(
+        &creator,
+        APPENDED_ASSET,
+        APPEND_SLOT,
+        100,
+        creator.pubkey(),
+        creator.pubkey(),
+        creator.pubkey(),
+        creator.pubkey(),
+        1,
+    );
+    assert!(
+        env.asset_market_id(APPENDED_ASSET) >= authorized_frontier,
+        "the appended generation must fall outside the earlier LP grant"
+    );
+
+    env.trade_cpi_with_cu_on_asset(
+        &taker_owner,
+        taker,
+        &lp_owner,
+        lp,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        EXISTING_ASSET,
+        10 * POS_SCALE as i128,
+        0,
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(lp), EXISTING_ASSET as usize).market_id,
+        authorized_market_id,
+        "a later unrelated generation must not revoke consent for an existing generation"
     );
 }

--- a/tests/invariants/cu/inv_019_cpi_invocation_and_return_data_binding.rs
+++ b/tests/invariants/cu/inv_019_cpi_invocation_and_return_data_binding.rs
@@ -100,6 +100,7 @@ fn v16_program_matcher_cpi_identity_incarnation_census_is_source_complete() {
             "matcher_ctx.owner != matcher_prog.key",
             "derive_matcher_delegate(",
             "expect_key(matcher_delegate, &delegate)?",
+            "matcher_asset_generation_frontier_authorizes",
             "matcher_tail_start_or_verify_lp_config(",
             "state::bump_matcher_req_seq",
             "validate_matcher_tail(",
@@ -112,6 +113,8 @@ fn v16_program_matcher_cpi_identity_incarnation_census_is_source_complete() {
 
     // The delegate has no mutable account state or incarnation. Its complete seed tuple binds the
     // wrapper deployment, market address, LP portfolio and owner, matcher program, and context.
+    // The asset-generation frontier is deliberately stored in the LP grant, not the external
+    // matcher PDA.
     for seed in [
         "b\"matcher\"",
         "market_key.as_ref()",

--- a/tests/invariants/cu/inv_055_state_indexed_admission.rs
+++ b/tests/invariants/cu/inv_055_state_indexed_admission.rs
@@ -591,6 +591,17 @@ fn v16_program_retired_slot_reactivation_restores_fresh_generation_trade_admissi
             AssetLifecycleV16::Active
         );
 
+        if matches!(route, "TradeCpi" | "BatchTradeCpi") {
+            env.set_matcher_config(
+                matcher_program,
+                &lp_owner,
+                lp,
+                matcher_context,
+                matcher_delegate,
+                1,
+            );
+        }
+
         env.svm.expire_blockhash();
         let open_cu = execute(&mut env).expect("fresh generation must restore trade admission");
         assert_cu_within(

--- a/tests/invariants/cu/inv_087_no_phantom_controls_or_dead_security_fields.rs
+++ b/tests/invariants/cu/inv_087_no_phantom_controls_or_dead_security_fields.rs
@@ -709,6 +709,9 @@ fn v16_program_all_wrapper_owned_persisted_structs_have_complete_field_rosters()
             "matcher_program: matcher_prog.key.to_bytes()",
             "matcher_context: matcher_ctx.key.to_bytes()",
             "matcher_delegate: matcher_delegate.key.to_bytes()",
+            "read_portfolio_matcher_asset_generation_frontier",
+            "write_portfolio_matcher_asset_generation_frontier",
+            "matcher_asset_generation_frontier_authorizes",
             "next_portfolio_position_control_for_matcher_sync",
         ],
     );

--- a/tests/invariants/kani/inv_012_capability_and_delegate_scope.rs
+++ b/tests/invariants/kani/inv_012_capability_and_delegate_scope.rs
@@ -42,3 +42,26 @@ fn kani_v16_matcher_capability_config_is_exact_at_full_width() {
     );
     kani::cover!(enabled > 1, "non-boolean enabled values reject");
 }
+
+#[kani::proof]
+fn kani_v16_matcher_asset_generation_frontier_requires_prior_generation_consent() {
+    let has_authorization: bool = kani::any();
+    let authorized_frontier: u64 = kani::any();
+    let current_market_id: u64 = kani::any();
+    let stored = has_authorization.then_some(authorized_frontier);
+
+    assert_eq!(
+        state::matcher_asset_generation_frontier_authorizes(stored, current_market_id),
+        has_authorization && current_market_id != 0 && current_market_id < authorized_frontier
+    );
+    kani::cover!(!has_authorization, "legacy or disabled grants reject");
+    kani::cover!(
+        has_authorization && current_market_id != 0 && current_market_id >= authorized_frontier,
+        "asset generations created after authorization reject"
+    );
+    kani::cover!(
+        has_authorization && current_market_id != 0 && current_market_id < authorized_frontier,
+        "generations existing at authorization remain usable"
+    );
+    kani::cover!(current_market_id == 0, "the disabled generation rejects");
+}

--- a/tests/support/invariant_discovery.rs
+++ b/tests/support/invariant_discovery.rs
@@ -7104,6 +7104,7 @@ fn discover_one_asset_generation_replay(
         return discover_backing_earnings_generation_replay(seed);
     }
     const ASSET: u16 = 1;
+    const COUNTERPARTY: usize = 1;
     const AUTHORITY_ACTOR: usize = 2;
     const ACTIVATION_PAYER: usize = 3;
     seed[0] ^= 0xc9;
@@ -7233,6 +7234,14 @@ fn discover_one_asset_generation_replay(
                 return Err(format!(
                     "{kind:?} stale asset transaction rejected for the wrong reason: expected {expected}, got {error}"
                 ));
+            }
+
+            if matches!(
+                kind,
+                AssetIntentKind::TradeCpi | AssetIntentKind::BatchTradeCpi
+            ) {
+                env.set_matcher_config(COUNTERPARTY, 1)
+                    .map_err(|error| format!("refresh replacement-asset matcher grant: {error}"))?;
             }
 
             let fresh =


### PR DESCRIPTION
## Classification

Privileged LoF. A malicious or compromised asset administrator can replace an empty asset generation and reuse an independent LP matcher grant that was authorized only before that replacement. No dishonest oracle signature or program-owned byte injection is used.

## Exact RED

- Exact main base: `d5e2ec6fa727a1049a62851c3be19c638815b4e2`
- RED commit: `9000e192`
- Public LiteSVM trace: two funded portfolios, LP authorizes an authenticated matcher, admin retires and reactivates asset 1, attacker opens through the stale unsigned LP grant, authenticated mark moves from 100 to 105, attacker closes and converts PnL.
- Parent result: attacker capital `1,000,000 -> 1,250,000`; independent LP capital `1,000,000 -> 750,000`.

## Fix

`SetMatcherConfig` snapshots the engine monotonic `next_market_id` frontier in a zero-copy portfolio tail. `TradeCpi` and `BatchTradeCpi` accept only nonzero asset generations below that frontier before invoking the matcher. Appended, retired-slot replacement, and Recovery-restart generations therefore require fresh LP consent. Existing generations remain usable after unrelated permissionless appends, and the stable matcher PDA/external ABI is unchanged. Legacy grants without the new tail fail closed.

## Verification

- INV-012 focused LiteSVM suite: 20 tests green after correcting the restart harness setup; stale single, mixed old/new batch, exact rollback, fresh reauthorization, restart, and unrelated-append liveness covered.
- Stateful INV-002 replay fuzz and full asset-operation matrix green; no discoveries.
- Full-width Kani frontier predicate: 0/8 failed, 4/4 covers satisfied.
- 14-leg BatchTradeCpi: 876,223 CU.
- 10 MiB market plus matcher tail: 881,877 CU.
- INV-019 identity census, INV-055 fresh-generation admission, INV-087 persisted-field roster, and 9/9 library tests green.
- All test targets compile when including the pre-existing `examples/dump_layout.rs` stale-field typo correction; that unrelated typo is intentionally excluded from this PR.