### PR TITLE
[BLOCKER DoS] Make terminal insurance payout permissionless

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10820,7 +10820,6 @@ pub mod processor {
         let vault_authority_ai = account(accounts, 4)?;
         let token_program = account(accounts, 5)?;
         let ledger_ai = accounts.get(6);
-        expect_signer(operator)?;
         expect_writable(market_ai)?;
         expect_writable(dest_token)?;
         expect_writable(vault_token)?;
@@ -10847,6 +10846,12 @@ pub mod processor {
             }
             if mode != MarketModeV16::Live && mode != MarketModeV16::Resolved {
                 return Err(PercolatorError::InvalidInstruction.into());
+            }
+            // Live insurance remains an operator-authorized withdrawal. Once every portfolio and
+            // capital claim is gone, the configured terminal authority is only a payout identity:
+            // anyone may deliver its exact remaining budget to a token account it owns.
+            if mode == MarketModeV16::Live {
+                expect_signer(operator)?;
             }
             let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
             expect_key(vault_authority_ai, &vault_authority)?;

--- a/tests/invariants/cu/inv_017_signer_writable_role_and_account_alias_safety.rs
+++ b/tests/invariants/cu/inv_017_signer_writable_role_and_account_alias_safety.rs
@@ -1607,11 +1607,38 @@ fn v16_program_reserve_custody_account_pairs_and_required_privileges_are_exhaust
             "pair matrix must be complete"
         );
 
