### PR TITLE
[BLOCKER LoF] Preserve oracle cap carry across interleaved trades

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -15468,11 +15468,11 @@ pub mod processor {
         Ok(target)
     }
 
-    fn zero_move_funding_segment_for_profile_view(
-        profile: &state::AssetOracleProfileV16,
+    fn zero_move_funding_path_for_profile_view(
+        profile: &mut state::AssetOracleProfileV16,
         group: &mut state::MarketViewMutV16<'_>,
         asset_index: usize,
-    ) -> Result<Option<(u64, i128)>, V16Error> {
+    ) -> Result<Option<(u64, u64, Vec<AccrualStepV16>)>, V16Error> {
         if !oracle_v16::profile_is_price_managed(profile)
             || asset_index >= group.header.config.max_market_slots.get() as usize
             || asset_index >= group.markets.len()
@@ -15489,30 +15489,28 @@ pub mod processor {
         let effective_price = asset.effective_price.get();
         let target =
             stored_mark_target_for_zero_move_accrual_view(profile, group, asset_index, now_slot)?;
-        let bounded_price = oracle_v16::effective_price_from_target(
-            effective_price,
-            target,
-            group.header.config.max_price_move_bps_per_slot.get(),
-            segment_dt,
-            true,
-        );
-        // This helper settles only the interval a normal crank would process without changing K.
-        // Price-moving intervals stay on the ordinary observation-bearing crank route.
-        if bounded_price != effective_price {
-            return Ok(None);
-        }
-        let funding_rate_e9 = permissionless_funding_rate_e9_view(
-            profile,
+        let mut simulated_profile = *profile;
+        let path = canonical_accrual_path_for_target_view(
+            &mut simulated_profile,
             group,
             asset_index,
             now_slot,
-            effective_price,
+            target,
+            asset.slot_last.get().saturating_add(1),
         )
-        .map_err(|_| V16Error::ArithmeticOverflow)?;
-        if funding_rate_e9 == 0 {
+        .map_err(|_| V16Error::InvalidConfig)?;
+        // This helper settles only the interval a normal crank would process without changing K.
+        // Price-moving intervals stay on the ordinary observation-bearing crank route.
+        if path.is_empty()
+            || path
+                .iter()
+                .any(|step| step.effective_price != effective_price)
+            || path.iter().all(|step| step.funding_rate_e9 == 0)
+        {
             return Ok(None);
         }
-        Ok(Some((effective_price, funding_rate_e9)))
+        *profile = simulated_profile;
+        Ok(Some((now_slot, target, path)))
     }
 
     fn pending_zero_move_funding_requires_crank_view(
@@ -15571,8 +15569,8 @@ pub mod processor {
         }
         let asset_slot = group.markets[asset_index].engine.asset.slot_last.get();
         advance_funding_mark_checkpoint_view(profile, asset_slot);
-        let Some((effective_price, funding_rate_e9)) =
-            zero_move_funding_segment_for_profile_view(profile, group, asset_index)?
+        let Some((now_slot, target, path)) =
+            zero_move_funding_path_for_profile_view(profile, group, asset_index)?
         else {
             if require_full_catchup
                 && pending_zero_move_funding_requires_crank_view(profile, group, asset_index)?
@@ -15581,21 +15579,14 @@ pub mod processor {
             }
             return Ok(());
         };
-        let now_slot = authenticated_market_slot_or_fallback_view(group);
-        group.accrue_asset_to_not_atomic(
-            asset_index,
-            now_slot,
-            effective_price,
-            funding_rate_e9,
-            true,
-        )?;
+        group.accrue_asset_path_to_not_atomic(asset_index, now_slot, target, &path, true)?;
         let asset_slot = group.markets[asset_index].engine.asset.slot_last.get();
         advance_funding_mark_checkpoint_view(profile, asset_slot);
         // One instruction never performs an attacker-sized catch-up loop. If more deterministic
         // zero-move funding remains, roll this inline segment back and require bounded public
         // cranks before the unchanged position operation retries.
         if require_full_catchup
-            && (zero_move_funding_segment_for_profile_view(profile, group, asset_index)?.is_some()
+            && (zero_move_funding_path_for_profile_view(profile, group, asset_index)?.is_some()
                 || pending_zero_move_funding_requires_crank_view(profile, group, asset_index)?)
         {
             return Err(V16Error::Stale);

--- a/tests/invariants/cu/inv_071_crank_progress.rs
+++ b/tests/invariants/cu/inv_071_crank_progress.rs
@@ -2308,8 +2308,10 @@ fn v16_attack_risk_reducing_trade_cannot_erase_canonical_price_movement_remainde
         interleaved.price_move_remainder_bps_num,
         canonical.price_move_remainder_bps_num
     );
-    assert!(interleaved.max_trade_cu < 1_400_000);
-    assert!(canonical.max_crank_cu < 1_400_000);
+    assert!(canonical.max_trade_cu < TRADE_CU_LIMIT);
+    assert!(interleaved.max_trade_cu < TRADE_CU_LIMIT);
+    assert!(canonical.max_crank_cu < CRANK_CU_LIMIT);
+    assert!(interleaved.max_crank_cu < CRANK_CU_LIMIT);
 }
 
 #[test]

--- a/tests/invariants/cu/inv_071_crank_progress.rs
+++ b/tests/invariants/cu/inv_071_crank_progress.rs
@@ -2096,6 +2096,222 @@ fn v16_program_micro_price_schedule_is_partition_invariant_and_eventually_progre
     assert_eq!(eager.vault_tokens, delayed.vault_tokens);
 }
 
+#[derive(Debug)]
+struct TradeInterleavedPriceRemainderOutcome {
+    effective_price: u64,
+    price_move_remainder_bps_num: u16,
+    victim_withdrawn: u128,
+    attacker_withdrawn: u128,
+    wash_withdrawn: u128,
+    vault_tokens: u64,
+    max_trade_cu: u64,
+    max_crank_cu: u64,
+}
+
+fn run_trade_interleaved_price_remainder_world(
+    trade_before_crank: bool,
+) -> TradeInterleavedPriceRemainderOutcome {
+    const PRICE: u64 = 100;
+    const TARGET: u64 = 200;
+    const FINAL_SLOT: u64 = 5;
+    const DEPOSIT: u128 = 1_000_000;
+    const MAIN_Q: i128 = 100 * POS_SCALE as i128;
+    const WASH_STEP_Q: i128 = POS_SCALE as i128;
+
+    let mut env = V16CuEnv::new_with_init_params(V16CuMarketParams {
+        initial_price: PRICE,
+        max_price_move_bps_per_slot: 24,
+        max_accrual_dt_slots: 20,
+        max_abs_funding_e9_per_slot: 1_000,
+        min_funding_lifetime_slots: 20,
+        ..V16CuMarketParams::default()
+    });
+    env.configure_auth_mark_with_cu(0, PRICE);
+    let matcher_program = Pubkey::new_unique();
+    let matcher_bytes = std::fs::read(matcher_program_path()).expect("read matcher BPF");
+    env.svm.add_program(matcher_program, &matcher_bytes);
+
+    let victim_owner = Keypair::new();
+    let attacker_owner = Keypair::new();
+    let wash_long_owner = Keypair::new();
+    let wash_short_owner = Keypair::new();
+    let observer_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let attacker = env.create_portfolio(&attacker_owner);
+    let wash_long = env.create_portfolio(&wash_long_owner);
+    let wash_short = env.create_portfolio(&wash_short_owner);
+    let observer = env.create_portfolio(&observer_owner);
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&attacker_owner, attacker),
+        (&wash_long_owner, wash_long),
+        (&wash_short_owner, wash_short),
+    ] {
+        env.deposit(owner, portfolio, DEPOSIT);
+    }
+    let (matcher_context, matcher_delegate, _) =
+        env.init_matcher_context_authorized(matcher_program, &victim_owner, victim);
+    // The victim authorizes a passive LP once. Only the attacker signs either CPI trade.
+    env.trade_cpi_with_cu(
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        -MAIN_Q,
+        0,
+    );
+    env.trade_with_cu(
+        &wash_long_owner,
+        wash_long,
+        &wash_short_owner,
+        wash_short,
+        WASH_STEP_Q * i128::from(FINAL_SLOT - 1),
+        PRICE,
+        0,
+    );
+
+    env.svm.warp_to_slot(1);
+    env.push_auth_mark_with_cu(1, TARGET);
+    env.svm.expire_blockhash();
+    let mut max_crank_cu = env.crank(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 1,
+            observations: crank_observations(0),
+        },
+    );
+    let mut max_trade_cu = 0;
+
+    for slot in 2..=FINAL_SLOT {
+        env.svm.warp_to_slot(slot);
+        if !trade_before_crank {
+            env.svm.expire_blockhash();
+            max_crank_cu = max_crank_cu.max(env.crank(
+                observer,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+            ));
+        }
+        env.svm.expire_blockhash();
+        max_trade_cu = max_trade_cu.max(env.trade_with_cu(
+            &wash_long_owner,
+            wash_long,
+            &wash_short_owner,
+            wash_short,
+            -WASH_STEP_Q,
+            PRICE,
+            0,
+        ));
+        if trade_before_crank {
+            env.svm.expire_blockhash();
+            if let Some(cu) = env.crank_if_actionable(
+                observer,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: slot,
+                    observations: crank_observations(0),
+                },
+            ) {
+                max_crank_cu = max_crank_cu.max(cu);
+            }
+        }
+    }
+
+    env.svm.expire_blockhash();
+    max_trade_cu = max_trade_cu.max(env.trade_cpi_with_cu(
+        &attacker_owner,
+        attacker,
+        &victim_owner,
+        victim,
+        matcher_program,
+        matcher_context,
+        matcher_delegate,
+        MAIN_Q,
+        0,
+    ));
+    let mut destinations = Vec::new();
+    for (owner, portfolio) in [
+        (&victim_owner, victim),
+        (&attacker_owner, attacker),
+        (&wash_long_owner, wash_long),
+        (&wash_short_owner, wash_short),
+    ] {
+        for _ in 0..8 {
+            env.svm.expire_blockhash();
+            if env
+                .crank_if_actionable(
+                    portfolio,
+                    ProgInstruction::PermissionlessCrank {
+                        now_slot: FINAL_SLOT,
+                        observations: crank_observations(0),
+                    },
+                )
+                .is_none()
+            {
+                break;
+            }
+        }
+        let before_convert = env.portfolio_state(portfolio);
+        if before_convert.pnl.get() > 0 {
+            env.convert_released_pnl_with_cu(
+                owner,
+                portfolio,
+                u128::try_from(before_convert.pnl.get()).unwrap(),
+            );
+        }
+        let after_convert = env.portfolio_state(portfolio);
+        assert_eq!(after_convert.pnl.get(), 0);
+        destinations.push(env.withdraw(owner, portfolio, after_convert.capital.get()));
+    }
+    let profile =
+        state::read_asset_oracle_profile(&env.svm.get_account(&env.market).unwrap().data, 0)
+            .unwrap();
+    TradeInterleavedPriceRemainderOutcome {
+        effective_price: env.market_state().1.assets[0].effective_price,
+        price_move_remainder_bps_num: profile.price_move_remainder_bps_num,
+        victim_withdrawn: u128::from(env.token_amount(destinations[0])),
+        attacker_withdrawn: u128::from(env.token_amount(destinations[1])),
+        wash_withdrawn: u128::from(env.token_amount(destinations[2]))
+            + u128::from(env.token_amount(destinations[3])),
+        vault_tokens: env.token_amount(env.vault),
+        max_trade_cu,
+        max_crank_cu,
+    }
+}
+
+#[test]
+fn v16_attack_risk_reducing_trade_cannot_erase_canonical_price_movement_remainder() {
+    let canonical = run_trade_interleaved_price_remainder_world(false);
+    let interleaved = run_trade_interleaved_price_remainder_world(true);
+    eprintln!("canonical={canonical:?}\ninterleaved={interleaved:?}");
+
+    assert_eq!(canonical.effective_price, 101);
+    assert_eq!(canonical.price_move_remainder_bps_num, 2_000);
+    assert_eq!(canonical.victim_withdrawn, 1_000_100);
+    assert_eq!(canonical.attacker_withdrawn, 999_900);
+    assert_eq!(canonical.wash_withdrawn, 2_000_000);
+    assert_eq!(canonical.vault_tokens, 0);
+    assert_eq!(
+        canonical.victim_withdrawn + canonical.attacker_withdrawn + canonical.wash_withdrawn,
+        4_000_000
+    );
+    assert_eq!(interleaved.victim_withdrawn, canonical.victim_withdrawn);
+    assert_eq!(interleaved.attacker_withdrawn, canonical.attacker_withdrawn);
+    assert_eq!(interleaved.wash_withdrawn, canonical.wash_withdrawn);
+    assert_eq!(interleaved.vault_tokens, canonical.vault_tokens);
+    assert_eq!(interleaved.effective_price, canonical.effective_price);
+    assert_eq!(
+        interleaved.price_move_remainder_bps_num,
+        canonical.price_move_remainder_bps_num
+    );
+    assert!(interleaved.max_trade_cu < 1_400_000);
+    assert!(canonical.max_crank_cu < 1_400_000);
+}
+
 #[test]
 fn v16_attack_resolved_permissionless_crank_survives_drained_owner_system_account() {
     let mut env = V16CuEnv::new();

--- a/tests/invariants/cu/inv_088_global_summaries_are_not_account_local_proofs.rs
+++ b/tests/invariants/cu/inv_088_global_summaries_are_not_account_local_proofs.rs
@@ -1096,7 +1096,7 @@ fn v16_program_every_wrapper_engine_transition_callsite_has_summary_disposition_
         Inv088EngineCallsite { owner: "handle_permissionless_crank_zero_copy", method: "accrue_asset_to_not_atomic", count: 1, summary_family: "asset-certificate", witness: "v16_program_per_asset_crank_isolation" },
         Inv088EngineCallsite { owner: "handle_permissionless_crank_zero_copy", method: "credit_account_from_insurance_not_atomic", count: 1, summary_family: "capital-insurance", witness: "v16_program_liquidation_updates_same_asset_summaries_without_clobbering_other_portfolios" },
         Inv088EngineCallsite { owner: "charge_account_backing_domain_fees_view", method: "charge_account_backing_fee_not_atomic", count: 1, summary_family: "capital-backing-earnings", witness: "v16_attack_backing_fee_split_conserves" },
-        Inv088EngineCallsite { owner: "accrue_zero_move_funding_before_position_change_for_profile_view", method: "accrue_asset_to_not_atomic", count: 1, summary_family: "asset-certificate", witness: "v16_bpf_existing_funding_ledger_refreshes_and_converts_between_sides" },
+        Inv088EngineCallsite { owner: "accrue_zero_move_funding_before_position_change_for_profile_view", method: "accrue_asset_path_to_not_atomic", count: 1, summary_family: "asset-certificate", witness: "v16_attack_risk_reducing_trade_cannot_erase_canonical_price_movement_remainder" },
         Inv088EngineCallsite { owner: "stage_trade_driven_mark_target_view", method: "set_asset_raw_oracle_target_not_atomic", count: 1, summary_family: "asset-oracle", witness: "v16_attack_repeated_ewma_moves_require_catchup_and_remain_fee_covered" },
     ];
 


