### PR TITLE
[BLOCKER LoF] Consume insurance withdrawal epoch on retained debit

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -645,7 +645,8 @@ pub mod state {
         /// backing watermark and preserves both old lanes without changing persisted layout.
         pub backing_fee: u64,
         /// Strict per-asset authority incarnation. Every market/asset authority handoff that can
-        /// affect this asset binds the exact value and increments it atomically.
+        /// affect this asset binds the exact value and increments it atomically. Successful
+        /// insurance withdrawals also consume their authorizing epoch to prevent retained replay.
         pub authority_epoch: u64,
         pub trade_fee: u64,
         pub liquidation_fee: u64,
@@ -10875,6 +10876,8 @@ pub mod processor {
             }
             require_asset_generation_view(&group, asset_index, expected_market_id)?;
             let authorities = domain_authorities_from_view(&group, &cfg, long_domain)?;
+            // Consume the withdrawal's authorizing epoch. Any later validation or token-CPI
+            // failure rolls this advance back along with the insurance debit.
             let ledger_authority = if live_mode {
                 let shutdown_drain =
                     live_domain_withdraw_health_or_shutdown_view(&cfg, &group, long_domain)?;
@@ -10887,7 +10890,11 @@ pub mod processor {
                     return Err(PercolatorError::Unauthorized.into());
                 }
                 let epoch_asset_index = if local_authorized { asset_index } else { 0 };
-                require_authority_epoch_view(&group, epoch_asset_index, expected_authority_epoch)?;
+                advance_authority_epoch_view(
+                    &mut group,
+                    epoch_asset_index,
+                    expected_authority_epoch,
+                )?;
                 if admin_shutdown_authorized && !local_authorized {
                     cfg.marketauth
                 } else {
@@ -10902,7 +10909,7 @@ pub mod processor {
                 if !live_authority_matches(&authorities.insurance_authority, operator.key) {
                     return Err(PercolatorError::Unauthorized.into());
                 }
-                require_authority_epoch_view(&group, asset_index, expected_authority_epoch)?;
+                advance_authority_epoch_view(&mut group, asset_index, expected_authority_epoch)?;
                 group
                     .recredit_terminal_claim_free_residual_for_asset_not_atomic(asset_index)
                     .map_err(map_v16_error)?;

--- a/tests/invariants/inv_008_replay_disposition.tsv
+++ b/tests/invariants/inv_008_replay_disposition.tsv
@@ -38,7 +38,7 @@ tag	variant	disposition	boundary
 54	SyncInsuranceLedger	state-derived	Current canonical market and ledger state determine synchronization.
 55	UpdateTradeFeePolicy	supersession:TradeFeePolicy	Scope-local policy sequence is exercised by the supersession matrix.
 56	TopUpInsuranceDomain	retry:InsuranceTopUp	The direct and domain routes share one executable insurance retry watermark.
-57	WithdrawInsuranceAsset	retry:InsuranceWithdrawal	Asset generation, current operator and available domain budget bind the debit; signed stock-sequence binding after replenishment remains open (415), not supplied by the portfolio-withdrawal owner.
+57	WithdrawInsuranceAsset	incarnation-episode	A successful debit consumes the authorizing epoch; the deterministic stateful row-415 probe checks retained rejection after replenishment, exact rollback, and fresh withdrawal liveness.
 58	UpdateFeeRedirectPolicy	supersession:FeeRedirectPolicy	Scope-local policy sequence is exercised by the supersession matrix.
 59	UpdateMarketInitFeePolicy	supersession:MarketInitFeePolicy	Scope-local policy sequence is exercised by the supersession matrix.
 60	UpdateBaseUnitMints	live-authority	Current market authority and canonical mint state gate the update.

--- a/tests/invariants/stateful/inv_008_intent_uniqueness_and_bounded_replay.rs
+++ b/tests/invariants/stateful/inv_008_intent_uniqueness_and_bounded_replay.rs
@@ -16,6 +16,8 @@
 //! The operation registry also retains two insurance-withdrawal requests before either lands,
 //! executes one, replenishes the same stock through a separate public top-up, and requires the
 //! stale request to reject before it can consume the newly available stock.
+//! The deterministic row-415 probe covers both asset scopes and fresh liveness after that
+//! stale rollback.
 //!
 //! Guarantee boundary: PRs 343/344/350/351/355/362 are fixed-pin certifications of the currently
 //! deployed retained families, not a claim that absent message fields exist. Successful partial
@@ -23,6 +25,123 @@
 //! schema requirements.
 
 use super::*;
+
+#[test]
+fn v16_program_row_415_retained_insurance_withdrawal_rejects_replenished_stock() {
+    use crate::support::v16_svm::{MarketConfig, V16Svm, TX_CU_LIMIT};
+    use percolator_prog::{error::PercolatorError, processor::ASSET_AUTH_INSURANCE_OPERATOR};
+
+    const OPERATOR: usize = 2;
+    const AMOUNT: u128 = 1_000;
+    for asset_index in [0u16, 1] {
+        for refill_side in [0u16, 1] {
+            let mut env = V16Svm::new([0x41; 32], MarketConfig::default());
+            env.begin_public_trace();
+            env.update_asset_authority_from_admin(
+                asset_index,
+                ASSET_AUTH_INSURANCE_OPERATOR,
+                OPERATOR,
+            )
+            .expect("install insurance operator through the wrapper");
+            let snapshot = |env: &V16Svm| {
+                (
+                    env.market_data(false),
+                    env.all_token_account_data(),
+                    env.all_primary_portfolio_data(),
+                    env.all_economic_account_lamports(),
+                )
+            };
+            let before_unfunded = snapshot(&env);
+            env.withdraw_insurance_asset(OPERATOR, asset_index, AMOUNT)
+                .expect_err("unfunded withdrawal must reject without consuming its epoch");
+            assert_eq!(snapshot(&env), before_unfunded);
+
+            let supply = env.token_supply_observed();
+            let destination = env.actors[OPERATOR].destination_token;
+            let destination_before = env.token_amount(destination);
+            let vault_before = env.token_amount(env.vault);
+            let domain = asset_index * 2;
+            env.top_up_insurance_domain(domain, AMOUNT)
+                .expect("fund insurance through the wrapper");
+
+            // Both transactions are signed before either lands. Only their compute-budget
+            // price differs, so runtime signature deduplication cannot mask wrapper replay.
+            let intended =
+                env.build_retained_insurance_withdrawal_for_actor(OPERATOR, asset_index, AMOUNT);
+            let retry =
+                env.build_retained_insurance_withdrawal_for_actor(OPERATOR, asset_index, AMOUNT);
+            assert_ne!(intended.signatures, retry.signatures);
+            assert_eq!(intended.message.account_keys, retry.message.account_keys);
+            assert_eq!(
+                intended.message.recent_blockhash,
+                retry.message.recent_blockhash
+            );
+            assert_eq!(
+                intended.message.instructions.last(),
+                retry.message.instructions.last()
+            );
+            let generation = env.primary_market_state().1.assets[asset_index as usize].market_id;
+            let profile = env.primary_profile(asset_index as usize);
+
+            let first = env
+                .land_retained(intended)
+                .expect("first withdrawal succeeds");
+            assert!(first.compute_units > 0 && first.compute_units < TX_CU_LIMIT);
+            assert_eq!(
+                env.token_amount(destination),
+                destination_before + AMOUNT as u64
+            );
+            assert_eq!(env.token_amount(env.vault), vault_before);
+            assert_eq!(env.primary_market_state().1.insurance, 0);
+
+            env.top_up_insurance_domain(domain + refill_side, AMOUNT)
+                .expect("replenish insurance through the wrapper");
+            let replenished = env.primary_market_state().1;
+            assert_eq!(
+                replenished.assets[asset_index as usize].market_id,
+                generation
+            );
+            assert_eq!(env.primary_profile(asset_index as usize), profile);
+            assert_eq!(replenished.insurance, AMOUNT);
+            assert_eq!(
+                replenished.insurance_domain_budget[(domain + refill_side) as usize],
+                AMOUNT
+            );
+            let before_retry = snapshot(&env);
+            let result = env.land_retained(retry);
+            assert_eq!(
+                (env.token_amount(destination), env.primary_market_state().1.insurance),
+                (destination_before + AMOUNT as u64, AMOUNT),
+                "row 415: retained withdrawal spent replenished insurance: asset={asset_index}, refill_side={refill_side}, result={result:?}"
+            );
+            let error = result.expect_err("retained withdrawal must reject");
+            assert!(
+                error.contains(&format!("Custom({})", PercolatorError::EngineStale as u32)),
+                "retained withdrawal must reject for a consumed epoch: {error}"
+            );
+            assert_eq!(
+                snapshot(&env),
+                before_retry,
+                "stale retry must roll back exactly"
+            );
+
+            let fresh =
+                env.build_retained_insurance_withdrawal_for_actor(OPERATOR, asset_index, AMOUNT);
+            let fresh = env
+                .land_retained(fresh)
+                .expect("fresh withdrawal remains live");
+            assert!(fresh.compute_units > 0 && fresh.compute_units < TX_CU_LIMIT);
+            assert_eq!(
+                env.token_amount(destination),
+                destination_before + 2 * AMOUNT as u64
+            );
+            assert_eq!(env.token_amount(env.vault), vault_before);
+            assert_eq!(env.primary_market_state().1.insurance, 0);
+            assert_eq!(env.token_supply_observed(), supply);
+            assert_eq!(env.finish_public_trace().out_of_band_economic_mutations, 0);
+        }
+    }
+}
 
 proptest! {
     #![proptest_config(ProptestConfig {


### PR DESCRIPTION
## Summary
- fixes retained WithdrawInsuranceAsset replay against replenished insurance stock
- consumes the authorizing authority epoch on successful live/resolved insurance withdrawals
- adds deterministic public-route row 415 regression under INV-008

## Public-route bug
Two retained WithdrawInsuranceAsset transactions can be signed before either lands. The first withdraws available insurance. A later public top-up replenishes stock. Before this fix, the second retained transaction could withdraw the replenished stock with the same old authority epoch, causing the same retained economic authorization to spend twice.

## Validation
- Parent SBF: new row 415 test fails; retained retry succeeds and destination receives a second 1,000-token withdrawal
- Fixed SBF: new row 415 test passes across asset 0/1 and long/short replenishment cases
- Existing INV-064 insurance policy selector: 10 passed
- cargo fmt --all -- --check: passed
- git diff --check: passed

No engine or schema changes.