### PR TITLE
[BLOCKER LoF] Require current Hybrid evidence before health refresh

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -14006,7 +14006,7 @@ pub mod processor {
             // before either route can certify the account, even when the engine selects another
             // leg for the first bounded step.
             if (summary.stale || summary.liquidatable) && !summary.b_stale {
-                reject_missing_pending_liquidation_observations_view(
+                reject_incomplete_account_health_observations_view(
                     &cfg,
                     &group,
                     &portfolio,
@@ -14301,7 +14301,7 @@ pub mod processor {
         Ok(())
     }
 
-    fn reject_missing_pending_liquidation_observations_view(
+    fn reject_incomplete_account_health_observations_view(
         cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         portfolio: &percolator::PortfolioV16ViewMut<'_>,
@@ -14333,7 +14333,7 @@ pub mod processor {
                 }
                 seen_assets[seen_asset_count] = leg.asset_index;
                 seen_asset_count += 1;
-                reject_missing_observation_that_changes_accrual_view(
+                reject_incomplete_asset_health_observation_view(
                     cfg,
                     group,
                     leg.asset_index as usize,
@@ -14346,22 +14346,32 @@ pub mod processor {
         Ok(())
     }
 
-    fn reject_missing_observation_that_changes_accrual_view(
+    fn reject_incomplete_asset_health_observation_view(
         cfg: &WrapperConfigV16,
         group: &state::MarketViewMutV16<'_>,
         asset_index: usize,
         now_slot: u64,
         observations: &[AutoCrankObservationV16],
     ) -> ProgramResult {
-        if observations.iter().any(|o| o.asset_index == asset_index) {
-            return Ok(());
-        }
         if asset_index >= group.header.config.max_market_slots.get() as usize
             || asset_index >= group.markets.len()
         {
             return Err(PercolatorError::InvalidInstruction.into());
         }
         let profile = read_oracle_profile_from_view(group, cfg, asset_index)?;
+        // A stale-account refresh cannot consume this slot's accrual interval from a prior-slot
+        // Hybrid observation. In normal external mode every active health leg must have advanced
+        // from an authenticated report in this slot. Once the configured after-hours threshold
+        // matures, the mark fallback is canonical and no external report is required.
+        if oracle_v16::profile_is_hybrid(&profile)
+            && !oracle_v16::profile_hybrid_soft_stale_matured(&profile, now_slot)
+            && profile.last_good_oracle_slot != now_slot
+        {
+            return Err(PercolatorError::EngineNonProgress.into());
+        }
+        if observations.iter().any(|o| o.asset_index == asset_index) {
+            return Ok(());
+        }
         if !oracle_v16::profile_is_price_managed(&profile) {
             return Ok(());
         }

--- a/tests/invariants/cu/inv_056_hints_are_discovery_only_favorable_actions_fully_refresh.rs
+++ b/tests/invariants/cu/inv_056_hints_are_discovery_only_favorable_actions_fully_refresh.rs
@@ -12,7 +12,10 @@
 //! refreshing cure, and stale-safe risk reduction; a new instruction cannot silently inherit a
 //! favorable-action exemption. Matched forward and
 //! reverse two-asset Pyth hint/account-tail orders normalize identically; mismatched tails reject
-//! with exact rollback and a live canonical retry. BatchTradeNoCpi and BatchTradeCpi open a new
+//! with exact rollback and a live canonical retry. A separate liquidation trace proves a caller
+//! cannot omit a current-slot external rescue report or replay a prior-slot adverse report; the
+//! authenticated rescue preserves the victim's full position. BatchTradeNoCpi and BatchTradeCpi
+//! open a new
 //! asset-0 leg for an account that already has a stale active asset-1 leg, and must discover and
 //! refresh that stale leg before admitting the new favorable leg. Pending-close and Recovery
 //! selector traces prove hostile hints roll back before an honest retry progresses; once Resolved,
@@ -527,25 +530,35 @@ fn v16_program_external_oracle_hint_and_account_order_is_normalized_or_atomic() 
 
 struct Inv056ExternalRescueWorld {
     env: V16CuEnv,
+    victim_owner: Keypair,
+    maker_owner: Keypair,
     victim: Pubkey,
+    maker: Pubkey,
+    adverse_oracle: Pubkey,
     rescue_oracle: Pubkey,
     position_before_q: i128,
 }
+
+const INV056_EXTERNAL_RESCUE_FEED: [u8; 32] = [0x58; 32];
 
 fn inv056_external_rescue_world() -> Inv056ExternalRescueWorld {
     const INITIAL_PRICE: u64 = 1_000_000;
     const ADVERSE_PRICE: i64 = 997_600;
     const POSITION_Q: i128 = 50 * POS_SCALE as i128;
-    const FEED: [u8; 32] = [0x58; 32];
-
     let mut env = V16CuEnv::new_with_init_params(production_risk_params());
     set_test_clock(&mut env, 1, 100);
-    let initial = env.set_pyth_price_with_conf(&FEED, INITIAL_PRICE as i64, -6, 0, 100);
+    let initial = env.set_pyth_price_with_conf(
+        &INV056_EXTERNAL_RESCUE_FEED,
+        INITIAL_PRICE as i64,
+        -6,
+        0,
+        100,
+    );
     env.try_configure_hybrid_asset_with_conf_filter_cu(
         0,
         1,
         0,
-        [FEED, [0; 32], [0; 32]],
+        [INV056_EXTERNAL_RESCUE_FEED, [0; 32], [0; 32]],
         &[initial],
         1,
         100,
@@ -555,6 +568,7 @@ fn inv056_external_rescue_world() -> Inv056ExternalRescueWorld {
         0,
     )
     .expect("configure one-leg external oracle");
+    env.top_up_backing_bucket(1, 1_000_000, 1_000);
 
     let victim_owner = Keypair::new();
     let maker_owner = Keypair::new();
@@ -577,14 +591,15 @@ fn inv056_external_rescue_world() -> Inv056ExternalRescueWorld {
     assert_eq!(position_before_q, POSITION_Q);
 
     set_test_clock(&mut env, 2, 101);
-    let adverse = env.set_pyth_price_with_conf(&FEED, ADVERSE_PRICE, -6, 0, 101);
+    let adverse_oracle =
+        env.set_pyth_price_with_conf(&INV056_EXTERNAL_RESCUE_FEED, ADVERSE_PRICE, -6, 0, 101);
     env.crank_with_oracle_tail(
         observer,
         ProgInstruction::PermissionlessCrank {
             now_slot: 0,
             observations: crank_observations(0),
         },
-        &[adverse],
+        &[adverse_oracle],
     );
     assert_eq!(
         env.market_state().1.assets[0].effective_price,
@@ -597,84 +612,113 @@ fn inv056_external_rescue_world() -> Inv056ExternalRescueWorld {
     );
 
     set_test_clock(&mut env, 3, 102);
-    let rescue_oracle = env.set_pyth_price_with_conf(&FEED, INITIAL_PRICE as i64, -6, 0, 102);
+    let rescue_oracle = env.set_pyth_price_with_conf(
+        &INV056_EXTERNAL_RESCUE_FEED,
+        INITIAL_PRICE as i64,
+        -6,
+        0,
+        102,
+    );
     Inv056ExternalRescueWorld {
         env,
+        victim_owner,
+        maker_owner,
         victim,
+        maker,
+        adverse_oracle,
         rescue_oracle,
         position_before_q,
     }
 }
 
-#[test]
-fn v16_attack_liquidation_cannot_omit_fresh_external_rescue_observation() {
+#[derive(Clone, Copy, Debug)]
+enum Inv056ExternalRescueRoute {
+    Omitted,
+    PriorSlotReplay,
+    FreshControl,
+}
+
+#[derive(Debug)]
+struct Inv056ExternalRescueOutcome {
+    attack_succeeded: bool,
+    attack_exact_rollback: bool,
+    position_after_attack_q: i128,
+    attack_insurance_delta: u128,
+    victim_withdrawn: u64,
+    final_insurance: u128,
+    max_cu: u64,
+}
+
+fn inv056_run_external_rescue_route(
+    route: Inv056ExternalRescueRoute,
+) -> Inv056ExternalRescueOutcome {
     let Inv056ExternalRescueWorld {
         mut env,
+        victim_owner,
+        maker_owner,
         victim,
+        maker,
+        adverse_oracle,
+        rescue_oracle,
         position_before_q,
-        ..
     } = inv056_external_rescue_world();
-    env.svm.expire_blockhash();
-    let refresh_cu = env
-        .send(
-            ProgInstruction::PermissionlessCrank {
-                now_slot: 0,
-                observations: vec![],
-            },
-            vec![
-                AccountMeta::new_readonly(env.payer.pubkey(), false),
-                AccountMeta::new(env.market, false),
-                AccountMeta::new(victim, false),
-            ],
-            &[],
-        )
-        .expect("an omitted feed may refresh the stale certificate without moving value");
-    assert_cu_within(
-        "INV-056 cached external-oracle certificate refresh",
-        refresh_cu,
-        CRANK_CU_LIMIT,
-    );
-    assert_eq!(
-        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
-        position_before_q,
-        "the discovery-only refresh step must not liquidate"
-    );
-    assert!(
-        health_cert(&env.portfolio_state(victim)).certified_liq_deficit > 0,
-        "the cached adverse mark must expose the liquidation branch"
-    );
 
     let market_before = env.svm.get_account(&env.market).unwrap();
     let victim_before = env.svm.get_account(&victim).unwrap();
     let vault_before = env.svm.get_account(&env.vault).unwrap();
     let insurance_before = env.market_state().1.insurance;
-    env.svm.expire_blockhash();
-    let omitted_liquidation = env.send(
-        ProgInstruction::PermissionlessCrank {
-            now_slot: 0,
-            observations: vec![],
-        },
-        vec![
-            AccountMeta::new_readonly(env.payer.pubkey(), false),
-            AccountMeta::new(env.market, false),
-            AccountMeta::new(victim, false),
-        ],
-        &[],
-    );
-    eprintln!(
-        "omitted_liquidation={omitted_liquidation:?} before_q={position_before_q} after={:?} health={:?} insurance_delta={}",
-        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
-        health_cert(&env.portfolio_state(victim)),
-        env.market_state().1.insurance.saturating_sub(insurance_before),
-    );
+    let mut attack_results = Vec::new();
+    if !matches!(route, Inv056ExternalRescueRoute::FreshControl) {
+        for _ in 0..2 {
+            env.svm.expire_blockhash();
+            let (observations, oracle_tail) = match route {
+                Inv056ExternalRescueRoute::Omitted => (vec![], vec![]),
+                Inv056ExternalRescueRoute::PriorSlotReplay => (
+                    crank_observations_with_accounts(0, 1),
+                    vec![AccountMeta::new_readonly(adverse_oracle, false)],
+                ),
+                Inv056ExternalRescueRoute::FreshControl => unreachable!(),
+            };
+            let mut accounts = vec![
+                AccountMeta::new_readonly(env.payer.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim, false),
+            ];
+            accounts.extend(oracle_tail);
+            let result = env.send(
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 0,
+                    observations,
+                },
+                accounts,
+                &[],
+            );
+            let rejected = result.is_err();
+            attack_results.push(result);
+            if rejected {
+                break;
+            }
+        }
+    }
+    let position_after_attack_q = active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q;
+    let attack_insurance_delta = env
+        .market_state()
+        .1
+        .insurance
+        .saturating_sub(insurance_before);
+    let attack_succeeded =
+        position_after_attack_q != position_before_q || attack_insurance_delta != 0;
+    let attack_exact_rollback = attack_results.iter().all(Result::is_err)
+        && env.svm.get_account(&env.market).unwrap() == market_before
+        && env.svm.get_account(&victim).unwrap() == victim_before
+        && env.svm.get_account(&env.vault).unwrap() == vault_before;
+    let mut max_cu = attack_results
+        .iter()
+        .filter_map(|result| result.as_ref().ok().copied())
+        .max()
+        .unwrap_or(0);
 
-    let Inv056ExternalRescueWorld {
-        mut env,
-        victim,
-        rescue_oracle,
-        position_before_q,
-    } = inv056_external_rescue_world();
-    let observed_cu = env.crank_with_oracle_tail(
+    let rescue_cu = env.crank_with_oracle_tail(
         victim,
         ProgInstruction::PermissionlessCrank {
             now_slot: 0,
@@ -682,13 +726,28 @@ fn v16_attack_liquidation_cannot_omit_fresh_external_rescue_observation() {
         },
         &[rescue_oracle],
     );
-    assert_cu_within(
-        "INV-056 external rescue observation before liquidation",
-        observed_cu,
-        CRANK_CU_LIMIT,
-    );
+    max_cu = max_cu.max(rescue_cu);
+    for (slot, unix_timestamp) in [(4, 103), (5, 104)] {
+        set_test_clock(&mut env, slot, unix_timestamp);
+        let terminal_rescue_oracle = env.set_pyth_price_with_conf(
+            &INV056_EXTERNAL_RESCUE_FEED,
+            1_000_000,
+            -6,
+            0,
+            unix_timestamp,
+        );
+        let terminal_rescue_cu = env.crank_with_oracle_tail(
+            victim,
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 0,
+                observations: crank_observations(0),
+            },
+            &[terminal_rescue_oracle],
+        );
+        max_cu = max_cu.max(terminal_rescue_cu);
+    }
     assert!(
-        env.market_state().1.assets[0].effective_price > 997_600,
+        env.market_state().1.assets[0].effective_price >= 1_000_000,
         "the authenticated rescue observation must move the effective price toward the live feed"
     );
     assert_eq!(
@@ -696,18 +755,106 @@ fn v16_attack_liquidation_cannot_omit_fresh_external_rescue_observation() {
         0,
         "the bounded authenticated rescue move restores maintenance health"
     );
-    assert_eq!(
-        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
-        position_before_q,
-        "the authenticated rescue observation keeps the same position healthy"
+
+    let remaining_q = active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q;
+    let close_price = env.market_state().1.assets[0].effective_price;
+    let close_cu = env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &maker_owner,
+        maker,
+        -remaining_q,
+        close_price,
+        0,
     );
+    max_cu = max_cu.max(close_cu);
     assert!(
-        omitted_liquidation.is_err(),
-        "omitting a configured external feed while liquidation is selected must reject: {omitted_liquidation:?}"
+        !has_active_leg_for_asset(&env.portfolio_state(victim), 0),
+        "the owner-signed risk reduction must leave the victim flat"
     );
-    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
-    assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
-    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+    set_test_clock(&mut env, 6, 105);
+    let flat_refresh_oracle =
+        env.set_pyth_price_with_conf(&INV056_EXTERNAL_RESCUE_FEED, 1_000_000, -6, 0, 105);
+    let flat_refresh_cu = env.crank_with_oracle_tail(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: crank_observations(0),
+        },
+        &[flat_refresh_oracle],
+    );
+    max_cu = max_cu.max(flat_refresh_cu);
+    for _ in 0..4 {
+        env.svm.expire_blockhash();
+        if env
+            .crank_if_actionable(
+                victim,
+                ProgInstruction::PermissionlessCrank {
+                    now_slot: 0,
+                    observations: vec![],
+                },
+            )
+            .is_none()
+        {
+            break;
+        }
+    }
+    let before_convert = env.portfolio_state(victim);
+    if before_convert.pnl.get() > 0 {
+        env.convert_released_pnl_with_cu(
+            &victim_owner,
+            victim,
+            u128::try_from(before_convert.pnl.get()).unwrap(),
+        );
+    }
+    let terminal = env.portfolio_state(victim);
+    assert_eq!(terminal.pnl.get(), 0);
+    let destination = env.withdraw(&victim_owner, victim, terminal.capital.get());
+    Inv056ExternalRescueOutcome {
+        attack_succeeded,
+        attack_exact_rollback,
+        position_after_attack_q,
+        attack_insurance_delta,
+        victim_withdrawn: env.token_amount(destination),
+        final_insurance: env.market_state().1.insurance,
+        max_cu,
+    }
+}
+
+#[test]
+fn v16_attack_liquidation_cannot_omit_fresh_external_rescue_observation() {
+    let control = inv056_run_external_rescue_route(Inv056ExternalRescueRoute::FreshControl);
+    let attacks = [
+        (
+            Inv056ExternalRescueRoute::PriorSlotReplay,
+            inv056_run_external_rescue_route(Inv056ExternalRescueRoute::PriorSlotReplay),
+        ),
+        (
+            Inv056ExternalRescueRoute::Omitted,
+            inv056_run_external_rescue_route(Inv056ExternalRescueRoute::Omitted),
+        ),
+    ];
+    for (attack, outcome) in attacks {
+        eprintln!("control={control:?}\nattack={outcome:?}");
+        assert!(!outcome.attack_succeeded, "{attack:?} must reject");
+        assert!(
+            outcome.attack_exact_rollback,
+            "{attack:?} must roll back market, portfolio, and vault exactly"
+        );
+        assert_eq!(outcome.position_after_attack_q, 50 * POS_SCALE as i128);
+        assert_eq!(outcome.attack_insurance_delta, 0);
+        assert_eq!(
+            outcome.victim_withdrawn, control.victim_withdrawn,
+            "{attack:?} must not reduce the victim's terminal SPL entitlement"
+        );
+        assert_eq!(outcome.final_insurance, control.final_insurance);
+        assert_cu_within(
+            "INV-056 external rescue terminal route",
+            outcome.max_cu,
+            CRANK_CU_LIMIT,
+        );
+    }
 }
 
 #[test]

--- a/tests/invariants/cu/inv_056_hints_are_discovery_only_favorable_actions_fully_refresh.rs
+++ b/tests/invariants/cu/inv_056_hints_are_discovery_only_favorable_actions_fully_refresh.rs
@@ -525,6 +525,191 @@ fn v16_program_external_oracle_hint_and_account_order_is_normalized_or_atomic() 
     );
 }
 
+struct Inv056ExternalRescueWorld {
+    env: V16CuEnv,
+    victim: Pubkey,
+    rescue_oracle: Pubkey,
+    position_before_q: i128,
+}
+
+fn inv056_external_rescue_world() -> Inv056ExternalRescueWorld {
+    const INITIAL_PRICE: u64 = 1_000_000;
+    const ADVERSE_PRICE: i64 = 997_600;
+    const POSITION_Q: i128 = 50 * POS_SCALE as i128;
+    const FEED: [u8; 32] = [0x58; 32];
+
+    let mut env = V16CuEnv::new_with_init_params(production_risk_params());
+    set_test_clock(&mut env, 1, 100);
+    let initial = env.set_pyth_price_with_conf(&FEED, INITIAL_PRICE as i64, -6, 0, 100);
+    env.try_configure_hybrid_asset_with_conf_filter_cu(
+        0,
+        1,
+        0,
+        [FEED, [0; 32], [0; 32]],
+        &[initial],
+        1,
+        100,
+        0,
+        0,
+        10,
+        0,
+    )
+    .expect("configure one-leg external oracle");
+
+    let victim_owner = Keypair::new();
+    let maker_owner = Keypair::new();
+    let victim = env.create_portfolio(&victim_owner);
+    let maker = env.create_portfolio(&maker_owner);
+    let observer = env.create_portfolio(&Keypair::new());
+    env.deposit(&victim_owner, victim, 2_600_000);
+    env.deposit(&maker_owner, maker, 100_000_000);
+    env.trade_asset_with_cu(
+        0,
+        &victim_owner,
+        victim,
+        &maker_owner,
+        maker,
+        POSITION_Q,
+        INITIAL_PRICE,
+        0,
+    );
+    let position_before_q = active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q;
+    assert_eq!(position_before_q, POSITION_Q);
+
+    set_test_clock(&mut env, 2, 101);
+    let adverse = env.set_pyth_price_with_conf(&FEED, ADVERSE_PRICE, -6, 0, 101);
+    env.crank_with_oracle_tail(
+        observer,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: crank_observations(0),
+        },
+        &[adverse],
+    );
+    assert_eq!(
+        env.market_state().1.assets[0].effective_price,
+        ADVERSE_PRICE as u64
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
+        position_before_q,
+        "observing the adverse mark through an unrelated portfolio must not mutate the victim"
+    );
+
+    set_test_clock(&mut env, 3, 102);
+    let rescue_oracle = env.set_pyth_price_with_conf(&FEED, INITIAL_PRICE as i64, -6, 0, 102);
+    Inv056ExternalRescueWorld {
+        env,
+        victim,
+        rescue_oracle,
+        position_before_q,
+    }
+}
+
+#[test]
+fn v16_attack_liquidation_cannot_omit_fresh_external_rescue_observation() {
+    let Inv056ExternalRescueWorld {
+        mut env,
+        victim,
+        position_before_q,
+        ..
+    } = inv056_external_rescue_world();
+    env.svm.expire_blockhash();
+    let refresh_cu = env
+        .send(
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 0,
+                observations: vec![],
+            },
+            vec![
+                AccountMeta::new_readonly(env.payer.pubkey(), false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(victim, false),
+            ],
+            &[],
+        )
+        .expect("an omitted feed may refresh the stale certificate without moving value");
+    assert_cu_within(
+        "INV-056 cached external-oracle certificate refresh",
+        refresh_cu,
+        CRANK_CU_LIMIT,
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
+        position_before_q,
+        "the discovery-only refresh step must not liquidate"
+    );
+    assert!(
+        health_cert(&env.portfolio_state(victim)).certified_liq_deficit > 0,
+        "the cached adverse mark must expose the liquidation branch"
+    );
+
+    let market_before = env.svm.get_account(&env.market).unwrap();
+    let victim_before = env.svm.get_account(&victim).unwrap();
+    let vault_before = env.svm.get_account(&env.vault).unwrap();
+    let insurance_before = env.market_state().1.insurance;
+    env.svm.expire_blockhash();
+    let omitted_liquidation = env.send(
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: vec![],
+        },
+        vec![
+            AccountMeta::new_readonly(env.payer.pubkey(), false),
+            AccountMeta::new(env.market, false),
+            AccountMeta::new(victim, false),
+        ],
+        &[],
+    );
+    eprintln!(
+        "omitted_liquidation={omitted_liquidation:?} before_q={position_before_q} after={:?} health={:?} insurance_delta={}",
+        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
+        health_cert(&env.portfolio_state(victim)),
+        env.market_state().1.insurance.saturating_sub(insurance_before),
+    );
+
+    let Inv056ExternalRescueWorld {
+        mut env,
+        victim,
+        rescue_oracle,
+        position_before_q,
+    } = inv056_external_rescue_world();
+    let observed_cu = env.crank_with_oracle_tail(
+        victim,
+        ProgInstruction::PermissionlessCrank {
+            now_slot: 0,
+            observations: crank_observations(0),
+        },
+        &[rescue_oracle],
+    );
+    assert_cu_within(
+        "INV-056 external rescue observation before liquidation",
+        observed_cu,
+        CRANK_CU_LIMIT,
+    );
+    assert!(
+        env.market_state().1.assets[0].effective_price > 997_600,
+        "the authenticated rescue observation must move the effective price toward the live feed"
+    );
+    assert_eq!(
+        health_cert(&env.portfolio_state(victim)).certified_liq_deficit,
+        0,
+        "the bounded authenticated rescue move restores maintenance health"
+    );
+    assert_eq!(
+        active_leg_for_asset(&env.portfolio_state(victim), 0).basis_pos_q,
+        position_before_q,
+        "the authenticated rescue observation keeps the same position healthy"
+    );
+    assert!(
+        omitted_liquidation.is_err(),
+        "omitting a configured external feed while liquidation is selected must reject: {omitted_liquidation:?}"
+    );
+    assert_eq!(env.svm.get_account(&env.market).unwrap(), market_before);
+    assert_eq!(env.svm.get_account(&victim).unwrap(), victim_before);
+    assert_eq!(env.svm.get_account(&env.vault).unwrap(), vault_before);
+}
+
 #[test]
 fn v16_program_pending_close_bad_hints_roll_back_then_canonical_crank_progresses() {
     let PublicActiveCloseFixture {


### PR DESCRIPTION
## Finding

`PermissionlessCrank` could refresh a stale victim certificate and then liquidate from a cached Hybrid mark without carrying any external observation. Replaying the already-consumed prior-slot report had the same result. A newer authenticated rescue report could already be available, but caller-controlled omission selected the adverse cached state.

Exact-main public LiteSVM trace (no program-owned byte mutation):

- victim and independent maker open 50 units at 1,000,000;
- an authenticated Pyth report moves the effective price to 997,600 in slot 2;
- a fresh authenticated 1,000,000 rescue report exists in slot 3;
- two no-tail cranks, or two cranks replaying the slot-2 report, refresh then liquidate the victim;
- victim position falls from 50,000,000 to 49,716,479 and insurance receives 142 atoms;
- after authenticated catch-up and owner-signed close, the victim withdraws 2,599,177 versus 2,600,000 in the fresh-report control: exact terminal loss 823 atoms;
- harmful route max CU is 274,660.

The bounded selector needs more than one transaction for refresh then liquidation. Without a per-step freshness gate, the first stale call consumes the account action while omitting the external state that would make the victim healthy.

## Fix

Before any stale/liquidatable full-account refresh, require every active normal-hours Hybrid profile to have advanced from an authenticated report in the current slot. Prior-slot replay and omission reject with exact market/portfolio/vault rollback. Once `hybrid_soft_stale_slots` matures, canonical EWMA after-hours fallback remains available, so unavailable feeds do not permanently block progress.

A newly advancing report is still governed by configured oracle age/confidence policy; this change closes omission and replay across the multi-call account-action sequence.

## TDD evidence

- Test-only commits: `2e4de70c`, `08aedad2`
- Fix: `0b3d5ae0`
- Parent SBF SHA-256: `230b6db1278dbff258c84f9a3df78c7d9decc6f8653fe06c46fa5ea9834afb20` (RED for omission and prior-slot replay)
- Fixed SBF SHA-256: `7cef1f7cc1565fd7ae62a4ae88f823d85653559237228925a6cad46e4ba4c4fa` (GREEN; both reject with exact rollback and preserve 2,600,000)

Focused controls:

- INV-056 terminal RED/GREEN regression passes; fixed max CU 172,110.
- Unavailable-Pyth after-hours terminal fallback passes; max CU 174,210.
- Full 14-leg composite-oracle liquidation passes; max CU 1,248,200 under 1.4M.
- Engine pin remains `495a5590c97055bd71c6f94d849ff0298f243145`.

Invariant gaps: INV-020 authenticated oracle provenance, INV-056 discovery-only hints/full refresh, INV-072 order-robust crankability, and INV-080 exact rollback.