### PR TITLE
[BLOCKER LoF] Preserve resolved receipts across late backing expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=b96b6ba4cea51613080175d5a85150a3488f3af2#b96b6ba4cea51613080175d5a85150a3488f3af2"
+source = "git+https://github.com/aeyakovenko/percolator?rev=0bb6f93a3b95457110aca491f3ed5729606502e1#0bb6f93a3b95457110aca491f3ed5729606502e1"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=394fd0bf2cb7d73df425eb3754dc3be1a0c44336#394fd0bf2cb7d73df425eb3754dc3be1a0c44336"
+source = "git+https://github.com/aeyakovenko/percolator?rev=b96b6ba4cea51613080175d5a85150a3488f3af2#b96b6ba4cea51613080175d5a85150a3488f3af2"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b96b6ba4cea51613080175d5a85150a3488f3af2" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0bb6f93a3b95457110aca491f3ed5729606502e1" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b96b6ba4cea51613080175d5a85150a3488f3af2" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "0bb6f93a3b95457110aca491f3ed5729606502e1" }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "394fd0bf2cb7d73df425eb3754dc3be1a0c44336" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b96b6ba4cea51613080175d5a85150a3488f3af2" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "394fd0bf2cb7d73df425eb3754dc3be1a0c44336" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "b96b6ba4cea51613080175d5a85150a3488f3af2" }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -7230,7 +7230,7 @@ pub mod processor {
                 amount,
             ),
             Instruction::CloseResolved { fee_rate_per_slot } => {
-                handle_close_resolved(program_id, accounts, fee_rate_per_slot, None)
+                handle_close_resolved(program_id, accounts, fee_rate_per_slot, None, None)
             }
             Instruction::UpdateAuthority {
                 authority_epoch,
@@ -13458,6 +13458,7 @@ pub mod processor {
         accounts: &'a [AccountInfo<'a>],
         _fee_rate_per_slot: u128,
         auto_crank_now_slot: Option<u64>,
+        backing_asset_hint: Option<usize>,
     ) -> ProgramResult {
         let owner = account(accounts, 0)?;
         let market_ai = account(accounts, 1)?;
@@ -13491,16 +13492,26 @@ pub mod processor {
                 expect_signer(owner)?;
             }
             let insurance_before = group.header.insurance.get();
-            // CloseResolved is a compatibility alias for the sole public engine crank. Routing
-            // both tags through the selector keeps stale/out-of-order calls atomic: a waiting
-            // winner selects NoAction and returns EngineNonProgress instead of landing as a
-            // successful CU-burning no-op.
+            // CloseResolved is a compatibility alias for the sole public engine crank. A resolved
+            // PermissionlessCrank may additionally carry one discovery-only asset hint; the
+            // engine reads the actual backing status and expiry and either advances one bucket or
+            // returns NonProgress atomically.
+            let backing_observation =
+                backing_asset_hint.map(|asset_index| AutoCrankObservationV16 {
+                    asset_index,
+                    effective_price: 0,
+                    funding_rate_e9: 0,
+                });
+            let observations = match backing_observation.as_ref() {
+                Some(observation) => core::slice::from_ref(observation),
+                None => &[],
+            };
             let result = group
                 .permissionless_auto_crank_not_atomic(
                     &mut portfolio,
                     AutoCrankWorkV16 {
                         now_slot: authenticated_slot,
-                        observations: &[],
+                        observations,
                         resolved_close_fee_rate_per_slot: cfg.maintenance_fee_per_slot,
                     },
                 )
@@ -14171,7 +14182,26 @@ pub mod processor {
         let (_, mode, max_market_slots, _) =
             state::read_market_config_mode_and_capacity(&market_ai.try_borrow_data()?)?;
         if mode == MarketModeV16::Resolved {
-            return handle_close_resolved(program_id, accounts, 0, Some(now_slot));
+            if observation_hints.len() > 1 {
+                return Err(PercolatorError::InvalidInstruction.into());
+            }
+            let backing_asset_hint = match observation_hints.first() {
+                Some(hint)
+                    if hint.oracle_accounts == 0
+                        && usize::from(hint.asset_index) < max_market_slots =>
+                {
+                    Some(usize::from(hint.asset_index))
+                }
+                Some(_) => return Err(PercolatorError::InvalidInstruction.into()),
+                None => None,
+            };
+            return handle_close_resolved(
+                program_id,
+                accounts,
+                0,
+                Some(now_slot),
+                backing_asset_hint,
+            );
         }
         handle_permissionless_crank_zero_copy(
             program_id,

--- a/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
+++ b/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
@@ -15,7 +15,206 @@
 //! invariant roadmap.
 
 use super::*;
-use crate::support::v16_svm::PublicTerminalClassification;
+use crate::support::v16_svm::{
+    assert_closed_market_tombstone, MarketConfig, PublicTerminalClassification, V16Svm, TX_CU_LIMIT,
+};
+use percolator::{active_bitmap_is_empty, MarketModeV16, POS_SCALE};
+use percolator_prog::{constants::HEADER_LEN, ix::CrankObservationHint, state};
+
+fn inv067_resolved_portfolio_is_terminal(env: &V16Svm, actor: usize) -> bool {
+    let group = env.primary_market_state().1;
+    let account = env.primary_portfolio(actor);
+    let Ok(receipt) = account.resolved_payout_receipt.try_to_runtime() else {
+        return false;
+    };
+    let Ok(close) = account.close_progress.try_to_runtime() else {
+        return false;
+    };
+    group.mode == MarketModeV16::Resolved
+        && account.capital.get() == 0
+        && account.pnl.get() == 0
+        && account.reserved_pnl.get() == 0
+        && account.fee_credits.get() == 0
+        && account.cancel_deposit_escrow.get() == 0
+        && active_bitmap_is_empty(state::portfolio_active_bitmap(&account))
+        && account.stale_state == 0
+        && account.b_stale_state == 0
+        && account.rebalance_lock == 0
+        && account.liquidation_lock == 0
+        && account.last_fee_slot.get() == group.resolved_slot
+        && account.health_cert.valid == 0
+        && account
+            .source_domains
+            .iter()
+            .all(|source| !source.is_occupied())
+        && (!receipt.present || receipt.finalized)
+        && (!close.active || (close.finalized && close.residual_remaining == 0))
+}
+
+fn inv067_drain_resolved_actor(env: &mut V16Svm, actor: usize, max_cu: &mut u64) {
+    for step in 0..16 {
+        if inv067_resolved_portfolio_is_terminal(env, actor) {
+            return;
+        }
+        let before_market = env.market_data(false);
+        let before_portfolio = env.primary_portfolio_data(actor);
+        let success = env
+            .close_resolved_primary_signed(actor)
+            .unwrap_or_else(|error| panic!("resolved actor {actor} step {step}: {error}"));
+        assert!(
+            success.compute_units < TX_CU_LIMIT,
+            "resolved actor {actor} step {step} consumed {} CU",
+            success.compute_units
+        );
+        *max_cu = (*max_cu).max(success.compute_units);
+        assert!(
+            env.market_data(false) != before_market
+                || env.primary_portfolio_data(actor) != before_portfolio,
+            "resolved actor {actor} accepted a nonprogressing step {step}"
+        );
+    }
+    panic!("resolved actor {actor} did not terminate in 16 public steps");
+}
+
+/// INV-067: a haircut receipt is not terminal while unrelated fresh backing can later expire into
+/// the payout snapshot. This public trace deliberately leaves no second unreceipted claimant: an
+/// unsigned close first pays the current haircut, authenticated time then expires unrelated
+/// backing, and permissionless terminal calls must deliver that newly released value exactly once
+/// instead of deleting the receipt and burning the value during `CloseSlab`.
+#[test]
+fn v16_program_late_unrelated_backing_cannot_outlive_and_erase_resolved_receipt() {
+    const WINNER: usize = 0;
+    const LOSER: usize = 1;
+    const PROVIDER: usize = 2;
+    const CLAIM_ASSET: u16 = 0;
+    const UNRELATED_ASSET: u16 = 1;
+    const UNRELATED_DOMAIN: u16 = 3;
+    const INITIAL_PRICE: u64 = 100;
+    const FINAL_PRICE: u64 = 150;
+    const SIZE_Q: i128 = 20 * POS_SCALE as i128;
+    const UNRELATED_BACKING: u128 = 500;
+    const RESOLVE_SLOT: u64 = 12;
+    const EXPIRY_SLOT: u64 = 40;
+    const EXPECTED_WINNER_PAYOUT: u64 = 1_750;
+
+    let config = MarketConfig {
+        initial_price: INITIAL_PRICE,
+        maintenance_margin_bps: 1_000,
+        initial_margin_bps: 1_000,
+        max_price_move_bps_per_slot: 500,
+        max_accrual_dt_slots: 1,
+        min_funding_lifetime_slots: 1,
+        actor_deposits: [1_000, 250, 0, 0, 0],
+        ..MarketConfig::default()
+    };
+    let mut env = V16Svm::new([0x67; 32], config);
+    let mint_supply_before = env.mint_supply();
+    let mut max_cu = 0u64;
+
+    env.configure_permissionless_resolve(100, 1)
+        .expect("configure unsigned terminal progress");
+    env.update_asset_authority_from_admin(
+        UNRELATED_ASSET,
+        percolator_prog::processor::ASSET_AUTH_BACKING_BUCKET,
+        PROVIDER,
+    )
+    .expect("install unrelated backing provider");
+    env.top_up_backing_bucket_for_actor(PROVIDER, UNRELATED_DOMAIN, UNRELATED_BACKING, EXPIRY_SLOT)
+        .expect("fund unrelated future residual");
+    env.trade_no_cpi(WINNER, LOSER, CLAIM_ASSET, SIZE_Q, INITIAL_PRICE, 0)
+        .expect("open underfunded matched position");
+
+    for (offset, mark) in (105..=FINAL_PRICE).step_by(5).enumerate() {
+        let slot = 2 + u64::try_from(offset).expect("bounded mark sequence");
+        env.warp_to_slot(slot);
+        env.push_auth_mark(CLAIM_ASSET, slot, mark)
+            .unwrap_or_else(|error| panic!("publish mark {mark}: {error}"));
+        let oracle_accounts = env.primary_profile(CLAIM_ASSET as usize).oracle_leg_count;
+        for actor in [LOSER, WINNER] {
+            let success = env
+                .crank(
+                    actor,
+                    slot,
+                    vec![CrankObservationHint {
+                        asset_index: CLAIM_ASSET,
+                        oracle_accounts,
+                    }],
+                )
+                .unwrap_or_else(|error| panic!("refresh actor {actor} at mark {mark}: {error}"));
+            max_cu = max_cu.max(success.compute_units);
+        }
+    }
+    env.trade_no_cpi(WINNER, LOSER, CLAIM_ASSET, -SIZE_Q, FINAL_PRICE, 0)
+        .expect("flatten underfunded matched position");
+
+    env.warp_to_slot(RESOLVE_SLOT);
+    env.resolve_market().expect("resolve market");
+    for actor in [LOSER, PROVIDER, 3, 4] {
+        inv067_drain_resolved_actor(&mut env, actor, &mut max_cu);
+        max_cu = max_cu.max(
+            env.close_primary_portfolio(actor)
+                .unwrap_or_else(|error| panic!("close terminal actor {actor}: {error}"))
+                .compute_units,
+        );
+    }
+
+    env.warp_to_slot(RESOLVE_SLOT + 2);
+    let initial_close = env
+        .close_resolved_primary(WINNER)
+        .expect("unsigned winner close after configured delay");
+    max_cu = max_cu.max(initial_close.compute_units);
+    let pre_expiry_receipt = env
+        .primary_portfolio(WINNER)
+        .resolved_payout_receipt
+        .try_to_runtime()
+        .expect("decode pre-expiry receipt");
+    let pre_expiry_payout = env.token_amount(env.actors[WINNER].destination_token);
+
+    env.warp_to_slot(EXPIRY_SLOT);
+    inv067_drain_resolved_actor(&mut env, WINNER, &mut max_cu);
+    max_cu = max_cu.max(
+        env.close_primary_portfolio(WINNER)
+            .expect("close fully paid winner portfolio")
+            .compute_units,
+    );
+
+    for step in 0..4 {
+        if env
+            .svm
+            .get_account(&env.market)
+            .is_some_and(|account| account.data.len() == HEADER_LEN)
+        {
+            break;
+        }
+        let success = env
+            .close_primary_slab()
+            .unwrap_or_else(|error| panic!("terminal slab step {step}: {error}"));
+        assert!(
+            success.compute_units < TX_CU_LIMIT,
+            "terminal slab step {step} consumed {} CU",
+            success.compute_units
+        );
+        max_cu = max_cu.max(success.compute_units);
+    }
+
+    let winner_payout = env.token_amount(env.actors[WINNER].destination_token);
+    let mint_supply_after = env.mint_supply();
+    eprintln!(
+        "INV-067 late-backing trace: initial_close_cu={}, max_cu={max_cu}, pre_expiry_receipt={pre_expiry_receipt:?}, winner={pre_expiry_payout}->{winner_payout}, mint={mint_supply_before}->{mint_supply_after}",
+        initial_close.compute_units,
+    );
+    assert!(
+        pre_expiry_receipt.present,
+        "the engine erased a haircut receipt while future backing could still raise its rate"
+    );
+    assert_eq!(winner_payout, EXPECTED_WINNER_PAYOUT);
+    assert_eq!(mint_supply_after, mint_supply_before);
+    assert_closed_market_tombstone(
+        &env.svm
+            .get_account(&env.market)
+            .expect("terminal market tombstone"),
+    );
+}
 
 proptest! {
     #![proptest_config(ProptestConfig {

--- a/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
+++ b/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
@@ -170,8 +170,62 @@ fn v16_program_late_unrelated_backing_cannot_outlive_and_erase_resolved_receipt(
         .expect("decode pre-expiry receipt");
     let pre_expiry_payout = env.token_amount(env.actors[WINNER].destination_token);
 
+    if pre_expiry_receipt.present {
+        let market_before = env.market_data(false);
+        let portfolio_before = env.primary_portfolio_data(WINNER);
+        let destination_before = pre_expiry_payout;
+        let vault_before = env.token_amount(env.vault);
+        let error = env
+            .crank(
+                WINNER,
+                RESOLVE_SLOT + 2,
+                vec![CrankObservationHint {
+                    asset_index: UNRELATED_ASSET,
+                    oracle_accounts: 0,
+                }],
+            )
+            .expect_err("a backing hint before its committed expiry must not be a successful no-op");
+        assert!(
+            error.contains("Custom(22)") || error.contains("custom program error: 0x16"),
+            "unexpected pre-expiry crank error: {error}"
+        );
+        assert_eq!(env.market_data(false), market_before);
+        assert_eq!(env.primary_portfolio_data(WINNER), portfolio_before);
+        assert_eq!(
+            env.token_amount(env.actors[WINNER].destination_token),
+            destination_before
+        );
+        assert_eq!(env.token_amount(env.vault), vault_before);
+    }
+
     env.warp_to_slot(EXPIRY_SLOT);
     if pre_expiry_receipt.present {
+        for observations in [
+            vec![],
+            vec![CrankObservationHint {
+                asset_index: CLAIM_ASSET,
+                oracle_accounts: 0,
+            }],
+        ] {
+            let market_before = env.market_data(false);
+            let portfolio_before = env.primary_portfolio_data(WINNER);
+            let destination_before = env.token_amount(env.actors[WINNER].destination_token);
+            let vault_before = env.token_amount(env.vault);
+            let error = env
+                .crank(WINNER, EXPIRY_SLOT, observations)
+                .expect_err("missing or unrelated backing discovery must reject atomically");
+            assert!(
+                error.contains("Custom(22)") || error.contains("custom program error: 0x16"),
+                "unexpected unresolved-backing crank error: {error}"
+            );
+            assert_eq!(env.market_data(false), market_before);
+            assert_eq!(env.primary_portfolio_data(WINNER), portfolio_before);
+            assert_eq!(
+                env.token_amount(env.actors[WINNER].destination_token),
+                destination_before
+            );
+            assert_eq!(env.token_amount(env.vault), vault_before);
+        }
         let backing_progress = env
             .crank(
                 WINNER,

--- a/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
+++ b/tests/invariants/stateful/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
@@ -171,6 +171,20 @@ fn v16_program_late_unrelated_backing_cannot_outlive_and_erase_resolved_receipt(
     let pre_expiry_payout = env.token_amount(env.actors[WINNER].destination_token);
 
     env.warp_to_slot(EXPIRY_SLOT);
+    if pre_expiry_receipt.present {
+        let backing_progress = env
+            .crank(
+                WINNER,
+                EXPIRY_SLOT,
+                vec![CrankObservationHint {
+                    asset_index: UNRELATED_ASSET,
+                    oracle_accounts: 0,
+                }],
+            )
+            .expect("permissionless resolved crank expires hinted backing from committed state");
+        assert!(backing_progress.compute_units < TX_CU_LIMIT);
+        max_cu = max_cu.max(backing_progress.compute_units);
+    }
     inv067_drain_resolved_actor(&mut env, WINNER, &mut max_cu);
     max_cu = max_cu.max(
         env.close_primary_portfolio(WINNER)


### PR DESCRIPTION
## Impact

A publicly reachable resolved payout sequence deleted a winner's haircut receipt while unrelated fresh backing could still expire into the terminal payout snapshot. After expiry, the newly released 500 atoms had no claimant and `CloseSlab` burned them. The winner received 1,250 atoms instead of 1,750.

The regression is a real LiteSVM trace using only public instructions and valid accounts. It performs matched trading, authenticated mark updates, resolution, unsigned close, backing expiry, payout, portfolio closure, and slab closure without mutating program-owned bytes.

## Fix

- Pin engine PR aeyakovenko/percolator#197 at `0bb6f93a3b95457110aca491f3ed5729606502e1`.
- Route one resolved `PermissionlessCrank` asset hint into the engine as discovery only; no oracle accounts or caller price are accepted in resolved mode.
- Preserve `CloseResolved` as a compatibility route with no backing hint.
- Add exact rollback checks for premature, missing, and unrelated hints.

## Red/green evidence

- Exact parent `d5e2ec6fa727a1049a62851c3be19c638815b4e2`, engine `495a5590c97055bd71c6f94d849ff0298f243145`, SBF SHA256 `230b6db1278dbff258c84f9a3df78c7d9decc6f8653fe06c46fa5ea9834afb20`: RED, winner `1250 -> 1250`, mint supply `4500000000 -> 4499999500`.
- Fixed SBF SHA256 `bfe4e7fbf9cf392ee9ca20dc9bee414dd2b7c1313cc3096d9fcc679a9f02be69`: GREEN, winner `1250 -> 1750`, mint supply unchanged.
- Maximum observed CU in the fixed trace: `207833`.
- Premature, missing, and unrelated hints return engine `NonProgress` with byte-for-byte market/portfolio rollback and unchanged destination/vault balances.

Depends on aeyakovenko/percolator#197.