### PR TITLE
[BLOCKER DoS] Permit unsigned terminal reserve payouts

### DIFF
--- a/src/v16_program.rs
+++ b/src/v16_program.rs
@@ -10282,6 +10282,11 @@ pub mod processor {
         let market_data = market_ai.try_borrow_data()?;
         let (cfg, mode, configured_slots, _) =
             state::read_market_config_mode_and_capacity(&market_data)?;
+        // Resolved payouts remain bound to the recorded beneficiary; Live withdrawals
+        // still require consent before any economic state can change.
+        if mode != MarketModeV16::Resolved {
+            expect_signer(authority)?;
+        }
         let asset_index = domain / 2;
         if (require_live_mode && mode != MarketModeV16::Live)
             || domain >= configured_slots.saturating_mul(2)
@@ -10316,7 +10321,7 @@ pub mod processor {
             vault_token,
             &vault_authority,
             &cfg,
-            false,
+            !authority.is_signer,
         )?;
         let amount_u64 = amount_to_u64(amount)?;
         require_token_balance(vault_balance, amount_u64)?;
@@ -10493,7 +10498,6 @@ pub mod processor {
         let vault_authority_ai = account(accounts, 4)?;
         let token_program = account(accounts, 5)?;
         let ledger_ai = accounts.get(6);
-        expect_signer(authority)?;
         expect_writable(market_ai)?;
         expect_writable(dest_token)?;
         expect_writable(vault_token)?;
@@ -10636,7 +10640,6 @@ pub mod processor {
         let vault_token = account(accounts, 4)?;
         let vault_authority_ai = account(accounts, 5)?;
         let token_program = account(accounts, 6)?;
-        expect_signer(authority)?;
         expect_writable(market_ai)?;
         expect_writable(ledger_ai)?;
         expect_writable(dest_token)?;
@@ -10820,7 +10823,6 @@ pub mod processor {
         let vault_authority_ai = account(accounts, 4)?;
         let token_program = account(accounts, 5)?;
         let ledger_ai = accounts.get(6);
-        expect_signer(operator)?;
         expect_writable(market_ai)?;
         expect_writable(dest_token)?;
         expect_writable(vault_token)?;
@@ -10848,6 +10850,9 @@ pub mod processor {
             if mode != MarketModeV16::Live && mode != MarketModeV16::Resolved {
                 return Err(PercolatorError::InvalidInstruction.into());
             }
+            if mode == MarketModeV16::Live {
+                expect_signer(operator)?;
+            }
             let (vault_authority, _) = derive_vault_authority(program_id, market_ai.key);
             expect_key(vault_authority_ai, &vault_authority)?;
             let vault_balance = verify_withdrawable_token_accounts(
@@ -10856,7 +10861,7 @@ pub mod processor {
                 vault_token,
                 &vault_authority,
                 &cfg,
-                false,
+                !operator.is_signer,
             )?;
             require_token_balance(vault_balance, amount_u64)?;
         }

--- a/tests/invariants/README.md
+++ b/tests/invariants/README.md
@@ -5076,6 +5076,25 @@ Results: isolated new selector **1/1**, combined focused run **3/3**, formatting
 and whitespace checks pass. Peak new-test exit CU: **219,404**. The existing
 `solana-client` future-incompatibility warning remains.
 
+## INV-073 terminal reserve consent (rows 420/421, 2026-09-09)
+
+[`cu/inv_073_terminal_provider_earnings.rs`](cu/inv_073_terminal_provider_earnings.rs)
+and the INV-073/INV-067 owners cover the wrapper-only conformance fix that
+permits canonical unsigned terminal reserve payouts while preserving live-mode
+signer requirements. Branch: `codex/astra-ultra-inv073-terminal-progress-20260909`.
+
+The public matrix creates real trading/source claims, reaches terminal reserve
+payment through public wrapper routes, and checks that unsigned terminal
+progress does not require the former live account owner while malformed,
+live-mode, or noncanonical attempts still reject with exact rollback. This is a
+focused terminal-liveness fix and regression, not a broad reclassification of
+all terminal cleanup as permissionless.
+
+Remaining gaps include broader terminal-policy products, provider-principal
+expiry/scanner interleavings, late receipts, optional-ledger products,
+secondary quote rails, and maximum-shape terminal sweeps. Rows 420/421 remain
+open for full invariant closure.
+
 ## INV-017 transaction-wide privileges and account-kind alias (2026-09-09)
 
 [`cu/inv_017_signer_writable_role_and_account_alias_safety.rs`](cu/inv_017_signer_writable_role_and_account_alias_safety.rs)

--- a/tests/invariants/cu/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
+++ b/tests/invariants/cu/inv_067_terminal_payout_completeness_and_exact_once_settlement.rs
@@ -39,7 +39,7 @@ mod receipt_partition_confluence;
 pub(super) mod late_expiry;
 
 #[path = "inv_067_terminal_provider_insurance_retries.rs"]
-mod provider_insurance_retries;
+pub(super) mod provider_insurance_retries;
 
 #[path = "inv_067_receipt_rail_liquidity.rs"]
 mod receipt_rail_liquidity;

--- a/tests/invariants/cu/inv_067_terminal_provider_insurance_retries.rs
+++ b/tests/invariants/cu/inv_067_terminal_provider_insurance_retries.rs
@@ -23,6 +23,29 @@ fn v16_program_absent_provider_preserves_user_order_and_operator_free_insurance_
 }
 
 fn run_terminal_provider_and_insurance(absent_provider: bool) {
+    verify_terminal_provider_and_insurance_disposition_with_absent_provider(
+        true,
+        &[false, true],
+        absent_provider,
+    );
+}
+
+pub(crate) fn verify_terminal_provider_and_insurance_disposition(
+    terminal_signed: bool,
+    orders: &[bool],
+) {
+    verify_terminal_provider_and_insurance_disposition_with_absent_provider(
+        terminal_signed,
+        orders,
+        false,
+    );
+}
+
+fn verify_terminal_provider_and_insurance_disposition_with_absent_provider(
+    terminal_signed: bool,
+    orders: &[bool],
+    absent_provider: bool,
+) {
     use inv_018_quote_mint_vault_token_program_and_authority_integrity::inv018_public_spl_market_with_params;
     use solana_sdk::{instruction::InstructionError, transaction::TransactionError};
 
@@ -30,7 +53,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
     const REMAINDER: [u64; 2] = [BACKING - FIRST[0], INSURANCE - FIRST[1]];
 
     let mut peak_cu = 0;
-    for insurance_first in [false, true] {
+    for &insurance_first in orders {
         let mut env = inv018_public_spl_market_with_params(
             0,
             V16CuMarketParams {
@@ -80,6 +103,62 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         let recipients = [&owners[0], &owners[1], &provider, &insurer, &admin];
         let tokens = recipients
             .map(|owner| create_ata_for_test(&mut env.svm, &env.payer, owner.pubkey(), env.mint));
+        let mut restricted = [Vec::new(), Vec::new()];
+        if !terminal_signed {
+            for role in 0..2 {
+                for close_authority in [false, true] {
+                    let token = Keypair::new();
+                    system_create_account_for_test(
+                        &mut env.svm,
+                        &env.payer,
+                        &token,
+                        TokenAccount::LEN,
+                        spl_token::ID,
+                    );
+                    send_raw_tx(
+                        &mut env.svm,
+                        &env.payer,
+                        spl_token::instruction::initialize_account3(
+                            &spl_token::ID,
+                            &token.pubkey(),
+                            &env.mint,
+                            &recipients[role + 2].pubkey(),
+                        )
+                        .unwrap(),
+                        &[],
+                    )
+                    .unwrap();
+                    let instruction = if close_authority {
+                        spl_token::instruction::set_authority(
+                            &spl_token::ID,
+                            &token.pubkey(),
+                            Some(&operator.pubkey()),
+                            spl_token::instruction::AuthorityType::CloseAccount,
+                            &recipients[role + 2].pubkey(),
+                            &[],
+                        )
+                    } else {
+                        spl_token::instruction::approve(
+                            &spl_token::ID,
+                            &token.pubkey(),
+                            &operator.pubkey(),
+                            &recipients[role + 2].pubkey(),
+                            &[],
+                            1,
+                        )
+                    }
+                    .unwrap();
+                    send_raw_tx(
+                        &mut env.svm,
+                        &env.payer,
+                        instruction,
+                        &[recipients[role + 2]],
+                    )
+                    .unwrap();
+                    restricted[role].push(token.pubkey());
+                }
+            }
+        }
         for (token, amount) in
             tokens
                 .into_iter()
@@ -245,6 +324,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         let mut frame_keys = vec![env.market, env.vault, env.mint, operator.pubkey()];
         frame_keys.extend(portfolios);
         frame_keys.extend(tokens);
+        frame_keys.extend(restricted.iter().flatten().copied());
         frame_keys.extend(recipients.map(|owner| owner.pubkey()));
         let frame = |env: &V16CuEnv| {
             frame_keys
@@ -281,6 +361,14 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
                 &all_signers,
                 env.svm.latest_blockhash(),
             );
+            if signers.is_empty() {
+                assert_eq!(tx.message.header.num_required_signatures, 1);
+                assert_eq!(tx.message.account_keys[0], env.payer.pubkey());
+                assert!(recipients
+                    .iter()
+                    .all(|owner| owner.pubkey() != env.payer.pubkey()));
+                assert_ne!(operator.pubkey(), env.payer.pubkey());
+            }
             env.svm.send_transaction(tx)
         };
         let withdraw = |env: &V16CuEnv, insurance: bool, amount: u64| {
@@ -411,6 +499,18 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         }
         let terminal = env.market_state().1;
         assert_eq!(terminal.materialized_portfolio_count, 0);
+        // INV-073 owns the unsigned product; INV-067 retains its signed retry product.
+        let retained = retained.map(|mut instruction| {
+            instruction.accounts[0].is_signer = terminal_signed;
+            instruction
+        });
+        let terminal_signers = |role: usize| -> Vec<&Keypair> {
+            if terminal_signed {
+                vec![authorities[role]]
+            } else {
+                vec![]
+            }
+        };
         assert_eq!(
             terminal.source_backing_buckets[3].fresh_unliened_backing_num,
             u128::from(BACKING) * BOUND_SCALE
@@ -460,7 +560,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         let mut paid = [0u64; 2];
         for role in order {
             let before = frame(&env);
-            let meta = land(&mut env, &[retained[role].clone()], &[authorities[role]])
+            let meta = land(&mut env, &[retained[role].clone()], &terminal_signers(role))
                 .expect("retained withdrawal becomes payable only after user exits");
             assert_cu_within(
                 "INV-067 terminal first withdrawal",
@@ -479,10 +579,33 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
                 }
             }
             partition(&env, paid);
+            if !terminal_signed {
+                for destination in restricted[role].iter().copied().chain([tokens[3 - role]]) {
+                    let mut invalid = retained[role].clone();
+                    invalid.accounts[2].pubkey = destination;
+                    reject(
+                        &mut env,
+                        &[invalid],
+                        &[],
+                        2,
+                        PercolatorError::InvalidTokenAccount,
+                    );
+                }
+                let mut wrong_beneficiary = retained[role].clone();
+                wrong_beneficiary.accounts[0].pubkey = admin.pubkey();
+                wrong_beneficiary.accounts[2].pubkey = tokens[4];
+                reject(
+                    &mut env,
+                    &[wrong_beneficiary],
+                    &[],
+                    2,
+                    PercolatorError::Unauthorized,
+                );
+            }
             reject(
                 &mut env,
                 &[retained[role].clone()],
-                &[authorities[role]],
+                &terminal_signers(role),
                 2,
                 PercolatorError::EngineLockActive,
             );
@@ -492,11 +615,12 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         // overdraw rejects. The whole prefix must roll back, leaving its remainder payable.
         for role in order {
             let other = 1 - role;
-            let remainder = withdraw(&env, role == 1, REMAINDER[role]);
+            let mut remainder = withdraw(&env, role == 1, REMAINDER[role]);
+            remainder.accounts[0].is_signer = terminal_signed;
             let rejected = reject(
                 &mut env,
                 &[remainder.clone(), retained[other].clone()],
-                &authorities,
+                if terminal_signed { &authorities } else { &[] },
                 3,
                 PercolatorError::EngineLockActive,
             );
@@ -514,7 +638,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
                 500_000,
             );
             peak_cu = peak_cu.max(rejected.compute_units_consumed);
-            let meta = land(&mut env, &[remainder.clone()], &[authorities[role]])
+            let meta = land(&mut env, &[remainder.clone()], &terminal_signers(role))
                 .expect("unchanged remainder pays after rollback");
             assert_cu_within(
                 "INV-067 terminal remainder retry",
@@ -528,7 +652,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
                 reject(
                     &mut env,
                     &[instruction],
-                    &[authorities[role]],
+                    &terminal_signers(role),
                     2,
                     PercolatorError::EngineLockActive,
                 );
@@ -549,11 +673,25 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
             0
         );
 
-        let cu = env.withdraw_insurance_domain_to_admin_token_with_cu(
-            tokens[4],
-            0,
-            u128::from(UNRELATED_INSURANCE),
-        );
+        let admin_signers = [&admin];
+        let cu = env
+            .send(
+                env.withdraw_insurance_asset_instruction(
+                    admin.pubkey(),
+                    0,
+                    UNRELATED_INSURANCE.into(),
+                ),
+                vec![
+                    AccountMeta::new_readonly(admin.pubkey(), terminal_signed),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(tokens[4], false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                if terminal_signed { &admin_signers } else { &[] },
+            )
+            .expect("remaining canonical insurance has the same public terminal disposition");
         assert_cu_within("INV-067 unrelated terminal insurance", cu, CUSTODY_CU_LIMIT);
         peak_cu = peak_cu.max(cu);
         assert_eq!(
@@ -565,7 +703,7 @@ fn run_terminal_provider_and_insurance(absent_provider: bool) {
         custody(&env);
         env.close_slab_with_cu();
         assert_closed_market_tombstone(&env.svm.get_account(&env.market).unwrap());
-        println!("INV-067 provider/insurance order insurance_first={insurance_first}: users=2000 backing={BACKING} insurance={INSURANCE} unrelated={UNRELATED_INSURANCE}; zero vault residue");
+        println!("INV-067/073 terminal_signed={terminal_signed} insurance_first={insurance_first}: users=2000 backing={BACKING} insurance={INSURANCE} unrelated={UNRELATED_INSURANCE}; zero vault residue");
     }
     if !absent_provider {
         println!("INV-067 provider/insurance terminal suffix peak CU {peak_cu}");

--- a/tests/invariants/cu/inv_073_no_permanent_user_lock.rs
+++ b/tests/invariants/cu/inv_073_no_permanent_user_lock.rs
@@ -82,6 +82,19 @@ mod recovery_claim_liability_exit;
 #[path = "inv_073_spent_insurance_terminal_exit.rs"]
 mod spent_insurance_terminal_exit;
 
+#[path = "inv_073_terminal_provider_earnings.rs"]
+mod terminal_provider_earnings;
+
+#[test]
+fn v16_program_terminal_provider_first_disposition_needs_no_reserve_signatures() {
+    inv_067_terminal_payout_completeness_and_exact_once_settlement::provider_insurance_retries::verify_terminal_provider_and_insurance_disposition(false, &[false]);
+}
+
+#[test]
+fn v16_program_terminal_insurance_first_disposition_needs_no_reserve_signatures() {
+    inv_067_terminal_payout_completeness_and_exact_once_settlement::provider_insurance_retries::verify_terminal_provider_and_insurance_disposition(false, &[true]);
+}
+
 #[test]
 fn v16_program_terminal_provider_earnings_and_lazy_ledger_reach_exact_slab_close() {
     use inv_018_quote_mint_vault_token_program_and_authority_integrity::inv018_public_spl_market_with_params;
@@ -6598,8 +6611,8 @@ enum Inv073TerminalAuthority {
     PermissionlessEconomic,
     PermissionlessMechanical,
     OwnerOrResolvedMarketAuthority,
-    BackingAuthorityOrShutdownMarketAuthority,
-    InsuranceAuthorityOrShutdownMarketAuthority,
+    LiveBackingConsentOrPublicTerminal,
+    LiveInsuranceConsentOrPublicTerminal,
     MarketAuthority,
 }
 
@@ -6704,19 +6717,25 @@ fn v16_program_terminal_disposition_and_administrative_retirement_are_source_com
             rank_lane: "provider-cleanup",
             handler: "fn handle_withdraw_backing_bucket<'a>(",
             transition: ".withdraw_fresh_counterparty_backing_not_atomic(",
-            authority: Inv073TerminalAuthority::BackingAuthorityOrShutdownMarketAuthority,
-            witness_path:
-                "tests/invariants/stateful/inv_086_reference_model_and_deployed_transition_equivalence.rs",
-            witness: "expired_backing_composes_through_insurance_recredit_and_terminal_slab_cleanup",
+            authority: Inv073TerminalAuthority::LiveBackingConsentOrPublicTerminal,
+            witness_path: "tests/invariants/cu/inv_073_no_permanent_user_lock.rs",
+            witness: "v16_program_terminal_provider_first_disposition_needs_no_reserve_signatures",
+        },
+        Inv073TerminalPhase {
+            rank_lane: "provider-cleanup",
+            handler: "fn handle_withdraw_backing_bucket_earnings<'a>(",
+            transition: ".withdraw_backing_provider_earnings_not_atomic(",
+            authority: Inv073TerminalAuthority::LiveBackingConsentOrPublicTerminal,
+            witness_path: "tests/invariants/cu/inv_073_terminal_provider_earnings.rs",
+            witness: "v16_program_terminal_earned_fees_have_unsigned_exact_disposition",
         },
         Inv073TerminalPhase {
             rank_lane: "insurance-cleanup",
             handler: "fn handle_withdraw_insurance_asset<'a>(",
             transition: "debit_market_insurance_budget_view(",
-            authority: Inv073TerminalAuthority::InsuranceAuthorityOrShutdownMarketAuthority,
-            witness_path:
-                "tests/invariants/stateful/inv_066_resolved_payout_fairness_and_order_independence.rs",
-            witness: "v16_program_prior_insurance_frames_all_partial_receipt_orders",
+            authority: Inv073TerminalAuthority::LiveInsuranceConsentOrPublicTerminal,
+            witness_path: "tests/invariants/cu/inv_073_no_permanent_user_lock.rs",
+            witness: "v16_program_terminal_insurance_first_disposition_needs_no_reserve_signatures",
         },
         Inv073TerminalPhase {
             rank_lane: "asset-cleanup",
@@ -6791,7 +6810,7 @@ fn v16_program_terminal_disposition_and_administrative_retirement_are_source_com
         "terminal administrative rank lane drift"
     );
     assert_eq!(authorities.len(), 6, "terminal authority-class drift");
-    assert_eq!(witnesses.len(), 9, "terminal public-witness drift");
+    assert_eq!(witnesses.len(), 10, "terminal public-witness drift");
 
     assert_eq!(
         production

--- a/tests/invariants/cu/inv_073_terminal_provider_earnings.rs
+++ b/tests/invariants/cu/inv_073_terminal_provider_earnings.rs
@@ -1,0 +1,358 @@
+//! Publicly earned provider fees keep their beneficiary through unsigned terminal payout.
+
+use super::*;
+
+#[test]
+fn v16_program_terminal_earned_fees_have_unsigned_exact_disposition() {
+    use inv_018_quote_mint_vault_token_program_and_authority_integrity::inv018_public_spl_market_with_params;
+
+    const CAPITAL: [u64; 2] = [3_130, 10_000];
+    const BACKING: u64 = 51_500;
+    const SUPPLY: u64 = CAPITAL[0] + CAPITAL[1] + 1_000 + BACKING;
+    const DOMAIN: u16 = 1;
+    let mut env = inv018_public_spl_market_with_params(
+        0,
+        V16CuMarketParams {
+            max_portfolio_assets: 4,
+            maintenance_margin_bps: 1_000,
+            initial_margin_bps: 1_000,
+            max_price_move_bps_per_slot: 500,
+            maintenance_fee_per_slot: 530,
+            ..V16CuMarketParams::default()
+        },
+    );
+    let admin = env.admin.insecure_clone();
+    let provider = Keypair::new();
+    let owners = [Keypair::new(), Keypair::new()];
+    env.try_update_per_asset_authority_with_cu(
+        &admin,
+        Some(&provider),
+        0,
+        processor::ASSET_AUTH_BACKING_BUCKET,
+        provider.pubkey().to_bytes(),
+    )
+    .unwrap();
+    env.svm.warp_to_slot(1);
+    env.configure_permissionless_resolve_with_cu(100, 5);
+    for asset in [0, 1] {
+        env.configure_auth_mark_for_asset_as_admin(asset, 1, 100);
+    }
+    env.update_backing_fee_policy_with_cu(DOMAIN, 5_000, 2_500);
+    env.svm.expire_blockhash();
+    env.configure_auth_mark_for_asset_as_admin(0, 1, 100);
+
+    let tokens = [&owners[0], &owners[1], &provider].map(|owner| {
+        env.ensure_signer_account(owner.pubkey());
+        create_ata_for_test(&mut env.svm, &env.payer, owner.pubkey(), env.mint)
+    });
+    for (token, amount) in tokens
+        .into_iter()
+        .zip([CAPITAL[0] + 500, CAPITAL[1] + 500, BACKING])
+    {
+        send_raw_tx(
+            &mut env.svm,
+            &env.payer,
+            spl_token::instruction::mint_to(
+                &spl_token::ID,
+                &env.mint,
+                &token,
+                &admin.pubkey(),
+                &[],
+                amount,
+            )
+            .unwrap(),
+            &[&admin],
+        )
+        .unwrap();
+    }
+    send_raw_tx(
+        &mut env.svm,
+        &env.payer,
+        spl_token::instruction::set_authority(
+            &spl_token::ID,
+            &env.mint,
+            None,
+            spl_token::instruction::AuthorityType::MintTokens,
+            &admin.pubkey(),
+            &[],
+        )
+        .unwrap(),
+        &[&admin],
+    )
+    .unwrap();
+    let portfolios = owners.each_ref().map(|owner| {
+        let key = Keypair::new();
+        system_create_account_for_test(
+            &mut env.svm,
+            &env.payer,
+            &key,
+            env.portfolio_account_len,
+            env.program_id,
+        );
+        env.send(
+            ProgInstruction::InitPortfolio,
+            vec![
+                AccountMeta::new(owner.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(key.pubkey(), false),
+            ],
+            &[owner],
+        )
+        .unwrap();
+        env.portfolios.push(key.pubkey());
+        key.pubkey()
+    });
+    let ledger_key = Keypair::new();
+    system_create_account_for_test(
+        &mut env.svm,
+        &env.payer,
+        &ledger_key,
+        state::backing_domain_ledger_account_len(),
+        env.program_id,
+    );
+    let ledger = ledger_key.pubkey();
+    let deposit = |env: &mut V16CuEnv, index: usize, amount: u64| {
+        env.send(
+            env.deposit_ix(portfolios[index], amount.into()),
+            vec![
+                AccountMeta::new(owners[index].pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(portfolios[index], false),
+                AccountMeta::new(tokens[index], false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+            &[&owners[index]],
+        )
+        .unwrap();
+    };
+    let top_up = |env: &mut V16CuEnv, amount: u128| {
+        env.send(
+            ProgInstruction::TopUpBackingBucket {
+                domain: DOMAIN,
+                market_id: env.asset_market_id(0),
+                authority_epoch: env.control_sequences(0).authority_epoch,
+                intent_id: 0,
+                backing_fee_bps: 5_000,
+                insurance_share_bps: 2_500,
+                amount,
+                expiry_slot: 100,
+            },
+            vec![
+                AccountMeta::new(provider.pubkey(), true),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(tokens[2], false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+                AccountMeta::new(ledger, false),
+            ],
+            &[&provider],
+        )
+        .unwrap();
+    };
+    for index in 0..2 {
+        deposit(&mut env, index, CAPITAL[index]);
+    }
+    top_up(&mut env, 1_500);
+    for (asset, quantity) in [(0, 200), (1, 100)] {
+        env.trade_asset_with_cu(
+            asset,
+            &owners[0],
+            portfolios[0],
+            &owners[1],
+            portfolios[1],
+            quantity * POS_SCALE as i128,
+            100,
+            0,
+        );
+    }
+    env.svm.warp_to_slot(2);
+    env.push_auth_mark_for_asset_as_admin(0, 2, 105);
+    env.push_auth_mark_for_asset_as_admin(1, 2, 95);
+    for (index, asset) in [(1, 0), (0, 0), (1, 1)] {
+        env.crank(
+            portfolios[index],
+            ProgInstruction::PermissionlessCrank {
+                now_slot: 2,
+                observations: crank_observations_for_assets(&[asset, 1 - asset]),
+            },
+        );
+    }
+    assert_eq!(env.portfolio_state(portfolios[0]).capital.get(), 2_100);
+    assert_eq!(env.portfolio_state(portfolios[0]).pnl.get(), 1_000);
+    top_up(&mut env, 50_000);
+    for index in 0..2 {
+        deposit(&mut env, index, 500);
+    }
+    env.try_trade_asset_with_backing_fee_cap_with_cu(
+        1,
+        &owners[0],
+        portfolios[0],
+        &owners[1],
+        portfolios[1],
+        20 * POS_SCALE as i128,
+        95,
+        0,
+        5_000,
+    )
+    .unwrap();
+    let earnings =
+        env.market_state().1.source_backing_buckets[DOMAIN as usize].utilization_fee_earnings;
+    assert!(
+        earnings > 1,
+        "real utilization creates a divisible provider claim"
+    );
+    env.resolve();
+    env.svm.warp_to_slot(7);
+    for _ in 0..16 {
+        for index in [1, 0] {
+            if resolved_portfolio_is_terminal(&env, portfolios[index]) {
+                continue;
+            }
+            env.svm.expire_blockhash();
+            env.send(
+                ProgInstruction::CloseResolved {
+                    fee_rate_per_slot: 0,
+                },
+                vec![
+                    AccountMeta::new_readonly(owners[index].pubkey(), false),
+                    AccountMeta::new(env.market, false),
+                    AccountMeta::new(portfolios[index], false),
+                    AccountMeta::new(tokens[index], false),
+                    AccountMeta::new(env.vault, false),
+                    AccountMeta::new_readonly(env.vault_authority, false),
+                    AccountMeta::new_readonly(spl_token::ID, false),
+                ],
+                &[],
+            )
+            .expect("funded user disposition progresses without reserve signers");
+        }
+        if portfolios
+            .iter()
+            .all(|p| resolved_portfolio_is_terminal(&env, *p))
+        {
+            break;
+        }
+    }
+    for index in 0..2 {
+        assert!(resolved_portfolio_is_terminal(&env, portfolios[index]));
+        env.close_portfolio_with_cu(&owners[index], portfolios[index]);
+    }
+    let beneficiary = provider.pubkey();
+    drop(provider);
+    assert_ne!(env.payer.pubkey(), beneficiary);
+    assert_ne!(env.payer.pubkey(), admin.pubkey());
+    let keys = [
+        env.market,
+        env.vault,
+        env.mint,
+        ledger,
+        tokens[0],
+        tokens[1],
+        tokens[2],
+        portfolios[0],
+        portfolios[1],
+        beneficiary,
+        admin.pubkey(),
+    ];
+    let mut paid = 0;
+    let mut max_cu = 0;
+    for amount in [earnings / 2, earnings - earnings / 2] {
+        let before = env.market_state().1;
+        let before_ledger =
+            state::read_backing_domain_ledger(&env.svm.get_account(&ledger).unwrap().data).unwrap();
+        let frame = keys.map(|key| env.svm.get_account(&key));
+        let ix = Instruction {
+            program_id: env.program_id,
+            data: ProgInstruction::WithdrawBackingBucketEarnings {
+                domain: DOMAIN,
+                market_id: env.asset_market_id(0),
+                authority_epoch: env.control_sequences(0).authority_epoch,
+                amount,
+            }
+            .encode(),
+            accounts: vec![
+                AccountMeta::new_readonly(beneficiary, false),
+                AccountMeta::new(env.market, false),
+                AccountMeta::new(ledger, false),
+                AccountMeta::new(tokens[2], false),
+                AccountMeta::new(env.vault, false),
+                AccountMeta::new_readonly(env.vault_authority, false),
+                AccountMeta::new_readonly(spl_token::ID, false),
+            ],
+        };
+        env.svm.expire_blockhash();
+        let tx = Transaction::new_signed_with_payer(
+            &[heap_ix(), cu_ix(), ix],
+            Some(&env.payer.pubkey()),
+            &[&env.payer],
+            env.svm.latest_blockhash(),
+        );
+        assert_eq!(tx.message.header.num_required_signatures, 1);
+        assert_eq!(tx.message.account_keys[0], env.payer.pubkey());
+        let meta = env
+            .svm
+            .send_transaction(tx)
+            .expect("earned terminal claim pays its recorded provider without a signature");
+        max_cu = max_cu.max(meta.compute_units_consumed);
+        assert_cu_within(
+            "INV-073 public terminal earned fees",
+            meta.compute_units_consumed,
+            CUSTODY_CU_LIMIT,
+        );
+        paid += amount;
+        let after = env.market_state().1;
+        assert_eq!(after.vault, before.vault - amount);
+        assert_eq!(after.insurance, before.insurance);
+        assert_eq!(
+            after.insurance_domain_budget,
+            before.insurance_domain_budget
+        );
+        assert_eq!(after.source_credit, before.source_credit);
+        for (domain, (old, new)) in before
+            .source_backing_buckets
+            .iter()
+            .zip(&after.source_backing_buckets)
+            .enumerate()
+        {
+            let mut expected = *old;
+            if domain == DOMAIN as usize {
+                expected.utilization_fee_earnings -= amount;
+            }
+            assert_eq!(*new, expected);
+        }
+        let after_ledger =
+            state::read_backing_domain_ledger(&env.svm.get_account(&ledger).unwrap().data).unwrap();
+        assert_eq!(after_ledger.authority, beneficiary.to_bytes());
+        assert_eq!(
+            after_ledger.total_principal_atoms,
+            before_ledger.total_principal_atoms
+        );
+        assert_eq!(after_ledger.total_earnings_withdrawn_atoms, paid);
+        assert_eq!(
+            after_ledger.last_observed_bucket_earnings_atoms,
+            earnings - paid
+        );
+        assert_eq!(u128::from(env.token_amount(tokens[2])), paid);
+        assert_eq!(after.vault, u128::from(env.token_amount(env.vault)));
+        assert_eq!(
+            tokens
+                .map(|token| env.token_amount(token))
+                .iter()
+                .sum::<u64>()
+                + env.token_amount(env.vault),
+            SUPPLY
+        );
+        for (key, account) in keys.into_iter().zip(frame) {
+            if ![env.market, env.vault, ledger, tokens[2]].contains(&key) {
+                assert_eq!(env.svm.get_account(&key), account);
+            }
+        }
+    }
+    assert_eq!(paid, earnings);
+    assert_eq!(
+        env.market_state().1.source_backing_buckets[DOMAIN as usize].utilization_fee_earnings,
+        0
+    );
+    println!("INV-073 public terminal provider earnings: paid={paid} max_cu={max_cu}; principal and insurance framed");
+}

--- a/tests/invariants/kani/inv_082_state_indexed_liveness_theorem.rs
+++ b/tests/invariants/kani/inv_082_state_indexed_liveness_theorem.rs
@@ -35,6 +35,7 @@ struct AccountLivenessRank {
 struct TerminalAdministrationRank {
     economic_work: u128,
     materialized_portfolios: u128,
+    // Payable terminal principal/earnings; expiry normalization belongs to the slab scan.
     provider_cleanup: u128,
     insurance_cleanup: u128,
     asset_cleanup: u128,
@@ -80,8 +81,6 @@ fn inv082_terminal_step_requires_signer(step: TerminalAdministrationStep) -> boo
     matches!(
         step,
         TerminalAdministrationStep::PortfolioMechanicalClose
-            | TerminalAdministrationStep::ProviderCleanup
-            | TerminalAdministrationStep::InsuranceCleanup
             | TerminalAdministrationStep::AssetRetire
             | TerminalAdministrationStep::TerminalSlabProgress
             | TerminalAdministrationStep::CloseSlab
@@ -381,7 +380,13 @@ fn kani_inv082_terminal_administration_is_finite_and_not_permissionless() {
     );
     assert_eq!(
         inv082_terminal_step_requires_signer(selected),
-        before.economic_work == 0 && before != TerminalAdministrationRank::default()
+        before.economic_work == 0
+            && (before.materialized_portfolios != 0
+                || (before.provider_cleanup == 0
+                    && before.insurance_cleanup == 0
+                    && (before.asset_cleanup != 0
+                        || before.terminal_scan_work != 0
+                        || before.market_account_open != 0)))
     );
     assert_eq!(after.economic_work, before.economic_work.saturating_sub(1));
 }


### PR DESCRIPTION
## Summary

Stacked on PR #427 / the PR135 invariant branch.

This fixes the rows 420/421 terminal-progress blocker where already-payable terminal provider/insurance reserve claims required the beneficiary signer, so an absent/adversarial reserve authority could block terminal economic disposition.

Changes:

- permit `WithdrawBackingBucket`, `WithdrawBackingBucketEarnings`, and `WithdrawInsuranceAsset` submission without the beneficiary signature in `Resolved` mode only
- keep live-mode withdrawals signer-gated
- keep beneficiary, market generation, authority epoch, zero-capital/materialized-portfolio gates, ledger/budget bounds, fresh-principal rule, and canonical vault checks enforced
- require unsigned destinations to be non-delegated and have no separate close authority through the existing token-account verifier
- add public LiteSVM regressions for terminal reserve payout ordering and provider earned-fee payout
- update the INV-082 terminal administration Kani model so payable economic disposition is permissionless while mechanical account deletion remains signer-dependent

## Verification

Rebased over `origin/codex/invariant-fidelity-reopen-20260904` at `95a4cf98`.

Focused selectors on the rebased branch:

```text
env CARGO_TARGET_DIR=/dev/shm/astra-ultra-inv073-terminal-progress-20260909 \
  PERCOLATOR_FUZZ_SBF=/dev/shm/astra-ultra-inv073-terminal-progress-20260909/after/percolator_prog.so \
  cargo test -q --test v16_cu needs_no_reserve_signatures -- --nocapture
```

Result: 2 passed.

```text
env CARGO_TARGET_DIR=/dev/shm/astra-ultra-inv073-terminal-progress-20260909 \
  PERCOLATOR_FUZZ_SBF=/dev/shm/astra-ultra-inv073-terminal-progress-20260909/after/percolator_prog.so \
  cargo test -q --test v16_cu inv_073_no_permanent_user_lock::terminal_provider_earnings::v16_program_terminal_earned_fees_have_unsigned_exact_disposition -- --exact --nocapture
```

Result: 1 passed, paid=240, max_cu=215890.

Compatibility selectors passed:

```text
inv_067_terminal_payout_completeness_and_exact_once_settlement::provider_insurance_retries::v16_program_terminal_provider_and_insurance_retries_preserve_separate_entitlements
inv_064_insurance_withdrawal_policy_equivalence::v16_program_live_and_resolved_insurance_withdrawals_share_one_finite_budget
inv_070_zero_unattributed_terminal_residue_and_close_slab::v16_program_recovery_force_close_reaches_zero_residue_and_close_slab
inv_071_crank_progress::v16_program_permissionless_crank_closes_capital_only_resolved_account
inv_073_no_permanent_user_lock::v16_program_drain_only_stale_exit_does_not_require_reserve_or_counterparty_signers
inv_078_permissionless_recovery_coverage::v16_program_unavailable_pyth_feed_has_bounded_terminal_fallback
```

Kani passed:

```text
env CARGO_TARGET_DIR=/dev/shm/astra-ultra-inv073-terminal-progress-20260909 \
  cargo kani --bin v16-kani --features kani --harness kani_inv082_terminal_administration_is_finite_and_not_permissionless
```

Result: verification successful, 0/128 failed, 8/8 cover properties satisfied.

Also passed:

```text
cargo fmt --all -- --check
git diff --check
```

## Notes

This does not claim full INV-073 closure. Rows 420/421 remain open for the broader invariant matrix: owner-signed mechanical deletion, market-authority final scan/slab closure, expiry and quote-variant products, optional-ledger combinations, and supported maximum-shape terminal paths remain outside this finite fix.