### PR DESCRIPTION
## Impact

A permissionless attacker can interleave public risk-reducing wash trades with the mark-accrual schedule and consume each interval without preserving the canonical fractional price-movement carry. Even with an honest crank submitted after every attacker trade, the old path leaves the effective mark at 100 instead of 101 and transfers 100 quote atoms from an independently owned, unsigned LP to the attacker.

The public LiteSVM trace uses only deposits, CPI/no-CPI trades, authenticated AuthMark updates, permissionless cranks, conversion, and withdrawal. It performs no program-owned state injection and ends in exact SPL balances:

- canonical: victim 1,000,100; attacker 999,900
- exploit ordering: victim 1,000,000; attacker 1,000,000
- both paths conserve the aggregate 4,000,000 atoms

## Fix

Use the same canonical accrual-path builder as PermissionlessCrank before a position-changing operation. Commit its target/checkpoint and fractional price-movement carry only when the entire bounded path has zero effective-price movement; price-moving intervals still require the ordinary crank route.

This removes the wrapper-only shortcut that advanced the engine slot while dropping oracle-profile carry.

## Regression

`v16_attack_risk_reducing_trade_cannot_erase_canonical_price_movement_remainder` is parent RED / fixed GREEN and compares terminal SPL entitlements, effective price, carry, custody, and CU across the two orderings.

- parent RED reproduced on `d5e2ec6f`
- fixed GREEN on `0fbeb696`
- peak affected trade: 290,503 CU fixed, below the 345,000 cap
- focused funding/order, route, boundary, library, and callsite-roster checks pass

Invariant gap: INV-024/041/045/052/071/086 history composition. Per-call conservation held, but operation partitioning could discard a canonical arithmetic carry and redistribute terminal entitlement.