-        assert_reserve_custody_alias_rejects_atomically(
+        if matches!(
             route,
-            "authority signer downgrade",
-            |accounts| accounts[0].is_signer = false,
-        );
+            ReserveCustodyAliasRoute::WithdrawResolvedInsuranceAsset
+                | ReserveCustodyAliasRoute::WithdrawResolvedInsuranceAssetWithLedger
+        ) {
+            let mut unsigned = reserve_custody_alias_fixture(route);
+            let instruction = reserve_custody_alias_instruction(&unsigned, route);
+            let mut accounts = reserve_custody_alias_accounts(&unsigned, route);
+            accounts[0].is_signer = false;
+            let before = reserve_custody_alias_snapshot(&unsigned);
+            unsigned.env.svm.expire_blockhash();
+            let accepted = unsigned.env.send(instruction, accounts, &[]);
+            assert!(
+                accepted.is_ok(),
+                "{route:?}: resolved payout to the configured authority must be permissionless: {accepted:?}"
+            );
+            let after = reserve_custody_alias_snapshot(&unsigned);
+            assert_eq!(
+                u128::from(before.vault_atoms.abs_diff(after.vault_atoms)),
+                unsigned.amount
+            );
+            assert_eq!(
+                u128::from(before.user_atoms.abs_diff(after.user_atoms)),
+                unsigned.amount
+            );
+        } else {
+            assert_reserve_custody_alias_rejects_atomically(
+                route,
+                "authority signer downgrade",
+                |accounts| accounts[0].is_signer = false,
+            );
+        }
         let required_writable_roles: &[usize] = match route {
             ReserveCustodyAliasRoute::TopUpInsuranceWithLedger
             | ReserveCustodyAliasRoute::TopUpInsuranceDomainWithLedger

--- a/tests/invariants/cu/inv_070_zero_unattributed_terminal_residue_and_close_slab.rs
+++ b/tests/invariants/cu/inv_070_zero_unattributed_terminal_residue_and_close_slab.rs
@@ -24,6 +24,377 @@
 
 use super::*;
 
+struct Inv070TerminalInsuranceWithholdFixture {
+    env: V16CuEnv,
+    insurance_authority: Keypair,
+    cranker: Keypair,
+    user_payouts: [u64; 2],
+    permissionless_create_cu: u64,
+    insurance_top_up_cu: u64,
+    resolve_cu: u64,
+}
+
+fn inv070_create_rent_funded_portfolio(env: &mut V16CuEnv, owner: &Keypair) -> Pubkey {
+    let portfolio = Pubkey::new_unique();
+    env.ensure_signer_account(owner.pubkey());
+    let configured_assets = env.market_state().1.config.max_market_slots as usize;
+    let data_len = state::portfolio_account_len_for_market_slots(configured_assets).unwrap();
+    let lamports = env
+        .svm
+        .get_sysvar::<solana_sdk::rent::Rent>()
+        .minimum_balance(data_len);
+    env.svm
+        .set_account(
+            portfolio,
+            Account {
+                lamports,
+                data: vec![0u8; data_len],
+                owner: env.program_id,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    env.send(
+        ProgInstruction::InitPortfolio,
+        vec![
+            AccountMeta::new(owner.pubkey(), true),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(portfolio, false),
+        ],
+        &[owner],
+    )
+    .expect("initialize rent-funded portfolio through the public wrapper");
+    portfolio
+}
+
+fn inv070_send_with_metadata(
+    env: &mut V16CuEnv,
+    instruction: ProgInstruction,
+    accounts: Vec<AccountMeta>,
+    extra_signers: &[&Keypair],
+) -> Result<u64, (String, u64)> {
+    let instruction = Instruction {
+        program_id: env.program_id,
+        accounts,
+        data: instruction.encode(),
+    };
+    let mut signers = Vec::with_capacity(1 + extra_signers.len());
+    signers.push(&env.payer);
+    signers.extend_from_slice(extra_signers);
+    let transaction = Transaction::new_signed_with_payer(
+        &[heap_ix(), cu_ix(), instruction],
+        Some(&env.payer.pubkey()),
+        &signers,
+        env.svm.latest_blockhash(),
+    );
+    match env.svm.send_transaction(transaction) {
+        Ok(metadata) => Ok(metadata.compute_units_consumed),
+        Err(failure) => Err((
+            format!("{:?}", failure.err),
+            failure.meta.compute_units_consumed,
+        )),
+    }
+}
+
+fn inv070_terminal_insurance_withhold_fixture() -> Inv070TerminalInsuranceWithholdFixture {
+    const CREATE_FEE: u128 = 2;
+    const INSURANCE_ATOMS: u128 = 1;
+    const USER_PRINCIPAL: u128 = 1_000;
+
+    let mut env = V16CuEnv::new();
+    env.update_market_init_fee_policy_with_cu(CREATE_FEE);
+
+    let insurance_authority = Keypair::new();
+    let cranker = Keypair::new();
+    env.ensure_signer_account(cranker.pubkey());
+    let authority = insurance_authority.pubkey();
+    let (_, permissionless_create_cu) = env.activate_permissionless_asset_with_fee(
+        &insurance_authority,
+        1,
+        1,
+        100,
+        authority,
+        authority,
+        authority,
+        authority,
+        CREATE_FEE,
+    );
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 1)
+            .unwrap();
+    assert_eq!(profile.asset_admin, authority.to_bytes());
+    assert_eq!(profile.insurance_authority, authority.to_bytes());
+    assert_eq!(profile.insurance_operator, authority.to_bytes());
+
+    let (insurance_source, insurance_top_up_cu) =
+        env.top_up_insurance_domain_with_authority_and_cu(&insurance_authority, 2, INSURANCE_ATOMS);
+    assert_eq!(env.token_amount(insurance_source), 0);
+
+    let long_owner = Keypair::new();
+    let short_owner = Keypair::new();
+    let long = inv070_create_rent_funded_portfolio(&mut env, &long_owner);
+    let short = inv070_create_rent_funded_portfolio(&mut env, &short_owner);
+    env.deposit(&long_owner, long, USER_PRINCIPAL);
+    env.deposit(&short_owner, short, USER_PRINCIPAL);
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        POS_SCALE as i128,
+        100,
+        0,
+    );
+    env.trade_asset_with_cu(
+        1,
+        &long_owner,
+        long,
+        &short_owner,
+        short,
+        -(POS_SCALE as i128),
+        100,
+        0,
+    );
+
+    let resolve_cu = env.resolve();
+    let long_destination = env.close_resolved(&long_owner, long);
+    let short_destination = env.close_resolved(&short_owner, short);
+    let user_payouts = [
+        env.token_amount(long_destination),
+        env.token_amount(short_destination),
+    ];
+    assert_eq!(user_payouts, [USER_PRINCIPAL as u64; 2]);
+    env.close_portfolio_with_cu(&long_owner, long);
+    env.close_portfolio_with_cu(&short_owner, short);
+
+    // Remove the permissionless-create fee from asset 0 through its legitimate terminal owner.
+    // The only remaining token and accounting stock is the attacker's one-atom asset-1 budget.
+    let admin = env.admin.insecure_clone();
+    let (asset_zero_destination, _) = env
+        .try_withdraw_insurance_asset_with_authority(&admin, 0, CREATE_FEE)
+        .expect("asset-0 authority recovers the permissionless-create fee");
+    assert_eq!(env.token_amount(asset_zero_destination), CREATE_FEE as u64);
+    let terminal = env.market_state().1;
+    assert_eq!(terminal.mode, MarketModeV16::Resolved);
+    assert_eq!(terminal.materialized_portfolio_count, 0);
+    assert_eq!(terminal.c_tot, 0);
+    assert_eq!(terminal.vault, INSURANCE_ATOMS);
+    assert_eq!(terminal.insurance, INSURANCE_ATOMS);
+    assert_eq!(terminal.insurance_domain_budget[2], INSURANCE_ATOMS);
+    assert_eq!(
+        terminal.insurance_domain_budget_remaining_total,
+        INSURANCE_ATOMS
+    );
+    assert_eq!(env.token_amount(env.vault), INSURANCE_ATOMS as u64);
+
+    Inv070TerminalInsuranceWithholdFixture {
+        env,
+        insurance_authority,
+        cranker,
+        user_payouts,
+        permissionless_create_cu,
+        insurance_top_up_cu,
+        resolve_cu,
+    }
+}
+
+// BLOCKER DoS RED: an unprivileged asset creator can retain a one-atom insurance claim forever.
+// Once all users are paid and the market is Resolved, the only route that clears that claim requires
+// the creator's insurance-authority signature. CloseSlab cannot retire attributed insurance, while
+// the honest market authority cannot withdraw it or replace the funded role. The future-safe route is
+// permissionless execution that transfers only to a token account owned by the configured authority.
+#[test]
+fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_close() {
+    const ASSET_INDEX: u16 = 1;
+    const INSURANCE_ATOMS: u128 = 1;
+
+    let mut attack = inv070_terminal_insurance_withhold_fixture();
+    let admin = attack.env.admin.insecure_clone();
+    let replacement = Keypair::new();
+    let admin_destination = attack.env.token_account(admin.pubkey(), 0);
+    let attacker_destination = attack
+        .env
+        .token_account(attack.insurance_authority.pubkey(), 0);
+    let market = attack.env.market;
+    let vault = attack.env.vault;
+    let vault_authority = attack.env.vault_authority;
+    let mint = attack.env.mint;
+    let market_id = attack.env.asset_market_id(ASSET_INDEX);
+    let authority_epoch = attack
+        .env
+        .control_sequences(ASSET_INDEX as usize)
+        .authority_epoch;
+
+    let market_before = attack.env.svm.get_account(&market).unwrap();
+    let vault_before = attack.env.svm.get_account(&vault).unwrap();
+    let admin_withdraw = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET_INDEX,
+            market_id,
+            authority_epoch,
+            amount: INSURANCE_ATOMS,
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(admin_destination, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&admin],
+    );
+    assert!(
+        admin_withdraw.is_err(),
+        "market authority must not seize the creator's terminal insurance entitlement"
+    );
+    assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
+    assert_eq!(attack.env.svm.get_account(&vault).unwrap(), vault_before);
+
+    attack.env.ensure_signer_account(replacement.pubkey());
+    attack.env.svm.expire_blockhash();
+    let admin_rotation = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::UpdateAssetAuthority {
+            asset_index: ASSET_INDEX,
+            market_id,
+            authority_epoch,
+            kind: processor::ASSET_AUTH_INSURANCE,
+            new_pubkey: replacement.pubkey().to_bytes(),
+        },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(replacement.pubkey(), true),
+            AccountMeta::new(market, false),
+        ],
+        &[&admin, &replacement],
+    );
+    assert!(
+        admin_rotation.is_err(),
+        "market authority must not replace a funded permissionless asset's insurance owner"
+    );
+    assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
+
+    // The cranker signs and supplies a destination owned by the configured insurance authority.
+    // This is the exact entitlement-preserving permissionless payout the fixed route must accept.
+    attack.env.svm.expire_blockhash();
+    let cranker = attack.cranker.insecure_clone();
+    let permissionless_payout = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET_INDEX,
+            market_id,
+            authority_epoch,
+            amount: INSURANCE_ATOMS,
+        },
+        vec![
+            AccountMeta::new(cranker.pubkey(), true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(attacker_destination, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[&cranker],
+    );
+
+    let rent = attack.env.svm.get_sysvar::<solana_sdk::rent::Rent>();
+    let terminal_market = attack.env.svm.get_account(&market).unwrap();
+    let terminal_vault = attack.env.svm.get_account(&vault).unwrap();
+    let market_refund = terminal_market
+        .lamports
+        .saturating_sub(rent.minimum_balance(percolator_prog::constants::HEADER_LEN));
+    let rent_locked = market_refund.saturating_add(terminal_vault.lamports);
+    let close_destination = attack.env.token_account(admin.pubkey(), 0);
+    attack.env.svm.expire_blockhash();
+    let first_close = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::CloseSlab { authority_epoch: 0 },
+        vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(market, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new(close_destination, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+            AccountMeta::new(mint, false),
+        ],
+        &[&admin],
+    );
+
+    let mut late_close = None;
+    if first_close.is_err() {
+        assert_eq!(
+            attack.env.svm.get_account(&market).unwrap(),
+            terminal_market
+        );
+        assert_eq!(attack.env.svm.get_account(&vault).unwrap(), terminal_vault);
+        attack.env.svm.warp_to_slot(1_000_000);
+        attack.env.svm.expire_blockhash();
+        late_close = Some(inv070_send_with_metadata(
+            &mut attack.env,
+            ProgInstruction::CloseSlab { authority_epoch: 0 },
+            vec![
+                AccountMeta::new(admin.pubkey(), true),
+                AccountMeta::new(market, false),
+                AccountMeta::new(vault, false),
+                AccountMeta::new_readonly(vault_authority, false),
+                AccountMeta::new(close_destination, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(mint, false),
+            ],
+            &[&admin],
+        ));
+        assert!(late_close.as_ref().unwrap().is_err());
+        let terminal = attack.env.market_state().1;
+        assert_eq!(terminal.insurance_domain_budget[2], INSURANCE_ATOMS);
+        assert_eq!(terminal.vault, INSURANCE_ATOMS);
+        assert_eq!(attack.env.token_amount(vault), INSURANCE_ATOMS as u64);
+    }
+
+    // Discriminating control: the same public lifecycle closes immediately when the attacker signs.
+    let mut control = inv070_terminal_insurance_withhold_fixture();
+    let (control_destination, attacker_withdraw_cu) =
+        control.env.withdraw_terminal_insurance_with_authority(
+            &control.insurance_authority,
+            ASSET_INDEX,
+            INSURANCE_ATOMS,
+        );
+    assert_eq!(
+        control.env.token_amount(control_destination),
+        INSURANCE_ATOMS as u64
+    );
+    let cooperative_close_cu = control.env.close_slab_with_cu();
+    assert_closed_market_tombstone(&control.env.svm.get_account(&control.env.market).unwrap());
+
+    println!(
+        "INV-070 terminal insurance withholding: users={:?}, create_cu={}, topup_cu={}, resolve_cu={}, admin_withdraw={:?}, admin_rotation={:?}, permissionless_payout={:?}, first_close={:?}, late_close={:?}, market_lamports={}, market_refund={}, vault_lamports={}, rent_locked={}, attacker_withdraw_cu={}, cooperative_close_cu={}",
+        attack.user_payouts,
+        attack.permissionless_create_cu,
+        attack.insurance_top_up_cu,
+        attack.resolve_cu,
+        admin_withdraw,
+        admin_rotation,
+        permissionless_payout,
+        first_close,
+        late_close,
+        terminal_market.lamports,
+        market_refund,
+        terminal_vault.lamports,
+        rent_locked,
+        attacker_withdraw_cu,
+        cooperative_close_cu,
+    );
+
+    assert!(
+        permissionless_payout.is_ok() && first_close.is_ok(),
+        "a funded permissionless-asset authority must not be able to withhold terminal progress; any cranker must be able to pay the exact claim only to the configured authority and then close the slab"
+    );
+}
+
 #[test]
 fn v16_program_recovery_force_close_reaches_zero_residue_and_close_slab() {
     const INITIAL_CAPITAL: u128 = 1_000_000;

--- a/tests/invariants/cu/inv_070_zero_unattributed_terminal_residue_and_close_slab.rs
+++ b/tests/invariants/cu/inv_070_zero_unattributed_terminal_residue_and_close_slab.rs
@@ -200,11 +200,11 @@ fn inv070_terminal_insurance_withhold_fixture() -> Inv070TerminalInsuranceWithho
     }
 }
 
-// BLOCKER DoS RED: an unprivileged asset creator can retain a one-atom insurance claim forever.
-// Once all users are paid and the market is Resolved, the only route that clears that claim requires
-// the creator's insurance-authority signature. CloseSlab cannot retire attributed insurance, while
-// the honest market authority cannot withdraw it or replace the funded role. The future-safe route is
-// permissionless execution that transfers only to a token account owned by the configured authority.
+// BLOCKER DoS regression: an unprivileged asset creator could retain a one-atom insurance claim
+// forever by withholding its insurance-authority signature. Once all users are paid and the market is
+// Resolved, account zero remains bound to the configured authority and the destination remains owned
+// by it, but the signature is no longer required to deliver that exact entitlement. Live withdrawals
+// remain signed. Every rejected identity/destination variant must roll back accounting and SPL state.
 #[test]
 fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_close() {
     const ASSET_INDEX: u16 = 1;
@@ -213,10 +213,11 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
     let mut attack = inv070_terminal_insurance_withhold_fixture();
     let admin = attack.env.admin.insecure_clone();
     let replacement = Keypair::new();
+    let insurance_authority = attack.insurance_authority.pubkey();
+    let cranker = attack.cranker.insecure_clone();
     let admin_destination = attack.env.token_account(admin.pubkey(), 0);
-    let attacker_destination = attack
-        .env
-        .token_account(attack.insurance_authority.pubkey(), 0);
+    let attacker_destination = attack.env.token_account(insurance_authority, 0);
+    let wrong_authority_destination = attack.env.token_account(cranker.pubkey(), 0);
     let market = attack.env.market;
     let vault = attack.env.vault;
     let vault_authority = attack.env.vault_authority;
@@ -229,6 +230,7 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
 
     let market_before = attack.env.svm.get_account(&market).unwrap();
     let vault_before = attack.env.svm.get_account(&vault).unwrap();
+    let admin_destination_before = attack.env.svm.get_account(&admin_destination).unwrap();
     let admin_withdraw = inv070_send_with_metadata(
         &mut attack.env,
         ProgInstruction::WithdrawInsuranceAsset {
@@ -251,8 +253,16 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
         admin_withdraw.is_err(),
         "market authority must not seize the creator's terminal insurance entitlement"
     );
+    assert_eq!(
+        admin_withdraw.as_ref().unwrap_err().0,
+        "InstructionError(2, Custom(8))"
+    );
     assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
     assert_eq!(attack.env.svm.get_account(&vault).unwrap(), vault_before);
+    assert_eq!(
+        attack.env.svm.get_account(&admin_destination).unwrap(),
+        admin_destination_before
+    );
 
     attack.env.ensure_signer_account(replacement.pubkey());
     attack.env.svm.expire_blockhash();
@@ -278,11 +288,11 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
     );
     assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
 
-    // The cranker signs and supplies a destination owned by the configured insurance authority.
-    // This is the exact entitlement-preserving permissionless payout the fixed route must accept.
+    // The configured authority key alone is insufficient if the payout token account belongs to
+    // anyone else. This check runs without the authority signature and must still fail atomically.
     attack.env.svm.expire_blockhash();
-    let cranker = attack.cranker.insecure_clone();
-    let permissionless_payout = inv070_send_with_metadata(
+    let wrong_destination_before = attack.env.svm.get_account(&admin_destination).unwrap();
+    let wrong_destination = inv070_send_with_metadata(
         &mut attack.env,
         ProgInstruction::WithdrawInsuranceAsset {
             asset_index: ASSET_INDEX,
@@ -291,14 +301,65 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
             amount: INSURANCE_ATOMS,
         },
         vec![
-            AccountMeta::new(cranker.pubkey(), true),
+            AccountMeta::new_readonly(insurance_authority, false),
             AccountMeta::new(market, false),
-            AccountMeta::new(attacker_destination, false),
+            AccountMeta::new(admin_destination, false),
             AccountMeta::new(vault, false),
             AccountMeta::new_readonly(vault_authority, false),
             AccountMeta::new_readonly(spl_token::ID, false),
         ],
-        &[&cranker],
+        &[],
+    );
+    assert_eq!(
+        wrong_destination.as_ref().unwrap_err().0,
+        "InstructionError(2, Custom(11))"
+    );
+    assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
+    assert_eq!(attack.env.svm.get_account(&vault).unwrap(), vault_before);
+    assert_eq!(
+        attack.env.svm.get_account(&admin_destination).unwrap(),
+        wrong_destination_before
+    );
+
+    // A permissionless caller also cannot redirect the budget by substituting its own key and a
+    // token account it owns. The supplied key must remain the configured insurance authority.
+    attack.env.svm.expire_blockhash();
+    let wrong_authority_destination_before = attack
+        .env
+        .svm
+        .get_account(&wrong_authority_destination)
+        .unwrap();
+    let wrong_authority = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET_INDEX,
+            market_id,
+            authority_epoch,
+            amount: INSURANCE_ATOMS,
+        },
+        vec![
+            AccountMeta::new_readonly(cranker.pubkey(), false),
+            AccountMeta::new(market, false),
+            AccountMeta::new(wrong_authority_destination, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert_eq!(
+        wrong_authority.as_ref().unwrap_err().0,
+        "InstructionError(2, Custom(8))"
+    );
+    assert_eq!(attack.env.svm.get_account(&market).unwrap(), market_before);
+    assert_eq!(attack.env.svm.get_account(&vault).unwrap(), vault_before);
+    assert_eq!(
+        attack
+            .env
+            .svm
+            .get_account(&wrong_authority_destination)
+            .unwrap(),
+        wrong_authority_destination_before
     );
 
     let rent = attack.env.svm.get_sysvar::<solana_sdk::rent::Rent>();
@@ -308,9 +369,43 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
         .lamports
         .saturating_sub(rent.minimum_balance(percolator_prog::constants::HEADER_LEN));
     let rent_locked = market_refund.saturating_add(terminal_vault.lamports);
+
+    // Any payer may now submit the canonical terminal payout: account zero is the configured
+    // authority but is deliberately not a signer, and custody can move only to its token account.
+    attack.env.svm.expire_blockhash();
+    let unsigned_canonical_payout = inv070_send_with_metadata(
+        &mut attack.env,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: ASSET_INDEX,
+            market_id,
+            authority_epoch,
+            amount: INSURANCE_ATOMS,
+        },
+        vec![
+            AccountMeta::new_readonly(insurance_authority, false),
+            AccountMeta::new(market, false),
+            AccountMeta::new(attacker_destination, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    )
+    .expect("resolved canonical insurance payout is permissionless");
+    let drained = attack.env.market_state().1;
+    assert_eq!(drained.insurance_domain_budget[2], 0);
+    assert_eq!(drained.insurance_domain_budget_remaining_total, 0);
+    assert_eq!(drained.insurance, 0);
+    assert_eq!(drained.vault, 0);
+    assert_eq!(attack.env.token_amount(vault), 0);
+    assert_eq!(
+        attack.env.token_amount(attacker_destination),
+        INSURANCE_ATOMS as u64
+    );
+
     let close_destination = attack.env.token_account(admin.pubkey(), 0);
     attack.env.svm.expire_blockhash();
-    let first_close = inv070_send_with_metadata(
+    let permissionless_close_cu = inv070_send_with_metadata(
         &mut attack.env,
         ProgInstruction::CloseSlab { authority_epoch: 0 },
         vec![
@@ -323,39 +418,11 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
             AccountMeta::new(mint, false),
         ],
         &[&admin],
-    );
+    )
+    .expect("permissionless terminal payout makes CloseSlab reachable");
+    assert_closed_market_tombstone(&attack.env.svm.get_account(&market).unwrap());
 
-    let mut late_close = None;
-    if first_close.is_err() {
-        assert_eq!(
-            attack.env.svm.get_account(&market).unwrap(),
-            terminal_market
-        );
-        assert_eq!(attack.env.svm.get_account(&vault).unwrap(), terminal_vault);
-        attack.env.svm.warp_to_slot(1_000_000);
-        attack.env.svm.expire_blockhash();
-        late_close = Some(inv070_send_with_metadata(
-            &mut attack.env,
-            ProgInstruction::CloseSlab { authority_epoch: 0 },
-            vec![
-                AccountMeta::new(admin.pubkey(), true),
-                AccountMeta::new(market, false),
-                AccountMeta::new(vault, false),
-                AccountMeta::new_readonly(vault_authority, false),
-                AccountMeta::new(close_destination, false),
-                AccountMeta::new_readonly(spl_token::ID, false),
-                AccountMeta::new(mint, false),
-            ],
-            &[&admin],
-        ));
-        assert!(late_close.as_ref().unwrap().is_err());
-        let terminal = attack.env.market_state().1;
-        assert_eq!(terminal.insurance_domain_budget[2], INSURANCE_ATOMS);
-        assert_eq!(terminal.vault, INSURANCE_ATOMS);
-        assert_eq!(attack.env.token_amount(vault), INSURANCE_ATOMS as u64);
-    }
-
-    // Discriminating control: the same public lifecycle closes immediately when the attacker signs.
+    // Compatibility control: the configured authority may still sign and withdraw exactly as before.
     let mut control = inv070_terminal_insurance_withhold_fixture();
     let (control_destination, attacker_withdraw_cu) =
         control.env.withdraw_terminal_insurance_with_authority(
@@ -370,28 +437,77 @@ fn v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_
     let cooperative_close_cu = control.env.close_slab_with_cu();
     assert_closed_market_tombstone(&control.env.svm.get_account(&control.env.market).unwrap());
 
+    // The signer relaxation is terminal-only. In Live mode the configured operator key without its
+    // signature still fails at the wrapper boundary, with every touched account byte-exactly rolled
+    // back by the failed transaction.
+    let mut live = V16CuEnv::new();
+    let live_admin = live.admin.insecure_clone();
+    live.enable_live_insurance_withdrawal();
+    live.top_up_insurance_domain_with_authority_and_cu(&live_admin, 0, INSURANCE_ATOMS);
+    let live_destination = live.token_account(live_admin.pubkey(), 0);
+    let live_market_before = live.svm.get_account(&live.market).unwrap();
+    let live_vault_before = live.svm.get_account(&live.vault).unwrap();
+    let live_destination_before = live.svm.get_account(&live_destination).unwrap();
+    let live_market_id = live.asset_market_id(0);
+    let live_authority_epoch = live.withdrawal_authority_epoch(live_admin.pubkey(), 0, true);
+    let live_market = live.market;
+    let live_vault = live.vault;
+    let live_vault_authority = live.vault_authority;
+    live.svm.expire_blockhash();
+    let live_unsigned = inv070_send_with_metadata(
+        &mut live,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: 0,
+            market_id: live_market_id,
+            authority_epoch: live_authority_epoch,
+            amount: INSURANCE_ATOMS,
+        },
+        vec![
+            AccountMeta::new_readonly(live_admin.pubkey(), false),
+            AccountMeta::new(live_market, false),
+            AccountMeta::new(live_destination, false),
+            AccountMeta::new(live_vault, false),
+            AccountMeta::new_readonly(live_vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    );
+    assert_eq!(
+        live_unsigned.as_ref().unwrap_err().0,
+        "InstructionError(2, Custom(6))"
+    );
+    assert_eq!(
+        live.svm.get_account(&live.market).unwrap(),
+        live_market_before
+    );
+    assert_eq!(
+        live.svm.get_account(&live.vault).unwrap(),
+        live_vault_before
+    );
+    assert_eq!(
+        live.svm.get_account(&live_destination).unwrap(),
+        live_destination_before
+    );
+
     println!(
-        "INV-070 terminal insurance withholding: users={:?}, create_cu={}, topup_cu={}, resolve_cu={}, admin_withdraw={:?}, admin_rotation={:?}, permissionless_payout={:?}, first_close={:?}, late_close={:?}, market_lamports={}, market_refund={}, vault_lamports={}, rent_locked={}, attacker_withdraw_cu={}, cooperative_close_cu={}",
+        "INV-070 terminal insurance withholding: users={:?}, create_cu={}, topup_cu={}, resolve_cu={}, admin_withdraw={:?}, admin_rotation={:?}, wrong_destination={:?}, wrong_authority={:?}, unsigned_canonical_payout_cu={}, permissionless_close_cu={}, live_unsigned={:?}, market_lamports={}, market_refund={}, vault_lamports={}, rent_locked={}, attacker_withdraw_cu={}, cooperative_close_cu={}",
         attack.user_payouts,
         attack.permissionless_create_cu,
         attack.insurance_top_up_cu,
         attack.resolve_cu,
         admin_withdraw,
         admin_rotation,
-        permissionless_payout,
-        first_close,
-        late_close,
+        wrong_destination,
+        wrong_authority,
+        unsigned_canonical_payout,
+        permissionless_close_cu,
+        live_unsigned,
         terminal_market.lamports,
         market_refund,
         terminal_vault.lamports,
         rent_locked,
         attacker_withdraw_cu,
         cooperative_close_cu,
-    );
-
-    assert!(
-        permissionless_payout.is_ok() && first_close.is_ok(),
-        "a funded permissionless-asset authority must not be able to withhold terminal progress; any cranker must be able to pay the exact claim only to the configured authority and then close the slab"
     );
 }
 

--- a/tests/invariants/cu/inv_073_no_permanent_user_lock.rs
+++ b/tests/invariants/cu/inv_073_no_permanent_user_lock.rs
@@ -5001,9 +5001,9 @@ fn v16_bpf_permissionless_stale_resolve_is_bounded_and_oracle_free() {
 enum Inv073TerminalAuthority {
     PermissionlessEconomic,
     PermissionlessMechanical,
+    PermissionlessBoundAuthorityPayout,
     OwnerOrResolvedMarketAuthority,
     BackingAuthorityOrShutdownMarketAuthority,
-    InsuranceAuthorityOrShutdownMarketAuthority,
     MarketAuthority,
 }
 
@@ -5117,10 +5117,10 @@ fn v16_program_terminal_disposition_and_administrative_retirement_are_source_com
             rank_lane: "insurance-cleanup",
             handler: "fn handle_withdraw_insurance_asset<'a>(",
             transition: "debit_market_insurance_budget_view(",
-            authority: Inv073TerminalAuthority::InsuranceAuthorityOrShutdownMarketAuthority,
+            authority: Inv073TerminalAuthority::PermissionlessBoundAuthorityPayout,
             witness_path:
-                "tests/invariants/stateful/inv_066_resolved_payout_fairness_and_order_independence.rs",
-            witness: "v16_program_prior_insurance_frames_all_partial_receipt_orders",
+                "tests/invariants/cu/inv_070_zero_unattributed_terminal_residue_and_close_slab.rs",
+            witness: "v16_attack_permissionless_asset_insurance_authority_cannot_withhold_terminal_close",
         },
         Inv073TerminalPhase {
             rank_lane: "asset-cleanup",
@@ -5258,6 +5258,15 @@ fn v16_program_terminal_disposition_and_administrative_retirement_are_source_com
     assert!(lifecycle.contains("expect_signer(authority)?;"));
     assert!(lifecycle.contains("if !live_authority_matches(&cfg_pre.marketauth, authority.key)"));
     assert!(lifecycle.contains("ASSET_ACTION_RETIRE =>"));
+
+    let insurance = inv073_braced_body_after(production, "fn handle_withdraw_insurance_asset<'a>(");
+    assert_eq!(insurance.matches("expect_signer(operator)?;").count(), 1);
+    assert!(insurance.contains("if mode == MarketModeV16::Live"));
+    assert!(insurance.contains("group.header.materialized_portfolio_count.get() != 0"));
+    assert!(insurance.contains("group.header.c_tot.get() != 0"));
+    assert!(insurance
+        .contains("live_authority_matches(&authorities.insurance_authority, operator.key)"));
+    assert!(insurance.contains("dest_token,\n                operator.key,"));
 
     let close_slab = inv073_braced_body_after(production, "fn handle_close_slab<'a>(");
     for guard in [

--- a/tests/invariants/cu/inv_077_bounded_work_and_maximum_shape_compute.rs
+++ b/tests/invariants/cu/inv_077_bounded_work_and_maximum_shape_compute.rs
@@ -5891,10 +5891,32 @@ fn v16_bpf_terminal_insurance_last_domain_withdraw_stays_bounded_on_10m_market()
     );
 
     env.resolve();
-    let (dest, withdraw_cu) =
-        env.withdraw_terminal_insurance_with_authority(&admin, HIGH_ASSET as u16, FUNDED);
+    let dest = env.token_account(admin.pubkey(), 0);
+    let market_id = env.asset_market_id(HIGH_ASSET as u16);
+    let authority_epoch = env.withdrawal_authority_epoch(admin.pubkey(), HIGH_ASSET, true);
+    let withdraw_cu = send_tx(
+        &mut env.svm,
+        env.program_id,
+        &env.payer,
+        ProgInstruction::WithdrawInsuranceAsset {
+            asset_index: HIGH_ASSET as u16,
+            market_id,
+            authority_epoch,
+            amount: FUNDED,
+        },
+        vec![
+            AccountMeta::new_readonly(admin.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(dest, false),
+            AccountMeta::new(env.vault, false),
+            AccountMeta::new_readonly(env.vault_authority, false),
+            AccountMeta::new_readonly(spl_token::ID, false),
+        ],
+        &[],
+    )
+    .expect("permissionless terminal insurance payout at maximum market shape");
     println!(
-        "v16 10MiB resolved WithdrawInsuranceAsset: domains={}, funded_domain={}, CU={withdraw_cu}",
+        "v16 10MiB permissionless resolved WithdrawInsuranceAsset: domains={}, funded_domain={}, CU={withdraw_cu}",
         2 * N,
         last_domain
     );


### PR DESCRIPTION
## Finding

A permissionless asset creator controls that asset's insurance authority. On exact `main`, it can top up a one-atom insurance budget, let every user claim settle and every portfolio close, then withhold its signature forever. The market remains Resolved with only that atom outstanding, so `CloseSlab` cannot release 2,133,896,480 lamports. The market authority cannot withdraw the atom or rotate the funded authority, and advancing to slot 1,000,000 does not create another path.

This is a public-interface persistent DoS under one honest cranker. It uses only valid instructions and account construction; no program-owned bytes are injected.

## Fix

In Resolved mode only, after `materialized_portfolio_count == 0` and `c_tot == 0`, treat the configured insurance authority as the payout identity rather than requiring its signature. Any caller can deliver the exact remaining insurance budget only to a token account owned by that configured authority.

Live withdrawals remain signer-gated. Authority, generation, epoch, domain-budget, vault, token-owner, and optional-ledger checks are unchanged.

## TDD evidence

Exact-parent RED commit: `2d936d9148ff43abd349668a3486993b1f96db61`

- Users are paid `[1000, 1000]`.
- Honest terminal withdrawal rejects `Custom(8)`.
- Admin authority rotation rejects `Custom(8)`.
- `CloseSlab` rejects `Custom(21)` immediately and at slot 1,000,000.
- Signing with the withholding key releases the atom and then permits close.

Fix commit: `ab075b735762ad1c4301e2f8a86f3a3fb56951df`

- Unsigned canonical terminal payout succeeds at 33,834 CU.
- Wrong destination and wrong authority reject with byte-exact rollback.
- Live unsigned withdrawal still rejects `Custom(6)` with exact rollback.
- Authority-signed compatibility path succeeds.
- 10 MiB / 11,564-domain terminal payout succeeds at 34,365 CU.
- INV-017 signer/alias matrix: 40/40.
- INV-027 protected principal: 11/11.
- `cargo fmt --all -- --check` and `git diff --check`: clean.

Engine pin remains `495a5590c97055bd71c6f94d849ff0298f243145`.