### PR TITLE
[BLOCKER LoF] Preserve Hybrid liquidation reward provenance

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -93,6 +93,8 @@ pub mod constants {
     pub const ORACLE_MODE_HYBRID_AFTER_HOURS: u8 = 1;
     pub const ORACLE_MODE_EWMA_MARK: u8 = 2;
     pub const ORACLE_MODE_AUTH_MARK: u8 = 3;
+    pub const EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED: u8 = 0;
+    pub const EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN: u8 = 1;
     pub const ORACLE_LEG_FLAG_DIVIDE_LEG2: u8 = 1 << 0;
     pub const ORACLE_LEG_FLAG_DIVIDE_LEG3: u8 = 1 << 1;
     pub const ORACLE_LEG_FLAGS_MASK: u8 = ORACLE_LEG_FLAG_DIVIDE_LEG2 | ORACLE_LEG_FLAG_DIVIDE_LEG3;
@@ -601,7 +603,10 @@ pub mod state {
         /// Canonical price-move numerator remainder. This occupies two bytes of the former
         /// six-byte padding lane, preserving the deployed account size and all later offsets.
         pub price_move_remainder_bps_num: u16,
-        pub _padding0: [u8; 4],
+        /// Whether the current effective-price path still includes a stale-Hybrid trade move.
+        /// It returns to authenticated only after the engine reaches a fresh oracle target.
+        pub effective_price_provenance: u8,
+        pub _padding0: [u8; 3],
         pub insurance_authority: [u8; 32],
         pub insurance_operator: [u8; 32],
         pub backing_bucket_authority: [u8; 32],
@@ -1487,7 +1492,12 @@ pub mod state {
             )
             || profile.invert > 1
             || profile.price_move_remainder_bps_num >= 10_000
-            || profile._padding0 != [0u8; 4]
+            || profile.effective_price_provenance
+                > crate::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
+            || (profile.oracle_mode != ORACLE_MODE_HYBRID_AFTER_HOURS
+                && profile.effective_price_provenance
+                    != crate::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED)
+            || profile._padding0 != [0u8; 3]
             || profile.oracle_leg_count as usize > ORACLE_LEG_CAP
             || (profile.oracle_leg_flags & !ORACLE_LEG_FLAGS_MASK) != 0
             || (profile.funding_mark_e6 != 0 && !valid_engine_oracle_price(profile.funding_mark_e6))
@@ -1584,7 +1594,8 @@ pub mod state {
             backing_trade_fee_insurance_share_bps_long: 0,
             backing_trade_fee_insurance_share_bps_short: 0,
             price_move_remainder_bps_num: 0,
-            _padding0: [0u8; 4],
+            effective_price_provenance: crate::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED,
+            _padding0: [0u8; 3],
             insurance_authority: [0u8; 32],
             insurance_operator: [0u8; 32],
             backing_bucket_authority: [0u8; 32],
@@ -1623,7 +1634,8 @@ pub mod state {
             backing_trade_fee_insurance_share_bps_short: config
                 .backing_trade_fee_insurance_share_bps_short,
             price_move_remainder_bps_num: 0,
-            _padding0: [0u8; 4],
+            effective_price_provenance: crate::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED,
+            _padding0: [0u8; 3],
             // At InitMarket the market key bootstraps asset 0 exactly like an activator bootstraps a
             // permissionless asset 1..N: it is asset 0's cold-storage admin and all its sub-authorities.
             insurance_authority: config.marketauth,
@@ -13140,7 +13152,8 @@ pub mod processor {
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
                 price_move_remainder_bps_num: 0,
-                _padding0: [0u8; 4],
+                effective_price_provenance: constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED,
+                _padding0: [0u8; 3],
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -13320,7 +13333,8 @@ pub mod processor {
                 backing_trade_fee_insurance_share_bps_short: existing_profile
                     .backing_trade_fee_insurance_share_bps_short,
                 price_move_remainder_bps_num: 0,
-                _padding0: [0u8; 4],
+                effective_price_provenance: constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED,
+                _padding0: [0u8; 3],
                 insurance_authority: existing_profile.insurance_authority,
                 insurance_operator: existing_profile.insurance_operator,
                 asset_admin: existing_profile.asset_admin,
@@ -13958,7 +13972,10 @@ pub mod processor {
                 }
                 liquidation_fee_reclaimability.push((
                     asset_index,
-                    !profile_updates_mark_from_trade_view(&oracle_profile, authenticated_now_slot),
+                    liquidation_penalty_reclaimable_from_profile_view(
+                        &oracle_profile,
+                        authenticated_now_slot,
+                    ),
                 ));
                 write_oracle_profile_to_view(&mut group, asset_index, &oracle_profile)?;
                 observations.push(AutoCrankObservationV16 {
@@ -14081,7 +14098,10 @@ pub mod processor {
                     *reclaimable
                 } else {
                     let profile = read_oracle_profile_from_view(&group, &cfg, selected_fee_asset)?;
-                    !profile_updates_mark_from_trade_view(&profile, authenticated_now_slot)
+                    liquidation_penalty_reclaimable_from_profile_view(
+                        &profile,
+                        authenticated_now_slot,
+                    )
                 }
             } else {
                 false
@@ -14962,6 +14982,15 @@ pub mod processor {
                 && oracle_v16::profile_hybrid_soft_stale_matured(profile, now_slot))
     }
 
+    fn liquidation_penalty_reclaimable_from_profile_view(
+        profile: &state::AssetOracleProfileV16,
+        now_slot: u64,
+    ) -> bool {
+        !profile_updates_mark_from_trade_view(profile, now_slot)
+            && profile.effective_price_provenance
+                == constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED
+    }
+
     fn accepted_reported_trade_price_view(
         profile: &state::AssetOracleProfileV16,
         group: &state::MarketViewMutV16<'_>,
@@ -15402,6 +15431,10 @@ pub mod processor {
             simulated_profile.mark_ewma_e6 = effective_price;
             simulated_profile.mark_ewma_last_slot = now_slot;
         }
+        if update_fresh_hybrid_mark && effective_price == target {
+            simulated_profile.effective_price_provenance =
+                constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED;
+        }
         set_price_move_remainder_bps_num_view(&mut simulated_profile, price_move_remainder)?;
         *profile = simulated_profile;
         Ok(steps)
@@ -15740,6 +15773,10 @@ pub mod processor {
             record_funding_mark_transition_view(profile, asset_slot, post_trade_mark_e6, now_slot)?;
             profile.mark_ewma_e6 = post_trade_mark_e6;
             profile.mark_ewma_last_slot = now_slot;
+            if oracle_v16::profile_is_hybrid(profile) {
+                profile.effective_price_provenance =
+                    constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN;
+            }
         }
         Ok(())
     }

--- a/tests/invariants/cu/inv_015_account_ownership_layout_discriminator_and_length_validity.rs
+++ b/tests/invariants/cu/inv_015_account_ownership_layout_discriminator_and_length_validity.rs
@@ -34,6 +34,7 @@ enum OracleProfileMalformedCase {
     InvalidLegFlags,
     InvalidInvert,
     RemainderOutOfRange,
+    InvalidEffectivePriceProvenance,
     ReservedByteNonzero,
 }
 
@@ -250,6 +251,7 @@ fn v16_program_oracle_remainder_wire_bounds_reject_malformed_profiles_exactly() 
         OracleProfileMalformedCase::InvalidLegFlags,
         OracleProfileMalformedCase::InvalidInvert,
         OracleProfileMalformedCase::RemainderOutOfRange,
+        OracleProfileMalformedCase::InvalidEffectivePriceProvenance,
         OracleProfileMalformedCase::ReservedByteNonzero,
     ] {
         let mut env = V16CuEnv::new();
@@ -285,6 +287,14 @@ fn v16_program_oracle_remainder_wire_bounds_reject_malformed_profiles_exactly() 
                         price_move_remainder_bps_num
                     );
                 malformed_market.data[offset..offset + 2].copy_from_slice(&10_000u16.to_le_bytes());
+            }
+            OracleProfileMalformedCase::InvalidEffectivePriceProvenance => {
+                let offset = profile_offset
+                    + core::mem::offset_of!(
+                        state::AssetOracleProfileV16,
+                        effective_price_provenance
+                    );
+                malformed_market.data[offset] = 2;
             }
             OracleProfileMalformedCase::ReservedByteNonzero => {
                 let offset =

--- a/tests/invariants/cu/inv_052_split_merge_invariance.rs
+++ b/tests/invariants/cu/inv_052_split_merge_invariance.rs
@@ -1048,7 +1048,11 @@ fn v16_program_target_change_resets_prior_price_movement_remainder() {
         2_400,
         "the new downward trajectory starts with zero carry instead of inheriting the old target's 2,400 numerator units"
     );
-    assert_eq!(second_profile._padding0, [0u8; 4]);
+    assert_eq!(
+        second_profile.effective_price_provenance,
+        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED
+    );
+    assert_eq!(second_profile._padding0, [0u8; 3]);
     assert_eq!(env.market_state().1.assets[0].raw_oracle_target_price, 50);
     assert_eq!(env.market_state().1.assets[0].effective_price, PRICE);
 }

--- a/tests/invariants/cu/inv_087_no_phantom_controls_or_dead_security_fields.rs
+++ b/tests/invariants/cu/inv_087_no_phantom_controls_or_dead_security_fields.rs
@@ -557,6 +557,7 @@ fn v16_program_all_wrapper_owned_persisted_structs_have_complete_field_rosters()
                 "backing_trade_fee_insurance_share_bps_long",
                 "backing_trade_fee_insurance_share_bps_short",
                 "price_move_remainder_bps_num",
+                "effective_price_provenance",
                 "_padding0",
                 "insurance_authority",
                 "insurance_operator",
@@ -661,6 +662,7 @@ fn v16_program_all_wrapper_owned_persisted_structs_have_complete_field_rosters()
             "record_funding_mark_transition_view",
             "advance_funding_mark_checkpoint_view",
             "price_move_remainder_bps_num_view",
+            "liquidation_penalty_reclaimable_from_profile_view",
             "write_oracle_profile_to_view",
         ],
     );

--- a/tests/invariants/kani/inv_052_split_merge_invariance.rs
+++ b/tests/invariants/kani/inv_052_split_merge_invariance.rs
@@ -2,7 +2,8 @@
 //!
 //! The engine proves the canonical accrual arithmetic and path partition theorem. This wrapper
 //! proof owns only the persisted carry boundary: every representable carry below the denominator
-//! is accepted, while an out-of-range carry or any nonzero reserved byte fails closed.
+//! is accepted, while an out-of-range carry, invalid provenance, or any nonzero reserved byte
+//! fails closed.
 
 use percolator_prog::state;
 
@@ -10,25 +11,44 @@ use percolator_prog::state;
 #[kani::unwind(34)]
 fn kani_v16_inv052_oracle_profile_accepts_exact_remainder_domain() {
     let remainder: u16 = kani::any();
-    let reserved: u32 = kani::any();
+    let provenance: u8 = kani::any();
+    let reserved: [u8; 3] = kani::any();
     let mut profile = state::manual_asset_oracle_profile(100, 0);
+    profile.oracle_mode = percolator_prog::constants::ORACLE_MODE_HYBRID_AFTER_HOURS;
+    profile.oracle_leg_count = 1;
+    profile.max_staleness_secs = 1;
+    profile.hybrid_soft_stale_slots = 1;
+    profile.oracle_leg_feeds[0] = [1u8; 32];
     profile.price_move_remainder_bps_num = remainder;
-    profile._padding0 = reserved.to_le_bytes();
+    profile.effective_price_provenance = provenance;
+    profile._padding0 = reserved;
 
     let accepted = state::validate_asset_oracle_profile(&profile).is_ok();
-    assert_eq!(accepted, remainder < 10_000 && reserved == 0);
+    assert_eq!(
+        accepted,
+        remainder < 10_000
+            && provenance <= percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
+            && reserved == [0; 3]
+    );
 
-    kani::cover!(remainder == 0 && reserved == 0, "zero carry is accepted");
     kani::cover!(
-        remainder == 9_999 && reserved == 0,
+        remainder == 0 && provenance == 0 && reserved == [0; 3],
+        "zero carry with authenticated provenance is accepted"
+    );
+    kani::cover!(
+        remainder == 9_999 && provenance == 1 && reserved == [0; 3],
         "maximum canonical carry is accepted"
     );
     kani::cover!(
-        remainder == 10_000 && reserved == 0,
+        remainder == 10_000 && provenance == 0 && reserved == [0; 3],
         "denominator-sized carry is rejected"
     );
     kani::cover!(
-        remainder < 10_000 && reserved != 0,
+        remainder < 10_000 && provenance > 1 && reserved == [0; 3],
+        "invalid provenance fails closed"
+    );
+    kani::cover!(
+        remainder < 10_000 && provenance <= 1 && reserved != [0; 3],
         "reserved bytes fail closed"
     );
 }

--- a/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
+++ b/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
@@ -186,3 +186,282 @@ fn v16_program_pr280_trade_driven_liquidation_penalty_is_not_reclaimable() {
         }
     }
 }
+
+#[test]
+fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() {
+    use crate::support::v16_svm::{MarketConfig, V16Svm};
+    use percolator::POS_SCALE;
+
+    const MARK: u64 = 1_000_000;
+    const VICTIM_DEPOSIT: u128 = 50_000;
+    const HONEST_DEPOSIT: u128 = 2_000_000;
+    const ATTACK_DEPOSIT: u128 = 1_000;
+    const CRANKER_DEPOSIT: u128 = 1;
+    const TINY_Q: i128 = (POS_SCALE / 10_000) as i128;
+
+    fn asset_q(env: &V16Svm, actor: usize) -> u128 {
+        env.primary_portfolio(actor)
+            .legs
+            .iter()
+            .filter_map(|leg| leg.try_to_runtime().ok())
+            .find(|leg| leg.active && leg.asset_index == 0)
+            .map(|leg| leg.basis_pos_q.unsigned_abs())
+            .unwrap_or(0)
+    }
+
+    fn effective_asset_q(env: &V16Svm, actor: usize) -> u128 {
+        let (_, group) = env.primary_market_state();
+        let Some(leg) = env
+            .primary_portfolio(actor)
+            .legs
+            .iter()
+            .filter_map(|leg| leg.try_to_runtime().ok())
+            .find(|leg| leg.active && leg.asset_index == 0)
+        else {
+            return 0;
+        };
+        let asset = &group.assets[0];
+        let (current_a, current_epoch, effective_oi, pending_count, mode) = match leg.side {
+            percolator::SideV16::Long => (
+                asset.a_long,
+                asset.epoch_long,
+                asset.oi_eff_long_q,
+                asset.pending_obligation_count_long,
+                asset.mode_long,
+            ),
+            percolator::SideV16::Short => (
+                asset.a_short,
+                asset.epoch_short,
+                asset.oi_eff_short_q,
+                asset.pending_obligation_count_short,
+                asset.mode_short,
+            ),
+        };
+        if (mode == percolator::SideModeV16::ResetPending
+            && leg.epoch_snap.checked_add(1) == Some(current_epoch))
+            || (effective_oi == 0
+                && pending_count == 0
+                && mode != percolator::SideModeV16::ResetPending)
+        {
+            return 0;
+        }
+        assert_eq!(leg.epoch_snap, current_epoch);
+        crate::support::reference_math::mul_div_ceil(
+            leg.basis_pos_q.unsigned_abs(),
+            current_a,
+            leg.a_basis,
+        )
+        .unwrap()
+    }
+
+    let mut env = V16Svm::new(
+        [0x91; 32],
+        MarketConfig {
+            initial_price: MARK,
+            h_max: 6_480_000,
+            min_nonzero_mm_req: 599,
+            min_nonzero_im_req: 600,
+            maintenance_margin_bps: 500,
+            initial_margin_bps: 500,
+            liquidation_fee_bps: 5,
+            liquidation_fee_cap: percolator::MAX_PROTOCOL_FEE_ABS,
+            min_liquidation_abs: 500,
+            max_price_move_bps_per_slot: 24,
+            max_accrual_dt_slots: 1,
+            max_abs_funding_e9_per_slot: 1_000,
+            min_funding_lifetime_slots: 10_000_000,
+            actor_deposits: [
+                VICTIM_DEPOSIT,
+                HONEST_DEPOSIT,
+                ATTACK_DEPOSIT,
+                ATTACK_DEPOSIT,
+                CRANKER_DEPOSIT,
+            ],
+            ..MarketConfig::default()
+        },
+    );
+    env.update_liquidation_fee_policy(10_000).unwrap();
+    env.begin_public_trace();
+    env.set_clock(1, 100);
+    let feed = [0xedu8; 32];
+    let pyth = env.set_pyth_price(&feed, MARK as i64, -6, 0, 100);
+    env.configure_hybrid_oracle(0, 1, 100, 0, [feed, [0; 32], [0; 32]], &[pyth], 1, 0)
+        .unwrap();
+    env.trade_no_cpi(0, 1, 0, POS_SCALE as i128, MARK, 0)
+        .unwrap();
+
+    let supply_before = env.token_supply_observed();
+    let mint_supply_before = env.mint_supply();
+    env.set_clock(3, 1_000);
+    let insurance_before_move = env.primary_market_state().1.insurance;
+    env.trade_no_cpi(2, 3, 0, TINY_Q, 999_850, 0).unwrap();
+    let (profile_after_move, group_after_move) = env.primary_market_state();
+    let movement_fee = group_after_move.insurance - insurance_before_move;
+    assert!(movement_fee > 0);
+    assert!(profile_after_move.mark_ewma_e6 < MARK);
+
+    let observation = vec![percolator_prog::ix::CrankObservationHint {
+        asset_index: 0,
+        oracle_accounts: 1,
+    }];
+    let mut max_crank_cu = 0;
+    let mut stale_crank_cus = Vec::new();
+    for _ in 0..4 {
+        let (_, group) = env.primary_market_state();
+        if group.assets[0].slot_last == 3
+            && group.assets[0].effective_price == profile_after_move.mark_ewma_e6
+        {
+            break;
+        }
+        let result = env
+            .crank_with_oracles(4, 3, observation.clone(), &[pyth])
+            .unwrap();
+        max_crank_cu = max_crank_cu.max(result.compute_units);
+        stale_crank_cus.push(result.compute_units);
+    }
+    let (_, stale_settled) = env.primary_market_state();
+    assert_eq!(stale_settled.assets[0].slot_last, 3);
+    assert_eq!(
+        stale_settled.assets[0].effective_price,
+        profile_after_move.mark_ewma_e6
+    );
+
+    env.update_pyth_price(pyth, &feed, MARK as i64, -6, 0, 1_000);
+    let victim_capital_before = env.primary_portfolio(0).capital.get();
+    let cranker_capital_before = env.primary_portfolio(4).capital.get();
+    let insurance_before_liquidation = env.primary_market_state().1.insurance;
+    let victim_q_before = asset_q(&env, 0);
+    let mut liquidation_landed = false;
+    let mut fresh_crank_steps = Vec::new();
+    for attempt in 0..6 {
+        let oracle_accounts = if attempt == 0 {
+            std::slice::from_ref(&pyth)
+        } else {
+            &[]
+        };
+        let result = env.crank_with_reward(
+            4,
+            0,
+            3,
+            if attempt == 0 {
+                observation.clone()
+            } else {
+                Vec::new()
+            },
+            oracle_accounts,
+        );
+        let result = result.unwrap_or_else(|error| panic!("fresh crank {attempt}: {error}"));
+        max_crank_cu = max_crank_cu.max(result.compute_units);
+        let (profile, group) = env.primary_market_state();
+        fresh_crank_steps.push((
+            result.compute_units,
+            profile.last_good_oracle_slot,
+            group.assets[0].effective_price,
+            asset_q(&env, 0),
+            env.primary_portfolio(4).capital.get() - cranker_capital_before,
+        ));
+        if asset_q(&env, 0) < victim_q_before {
+            liquidation_landed = true;
+            break;
+        }
+    }
+    assert!(liquidation_landed);
+    let (fresh_profile, after_liquidation) = env.primary_market_state();
+    let cranker_reward = env.primary_portfolio(4).capital.get() - cranker_capital_before;
+    let retained_penalty = after_liquidation.insurance - insurance_before_liquidation;
+    let victim_capital_loss = victim_capital_before - env.primary_portfolio(0).capital.get();
+    eprintln!(
+        "hybrid provenance probe: movement_fee={movement_fee}, cranker_reward={cranker_reward}, retained_penalty={retained_penalty}, victim_capital_loss={victim_capital_loss}, effective={}, target={}, mark={}, last_good={}, max_cu={max_crank_cu}",
+        after_liquidation.assets[0].effective_price,
+        after_liquidation.assets[0].raw_oracle_target_price,
+        fresh_profile.mark_ewma_e6,
+        fresh_profile.last_good_oracle_slot,
+    );
+    eprintln!(
+        "hybrid provenance cranks: stale_settle_cu={stale_crank_cus:?}, fresh_steps=(cu,last_good,effective,victim_q,reward)={fresh_crank_steps:?}"
+    );
+    assert_eq!(fresh_profile.last_good_oracle_slot, 3);
+    assert!(after_liquidation.assets[0].effective_price < MARK);
+    assert_eq!(after_liquidation.assets[0].raw_oracle_target_price, MARK);
+
+    for actor in [0usize, 1, 2, 3] {
+        for attempt in 0..8 {
+            if asset_q(&env, actor) == 0 {
+                break;
+            }
+            let effective_q = effective_asset_q(&env, actor);
+            let result = if effective_q == 0 {
+                env.crank(actor, 3, Vec::new())
+            } else {
+                env.rebalance_reduce(actor, 0, effective_q)
+            };
+            let result = result.unwrap_or_else(|error| {
+                panic!("terminal reduction actor {actor} attempt {attempt}: {error}")
+            });
+            max_crank_cu = max_crank_cu.max(result.compute_units);
+        }
+        assert_eq!(asset_q(&env, actor), 0, "actor {actor} retained a leg");
+    }
+
+    for actor in 0..5 {
+        match env.crank_with_oracles(actor, 3, observation.clone(), &[pyth]) {
+            Ok(result) => max_crank_cu = max_crank_cu.max(result.compute_units),
+            Err(error)
+                if error.contains("Custom(22)") || error.contains("custom program error: 0x16") => {
+            }
+            Err(error) => panic!("terminal refresh actor {actor}: {error}"),
+        }
+        let pnl = env.primary_portfolio(actor).pnl.get();
+        if pnl > 0 {
+            let result = env
+                .convert_released_pnl(actor, pnl as u128)
+                .unwrap_or_else(|error| panic!("convert actor {actor} pnl {pnl}: {error}"));
+            max_crank_cu = max_crank_cu.max(result.compute_units);
+        }
+        let capital = env.primary_portfolio(actor).capital.get();
+        if capital != 0 {
+            let result = env.withdraw_primary(actor, capital).unwrap();
+            max_crank_cu = max_crank_cu.max(result.compute_units);
+        }
+    }
+    let victim_payout = u128::from(env.token_amount(env.actors[0].destination_token));
+    let honest_payout = u128::from(env.token_amount(env.actors[1].destination_token));
+    let attacker_withdrawn = [2usize, 3, 4]
+        .into_iter()
+        .map(|actor| u128::from(env.token_amount(env.actors[actor].destination_token)))
+        .sum::<u128>();
+    let attacker_deposited = ATTACK_DEPOSIT * 2 + CRANKER_DEPOSIT;
+    let attacker_gain = attacker_withdrawn.saturating_sub(attacker_deposited);
+    let attacker_loss = attacker_deposited.saturating_sub(attacker_withdrawn);
+    let victim_loss = VICTIM_DEPOSIT.saturating_sub(victim_payout);
+    let trace = env.finish_public_trace();
+    trace.validate_public_execution().unwrap();
+    assert_eq!(trace.out_of_band_economic_mutations, 0);
+    let public_trace_cu = trace
+        .steps
+        .iter()
+        .map(|step| {
+            (
+                step.instruction_data.first().copied().unwrap_or(u8::MAX),
+                step.compute_units,
+            )
+        })
+        .collect::<Vec<_>>();
+    eprintln!(
+        "hybrid terminal accounting: attacker deposited={attacker_deposited}, withdrawn={attacker_withdrawn}, gain={attacker_gain}, loss={attacker_loss}; victim deposited={VICTIM_DEPOSIT}, withdrawn={victim_payout}, loss={victim_loss}; honest deposited={HONEST_DEPOSIT}, withdrawn={honest_payout}; movement_fee={movement_fee}, cranker_reward={cranker_reward}, observed_supply={}/{supply_before}, mint_supply={}/{mint_supply_before}, public_steps={}, max_cu={max_crank_cu}",
+        env.token_supply_observed(),
+        env.mint_supply(),
+        trace.steps.len(),
+    );
+    eprintln!("hybrid public trace (instruction tag, CU): {public_trace_cu:?}");
+    assert_eq!(env.token_supply_observed(), supply_before);
+    assert_eq!(env.mint_supply(), mint_supply_before);
+    assert!(max_crank_cu < crate::support::v16_svm::TX_CU_LIMIT);
+    assert!(victim_loss > 0);
+    assert!(cranker_reward > movement_fee);
+    assert!(attacker_gain > 0);
+    assert_eq!(
+        cranker_reward, 0,
+        "a fresh feed must not make the inherited trade-driven liquidation penalty reclaimable"
+    );
+}

--- a/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
+++ b/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
@@ -404,10 +404,6 @@ fn v16_program_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_rew
     let movement_fee = group_after_move.insurance - insurance_before_move;
     assert!(movement_fee > 0);
     assert!(profile_after_move.mark_ewma_e6 < MARK);
-    assert_eq!(
-        env.primary_profile(0).effective_price_provenance,
-        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
-    );
 
     let observation = vec![percolator_prog::ix::CrankObservationHint {
         asset_index: 0,
@@ -492,10 +488,6 @@ fn v16_program_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_rew
     assert_eq!(fresh_profile.last_good_oracle_slot, 3);
     assert!(after_liquidation.assets[0].effective_price < MARK);
     assert_eq!(after_liquidation.assets[0].raw_oracle_target_price, MARK);
-    assert_eq!(
-        env.primary_profile(0).effective_price_provenance,
-        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
-    );
 
     env.set_clock(4, 1_001);
     let catchup = env

--- a/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
+++ b/tests/invariants/public_sbf/inv_045_no_free_mark_movement.rs
@@ -2,14 +2,16 @@
 //!
 //! Normative obligation: Every mark movement remains elapsed-time bounded and economically paid across every trade route.
 //!
-//! Evidence in this file (I plus invariant-specific F/M assertions): `v16_program_pr260_pending_ewma_inheritance_rejects_then_trades_on_every_route`, `v16_program_pr282_pending_ewma_target_override_rejects_without_value_drift`, `v16_program_pr264_pr265_pr332_pr333_targets_stage_before_stale_cpi`, `v16_program_pr356_pending_mark_fee_sync_rejects_then_preserves_terminal_value`, `v16_program_pr369_one_sided_cpi_fee_cannot_subsidize_mark_gain`, `v16_program_pr225_mark_movement_fee_is_nonwithdrawable_and_terminally_burned`, `v16_program_pr280_trade_driven_liquidation_penalty_is_not_reclaimable`. These tests exercise the deployed public
+//! Evidence in this file (I plus invariant-specific F/M assertions): `v16_program_pr260_pending_ewma_inheritance_rejects_then_trades_on_every_route`, `v16_program_pr282_pending_ewma_target_override_rejects_without_value_drift`, `v16_program_pr264_pr265_pr332_pr333_targets_stage_before_stale_cpi`, `v16_program_pr356_pending_mark_fee_sync_rejects_then_preserves_terminal_value`, `v16_program_pr369_one_sided_cpi_fee_cannot_subsidize_mark_gain`, `v16_program_pr225_mark_movement_fee_is_nonwithdrawable_and_terminally_burned`, `v16_program_pr280_trade_driven_liquidation_penalty_is_not_reclaimable`, `v16_program_fresh_hybrid_oracle_liquidation_reward_remains_enabled`, and `v16_program_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward`. These tests exercise the deployed public
 //! wrapper with real SBF/LiteSVM account construction and assert economic state, token,
 //! rollback, liveness, or compute outcomes appropriate to the invariant.
 //!
 //! Guarantee boundary: PR260, PR264/265/332/333, PR282, PR356, and PR369 are fixed-pin regressions
 //! covering target staging, stale-admission rollback, post-catch-up liveness, target-aware fees,
 //! authenticated mark/fee ordering, bilateral CPI fee support, nonwithdrawable movement reserves,
-//! and nonreclaimable trade-driven liquidation penalties.
+//! and nonreclaimable trade-driven liquidation penalties. The cross-mode Hybrid regression proves
+//! freshness cannot erase stale-trade provenance before effective-price catch-up, while its fresh
+//! control and terminal catch-up prove ordinary authenticated rewards are preserved.
 
 use super::*;
 
@@ -188,7 +190,110 @@ fn v16_program_pr280_trade_driven_liquidation_penalty_is_not_reclaimable() {
 }
 
 #[test]
-fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() {
+fn v16_program_fresh_hybrid_oracle_liquidation_reward_remains_enabled() {
+    use crate::support::v16_svm::{MarketConfig, V16Svm};
+    use percolator::POS_SCALE;
+
+    const MARK: u64 = 1_000_000;
+    const FRESH_MARK: u64 = 999_900;
+
+    fn asset_q(env: &V16Svm, actor: usize) -> u128 {
+        env.primary_portfolio(actor)
+            .legs
+            .iter()
+            .filter_map(|leg| leg.try_to_runtime().ok())
+            .find(|leg| leg.active && leg.asset_index == 0)
+            .map(|leg| leg.basis_pos_q.unsigned_abs())
+            .unwrap_or(0)
+    }
+
+    let mut env = V16Svm::new(
+        [0x92; 32],
+        MarketConfig {
+            initial_price: MARK,
+            h_max: 6_480_000,
+            min_nonzero_mm_req: 599,
+            min_nonzero_im_req: 600,
+            maintenance_margin_bps: 500,
+            initial_margin_bps: 500,
+            liquidation_fee_bps: 5,
+            liquidation_fee_cap: percolator::MAX_PROTOCOL_FEE_ABS,
+            min_liquidation_abs: 500,
+            max_price_move_bps_per_slot: 24,
+            max_accrual_dt_slots: 1,
+            max_abs_funding_e9_per_slot: 1_000,
+            min_funding_lifetime_slots: 10_000_000,
+            actor_deposits: [50_000, 2_000_000, 1, 1, 1],
+            ..MarketConfig::default()
+        },
+    );
+    env.update_liquidation_fee_policy(10_000).unwrap();
+    env.set_clock(1, 100);
+    let feed = [0xefu8; 32];
+    let pyth = env.set_pyth_price(&feed, MARK as i64, -6, 0, 100);
+    env.configure_hybrid_oracle(0, 1, 100, 0, [feed, [0; 32], [0; 32]], &[pyth], 10, 0)
+        .unwrap();
+    env.trade_no_cpi(0, 1, 0, POS_SCALE as i128, MARK, 0)
+        .unwrap();
+
+    let supply_before = env.token_supply_observed();
+    let mint_supply_before = env.mint_supply();
+    let cranker_before = env.primary_portfolio(2).capital.get();
+    env.set_clock(2, 101);
+    env.update_pyth_price(pyth, &feed, FRESH_MARK as i64, -6, 0, 101);
+    let observation = vec![percolator_prog::ix::CrankObservationHint {
+        asset_index: 0,
+        oracle_accounts: 1,
+    }];
+    let mut max_cu = 0;
+    for attempt in 0..4 {
+        let result = env
+            .crank_with_reward(
+                2,
+                0,
+                2,
+                if attempt == 0 {
+                    observation.clone()
+                } else {
+                    Vec::new()
+                },
+                if attempt == 0 {
+                    std::slice::from_ref(&pyth)
+                } else {
+                    &[]
+                },
+            )
+            .unwrap_or_else(|error| panic!("fresh Hybrid crank {attempt}: {error}"));
+        max_cu = max_cu.max(result.compute_units);
+        if asset_q(&env, 0) < POS_SCALE {
+            break;
+        }
+    }
+
+    let (wrapper, group) = env.primary_market_state();
+    let profile = env.primary_profile(0);
+    let reward = env.primary_portfolio(2).capital.get() - cranker_before;
+    assert!(asset_q(&env, 0) < POS_SCALE, "fresh mark must liquidate");
+    assert!(
+        reward > 0,
+        "authenticated Hybrid liquidation keeps its reward"
+    );
+    assert_eq!(wrapper.last_good_oracle_slot, 2);
+    assert_eq!(profile.last_good_oracle_slot, 2);
+    assert_eq!(
+        profile.effective_price_provenance,
+        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED
+    );
+    assert_eq!(group.assets[0].raw_oracle_target_price, FRESH_MARK);
+    assert_eq!(group.assets[0].effective_price, FRESH_MARK);
+    assert_eq!(env.token_supply_observed(), supply_before);
+    assert_eq!(env.mint_supply(), mint_supply_before);
+    assert!(max_cu < crate::support::v16_svm::TX_CU_LIMIT);
+    eprintln!("fresh Hybrid liquidation reward={reward}, max_cu={max_cu}");
+}
+
+#[test]
+fn v16_program_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() {
     use crate::support::v16_svm::{MarketConfig, V16Svm};
     use percolator::POS_SCALE;
 
@@ -299,6 +404,10 @@ fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() 
     let movement_fee = group_after_move.insurance - insurance_before_move;
     assert!(movement_fee > 0);
     assert!(profile_after_move.mark_ewma_e6 < MARK);
+    assert_eq!(
+        env.primary_profile(0).effective_price_provenance,
+        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
+    );
 
     let observation = vec![percolator_prog::ix::CrankObservationHint {
         asset_index: 0,
@@ -383,6 +492,25 @@ fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() 
     assert_eq!(fresh_profile.last_good_oracle_slot, 3);
     assert!(after_liquidation.assets[0].effective_price < MARK);
     assert_eq!(after_liquidation.assets[0].raw_oracle_target_price, MARK);
+    assert_eq!(
+        env.primary_profile(0).effective_price_provenance,
+        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_TRADE_DRIVEN
+    );
+
+    env.set_clock(4, 1_001);
+    let catchup = env
+        .crank_with_oracles(4, 4, observation.clone(), &[pyth])
+        .expect("fresh authenticated target catch-up");
+    max_crank_cu = max_crank_cu.max(catchup.compute_units);
+    let caught_up_profile = env.primary_profile(0);
+    let (_, caught_up_group) = env.primary_market_state();
+    assert_eq!(caught_up_group.assets[0].effective_price, MARK);
+    assert_eq!(caught_up_group.assets[0].raw_oracle_target_price, MARK);
+    assert_eq!(
+        caught_up_profile.effective_price_provenance,
+        percolator_prog::constants::EFFECTIVE_PRICE_PROVENANCE_AUTHENTICATED,
+        "rewards become eligible again once effective price reaches the authenticated target"
+    );
 
     for actor in [0usize, 1, 2, 3] {
         for attempt in 0..8 {
@@ -391,7 +519,7 @@ fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() 
             }
             let effective_q = effective_asset_q(&env, actor);
             let result = if effective_q == 0 {
-                env.crank(actor, 3, Vec::new())
+                env.crank(actor, 4, Vec::new())
             } else {
                 env.rebalance_reduce(actor, 0, effective_q)
             };
@@ -404,7 +532,7 @@ fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() 
     }
 
     for actor in 0..5 {
-        match env.crank_with_oracles(actor, 3, observation.clone(), &[pyth]) {
+        match env.crank_with_oracles(actor, 4, observation.clone(), &[pyth]) {
             Ok(result) => max_crank_cu = max_crank_cu.max(result.compute_units),
             Err(error)
                 if error.contains("Custom(22)") || error.contains("custom program error: 0x16") => {
@@ -458,10 +586,11 @@ fn probe_fresh_hybrid_report_does_not_reenable_stale_trade_liquidation_reward() 
     assert_eq!(env.mint_supply(), mint_supply_before);
     assert!(max_crank_cu < crate::support::v16_svm::TX_CU_LIMIT);
     assert!(victim_loss > 0);
-    assert!(cranker_reward > movement_fee);
-    assert!(attacker_gain > 0);
     assert_eq!(
         cranker_reward, 0,
         "a fresh feed must not make the inherited trade-driven liquidation penalty reclaimable"
     );
+    assert_eq!(attacker_gain, 0);
+    assert!(attacker_loss > 0);
+    assert!(retained_penalty > 0);
 }

--- a/tests/support/v16_svm.rs
+++ b/tests/support/v16_svm.rs
@@ -5488,6 +5488,27 @@ impl V16Svm {
         key
     }
 
+    pub fn update_pyth_price(
+        &mut self,
+        key: Pubkey,
+        feed: &[u8; 32],
+        price: i64,
+        expo: i32,
+        conf: u64,
+        publish_time: i64,
+    ) {
+        let mut account = self.svm.get_account(&key).expect("existing Pyth fixture");
+        assert_eq!(
+            account.owner,
+            percolator_prog::oracle_v16::PYTH_RECEIVER_PROGRAM_ID,
+            "only the external Pyth fixture may be updated out of band"
+        );
+        account.data = make_pyth_data(feed, price, expo, conf, publish_time);
+        self.svm
+            .set_account(key, account)
+            .expect("update external Pyth fixture");
+    }
+
     pub fn current_slot(&self) -> u64 {
         self.svm.get_sysvar::<Clock>().slot
     }


### PR DESCRIPTION
## Finding

A stale `ORACLE_MODE_HYBRID_AFTER_HOURS` self-trade can move the effective mark after paying its movement fee. When an authenticated oracle report later becomes fresh in the same slot, the wrapper updates `last_good_oracle_slot` immediately even though the effective price is still the stale trade-derived value. The liquidation path then classifies an unrelated victim's penalty as authenticated and pays it to the attacker's cranker account.

Exact-main public LiteSVM trace:

- attacker coalition deposits 2,001 atoms;
- stale Hybrid self-trade pays a 200-atom movement fee;
- fresh report targets 1,000,000 while effective remains 999,901;
- unrelated victim is liquidated at that inherited effective price;
- attacker receives a 500-atom liquidation reward and withdraws 2,301 atoms, net +300;
- victim deposits 50,000 and withdraws 49,401, losing 599;
- all 22 successful steps use public wrapper instructions, no program-owned state injection;
- SPL observed supply and mint supply remain exact.

This is distinct from PR #280: that regression covers a currently stale feed. Here a newly fresh report erases reward provenance before effective-price catch-up.

## Fix

Use one former padding byte in `AssetOracleProfileV16` to persist whether the current Hybrid effective-price path includes trade-driven movement. Layout remains 424 bytes and the instruction ABI is unchanged.

- Hybrid trade movement marks provenance trade-driven.
- Oracle freshness alone does not restore liquidation rewards.
- Provenance returns to authenticated only after effective price reaches the authenticated target.
- Non-Hybrid profiles reject non-authenticated provenance.
- Existing zeroed accounts decode as authenticated.

## TDD evidence

Parent SBF `6660d1e7c41b5003675d3ed98f7ff0a88fa9899234a3c4e68a0ecd67990131be` fails on the economic postcondition:

- movement fee 200;
- cranker reward 500;
- retained penalty 0;
- attacker gain 300;
- victim loss 599;
- max CU 233,550.

Fixed SBF `7b4134785cc47f3ae322192a4b98bba0b1e83aae6468334a01a869f0ded7cd61`:

- cranker reward 0;
- retained penalty 500;
- attacker gain 0 and loss 200;
- victim liquidation still completes;
- authenticated catch-up restores normal reward eligibility;
- ordinary fresh-Hybrid liquidation still pays 500;
- focused INV-045 public suite 9/9;
- targeted Kani 655 checks and 5 cover properties;
- malformed-layout, adjacent mark/CPI, reward, rollback, and PR #280 regressions pass;
- normal fresh path adds 50 CU.

Engine pin remains `495a5590c97055bd71c6f94d849ff0298f243145`.