### PR TITLE
[BLOCKER LoF] Retain pending loss weight through resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "percolator"
 version = "0.1.1"
-source = "git+https://github.com/aeyakovenko/percolator?rev=394fd0bf2cb7d73df425eb3754dc3be1a0c44336#394fd0bf2cb7d73df425eb3754dc3be1a0c44336"
+source = "git+https://github.com/aeyakovenko/percolator?rev=93c350ec06b406265ce9ae916348b3e9c31b74ac#93c350ec06b406265ce9ae916348b3e9c31b74ac"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ pinocchio = "0.6"
 arrayref = "0.3"
 num-derive = "0.4"
 num-traits = "0.2"
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "394fd0bf2cb7d73df425eb3754dc3be1a0c44336" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "93c350ec06b406265ce9ae916348b3e9c31b74ac" }
 anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor", rev = "e3cf760826fa0a60f247635ea0572e59861ec9b5", package = "anchor-lang-v2", default-features = false, features = ["alloc", "guardrails"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 # Host tests use the same zero-copy account/view API as the SBF/program target.
-percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "394fd0bf2cb7d73df425eb3754dc3be1a0c44336" }
+percolator = { git = "https://github.com/aeyakovenko/percolator", rev = "93c350ec06b406265ce9ae916348b3e9c31b74ac" }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
## Impact

A public Recovery-to-Resolved close ordering could clear a zero-basis winner's unreleased pending-loss weight before the opposing debtor settled. The attacker-first order paid the attacker 14 atoms and an independent winner 10; debtor-first paid both 12. Aggregate vault conservation still held, so this violated owner entitlement and payout order-independence rather than aggregate stock.

The trace uses only public wrapper instructions and ordinary accounts: matched trades on two assets, authenticated mark pushes, shutdown, Recovery forfeit, an independently expired close to enter global Recovery, permissionless resolution, and resolved closes. No program-owned bytes are injected.

## Fix

Pin engine PR aeyakovenko/percolator#198 at `93c350ec06b406265ce9ae916348b3e9c31b74ac`. Resolved detach now skips an unreleased zero-basis/nonzero-loss-weight leg while its opposing real exposure remains. Other legs and accounts can continue progressing; after the debtor closes, the obligation releases and the retained leg closes normally.

## RED / GREEN evidence

- Exact wrapper parent `d5e2ec6fa727a1049a62851c3be19c638815b4e2`, engine `495a5590c97055bd71c6f94d849ff0298f243145`, SBF SHA256 `230b6db1278dbff258c84f9a3df78c7d9decc6f8653fe06c46fa5ea9834afb20`: RED (`attacker=14`, independent victim=`10`, pending count dropped to `0` before debtor).
- Fixed engine `93c350ec06b406265ce9ae916348b3e9c31b74ac`: GREEN in both orders (`attacker=12`, victim=`12`, pending count remains `1` and loss weight `40000` before debtor; all terminal counters and vault reach zero).
- Focused INV-039 module: 2/2 green.
- Adjacent public INV-066 payout-order tests: 7/7 behavioral tests green. Its exact-certified-pin sentinel intentionally remains red until the roadmap engine line is reviewed/merged and adopted as the wrapper certification pin; this PR does not mechanically bless that unrelated engine delta.

Depends on aeyakovenko/percolator#198.